### PR TITLE
feat: add error types with thiserror (#1)

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,95 @@
+use std::path::PathBuf;
+use thiserror::Error;
+
+// Variants will be constructed by downstream modules (db, search, reflect, recall).
+#[derive(Debug, Error)]
+#[allow(dead_code)]
+pub enum LegionError {
+    #[error("database error: {0}")]
+    Database(#[from] rusqlite::Error),
+
+    #[error("search index error: {0}")]
+    Search(String),
+
+    #[error("IO error: {0}")]
+    Io(#[from] std::io::Error),
+
+    #[error("JSON parse error: {0}")]
+    Json(#[from] serde_json::Error),
+
+    #[error("no reflection text provided (use --text or --transcript)")]
+    NoReflectionInput,
+
+    #[error("transcript file not found: {0}")]
+    TranscriptNotFound(PathBuf),
+
+    #[error("data directory not available")]
+    NoDataDir,
+}
+
+pub type Result<T> = std::result::Result<T, LegionError>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn error_display_messages() {
+        let err = LegionError::NoReflectionInput;
+        assert_eq!(
+            err.to_string(),
+            "no reflection text provided (use --text or --transcript)"
+        );
+    }
+
+    #[test]
+    fn error_from_io() {
+        let io_err = std::io::Error::new(std::io::ErrorKind::NotFound, "gone");
+        let err: LegionError = io_err.into();
+        assert!(matches!(err, LegionError::Io(_)));
+    }
+
+    #[test]
+    fn error_from_json() {
+        let json_err = serde_json::from_str::<String>("not json").unwrap_err();
+        let err: LegionError = json_err.into();
+        assert!(matches!(err, LegionError::Json(_)));
+    }
+
+    #[test]
+    fn error_from_rusqlite() {
+        let db_err = rusqlite::Error::InvalidParameterName("bad".to_string());
+        let err: LegionError = db_err.into();
+        assert!(matches!(err, LegionError::Database(_)));
+    }
+
+    #[test]
+    fn error_display_transcript_not_found() {
+        let err = LegionError::TranscriptNotFound(PathBuf::from("/tmp/missing.jsonl"));
+        assert_eq!(
+            err.to_string(),
+            "transcript file not found: /tmp/missing.jsonl"
+        );
+    }
+
+    #[test]
+    fn error_display_search() {
+        let err = LegionError::Search("index corrupted".to_string());
+        assert_eq!(err.to_string(), "search index error: index corrupted");
+    }
+
+    #[test]
+    fn error_display_no_data_dir() {
+        let err = LegionError::NoDataDir;
+        assert_eq!(err.to_string(), "data directory not available");
+    }
+
+    #[test]
+    fn result_type_alias_works() {
+        let ok: Result<i32> = Ok(42);
+        assert_eq!(ok.unwrap(), 42);
+
+        let err: Result<i32> = Err(LegionError::NoDataDir);
+        assert!(err.is_err());
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,5 @@
+mod error;
+
 use clap::{Parser, Subcommand};
 use std::path::PathBuf;
 
@@ -51,7 +53,7 @@ enum Commands {
     },
 }
 
-fn main() {
+fn main() -> error::Result<()> {
     let cli = Cli::parse();
 
     match cli.command {
@@ -73,4 +75,6 @@ fn main() {
             println!("stats: repo={repo:?}");
         }
     }
+
+    Ok(())
 }


### PR DESCRIPTION
## Summary

- Define `LegionError` enum in `src/error.rs` with 7 variants covering all legion module error cases: Database (rusqlite), Search, IO, JSON, NoReflectionInput, TranscriptNotFound, and NoDataDir
- Add `#[from]` derive for automatic conversion from `rusqlite::Error`, `std::io::Error`, and `serde_json::Error`
- Export `Result<T>` type alias for ergonomic error propagation across the codebase
- Wire `main()` to return `error::Result<()>` so downstream modules can use `?` operator
- 8 tests validating display messages, From conversions, and the Result type alias

## Test plan

- [x] `cargo test` -- 8 tests passing
- [x] `cargo clippy -- -D warnings` -- clean
- [x] `cargo fmt -- --check` -- clean

Closes #1

Generated with [Claude Code](https://claude.com/claude-code)