### PR TITLE
feat: add GitHub Actions release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,93 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    name: Build ${{ matrix.target }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+            artifact: legion-linux-x64
+            ext: tar.gz
+          - target: x86_64-apple-darwin
+            os: macos-latest
+            artifact: legion-macos-x64
+            ext: tar.gz
+          - target: aarch64-apple-darwin
+            os: macos-latest
+            artifact: legion-macos-arm64
+            ext: tar.gz
+          - target: x86_64-pc-windows-msvc
+            os: windows-latest
+            artifact: legion-windows-x64
+            ext: zip
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: ${{ matrix.target }}
+
+      - name: Build
+        run: cargo build --release --target ${{ matrix.target }}
+
+      - name: Package (Unix)
+        if: matrix.os != 'windows-latest'
+        run: |
+          cd target/${{ matrix.target }}/release
+          tar czf ../../../${{ matrix.artifact }}.${{ matrix.ext }} legion
+
+      - name: Package (Windows)
+        if: matrix.os == 'windows-latest'
+        run: |
+          cd target/${{ matrix.target }}/release
+          7z a ../../../${{ matrix.artifact }}.${{ matrix.ext }} legion.exe
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.artifact }}
+          path: ${{ matrix.artifact }}.${{ matrix.ext }}
+
+  release:
+    name: Create Release
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: Generate checksums
+        run: |
+          cd artifacts
+          find . -type f \( -name "*.tar.gz" -o -name "*.zip" \) -print0 | \
+            xargs -0 sha256sum | sed 's|  \./[^/]*/|  |' > ../checksums.txt
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          files: |
+            artifacts/**/*
+            checksums.txt


### PR DESCRIPTION
## Summary

Closes #25

Adds `.github/workflows/release.yml` triggered on `v*` tag push that builds cross-platform binaries and creates GitHub Releases.

- 4-target build matrix: linux-x64, macos-x64, macos-arm64, windows-x64
- Rust toolchain via `dtolnay/rust-toolchain@stable`, caching via `Swatinem/rust-cache@v2`
- tar.gz for Unix, zip for Windows
- SHA256 checksums.txt attached to release
- Auto-generated release notes via `softprops/action-gh-release@v2`

## Test plan

- [x] Workflow YAML is valid
- [x] Follows smuggler release workflow pattern
- [ ] `git tag v0.2.0 && git push --tags` triggers the workflow (verify after merge)

Generated with [Claude Code](https://claude.com/claude-code)