### PR TITLE
feat: legion watch -- auto-wake sleeping agents on signal arrival

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1223,6 +1223,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
+ "toml",
  "tower-http",
  "uuid",
 ]
@@ -2064,6 +2065,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2520,6 +2530,47 @@ dependencies = [
  "pin-project-lite",
  "tokio",
 ]
+
+[[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tower"
@@ -3184,6 +3235,15 @@ name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ tower-http = { version = "0.6", features = ["cors"] }
 mime_guess = "2"
 tokio-stream = "0.1"
 async-stream = "0.3"
+toml = "0.8"
 
 [dev-dependencies]
 tempfile = "3"

--- a/src/db.rs
+++ b/src/db.rs
@@ -350,6 +350,11 @@ impl Database {
             conn.execute_batch("ALTER TABLE schedules ADD COLUMN active_end TEXT;")?;
         }
 
+        // Migration 6: Add handled_at column for watch auto-wake tracking.
+        if !Self::has_column(conn, "reflections", "handled_at")? {
+            conn.execute_batch("ALTER TABLE reflections ADD COLUMN handled_at TEXT;")?;
+        }
+
         Ok(())
     }
 
@@ -612,6 +617,44 @@ impl Database {
         )?;
 
         Ok(())
+    }
+
+    /// Find unhandled signals directed at a specific repo.
+    ///
+    /// Returns team posts whose text starts with `@<repo_name> ` (case-sensitive)
+    /// or `@all ` that have not yet been marked as handled (`handled_at IS NULL`).
+    pub fn get_unhandled_signals_for_repo(&self, repo_name: &str) -> Result<Vec<Reflection>> {
+        let pattern_specific = format!("@{} %", repo_name);
+        let pattern_all = "@all %";
+        let mut stmt = self.conn.prepare(
+            "SELECT id, repo, text, created_at, audience, domain, tags, recall_count, \
+             last_recalled_at, parent_id \
+             FROM reflections \
+             WHERE audience = 'team' \
+               AND handled_at IS NULL \
+               AND (text LIKE ?1 OR text LIKE ?2) \
+               AND repo != ?3 \
+             ORDER BY created_at ASC",
+        )?;
+        let rows = stmt.query_map(
+            rusqlite::params![&pattern_specific, pattern_all, repo_name],
+            map_reflection_row,
+        )?;
+        rows.collect::<std::result::Result<Vec<_>, _>>()
+            .map_err(LegionError::Database)
+    }
+
+    /// Mark a signal as handled by the watch daemon.
+    ///
+    /// Sets `handled_at` to the current timestamp. Returns true if a row
+    /// was updated, false if the id was not found.
+    pub fn mark_signal_handled(&self, id: &str) -> Result<bool> {
+        let now = Utc::now().to_rfc3339();
+        let rows = self.conn.execute(
+            "UPDATE reflections SET handled_at = ?1 WHERE id = ?2 AND handled_at IS NULL",
+            rusqlite::params![&now, id],
+        )?;
+        Ok(rows > 0)
     }
 
     /// Retrieve all reflections for reindexing.

--- a/src/error.rs
+++ b/src/error.rs
@@ -50,6 +50,15 @@ pub enum LegionError {
 
     #[error("schedule not found: {0}")]
     ScheduleNotFound(String),
+
+    #[error("watch config error: {0}")]
+    WatchConfig(String),
+
+    #[error("watch already running (pid {0})")]
+    WatchAlreadyRunning(u32),
+
+    #[error("TOML parse error: {0}")]
+    Toml(#[from] toml::de::Error),
 }
 
 pub type Result<T> = std::result::Result<T, LegionError>;

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,7 @@ mod surface;
 mod task;
 #[cfg(test)]
 mod testutil;
+mod watch;
 
 use std::path::PathBuf;
 
@@ -259,6 +260,9 @@ enum Commands {
         #[command(subcommand)]
         action: ScheduleAction,
     },
+
+    /// Watch for signals and auto-wake sleeping agents
+    Watch,
 }
 
 #[derive(Subcommand)]
@@ -961,6 +965,10 @@ fn main() -> error::Result<()> {
                     }
                 }
             }
+        }
+        Commands::Watch => {
+            let base = data_dir()?;
+            watch::run(&base)?;
         }
     }
 

--- a/src/watch.rs
+++ b/src/watch.rs
@@ -1,0 +1,566 @@
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
+
+use serde::Deserialize;
+
+use crate::db::Database;
+use crate::error::{LegionError, Result};
+use crate::signal;
+
+// -- Config ------------------------------------------------------------------
+
+/// A watched repository entry from watch.toml.
+#[derive(Debug, Clone, Deserialize)]
+pub struct WatchRepoConfig {
+    pub name: String,
+    pub workdir: String,
+}
+
+/// Top-level watch configuration.
+#[derive(Debug, Clone, Deserialize)]
+pub struct WatchConfig {
+    #[serde(default = "default_poll_interval")]
+    pub poll_interval_secs: u64,
+
+    #[serde(default = "default_cooldown_secs")]
+    pub cooldown_secs: u64,
+
+    #[serde(default)]
+    pub repos: Vec<WatchRepoConfig>,
+}
+
+fn default_poll_interval() -> u64 {
+    30
+}
+
+fn default_cooldown_secs() -> u64 {
+    300
+}
+
+impl Default for WatchConfig {
+    fn default() -> Self {
+        Self {
+            poll_interval_secs: default_poll_interval(),
+            cooldown_secs: default_cooldown_secs(),
+            repos: Vec::new(),
+        }
+    }
+}
+
+/// Load watch config from the given path. Returns a default config if the
+/// file does not exist.
+pub fn load_config(path: &Path) -> Result<WatchConfig> {
+    if !path.exists() {
+        return Err(LegionError::WatchConfig(format!(
+            "config file not found: {}. Create it with watched repos.",
+            path.display()
+        )));
+    }
+
+    let contents = std::fs::read_to_string(path)?;
+    let config: WatchConfig = toml::from_str(&contents)?;
+
+    if config.repos.is_empty() {
+        return Err(LegionError::WatchConfig(
+            "no repos configured in watch.toml".to_string(),
+        ));
+    }
+
+    // Validate workdirs exist
+    for repo in &config.repos {
+        if !Path::new(&repo.workdir).is_dir() {
+            return Err(LegionError::WatchConfig(format!(
+                "workdir does not exist for repo '{}': {}",
+                repo.name, repo.workdir
+            )));
+        }
+    }
+
+    Ok(config)
+}
+
+// -- PID Lock ----------------------------------------------------------------
+
+/// Acquire a PID lock file. Returns an error if another watcher is running.
+pub fn acquire_pid_lock(lock_path: &Path) -> Result<()> {
+    if lock_path.exists() {
+        let contents = std::fs::read_to_string(lock_path).unwrap_or_default();
+        if let Ok(pid) = contents.trim().parse::<u32>() {
+            // Check if the process is actually running
+            if process_alive(pid) {
+                return Err(LegionError::WatchAlreadyRunning(pid));
+            }
+            // Stale lock file -- process is dead, remove it
+            eprintln!("[legion watch] removing stale lock (pid {})", pid);
+        }
+    }
+
+    let pid = std::process::id();
+    if let Some(parent) = lock_path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    std::fs::write(lock_path, pid.to_string())?;
+    Ok(())
+}
+
+/// Release the PID lock file.
+pub fn release_pid_lock(lock_path: &Path) {
+    let _ = std::fs::remove_file(lock_path);
+}
+
+/// RAII guard that releases the PID lock file on drop.
+struct PidLockGuard(PathBuf);
+
+impl Drop for PidLockGuard {
+    fn drop(&mut self) {
+        release_pid_lock(&self.0);
+        eprintln!("[legion watch] released lock");
+    }
+}
+
+/// Check whether a process with the given PID is alive.
+fn process_alive(pid: u32) -> bool {
+    // On Unix, signal 0 checks process existence without sending a signal.
+    // SAFETY: this is not unsafe -- libc::kill with signal 0 is a standard POSIX check.
+    #[cfg(unix)]
+    {
+        // kill(pid, 0) returns 0 if the process exists and we can signal it
+        let result = std::process::Command::new("kill")
+            .args(["-0", &pid.to_string()])
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status();
+        matches!(result, Ok(status) if status.success())
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = pid;
+        false
+    }
+}
+
+// -- Cooldown ----------------------------------------------------------------
+
+/// Tracks per-repo cooldown to prevent wake storms.
+pub struct CooldownTracker {
+    last_wake: HashMap<String, Instant>,
+    cooldown: Duration,
+}
+
+impl CooldownTracker {
+    pub fn new(cooldown_secs: u64) -> Self {
+        Self {
+            last_wake: HashMap::new(),
+            cooldown: Duration::from_secs(cooldown_secs),
+        }
+    }
+
+    /// Check whether the repo is on cooldown. Returns true if we should skip.
+    pub fn is_cooling_down(&self, repo: &str) -> bool {
+        self.last_wake
+            .get(repo)
+            .is_some_and(|t| t.elapsed() < self.cooldown)
+    }
+
+    /// Record that a repo was just woken.
+    pub fn record_wake(&mut self, repo: &str) {
+        self.last_wake.insert(repo.to_string(), Instant::now());
+    }
+}
+
+// -- Signal Detection --------------------------------------------------------
+
+/// Find unhandled signals targeting a specific repo.
+///
+/// Returns signal reflection IDs and their text, filtered to only actual
+/// signals (text starts with @).
+pub fn find_pending_signals(
+    db: &Database,
+    repo_name: &str,
+) -> Result<Vec<(String, String, String)>> {
+    let reflections = db.get_unhandled_signals_for_repo(repo_name)?;
+
+    let mut signals: Vec<(String, String, String)> = Vec::new();
+    for r in reflections {
+        if signal::is_signal(&r.text) {
+            signals.push((r.id, r.text, r.repo));
+        }
+    }
+
+    Ok(signals)
+}
+
+// -- Agent Spawning ----------------------------------------------------------
+
+/// Build the prompt context for a woken agent from pending signals.
+pub fn build_wake_prompt(repo_name: &str, signals: &[(String, String, String)]) -> String {
+    let mut prompt = format!(
+        "You were auto-woken by legion watch. The following signal(s) are directed at you ({}):\n\n",
+        repo_name
+    );
+
+    for (id, text, from_repo) in signals {
+        prompt.push_str(&format!("- [from {}] {} (id: {})\n", from_repo, text, id));
+    }
+
+    prompt.push_str(
+        "\nRead and respond to each signal. Use `legion signal` to reply if needed. \
+         Use `legion bullpen` to check for broader context. When done, use `legion reflect` \
+         to store any learnings.",
+    );
+
+    prompt
+}
+
+/// Spawn a `claude --print` session for the given repo.
+///
+/// Returns Ok(()) after spawning (does not wait for completion).
+pub fn spawn_agent(workdir: &str, prompt: &str) -> Result<()> {
+    let child = std::process::Command::new("claude")
+        .args(["--print", "-p", prompt])
+        .current_dir(workdir)
+        .env("LEGION_AUTO_WAKE", "1")
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .spawn();
+
+    match child {
+        Ok(_) => Ok(()),
+        Err(e) => {
+            eprintln!("[legion watch] failed to spawn agent: {}", e);
+            Err(LegionError::Io(e))
+        }
+    }
+}
+
+// -- Main Loop ---------------------------------------------------------------
+
+/// Run a single poll cycle across all configured repos.
+///
+/// Returns the number of agents spawned in this cycle.
+pub fn poll_cycle(
+    db: &Database,
+    config: &WatchConfig,
+    cooldown: &mut CooldownTracker,
+) -> Result<u32> {
+    let mut spawned: u32 = 0;
+
+    for repo in &config.repos {
+        if cooldown.is_cooling_down(&repo.name) {
+            continue;
+        }
+
+        let signals = find_pending_signals(db, &repo.name)?;
+        if signals.is_empty() {
+            continue;
+        }
+
+        eprintln!(
+            "[legion watch] {} signal(s) for {} -- waking agent",
+            signals.len(),
+            repo.name
+        );
+
+        let prompt = build_wake_prompt(&repo.name, &signals);
+
+        // Mark all signals as handled BEFORE spawning to prevent re-processing
+        for (id, _, _) in &signals {
+            if let Err(e) = db.mark_signal_handled(id) {
+                eprintln!(
+                    "[legion watch] failed to mark signal {} as handled: {}",
+                    id, e
+                );
+            }
+        }
+
+        match spawn_agent(&repo.workdir, &prompt) {
+            Ok(()) => {
+                cooldown.record_wake(&repo.name);
+                spawned += 1;
+                eprintln!("[legion watch] spawned agent for {}", repo.name);
+            }
+            Err(e) => {
+                eprintln!("[legion watch] spawn failed for {}: {}", repo.name, e);
+            }
+        }
+    }
+
+    Ok(spawned)
+}
+
+/// Run the watch daemon main loop.
+///
+/// This function blocks indefinitely, polling SQLite at the configured
+/// interval. It handles SIGINT/SIGTERM for graceful shutdown.
+pub fn run(data_dir: &Path) -> Result<()> {
+    let config_path: PathBuf = data_dir.join("watch.toml");
+    let lock_path: PathBuf = data_dir.join("watch.pid");
+    let db_path: PathBuf = data_dir.join("legion.db");
+
+    let config = load_config(&config_path)?;
+
+    eprintln!(
+        "[legion watch] config loaded: {} repo(s), poll every {}s, cooldown {}s",
+        config.repos.len(),
+        config.poll_interval_secs,
+        config.cooldown_secs
+    );
+
+    acquire_pid_lock(&lock_path)?;
+    eprintln!("[legion watch] acquired lock (pid {})", std::process::id());
+
+    // Guard that releases the PID lock when dropped
+    let _guard = PidLockGuard(lock_path);
+
+    let db = Database::open(&db_path)?;
+    let mut cooldown = CooldownTracker::new(config.cooldown_secs);
+    let poll_interval = Duration::from_secs(config.poll_interval_secs);
+
+    eprintln!(
+        "[legion watch] watching repos: {}",
+        config
+            .repos
+            .iter()
+            .map(|r| r.name.as_str())
+            .collect::<Vec<_>>()
+            .join(", ")
+    );
+
+    loop {
+        match poll_cycle(&db, &config, &mut cooldown) {
+            Ok(n) if n > 0 => {
+                eprintln!("[legion watch] cycle complete: {} agent(s) spawned", n);
+            }
+            Ok(_) => {} // quiet cycle, no spam
+            Err(e) => {
+                eprintln!("[legion watch] poll error: {}", e);
+            }
+        }
+
+        std::thread::sleep(poll_interval);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::testutil::test_storage;
+
+    #[test]
+    fn parse_config_basic() {
+        let toml_str = r#"
+poll_interval_secs = 15
+cooldown_secs = 120
+
+[[repos]]
+name = "rafters"
+workdir = "/tmp"
+
+[[repos]]
+name = "legion"
+workdir = "/tmp"
+"#;
+        let config: WatchConfig = toml::from_str(toml_str).expect("parse config");
+        assert_eq!(config.poll_interval_secs, 15);
+        assert_eq!(config.cooldown_secs, 120);
+        assert_eq!(config.repos.len(), 2);
+        assert_eq!(config.repos[0].name, "rafters");
+        assert_eq!(config.repos[1].name, "legion");
+    }
+
+    #[test]
+    fn parse_config_defaults() {
+        let toml_str = r#"
+[[repos]]
+name = "test"
+workdir = "/tmp"
+"#;
+        let config: WatchConfig = toml::from_str(toml_str).expect("parse config");
+        assert_eq!(config.poll_interval_secs, 30);
+        assert_eq!(config.cooldown_secs, 300);
+    }
+
+    #[test]
+    fn cooldown_tracker_prevents_rapid_wake() {
+        let mut tracker = CooldownTracker::new(300);
+        assert!(!tracker.is_cooling_down("rafters"));
+
+        tracker.record_wake("rafters");
+        assert!(tracker.is_cooling_down("rafters"));
+        assert!(!tracker.is_cooling_down("legion"));
+    }
+
+    #[test]
+    fn find_pending_signals_detects_targeted_signals() {
+        let (db, _index, _dir) = test_storage();
+
+        // Post a signal from kelex to legion
+        db.insert_reflection("kelex", "@legion review:approved", "team")
+            .expect("insert signal");
+
+        // Post a non-signal
+        db.insert_reflection("rafters", "just a musing", "team")
+            .expect("insert musing");
+
+        // Post a signal to all
+        db.insert_reflection("rafters", "@all announce: shipped", "team")
+            .expect("insert broadcast");
+
+        let signals = find_pending_signals(&db, "legion").expect("find signals");
+        assert_eq!(signals.len(), 2);
+
+        // Verify the targeted signal is found
+        assert!(
+            signals
+                .iter()
+                .any(|(_, text, _)| text == "@legion review:approved")
+        );
+        // Verify the broadcast is found
+        assert!(
+            signals
+                .iter()
+                .any(|(_, text, _)| text == "@all announce: shipped")
+        );
+    }
+
+    #[test]
+    fn find_pending_signals_excludes_self_signals() {
+        let (db, _index, _dir) = test_storage();
+
+        // Signal from legion to legion should not be returned
+        db.insert_reflection("legion", "@legion review:approved", "team")
+            .expect("insert self-signal");
+
+        let signals = find_pending_signals(&db, "legion").expect("find signals");
+        assert!(signals.is_empty(), "self-signals should be excluded");
+    }
+
+    #[test]
+    fn mark_handled_prevents_re_detection() {
+        let (db, _index, _dir) = test_storage();
+
+        db.insert_reflection("kelex", "@legion review:approved", "team")
+            .expect("insert signal");
+
+        let signals = find_pending_signals(&db, "legion").expect("first poll");
+        assert_eq!(signals.len(), 1);
+
+        // Mark as handled
+        let (id, _, _) = &signals[0];
+        db.mark_signal_handled(id).expect("mark handled");
+
+        // Should not appear again
+        let signals = find_pending_signals(&db, "legion").expect("second poll");
+        assert!(signals.is_empty());
+    }
+
+    #[test]
+    fn build_wake_prompt_formats_signals() {
+        let signals = vec![
+            (
+                "id-1".to_string(),
+                "@legion review:approved".to_string(),
+                "kelex".to_string(),
+            ),
+            (
+                "id-2".to_string(),
+                "@all announce: shipped".to_string(),
+                "rafters".to_string(),
+            ),
+        ];
+
+        let prompt = build_wake_prompt("legion", &signals);
+        assert!(prompt.contains("auto-woken by legion watch"));
+        assert!(prompt.contains("@legion review:approved"));
+        assert!(prompt.contains("@all announce: shipped"));
+        assert!(prompt.contains("from kelex"));
+        assert!(prompt.contains("from rafters"));
+    }
+
+    #[test]
+    fn poll_cycle_skips_cooling_repos() {
+        let (db, _index, _dir) = test_storage();
+
+        let config = WatchConfig {
+            poll_interval_secs: 1,
+            cooldown_secs: 300,
+            repos: vec![WatchRepoConfig {
+                name: "legion".to_string(),
+                workdir: "/tmp".to_string(),
+            }],
+        };
+
+        // Insert a signal
+        db.insert_reflection("kelex", "@legion review:ready", "team")
+            .expect("insert");
+
+        // Pre-cool the repo
+        let mut cooldown = CooldownTracker::new(300);
+        cooldown.record_wake("legion");
+
+        let spawned = poll_cycle(&db, &config, &mut cooldown).expect("poll");
+        assert_eq!(spawned, 0, "cooling repo should be skipped");
+    }
+
+    #[test]
+    fn load_config_rejects_empty_repos() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let config_path = dir.path().join("watch.toml");
+        std::fs::write(&config_path, "poll_interval_secs = 10\n").expect("write");
+
+        let err = load_config(&config_path).unwrap_err();
+        assert!(err.to_string().contains("no repos configured"));
+    }
+
+    #[test]
+    fn load_config_rejects_missing_file() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let config_path = dir.path().join("nonexistent.toml");
+
+        let err = load_config(&config_path).unwrap_err();
+        assert!(err.to_string().contains("config file not found"));
+    }
+
+    #[test]
+    fn load_config_rejects_bad_workdir() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let config_path = dir.path().join("watch.toml");
+        std::fs::write(
+            &config_path,
+            r#"
+[[repos]]
+name = "test"
+workdir = "/nonexistent/path/that/does/not/exist"
+"#,
+        )
+        .expect("write");
+
+        let err = load_config(&config_path).unwrap_err();
+        assert!(err.to_string().contains("workdir does not exist"));
+    }
+
+    #[test]
+    fn pid_lock_acquire_and_release() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let lock_path = dir.path().join("test.pid");
+
+        acquire_pid_lock(&lock_path).expect("acquire lock");
+        assert!(lock_path.exists());
+
+        release_pid_lock(&lock_path);
+        assert!(!lock_path.exists());
+    }
+
+    #[test]
+    fn pid_lock_detects_stale_lock() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let lock_path = dir.path().join("test.pid");
+
+        // Write a fake PID that is very unlikely to be running
+        std::fs::write(&lock_path, "999999999").expect("write stale lock");
+
+        // Should succeed because the process is not running
+        acquire_pid_lock(&lock_path).expect("acquire lock over stale");
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `legion watch` subcommand -- a long-lived daemon that polls SQLite for unhandled signals directed at configured repos and spawns `claude --print` sessions to handle them
- PID lock file prevents multiple watchers, per-repo cooldown (default 5 min) prevents wake storms, TOML config for opt-in repos
- Adds `handled_at` nullable column to reflections table for signal dedup, with DB query methods for unhandled signal detection and marking

## Design

Config at `~/.local/share/legion/watch.toml`:
```toml
poll_interval_secs = 30
cooldown_secs = 300

[[repos]]
name = "rafters"
workdir = "/Volumes/store/projects/rafters-studio/rafters"
```

Signals targeting a repo (e.g. `@legion review:approved`) or broadcast (`@all announce: shipped`) are detected, aggregated into a wake prompt, and dispatched via `claude --print -p` with `LEGION_AUTO_WAKE=1` env var set.

## Test plan

- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt -- --check` passes
- [x] All 229 tests pass (199 unit + 30 integration)
- [x] New unit tests: config parsing, signal detection, cooldown logic, PID lock, self-signal exclusion, handled-at dedup, wake prompt formatting
- [x] Binary installs cleanly via `cargo install --path .`
- [ ] Manual test: create watch.toml, run `legion watch`, send a signal, verify agent spawns

Closes #80

Generated with [Claude Code](https://claude.com/claude-code)