### PR TITLE
refactor: simplify codebase

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -29,6 +29,18 @@ pub struct RepoStats {
     pub newest: String,
 }
 
+/// Map a database row to a Reflection struct.
+///
+/// Shared by all queries that select (id, repo, text, created_at).
+fn map_reflection_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<Reflection> {
+    Ok(Reflection {
+        id: row.get(0)?,
+        repo: row.get(1)?,
+        text: row.get(2)?,
+        created_at: row.get(3)?,
+    })
+}
+
 impl Database {
     /// Open (or create) a SQLite database at the given path.
     ///
@@ -58,8 +70,8 @@ impl Database {
             );
             CREATE INDEX IF NOT EXISTS idx_reflections_repo ON reflections(repo);
             CREATE INDEX IF NOT EXISTS idx_reflections_created ON reflections(created_at);",
-        )
-        .map_err(LegionError::Database)
+        )?;
+        Ok(())
     }
 
     /// Insert a new reflection for the given repository.
@@ -90,14 +102,7 @@ impl Database {
             .conn
             .prepare("SELECT id, repo, text, created_at FROM reflections WHERE id = ?1")?;
 
-        let mut rows = stmt.query_map([id], |row| {
-            Ok(Reflection {
-                id: row.get(0)?,
-                repo: row.get(1)?,
-                text: row.get(2)?,
-                created_at: row.get(3)?,
-            })
-        })?;
+        let mut rows = stmt.query_map([id], map_reflection_row)?;
 
         match rows.next() {
             Some(row) => Ok(Some(row?)),
@@ -112,21 +117,9 @@ impl Database {
             "SELECT id, repo, text, created_at FROM reflections WHERE repo = ?1 ORDER BY created_at DESC",
         )?;
 
-        let rows = stmt.query_map([repo], |row| {
-            Ok(Reflection {
-                id: row.get(0)?,
-                repo: row.get(1)?,
-                text: row.get(2)?,
-                created_at: row.get(3)?,
-            })
-        })?;
-
-        let mut reflections = Vec::new();
-        for row in rows {
-            reflections.push(row?);
-        }
-
-        Ok(reflections)
+        let rows = stmt.query_map([repo], map_reflection_row)?;
+        rows.collect::<std::result::Result<Vec<_>, _>>()
+            .map_err(LegionError::Database)
     }
 
     /// Get aggregate statistics, optionally filtered to a single repository.
@@ -140,32 +133,23 @@ impl Database {
             })
         };
 
-        let mut stats = Vec::new();
+        let base = "SELECT repo, COUNT(*) as count, MIN(created_at) as oldest, \
+                     MAX(created_at) as newest FROM reflections";
 
-        match repo {
-            Some(r) => {
-                let mut stmt = self.conn.prepare(
-                    "SELECT repo, COUNT(*) as count, MIN(created_at) as oldest, MAX(created_at) as newest \
-                     FROM reflections WHERE repo = ?1 GROUP BY repo",
-                )?;
-                let rows = stmt.query_map([r], map_row)?;
-                for row in rows {
-                    stats.push(row?);
-                }
-            }
-            None => {
-                let mut stmt = self.conn.prepare(
-                    "SELECT repo, COUNT(*) as count, MIN(created_at) as oldest, MAX(created_at) as newest \
-                     FROM reflections GROUP BY repo ORDER BY repo",
-                )?;
-                let rows = stmt.query_map([], map_row)?;
-                for row in rows {
-                    stats.push(row?);
-                }
-            }
-        }
+        let sql = match repo {
+            Some(_) => format!("{base} WHERE repo = ?1 GROUP BY repo"),
+            None => format!("{base} GROUP BY repo ORDER BY repo"),
+        };
 
-        Ok(stats)
+        let mut stmt = self.conn.prepare(&sql)?;
+
+        let rows = match repo {
+            Some(r) => stmt.query_map([r], map_row)?,
+            None => stmt.query_map([], map_row)?,
+        };
+
+        rows.collect::<std::result::Result<Vec<_>, _>>()
+            .map_err(LegionError::Database)
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,8 @@ mod recall;
 mod reflect;
 mod search;
 mod stats;
+#[cfg(test)]
+mod testutil;
 
 use std::path::PathBuf;
 

--- a/src/recall.rs
+++ b/src/recall.rs
@@ -79,15 +79,7 @@ pub fn format_for_hook(result: &RecallResult) -> String {
 mod tests {
     use super::*;
     use crate::reflect::reflect_from_text;
-
-    /// Create a Database and SearchIndex backed by a single temporary directory.
-    fn test_storage() -> (Database, SearchIndex, tempfile::TempDir) {
-        let dir = tempfile::tempdir().expect("failed to create tempdir");
-        let db = Database::open(&dir.path().join("test.db")).expect("failed to open database");
-        let index =
-            SearchIndex::open(&dir.path().join("index")).expect("failed to open search index");
-        (db, index, dir)
-    }
+    use crate::testutil::test_storage;
 
     #[test]
     fn recall_returns_ranked_results() {

--- a/src/reflect.rs
+++ b/src/reflect.rs
@@ -83,18 +83,7 @@ pub fn reflect_from_transcript(
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    /// Create a Database and SearchIndex backed by a single temporary directory.
-    ///
-    /// Returns both handles and the TempDir. The TempDir must outlive the
-    /// handles to keep the underlying files accessible.
-    fn test_storage() -> (Database, SearchIndex, tempfile::TempDir) {
-        let dir = tempfile::tempdir().expect("failed to create tempdir");
-        let db = Database::open(&dir.path().join("test.db")).expect("failed to open database");
-        let index =
-            SearchIndex::open(&dir.path().join("index")).expect("failed to open search index");
-        (db, index, dir)
-    }
+    use crate::testutil::test_storage;
 
     #[test]
     fn reflect_from_text_stores_in_db_and_index() {

--- a/src/search.rs
+++ b/src/search.rs
@@ -16,8 +16,6 @@ use crate::error::{LegionError, Result};
 /// BM25 score on the text field (tokenized, stemmed).
 pub struct SearchIndex {
     index: Index,
-    #[allow(dead_code)]
-    schema: Schema,
     id_field: Field,
     repo_field: Field,
     text_field: Field,
@@ -61,7 +59,6 @@ impl SearchIndex {
 
         Ok(Self {
             index,
-            schema,
             id_field,
             repo_field,
             text_field,

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -58,7 +58,6 @@ pub fn stats(db: &Database, repo: Option<&str>) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::db::Database;
     use tempfile::TempDir;
 
     /// Create a test database and keep TempDir alive so SQLite

--- a/src/testutil.rs
+++ b/src/testutil.rs
@@ -1,0 +1,13 @@
+use crate::db::Database;
+use crate::search::SearchIndex;
+
+/// Create a Database and SearchIndex backed by a single temporary directory.
+///
+/// Returns both handles and the TempDir. The TempDir must outlive the
+/// handles to keep the underlying files accessible.
+pub fn test_storage() -> (Database, SearchIndex, tempfile::TempDir) {
+    let dir = tempfile::tempdir().expect("failed to create tempdir");
+    let db = Database::open(&dir.path().join("test.db")).expect("failed to open database");
+    let index = SearchIndex::open(&dir.path().join("index")).expect("failed to open search index");
+    (db, index, dir)
+}


### PR DESCRIPTION
## Summary

- Extract shared `map_reflection_row()` to DRY duplicated row-mapping closures across `get_reflection_by_id` and `get_reflections_by_repo`
- Replace manual `for row in rows { vec.push(row?) }` loops with idiomatic `.collect()` in `get_reflections_by_repo` and `get_stats`
- Consolidate `get_stats` from two duplicated query branches into a single dynamic SQL builder
- Remove redundant `.map_err(LegionError::Database)` on `init_schema` where `?` already handles the `From` conversion
- Remove unused `schema` field and `#[allow(dead_code)]` suppression from `SearchIndex`
- Remove redundant `crate::db::Database` import in `stats.rs` tests (already available via `use super::*`)
- Extract duplicated `test_storage()` helper from `reflect.rs` and `recall.rs` into shared `src/testutil.rs` (cfg(test) gated)

Net result: -24 lines, zero behavior changes, all 53 tests passing.

## Test plan

- [x] `cargo test` -- all 53 tests pass (47 unit + 6 integration)
- [x] `cargo clippy -- -D warnings` -- zero warnings
- [x] `cargo fmt -- --check` -- clean


Generated with [Claude Code](https://claude.com/claude-code)