### PR TITLE
feat: interactive kanban with task state transitions from dashboard

### DIFF
--- a/src/serve.rs
+++ b/src/serve.rs
@@ -60,6 +60,10 @@ pub fn run_server(port: u16, data_dir: PathBuf) -> error::Result<()> {
             .route("/api/done", post(api_done))
             .route("/api/post", post(api_post))
             .route("/api/tasks/create", post(api_create_task))
+            .route("/api/tasks/{id}/accept", post(api_task_accept))
+            .route("/api/tasks/{id}/done", post(api_task_done))
+            .route("/api/tasks/{id}/block", post(api_task_block))
+            .route("/api/tasks/{id}/unblock", post(api_task_unblock))
             .route("/api/chat", get(api_chat))
             .route("/api/boost/{id}", post(api_boost))
             .route("/api/schedules", get(api_schedules))
@@ -689,6 +693,76 @@ async fn api_create_task(
     };
 
     (StatusCode::CREATED, Json(task)).into_response()
+}
+
+/// Optional request body for task state transitions.
+#[derive(serde::Deserialize, Default)]
+struct TaskTransitionBody {
+    note: Option<String>,
+}
+
+/// POST /api/tasks/:id/accept -- accept a pending task.
+async fn api_task_accept(
+    State(state): State<AppState>,
+    AxumPath(id): AxumPath<String>,
+) -> Response {
+    let db = match open_db(&state.data_dir) {
+        Ok(db) => db,
+        Err(_) => return json_error(StatusCode::INTERNAL_SERVER_ERROR, "failed to open database"),
+    };
+    match crate::task::accept_task(&db, &id) {
+        Ok(()) => Json(serde_json::json!({"ok": true})).into_response(),
+        Err(e) => json_error(StatusCode::BAD_REQUEST, &format!("{e}")),
+    }
+}
+
+/// POST /api/tasks/:id/done -- complete an accepted task.
+async fn api_task_done(
+    State(state): State<AppState>,
+    AxumPath(id): AxumPath<String>,
+    body: Option<Json<TaskTransitionBody>>,
+) -> Response {
+    let db = match open_db(&state.data_dir) {
+        Ok(db) => db,
+        Err(_) => return json_error(StatusCode::INTERNAL_SERVER_ERROR, "failed to open database"),
+    };
+    let note = body.and_then(|b| b.note.clone());
+    match crate::task::complete_task(&db, &id, note.as_deref()) {
+        Ok(()) => Json(serde_json::json!({"ok": true})).into_response(),
+        Err(e) => json_error(StatusCode::BAD_REQUEST, &format!("{e}")),
+    }
+}
+
+/// POST /api/tasks/:id/block -- block an accepted task.
+async fn api_task_block(
+    State(state): State<AppState>,
+    AxumPath(id): AxumPath<String>,
+    body: Option<Json<TaskTransitionBody>>,
+) -> Response {
+    let db = match open_db(&state.data_dir) {
+        Ok(db) => db,
+        Err(_) => return json_error(StatusCode::INTERNAL_SERVER_ERROR, "failed to open database"),
+    };
+    let reason = body.and_then(|b| b.note.clone());
+    match crate::task::block_task(&db, &id, reason.as_deref()) {
+        Ok(()) => Json(serde_json::json!({"ok": true})).into_response(),
+        Err(e) => json_error(StatusCode::BAD_REQUEST, &format!("{e}")),
+    }
+}
+
+/// POST /api/tasks/:id/unblock -- unblock a blocked task.
+async fn api_task_unblock(
+    State(state): State<AppState>,
+    AxumPath(id): AxumPath<String>,
+) -> Response {
+    let db = match open_db(&state.data_dir) {
+        Ok(db) => db,
+        Err(_) => return json_error(StatusCode::INTERNAL_SERVER_ERROR, "failed to open database"),
+    };
+    match crate::task::unblock_task(&db, &id) {
+        Ok(()) => Json(serde_json::json!({"ok": true})).into_response(),
+        Err(e) => json_error(StatusCode::BAD_REQUEST, &format!("{e}")),
+    }
 }
 
 /// Query parameters for GET /api/chat.

--- a/static/app.js
+++ b/static/app.js
@@ -696,6 +696,22 @@
     return true;
   }
 
+  function getTaskActions(status) {
+    switch (status) {
+      case "pending":
+        return [{ type: "accept", label: "Accept" }];
+      case "accepted":
+        return [
+          { type: "done", label: "Done" },
+          { type: "block", label: "Block" },
+        ];
+      case "blocked":
+        return [{ type: "unblock", label: "Unblock" }];
+      default:
+        return [];
+    }
+  }
+
   function buildKanbanColumns() {
     var frag = document.createDocumentFragment();
     var columns = ["pending", "accepted", "done", "blocked"];
@@ -722,10 +738,54 @@
         var text = el("div", "kanban-card-text", truncate(task.text, 120));
         card.appendChild(text);
 
+        if (task.context) {
+          var ctx = el("div", "kanban-card-context", truncate(task.context, 80));
+          card.appendChild(ctx);
+        }
+
+        if (task.note) {
+          var note = el("div", "kanban-card-note", task.note);
+          card.appendChild(note);
+        }
+
         var footer = el("div", "kanban-card-footer");
         footer.appendChild(el("span", priorityBadgeClass(task.priority), task.priority));
         footer.appendChild(el("span", null, relativeTime(task.created_at)));
         card.appendChild(footer);
+
+        var actions = el("div", "kanban-card-actions");
+        var taskActions = getTaskActions(task.status);
+        taskActions.forEach(function (action) {
+          var btn = el("button", "kanban-action-btn kanban-action-" + action.type, action.label);
+          (function (taskId, actionType, button) {
+            button.addEventListener("click", function () {
+              button.disabled = true;
+              postToApi("/api/tasks/" + taskId + "/" + actionType)
+                .then(function (r) {
+                  if (r.ok) {
+                    fetch("/api/tasks")
+                      .then(function (r) { return r.json(); })
+                      .then(function (data) {
+                        state.tasks = data;
+                        updateKanban();
+                      });
+                  } else {
+                    button.disabled = false;
+                    r.json().then(function (data) {
+                      console.error("[legion] task action failed:", data.error);
+                    });
+                  }
+                })
+                .catch(function () {
+                  button.disabled = false;
+                });
+            });
+          })(task.id, action.type, btn);
+          actions.appendChild(btn);
+        });
+        if (taskActions.length > 0) {
+          card.appendChild(actions);
+        }
 
         cards.appendChild(card);
       });

--- a/static/style.css
+++ b/static/style.css
@@ -520,10 +520,68 @@ main {
   margin-bottom: 8px;
 }
 
+.kanban-card-context {
+  font-size: 11px;
+  color: var(--text-muted);
+  margin-bottom: 6px;
+  font-style: italic;
+}
+
+.kanban-card-note {
+  font-size: 11px;
+  color: var(--accent);
+  margin-bottom: 6px;
+}
+
 .kanban-card-footer {
   display: flex;
   gap: 8px;
   align-items: center;
+}
+
+.kanban-card-actions {
+  display: flex;
+  gap: 6px;
+  margin-top: 8px;
+}
+
+.kanban-action-btn {
+  font-size: 11px;
+  padding: 3px 10px;
+  border-radius: 4px;
+  border: 1px solid var(--border);
+  background: var(--bg-surface);
+  color: var(--text);
+  cursor: pointer;
+}
+
+.kanban-action-btn:hover {
+  background: var(--bg-hover);
+}
+
+.kanban-action-btn:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
+.kanban-action-accept {
+  border-color: var(--green, #4a9);
+  color: var(--green, #4a9);
+}
+
+.kanban-action-done {
+  border-color: var(--green, #4a9);
+  color: var(--green, #4a9);
+}
+
+.kanban-action-block {
+  border-color: var(--red, #d63);
+  color: var(--red, #d63);
+}
+
+.kanban-action-unblock {
+  border-color: var(--yellow, #da3);
+  color: var(--yellow, #da3);
 }
 
 /* Stats table */


### PR DESCRIPTION
## Summary
- Accept/Done/Block/Unblock buttons on kanban cards
- 4 new API endpoints: POST /api/tasks/{id}/accept|done|block|unblock
- Board auto-refreshes after successful state transition
- Cards now show context and notes when present
- CSS for action buttons with theme-safe colors

## Test plan
- [x] All 221 tests pass, clippy clean, fmt clean
- [x] Simplify review: fixed board refresh after action, CSS variables for colors
- [x] API endpoints call existing task.rs functions (accept_task, complete_task, block_task, unblock_task)

Closes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)