### PR TITLE
feat: add legion done command with auto-notify for blocked agents

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -237,6 +237,17 @@ enum Commands {
         repo: String,
     },
 
+    /// Announce completed work and notify blocked agents
+    Done {
+        /// Repository name
+        #[arg(long)]
+        repo: String,
+
+        /// Description of what was completed
+        #[arg(long)]
+        text: String,
+    },
+
     /// Manage delegated tasks between agents
     Task {
         #[command(subcommand)]
@@ -783,6 +794,44 @@ fn main() -> error::Result<()> {
             let database = db::Database::open(&base.join("legion.db"))?;
             let items = status::get_needs(&database, &repo)?;
             print!("{}", status::format_needs(&repo, &items));
+        }
+        Commands::Done { repo, text } => {
+            let base = data_dir()?;
+            let database = db::Database::open(&base.join("legion.db"))?;
+            let index = search::SearchIndex::open(&base.join("index"))?;
+
+            let announcement = format!("{repo} completed: {text}");
+            let reflection = database.insert_reflection_with_meta(
+                &repo,
+                &announcement,
+                "team",
+                &db::ReflectionMeta::default(),
+            )?;
+            if let Err(e) = index.add(&reflection.id, &reflection.repo, &announcement) {
+                eprintln!("[legion] search index add failed: {e}");
+            }
+            eprintln!("[legion] done: {text}");
+
+            let blocked_agents = status::find_blocked_agents(&database, &repo)?;
+            for agent in &blocked_agents {
+                let notify_text = format!(
+                    "@{agent} announce from {repo} -- {repo} completed: {text}. Your blocker may be cleared."
+                );
+                let notify_ref = database.insert_reflection_with_meta(
+                    &repo,
+                    &notify_text,
+                    "team",
+                    &db::ReflectionMeta::default(),
+                )?;
+                if let Err(e) = index.add(&notify_ref.id, &notify_ref.repo, &notify_text) {
+                    eprintln!("[legion] search index add failed: {e}");
+                }
+                eprintln!("[legion] notified {agent} (was blocked on {repo})");
+            }
+
+            if blocked_agents.is_empty() {
+                eprintln!("[legion] no blocked agents found");
+            }
         }
         Commands::Task { action } => {
             let base = data_dir()?;

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -57,6 +57,7 @@ pub fn run_server(port: u16, data_dir: PathBuf) -> error::Result<()> {
             .route("/api/signals", get(api_signals))
             .route("/api/status", get(api_status))
             .route("/api/needs", get(api_needs))
+            .route("/api/done", post(api_done))
             .route("/api/post", post(api_post))
             .route("/api/tasks/create", post(api_create_task))
             .route("/api/chat", get(api_chat))
@@ -474,6 +475,75 @@ async fn api_needs(State(state): State<AppState>, Query(params): Query<StatusQue
             &format!("needs error: {e}"),
         ),
     }
+}
+
+/// Request body for POST /api/done.
+#[derive(serde::Deserialize)]
+struct DoneRequest {
+    repo: String,
+    text: String,
+}
+
+/// POST /api/done -- announce completed work and notify blocked agents.
+async fn api_done(State(state): State<AppState>, Json(body): Json<DoneRequest>) -> Response {
+    let repo = body.repo.trim();
+    let text = body.text.trim();
+    if repo.is_empty() || text.is_empty() {
+        return json_error(StatusCode::BAD_REQUEST, "repo and text are required");
+    }
+
+    let db = match open_db(&state.data_dir) {
+        Ok(db) => db,
+        Err(_) => return json_error(StatusCode::INTERNAL_SERVER_ERROR, "failed to open database"),
+    };
+
+    let index = match open_search_index(&state.data_dir) {
+        Ok(idx) => idx,
+        Err(_) => {
+            return json_error(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "failed to open search index",
+            );
+        }
+    };
+
+    let announcement = format!("{repo} completed: {text}");
+    let reflection = match db.insert_reflection_with_meta(
+        repo,
+        &announcement,
+        "team",
+        &ReflectionMeta::default(),
+    ) {
+        Ok(r) => r,
+        Err(e) => {
+            return json_error(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                &format!("insert error: {e}"),
+            );
+        }
+    };
+
+    let _ = index.add(&reflection.id, &reflection.repo, &announcement);
+
+    let blocked_agents = status::find_blocked_agents(&db, repo).unwrap_or_default();
+    let mut notified: Vec<String> = Vec::new();
+    for agent in &blocked_agents {
+        let notify_text = format!(
+            "@{agent} announce from {repo} -- {repo} completed: {text}. Your blocker may be cleared."
+        );
+        if let Ok(r) =
+            db.insert_reflection_with_meta(repo, &notify_text, "team", &ReflectionMeta::default())
+        {
+            let _ = index.add(&r.id, &r.repo, &notify_text);
+            notified.push(agent.clone());
+        }
+    }
+
+    Json(status::DoneResult {
+        announcement,
+        notified,
+    })
+    .into_response()
 }
 
 /// Request body for POST /api/post.

--- a/src/status.rs
+++ b/src/status.rs
@@ -48,6 +48,36 @@ pub fn get_status(db: &Database, repo: &str) -> Result<StatusOutput> {
     })
 }
 
+/// Result of a `legion done` operation.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct DoneResult {
+    pub announcement: String,
+    pub notified: Vec<String>,
+}
+
+/// Find agents who mentioned being blocked on this repo in recent bullpen posts.
+pub fn find_blocked_agents(db: &Database, repo: &str) -> Result<Vec<String>> {
+    let posts: Vec<Reflection> = db.get_recent_board_posts(NEEDS_LOOKBACK_HOURS)?;
+    let repo_lower: String = repo.to_lowercase();
+    let blocked_pattern: String = format!("blocked on {}", repo_lower);
+    let waiting_pattern: String = format!("waiting on {}", repo_lower);
+    let mut agents: Vec<String> = Vec::new();
+
+    for p in &posts {
+        if p.repo.to_lowercase() == repo_lower {
+            continue;
+        }
+        let text_lower: String = p.text.to_lowercase();
+        if (text_lower.contains(&blocked_pattern) || text_lower.contains(&waiting_pattern))
+            && !agents.contains(&p.repo)
+        {
+            agents.push(p.repo.clone());
+        }
+    }
+
+    Ok(agents)
+}
+
 /// Gather focused team needs for a repo (wider lookback, more items than status).
 /// Used by `legion needs` when an agent is idle and looking for ways to help.
 pub fn get_needs(db: &Database, repo: &str) -> Result<Vec<StatusItem>> {


### PR DESCRIPTION
## Summary
- New `legion done --repo <name> --text "description"` command
- Posts completion announcement to the bullpen
- Searches recent posts for agents mentioning "blocked on <repo>" or "waiting on <repo>"
- Auto-posts notification signal to each blocked agent
- API endpoint: `POST /api/done` with {repo, text}
- Rebased on current main (includes #64 time windows + #65 needs command)

## Test plan
- [x] All 221 tests pass, clippy clean, fmt clean
- [x] Command posts to bullpen and searches for blocked agents
- [x] API endpoint returns DoneResult with announcement + notified list

Closes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)