### PR TITLE
feat: compound --repo flag for multi-repo reflections

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -23,6 +23,9 @@ pub enum LegionError {
 
     #[error("data directory not available")]
     NoDataDir,
+
+    #[error("one or more repos failed during compound reflect")]
+    ReflectPartialFailure,
 }
 
 pub type Result<T> = std::result::Result<T, LegionError>;

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,9 +26,9 @@ struct Cli {
 enum Commands {
     /// Store a reflection from a completed session
     Reflect {
-        /// Repository name (e.g., "kelex", "rafters")
-        #[arg(long)]
-        repo: String,
+        /// Repository name(s), comma-separated (e.g., "kelex" or "platform,legion")
+        #[arg(long, value_delimiter = ',', required = true)]
+        repo: Vec<String>,
 
         /// Reflection text (mutually exclusive with --transcript)
         #[arg(long, conflicts_with = "transcript")]
@@ -102,12 +102,26 @@ fn main() -> error::Result<()> {
             let database = db::Database::open(&base.join("legion.db"))?;
             let index = search::SearchIndex::open(&base.join("index"))?;
 
-            match (text, transcript) {
-                (Some(t), None) => reflect::reflect_from_text(&database, &index, &repo, &t)?,
-                (None, Some(path)) => {
-                    reflect::reflect_from_transcript(&database, &index, &repo, &path)?
+            if text.is_none() && transcript.is_none() {
+                return Err(error::LegionError::NoReflectionInput);
+            }
+
+            let mut had_error = false;
+            for r in &repo {
+                let result = match (&text, &transcript) {
+                    (Some(t), None) => reflect::reflect_from_text(&database, &index, r, t),
+                    (None, Some(path)) => {
+                        reflect::reflect_from_transcript(&database, &index, r, path)
+                    }
+                    _ => unreachable!("validated above"),
+                };
+                if let Err(e) = result {
+                    eprintln!("[legion] error storing reflection for {r}: {e}");
+                    had_error = true;
                 }
-                _ => return Err(error::LegionError::NoReflectionInput),
+            }
+            if had_error {
+                return Err(error::LegionError::ReflectPartialFailure);
             }
         }
         Commands::Recall {

--- a/src/reflect.rs
+++ b/src/reflect.rs
@@ -28,7 +28,7 @@ pub fn reflect_from_text(db: &Database, index: &SearchIndex, repo: &str, text: &
     let reflection = db.insert_reflection(repo, trimmed)?;
     index.add(&reflection.id, repo, trimmed)?;
 
-    println!("stored reflection for {} ({})", repo, reflection.id);
+    eprintln!("stored reflection for {} ({})", repo, reflection.id);
 
     Ok(())
 }
@@ -183,6 +183,26 @@ mod tests {
         let (db, index, _idx_dir) = test_storage();
         let err = reflect_from_transcript(&db, &index, "kelex", &transcript).unwrap_err();
         assert!(matches!(err, LegionError::NoReflectionInput));
+    }
+
+    #[test]
+    fn compound_repo_stores_in_both() {
+        let (db, index, _dir) = test_storage();
+        reflect_from_text(&db, &index, "platform", "cross-repo knowledge").unwrap();
+        reflect_from_text(&db, &index, "legion", "cross-repo knowledge").unwrap();
+
+        let platform = db.get_reflections_by_repo("platform").unwrap();
+        let legion = db.get_reflections_by_repo("legion").unwrap();
+
+        assert_eq!(platform.len(), 1);
+        assert_eq!(legion.len(), 1);
+        assert_eq!(platform[0].text, legion[0].text);
+        assert_ne!(platform[0].id, legion[0].id);
+
+        let platform_search = index.search("platform", "cross-repo", 5).unwrap();
+        let legion_search = index.search("legion", "cross-repo", 5).unwrap();
+        assert_eq!(platform_search.len(), 1);
+        assert_eq!(legion_search.len(), 1);
     }
 
     #[test]

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -238,6 +238,85 @@ fn consult_across_repos() {
 }
 
 #[test]
+fn cli_compound_repo_flag() {
+    let dir = tempfile::tempdir().unwrap();
+
+    let output = legion_cmd(dir.path())
+        .args([
+            "reflect",
+            "--repo",
+            "platform,legion",
+            "--text",
+            "compound test reflection",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "compound reflect failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("stored reflection for platform"),
+        "expected platform confirmation, got: {stderr}"
+    );
+    assert!(
+        stderr.contains("stored reflection for legion"),
+        "expected legion confirmation, got: {stderr}"
+    );
+
+    // Verify both repos have the reflection via recall
+    let output = legion_cmd(dir.path())
+        .args(["recall", "--repo", "platform", "--context", "compound test"])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(
+        stdout.contains("compound test reflection"),
+        "expected reflection in platform recall, got: {stdout}"
+    );
+
+    let output = legion_cmd(dir.path())
+        .args(["recall", "--repo", "legion", "--context", "compound test"])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(
+        stdout.contains("compound test reflection"),
+        "expected reflection in legion recall, got: {stdout}"
+    );
+}
+
+#[test]
+fn cli_single_repo_still_works() {
+    let dir = tempfile::tempdir().unwrap();
+
+    let output = legion_cmd(dir.path())
+        .args([
+            "reflect",
+            "--repo",
+            "platform",
+            "--text",
+            "single repo test",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "single repo reflect failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("stored reflection for platform"),
+        "expected confirmation, got: {stderr}"
+    );
+}
+
+#[test]
 fn consult_no_matches() {
     let dir = tempfile::tempdir().unwrap();
 


### PR DESCRIPTION
## Summary

Closes #28

- `--repo platform,legion` stores the same reflection in both corpora with separate UUIDv7 IDs
- `--repo platform` (single value) continues to work unchanged
- Reflect confirmation messages moved from stdout to stderr (status output, not data)
- Partial failure handling: if one repo fails, continues with remaining, exits non-zero
- Input validation hoisted before the loop per review feedback
- `required = true` added to prevent silent no-op on empty `--repo`

## Changes

- `src/main.rs` - `--repo` from `String` to `Vec<String>` with `value_delimiter = ','`, loop dispatch
- `src/reflect.rs` - `println!` to `eprintln!` for confirmation, new unit test
- `src/error.rs` - `ReflectPartialFailure` variant
- `tests/integration.rs` - compound flag test, single repo backward compat test

## Test plan

- [x] `cargo test` - 67 tests pass (57 unit + 10 integration)
- [x] `cargo clippy -- -D warnings` - clean
- [x] `cargo fmt -- --check` - clean
- [x] New unit test: `compound_repo_stores_in_both`
- [x] New integration test: `cli_compound_repo_flag` (round-trip through recall)
- [x] New integration test: `cli_single_repo_still_works` (backward compat)

Generated with [Claude Code](https://claude.com/claude-code)