### PR TITLE
refactor: deduplicate codebase and harden error handling

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,9 @@ legion reflect --repo <name> --text "reflection text"
 legion reflect --repo <name> --transcript /path/to/transcript.jsonl
 legion recall --repo <name> --context "what I'm working on"
 legion consult --context "problem outside your domain" --limit <n>
+legion post --repo <name> --text "share with the team"
+legion board --repo <name>
+legion board --count --repo <name>
 legion stats --repo <name>
 ```
 
@@ -60,19 +63,34 @@ CREATE INDEX idx_reflections_repo ON reflections(repo);
 CREATE INDEX idx_reflections_created ON reflections(created_at);
 ```
 
+### Water Cooler (Push-Based Communication)
+
+Push something to the team instead of keeping it to yourself:
+
+```bash
+legion post --repo rafters --text "OKLCH bet paid off"
+legion board --repo kelex              # read all posts, mark as read
+legion board --count --repo kelex      # unread count only (for hooks)
+```
+
+Posts are reflections with `audience = 'team'`. Discoverable via `consult` for free.
+
 ## Phase Plan
 
 1. **Phase 1** (complete): SQLite + Tantivy BM25. Store reflections, recall by text similarity.
 2. **Phase 1.5** (complete): Cross-agent consultation via `legion consult`. BM25 search across all repos.
-3. **Phase 2** (when BM25 hits semantic wall): Add model2vec-rs, hybrid BM25 + cosine scoring. Synapse agent for quality gating.
-4. **Phase 3** (if needed): fastembed-rs with bge-small-en-v1.5 for higher quality.
+3. **Phase 1.75** (issues #33-#35): Water cooler. `legion post` and `legion board` for push-based agent communication.
+4. **Phase 2** (when BM25 hits semantic wall): Add model2vec-rs, hybrid BM25 + cosine scoring. Synapse agent for quality gating.
+5. **Phase 3** (if needed): fastembed-rs with bge-small-en-v1.5 for higher quality.
 
 ## Hook Integration
 
 Legion is called by Claude Code hooks:
-- `SessionStart` hook calls `legion recall` and injects context via additionalContext
+- `SessionStart` hook calls `legion recall` and injects context via additionalContext. Also shows unread board post count.
 - `Stop` hook prompts the agent to reflect before closing
 - `consult` is agent-initiated (called via Bash mid-session), not hook-driven
+- `post` is agent-initiated (when agent has something worth sharing with the team)
+- `board` is agent-initiated (when agent wants to read what others posted)
 
 ## Project Layout
 
@@ -83,9 +101,12 @@ src/
   search.rs        -- Tantivy index management
   reflect.rs       -- Reflection creation (from text or transcript)
   recall.rs        -- Query and rank reflections
+  board.rs         -- Water cooler: post and board commands
   stats.rs         -- Reflection statistics reporting
   error.rs         -- Error types
   testutil.rs      -- Shared test helpers (#[cfg(test)] only)
 tests/
   integration.rs   -- End-to-end binary tests
+docs/
+  plans/           -- Design documents
 ```

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Agent memory for one engineer's craft.
 
-Legion is a local Rust CLI that stores and retrieves agent reflections. It's the memory layer for Claude Code agents: every session ends with a reflection, every session starts with relevant context from past work. Agents consult each other when they're stuck. Each repo builds its own corpus of learned heuristics over time. The shape of the corpus IS the expertise.
+Legion is a local Rust CLI that stores and retrieves agent reflections. It's the memory layer for Claude Code agents: every session ends with a reflection, every session starts with relevant context from past work. Agents consult each other when they're stuck. Agents post to the board when they have something worth sharing. Each repo builds its own corpus of learned heuristics over time. The shape of the corpus IS the expertise.
 
 ## Install
 
@@ -30,6 +30,15 @@ legion recall --repo kelex --latest --limit 3
 # Consult across all repos (cross-agent knowledge sharing)
 legion consult --context "discriminated unions in composite rules" --limit 3
 
+# Post to the board (push something to the team)
+legion post --repo rafters --text "OKLCH bet paid off"
+
+# Read the board (shows all posts, marks as read)
+legion board --repo kelex
+
+# Check unread count (for hooks)
+legion board --count --repo kelex
+
 # Statistics
 legion stats
 legion stats --repo kelex
@@ -43,7 +52,11 @@ legion stats --repo kelex
 
 **Consult**: When an agent hits something outside its domain, it searches reflections from ALL repos. The output includes repo attribution so the agent knows which domain the knowledge came from. Pull-based: the agent asks when it's stuck.
 
-**Isolation**: Reflections are scoped by repo name. Kelex reflections never leak into rafters queries. Each codebase builds its own expertise corpus. Cross-repo access is explicit via `consult`.
+**Post**: When an agent has something worth sharing -- an insight, a discovery, a poem -- it posts to the board. Posts are reflections intended for the team instead of yourself. Same storage, different audience. Discoverable via `consult` for free.
+
+**Board**: On session start, agents see an unread count. They choose when to read. The count creates curiosity without forcing content. All posts are shown unfiltered with attribution (author repo + timestamp). Serendipity over relevance.
+
+**Isolation**: Reflections are scoped by repo name. Kelex reflections never leak into rafters queries. Each codebase builds its own expertise corpus. Cross-repo access is explicit via `consult`. Posts are visible to all agents by design.
 
 ## Claude Code Hooks
 
@@ -96,6 +109,8 @@ Legion integrates via three hooks in `~/.claude/settings.json`:
 
 **Stop** (`legion-reflect.sh`): Blocks the agent from stopping and prompts it to reflect. Uses `stop_hook_active` to prevent loops: the agent reflects, tries to stop again, and passes through cleanly.
 
+**Post/Board**: Agent-initiated, not hook-driven. Agents post when they have something worth sharing. Agents read the board when curious. The SessionStart hook shows the unread count to create pull.
+
 ## Architecture
 
 - **Storage**: SQLite via rusqlite with WAL mode. XDG data dir (`~/Library/Application Support/legion/` on macOS, `~/.local/share/legion/` on Linux). Override with `LEGION_DATA_DIR` env var.
@@ -110,13 +125,21 @@ CREATE TABLE reflections (
     repo TEXT NOT NULL,         -- repository name
     text TEXT NOT NULL,         -- the reflection
     created_at TEXT NOT NULL,   -- ISO 8601
+    audience TEXT NOT NULL DEFAULT 'self',  -- 'self' or 'team'
     embedding BLOB              -- nullable, reserved for hybrid search
+);
+
+CREATE TABLE board_reads (
+    reader_repo TEXT NOT NULL PRIMARY KEY,  -- the agent that read
+    last_read_at TEXT NOT NULL              -- ISO 8601
 );
 ```
 
 ## What's Next
 
-BM25 handles keyword-dense technical reflections well. When the corpus grows large enough that keyword matching hits a semantic wall, the next step is hybrid BM25 + cosine scoring with model2vec-rs for local embeddings. Still local, still a single binary. No cloud dependency.
+**Water cooler** (Phase 1.75, issues #33-#35): Push-based agent communication via `legion post` and `legion board`. Posts are reflections with `audience = 'team'`. Unread count on session start creates pull without forcing content.
+
+**Hybrid search** (Phase 2): When the corpus grows large enough that keyword matching hits a semantic wall, the next step is hybrid BM25 + cosine scoring with model2vec-rs for local embeddings. Still local, still a single binary. No cloud dependency.
 
 ## Development
 

--- a/src/board.rs
+++ b/src/board.rs
@@ -1,7 +1,8 @@
 use std::path::Path;
 
-use crate::db::{Database, Reflection};
+use crate::db::{self, Database, Reflection};
 use crate::error::{LegionError, Result};
+use crate::reflect;
 use crate::search::SearchIndex;
 
 /// Store a board post from direct text input.
@@ -24,50 +25,16 @@ pub fn post_from_text(db: &Database, index: &SearchIndex, repo: &str, text: &str
 
 /// Extract and store a board post from a transcript JSONL file.
 ///
-/// Reads the file and uses the last assistant message as the post text.
-/// Sets audience to "team" for board visibility.
+/// Uses `reflect::extract_last_assistant_message` to get the last assistant
+/// message, then stores it as a board post via `post_from_text`.
 pub fn post_from_transcript(
     db: &Database,
     index: &SearchIndex,
     repo: &str,
     transcript_path: &Path,
 ) -> Result<()> {
-    if !transcript_path.exists() {
-        return Err(LegionError::TranscriptNotFound(
-            transcript_path.to_path_buf(),
-        ));
-    }
-
-    let file = std::fs::File::open(transcript_path)?;
-    let reader = std::io::BufReader::new(file);
-
-    let mut last_assistant_content: Option<String> = None;
-
-    use std::io::BufRead;
-    for line in reader.lines() {
-        let line = line?;
-        let trimmed = line.trim();
-        if trimmed.is_empty() {
-            continue;
-        }
-
-        #[derive(serde::Deserialize)]
-        struct TranscriptLine {
-            role: String,
-            content: String,
-        }
-
-        if let Ok(entry) = serde_json::from_str::<TranscriptLine>(trimmed)
-            && entry.role == "assistant"
-        {
-            last_assistant_content = Some(entry.content);
-        }
-    }
-
-    match last_assistant_content {
-        Some(content) => post_from_text(db, index, repo, &content),
-        None => Err(LegionError::NoReflectionInput),
-    }
+    let content = reflect::extract_last_assistant_message(transcript_path)?;
+    post_from_text(db, index, repo, &content)
 }
 
 /// Retrieve all board posts and mark them as read for the given reader repo.
@@ -103,7 +70,7 @@ pub fn format_board(posts: &[Reflection]) -> String {
     let mut output = format!("[Legion] Board ({} posts):\n", posts.len());
 
     for p in posts {
-        let date = format_date(&p.created_at);
+        let date = db::format_date(&p.created_at);
         output.push_str(&format!("- [{}] {} ({})\n", p.repo, p.text, date));
     }
 
@@ -120,14 +87,6 @@ pub fn format_board_count(count: u64) -> String {
     }
 
     format!("{} unread posts on the board", count)
-}
-
-/// Format an ISO 8601 timestamp to a date-only string (YYYY-MM-DD).
-fn format_date(iso_timestamp: &str) -> String {
-    match iso_timestamp.split_once('T') {
-        Some((date, _)) => date.to_owned(),
-        None => iso_timestamp.to_owned(),
-    }
 }
 
 #[cfg(test)]

--- a/src/db.rs
+++ b/src/db.rs
@@ -6,6 +6,17 @@ use uuid::Uuid;
 
 use crate::error::{LegionError, Result};
 
+/// Format an ISO 8601 timestamp to a date-only string (YYYY-MM-DD).
+///
+/// Falls back to the raw value if parsing fails, which keeps output
+/// usable even with unexpected timestamp formats.
+pub(crate) fn format_date(iso_timestamp: &str) -> &str {
+    match iso_timestamp.split_once('T') {
+        Some((date, _)) => date,
+        None => iso_timestamp,
+    }
+}
+
 /// Persistent storage for reflections backed by SQLite.
 pub struct Database {
     conn: Connection,
@@ -54,17 +65,37 @@ impl Database {
         }
 
         let conn = Connection::open(path)?;
-        conn.pragma_update(None, "journal_mode", "WAL")?;
+
+        let mode: String = conn
+            .pragma_query_value(None, "journal_mode", |row| row.get(0))
+            .map_err(LegionError::Database)?;
+        if mode != "wal" {
+            conn.pragma_update(None, "journal_mode", "WAL")?;
+        }
+
         Self::init_schema(&conn)?;
 
         Ok(Self { conn })
     }
 
+    /// Check whether a table has a specific column via PRAGMA table_info.
+    fn has_column(conn: &Connection, table: &str, column: &str) -> Result<bool> {
+        let mut stmt = conn.prepare(&format!("PRAGMA table_info({})", table))?;
+        let names: Vec<String> = stmt
+            .query_map([], |row| {
+                let name: String = row.get(1)?;
+                Ok(name)
+            })?
+            .collect::<std::result::Result<Vec<_>, _>>()
+            .map_err(LegionError::Database)?;
+        Ok(names.iter().any(|n| n == column))
+    }
+
     /// Create the reflections table, indexes, and supporting tables.
     ///
-    /// Runs migrations for columns added after the initial schema (e.g.
-    /// audience). ALTER TABLE failures are caught so that running against
-    /// an already-migrated database is safe.
+    /// Uses `has_column` checks to skip already-applied migrations, so
+    /// on a fully-migrated database this does minimal work (CREATE IF NOT
+    /// EXISTS checks and a single PRAGMA query).
     fn init_schema(conn: &Connection) -> Result<()> {
         conn.execute_batch(
             "CREATE TABLE IF NOT EXISTS reflections (
@@ -78,16 +109,12 @@ impl Database {
             CREATE INDEX IF NOT EXISTS idx_reflections_created ON reflections(created_at);",
         )?;
 
-        // Migration: add audience column. Catches "duplicate column name" errors
-        // so this is safe to run on databases that already have the column.
-        let add_audience = conn.execute_batch(
-            "ALTER TABLE reflections ADD COLUMN audience TEXT NOT NULL DEFAULT 'self';",
-        );
-        match add_audience {
-            Ok(()) => {}
-            Err(rusqlite::Error::SqliteFailure(_, Some(ref msg)))
-                if msg.contains("duplicate column name") => {}
-            Err(e) => return Err(LegionError::Database(e)),
+        // Migration 1: add audience column + board_reads table.
+        // Only run when the column does not yet exist.
+        if !Self::has_column(conn, "reflections", "audience")? {
+            conn.execute_batch(
+                "ALTER TABLE reflections ADD COLUMN audience TEXT NOT NULL DEFAULT 'self';",
+            )?;
         }
 
         conn.execute_batch(
@@ -140,12 +167,27 @@ impl Database {
     }
 
     /// Retrieve all reflections for a repository, ordered newest first.
+    #[cfg(test)]
     pub fn get_reflections_by_repo(&self, repo: &str) -> Result<Vec<Reflection>> {
         let mut stmt = self.conn.prepare(
             "SELECT id, repo, text, created_at, audience FROM reflections WHERE repo = ?1 ORDER BY created_at DESC",
         )?;
 
         let rows = stmt.query_map([repo], map_reflection_row)?;
+        rows.collect::<std::result::Result<Vec<_>, _>>()
+            .map_err(LegionError::Database)
+    }
+
+    /// Retrieve the most recent reflections for a repository, limited by SQL.
+    ///
+    /// More efficient than `get_reflections_by_repo` when only a small
+    /// number of results are needed, since the database handles the LIMIT.
+    pub fn get_latest_reflections(&self, repo: &str, limit: usize) -> Result<Vec<Reflection>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT id, repo, text, created_at, audience FROM reflections WHERE repo = ?1 ORDER BY created_at DESC LIMIT ?2",
+        )?;
+
+        let rows = stmt.query_map(rusqlite::params![repo, limit], map_reflection_row)?;
         rows.collect::<std::result::Result<Vec<_>, _>>()
             .map_err(LegionError::Database)
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -124,6 +124,49 @@ fn data_dir() -> error::Result<PathBuf> {
     Ok(path)
 }
 
+/// Run a compound command (text or transcript) across multiple repos.
+///
+/// Shared by both Reflect and Post to avoid duplicating the repo loop,
+/// input validation, and error-collection logic.
+#[allow(clippy::too_many_arguments)]
+fn run_compound_command(
+    db: &db::Database,
+    index: &search::SearchIndex,
+    repos: &[String],
+    text: &Option<String>,
+    transcript: &Option<PathBuf>,
+    from_text: fn(&db::Database, &search::SearchIndex, &str, &str) -> error::Result<()>,
+    from_transcript: fn(
+        &db::Database,
+        &search::SearchIndex,
+        &str,
+        &std::path::Path,
+    ) -> error::Result<()>,
+    label: &str,
+) -> error::Result<()> {
+    if text.is_none() && transcript.is_none() {
+        return Err(error::LegionError::NoReflectionInput);
+    }
+
+    let mut had_error = false;
+    for r in repos {
+        let result = match (text, transcript) {
+            (Some(t), None) => from_text(db, index, r, t),
+            (None, Some(path)) => from_transcript(db, index, r, path),
+            (Some(_), Some(_)) => return Err(error::LegionError::NoReflectionInput),
+            (None, None) => unreachable!("guarded by early return above"),
+        };
+        if let Err(e) = result {
+            eprintln!("[legion] error {label} for {r}: {e}");
+            had_error = true;
+        }
+    }
+    if had_error {
+        return Err(error::LegionError::ReflectPartialFailure);
+    }
+    Ok(())
+}
+
 fn main() -> error::Result<()> {
     let cli = Cli::parse();
 
@@ -137,27 +180,16 @@ fn main() -> error::Result<()> {
             let database = db::Database::open(&base.join("legion.db"))?;
             let index = search::SearchIndex::open(&base.join("index"))?;
 
-            if text.is_none() && transcript.is_none() {
-                return Err(error::LegionError::NoReflectionInput);
-            }
-
-            let mut had_error = false;
-            for r in &repo {
-                let result = match (&text, &transcript) {
-                    (Some(t), None) => reflect::reflect_from_text(&database, &index, r, t),
-                    (None, Some(path)) => {
-                        reflect::reflect_from_transcript(&database, &index, r, path)
-                    }
-                    _ => unreachable!("validated above"),
-                };
-                if let Err(e) = result {
-                    eprintln!("[legion] error storing reflection for {r}: {e}");
-                    had_error = true;
-                }
-            }
-            if had_error {
-                return Err(error::LegionError::ReflectPartialFailure);
-            }
+            run_compound_command(
+                &database,
+                &index,
+                &repo,
+                &text,
+                &transcript,
+                reflect::reflect_from_text,
+                reflect::reflect_from_transcript,
+                "storing reflection",
+            )?;
         }
         Commands::Recall {
             repo,
@@ -201,25 +233,16 @@ fn main() -> error::Result<()> {
             let database = db::Database::open(&base.join("legion.db"))?;
             let index = search::SearchIndex::open(&base.join("index"))?;
 
-            if text.is_none() && transcript.is_none() {
-                return Err(error::LegionError::NoReflectionInput);
-            }
-
-            let mut had_error = false;
-            for r in &repo {
-                let result = match (&text, &transcript) {
-                    (Some(t), None) => board::post_from_text(&database, &index, r, t),
-                    (None, Some(path)) => board::post_from_transcript(&database, &index, r, path),
-                    _ => unreachable!("validated above"),
-                };
-                if let Err(e) = result {
-                    eprintln!("[legion] error posting for {r}: {e}");
-                    had_error = true;
-                }
-            }
-            if had_error {
-                return Err(error::LegionError::ReflectPartialFailure);
-            }
+            run_compound_command(
+                &database,
+                &index,
+                &repo,
+                &text,
+                &transcript,
+                board::post_from_text,
+                board::post_from_transcript,
+                "posting",
+            )?;
         }
         Commands::Board { repo, count } => {
             let base = data_dir()?;

--- a/src/recall.rs
+++ b/src/recall.rs
@@ -79,13 +79,13 @@ pub fn recall(
 /// Return the most recent reflections for a repo, bypassing BM25 search.
 ///
 /// Useful for session-start hooks where no meaningful search context
-/// is available yet. Returns results ordered newest first.
+/// is available yet. Returns results ordered newest first. Uses SQL
+/// LIMIT for efficiency instead of fetching all and truncating.
 pub fn recall_latest(db: &Database, repo: &str, limit: usize) -> Result<RecallResult> {
-    let all = db.get_reflections_by_repo(repo)?;
+    let latest = db.get_latest_reflections(repo, limit)?;
 
-    let reflections: Vec<RecalledReflection> = all
+    let reflections: Vec<RecalledReflection> = latest
         .into_iter()
-        .take(limit)
         .map(|r| RecalledReflection {
             id: r.id,
             repo: r.repo,

--- a/src/reflect.rs
+++ b/src/reflect.rs
@@ -14,6 +14,46 @@ struct TranscriptLine {
     content: String,
 }
 
+/// Extract the last assistant message from a transcript JSONL file.
+///
+/// Reads the file line by line. Each line is expected to be JSON with
+/// "role" and "content" fields. Malformed lines are silently skipped.
+/// The last line where `role == "assistant"` is returned.
+///
+/// Returns `LegionError::TranscriptNotFound` if the file does not exist.
+/// Returns `LegionError::NoReflectionInput` if no assistant message is found.
+pub fn extract_last_assistant_message(transcript_path: &Path) -> Result<String> {
+    let file = match std::fs::File::open(transcript_path) {
+        Ok(f) => f,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            return Err(LegionError::TranscriptNotFound(
+                transcript_path.to_path_buf(),
+            ));
+        }
+        Err(e) => return Err(e.into()),
+    };
+    let reader = std::io::BufReader::new(file);
+
+    let mut last_assistant_content: Option<String> = None;
+
+    for line in reader.lines() {
+        let line = line?;
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+
+        // Malformed lines are skipped
+        if let Ok(entry) = serde_json::from_str::<TranscriptLine>(trimmed)
+            && entry.role == "assistant"
+        {
+            last_assistant_content = Some(entry.content);
+        }
+    }
+
+    last_assistant_content.ok_or(LegionError::NoReflectionInput)
+}
+
 /// Store a reflection from direct text input.
 ///
 /// Validates that text is non-empty, inserts into SQLite via
@@ -35,49 +75,16 @@ pub fn reflect_from_text(db: &Database, index: &SearchIndex, repo: &str, text: &
 
 /// Extract and store a reflection from a transcript JSONL file.
 ///
-/// Reads the file line by line. Each line is expected to be JSON with
-/// "role" and "content" fields. Malformed lines are silently skipped.
-/// The last line where `role == "assistant"` is used as the reflection
-/// text.
-///
-/// Returns `LegionError::TranscriptNotFound` if the file does not exist.
-/// Returns `LegionError::NoReflectionInput` if no assistant message is found.
+/// Uses `extract_last_assistant_message` to get the last assistant
+/// message, then stores it as a reflection via `reflect_from_text`.
 pub fn reflect_from_transcript(
     db: &Database,
     index: &SearchIndex,
     repo: &str,
     transcript_path: &Path,
 ) -> Result<()> {
-    if !transcript_path.exists() {
-        return Err(LegionError::TranscriptNotFound(
-            transcript_path.to_path_buf(),
-        ));
-    }
-
-    let file = std::fs::File::open(transcript_path)?;
-    let reader = std::io::BufReader::new(file);
-
-    let mut last_assistant_content: Option<String> = None;
-
-    for line in reader.lines() {
-        let line = line?;
-        let trimmed = line.trim();
-        if trimmed.is_empty() {
-            continue;
-        }
-
-        // Malformed lines are skipped
-        if let Ok(entry) = serde_json::from_str::<TranscriptLine>(trimmed)
-            && entry.role == "assistant"
-        {
-            last_assistant_content = Some(entry.content);
-        }
-    }
-
-    match last_assistant_content {
-        Some(content) => reflect_from_text(db, index, repo, &content),
-        None => Err(LegionError::NoReflectionInput),
-    }
+    let content = extract_last_assistant_message(transcript_path)?;
+    reflect_from_text(db, index, repo, &content)
 }
 
 #[cfg(test)]

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -1,18 +1,5 @@
-use crate::db::Database;
+use crate::db::{self, Database};
 use crate::error::Result;
-
-/// Format an ISO 8601 timestamp to a date-only string (YYYY-MM-DD).
-///
-/// Falls back to the raw value if parsing fails, which keeps output
-/// usable even with unexpected timestamp formats.
-fn format_date(iso_timestamp: &str) -> String {
-    // created_at is RFC 3339, e.g. "2026-03-05T12:34:56.789+00:00"
-    // Extract the date portion before the 'T' separator.
-    match iso_timestamp.split_once('T') {
-        Some((date, _)) => date.to_owned(),
-        None => iso_timestamp.to_owned(),
-    }
-}
 
 /// Print stats for a specific repo or all repos.
 ///
@@ -34,8 +21,8 @@ pub fn stats(db: &Database, repo: Option<&str>) -> Result<()> {
 
     for s in &repo_stats {
         total_count += s.count;
-        let oldest = format_date(&s.oldest);
-        let newest = format_date(&s.newest);
+        let oldest = db::format_date(&s.oldest);
+        let newest = db::format_date(&s.newest);
         println!(
             "{}: {} reflections ({} to {})",
             s.repo, s.count, oldest, newest
@@ -115,19 +102,19 @@ mod tests {
     #[test]
     fn format_date_extracts_date_portion() {
         let ts = "2026-03-05T12:34:56.789+00:00";
-        assert_eq!(format_date(ts), "2026-03-05");
+        assert_eq!(db::format_date(ts), "2026-03-05");
     }
 
     #[test]
     fn format_date_handles_no_time() {
         // If for some reason the value has no 'T', return it as-is.
         let ts = "2026-03-05";
-        assert_eq!(format_date(ts), "2026-03-05");
+        assert_eq!(db::format_date(ts), "2026-03-05");
     }
 
     #[test]
     fn format_date_handles_utc_z_suffix() {
         let ts = "2026-03-05T08:00:00Z";
-        assert_eq!(format_date(ts), "2026-03-05");
+        assert_eq!(db::format_date(ts), "2026-03-05");
     }
 }


### PR DESCRIPTION
## Summary

- Extract shared utilities (`format_date`, `extract_last_assistant_message`, `run_compound_command`) to eliminate copy-paste across board, stats, reflect, and main modules
- Replace fetch-all-then-truncate with SQL LIMIT in `recall_latest` for efficiency
- Use `PRAGMA table_info` for migration checks instead of catching ALTER TABLE errors
- Fix silent error suppression in `has_column` (`unwrap_or(false)` -> `collect` + `map_err`)
- Replace `unreachable!()` catch-all with explicit match arms in compound command handler
- Update CLAUDE.md and README.md with water cooler documentation

## Test plan

- [x] All 97 tests pass (`cargo test`)
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt -- --check` clean
- [x] Simplification pass completed (3 review agents)
- [x] Code review pass completed (code-reviewer + silent-failure-hunter)
- [x] Two review findings fixed and verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)