### PR TITLE
fix: broadcast @all signals visible to all repos

### DIFF
--- a/src/watch.rs
+++ b/src/watch.rs
@@ -271,10 +271,7 @@ pub fn poll_cycle(
         // every configured repo. Cooldown + since-timestamp prevent duplicate wakes.
         for (id, text, _) in &signals {
             if !text.starts_with("@all ") && db.mark_signal_handled(id).is_err() {
-                eprintln!(
-                    "[legion watch] failed to mark signal {} as handled",
-                    id
-                );
+                eprintln!("[legion watch] failed to mark signal {} as handled", id);
             }
         }
 


### PR DESCRIPTION
## Summary
- `@all` signals are no longer marked as `handled_at` after the first repo processes them
- Only targeted signals (`@specific-repo`) get marked handled
- Broadcasts rely on cooldown + since-timestamp for dedup
- New test: `broadcast_signals_visible_to_all_repos`

## Test plan
- [x] 230 tests passing (200 unit + 30 integration)
- [x] Clippy clean
- [ ] Send @all signal, verify all configured repos wake

🤖 Generated with [Claude Code](https://claude.com/claude-code)