### PR TITLE
feat: add CI workflow for PR checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,50 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Run tests
+        run: cargo test
+
+  clippy:
+    name: Clippy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Run clippy
+        run: cargo clippy -- -D warnings
+
+  fmt:
+    name: Format
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+
+      - name: Check formatting
+        run: cargo fmt -- --check


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/ci.yml` with three parallel jobs: test, clippy, and fmt
- All jobs run on `ubuntu-latest` using `dtolnay/rust-toolchain@stable` and `Swatinem/rust-cache@v2`
- Triggered on pull requests to `main`

Closes #32

## Test plan

- [ ] Open this PR and verify all three checks (Test, Clippy, Format) appear as separate status checks
- [ ] Confirm all three jobs run in parallel and pass

Generated with [Claude Code](https://claude.com/claude-code)