### PR TITLE
feat: kanban CLI commands -- work, done, kanban subcommands

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,12 +26,22 @@ legion chain --id <reflection-id>
 legion surface --repo <name>
 legion stats --repo <name>
 legion reindex
-legion task create --from <repo> --to <repo> --text "task description" --priority <low|med|high> --context "optional context"
-legion task list --repo <name>               # inbound tasks (assigned to repo)
-legion task list --repo <name> --from        # outbound tasks (created by repo)
-legion task accept --id <task-id>
-legion task done --id <task-id> --note "optional completion note"
-legion task block --id <task-id> --reason "optional reason"
+legion work --repo <name>                    # get next card from scheduler (auto-accepts)
+legion work --repo <name> --peek             # peek at next card without accepting
+legion done --repo <name> --text "what was completed" --id <card-id>  # complete card + announce
+legion kanban create --from <repo> --to <repo> --text "description" --priority <low|med|high|critical>
+legion kanban create --from <repo> --to <repo> --text "..." --labels "tag1,tag2" --source-url "https://..."
+legion kanban list --repo <name>             # inbound cards (assigned to repo)
+legion kanban list --repo <name> --from      # outbound cards (created by repo)
+legion kanban accept --id <card-id>          # pending -> in-progress
+legion kanban block --id <card-id> --reason "blocker description"
+legion kanban unblock --id <card-id>         # blocked -> in-progress
+legion kanban review --id <card-id>          # in-progress -> in-review
+legion kanban need-input --id <card-id>      # in-progress -> needs-input (blocked on human)
+legion kanban resume --id <card-id>          # needs-input/in-review -> in-progress
+legion kanban cancel --id <card-id>          # any active -> cancelled
+legion kanban assign --id <card-id> --to <repo>  # backlog -> assigned to agent
+legion kanban reopen --id <card-id>          # done/cancelled -> backlog
 legion watch                                 # auto-wake sleeping agents on signal arrival
 legion -v <command>                          # show informational messages (quiet by default)
 ```

--- a/src/db.rs
+++ b/src/db.rs
@@ -1310,6 +1310,30 @@ impl Database {
         Ok(())
     }
 
+    /// Assign a backlog card to an agent and transition to pending.
+    ///
+    /// Atomic: updates to_repo, status, and assigned_at in one statement.
+    /// Only works on backlog cards -- returns InvalidCardTransition otherwise.
+    pub fn assign_card(&self, id: &str, to_repo: &str) -> Result<()> {
+        let now = chrono::Utc::now().to_rfc3339();
+        let rows = self.conn.execute(
+            "UPDATE tasks SET to_repo = ?1, status = 'pending', \
+             assigned_at = ?2, updated_at = ?3 WHERE id = ?4 AND status = 'backlog'",
+            rusqlite::params![to_repo, now, now, id],
+        )?;
+        if rows == 0 {
+            let exists = self.get_card_by_id(id)?;
+            return match exists {
+                None => Err(LegionError::CardNotFound(id.to_string())),
+                Some(card) => Err(LegionError::InvalidCardTransition {
+                    action: "assign".to_string(),
+                    current: card.status.to_string(),
+                }),
+            };
+        }
+        Ok(())
+    }
+
     /// Get per-agent workload summary.
     pub fn get_agent_workloads(&self) -> Result<Vec<crate::kanban::AgentWorkload>> {
         let mut stmt = self.conn.prepare(

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,7 @@ mod embed;
 mod error;
 mod health;
 mod init;
-#[allow(dead_code)]
+#[allow(dead_code)] // Items used by tests + pending surface/status/serve migration
 mod kanban;
 mod recall;
 mod reflect;
@@ -266,9 +266,30 @@ enum Commands {
         /// Description of what was completed
         #[arg(long)]
         text: String,
+
+        /// Card ID to mark as complete (optional)
+        #[arg(long)]
+        id: Option<String>,
     },
 
-    /// Manage delegated tasks between agents
+    /// Get next work item from the scheduler
+    Work {
+        /// Repository name
+        #[arg(long)]
+        repo: String,
+
+        /// Peek only (don't auto-accept the card)
+        #[arg(long)]
+        peek: bool,
+    },
+
+    /// Manage the kanban board
+    Kanban {
+        #[command(subcommand)]
+        action: KanbanAction,
+    },
+
+    /// Manage delegated tasks between agents (deprecated, use kanban)
     Task {
         #[command(subcommand)]
         action: TaskAction,
@@ -367,6 +388,134 @@ enum TaskAction {
     /// Unblock a blocked task (returns to accepted)
     Unblock {
         /// Task ID
+        #[arg(long)]
+        id: String,
+    },
+}
+
+#[derive(Subcommand)]
+enum KanbanAction {
+    /// Create a new card on the kanban board
+    Create {
+        /// Who is creating the card
+        #[arg(long)]
+        from: String,
+
+        /// Which agent this card is assigned to
+        #[arg(long)]
+        to: String,
+
+        /// Card description
+        #[arg(long)]
+        text: String,
+
+        /// Additional context
+        #[arg(long)]
+        context: Option<String>,
+
+        /// Priority: low, med, high, critical (default: med)
+        #[arg(long, default_value = "med", value_parser = ["low", "med", "high", "critical"])]
+        priority: String,
+
+        /// Comma-separated labels
+        #[arg(long)]
+        labels: Option<String>,
+
+        /// Parent card ID (for delegation chains)
+        #[arg(long)]
+        parent: Option<String>,
+
+        /// Link to external issue (e.g., GitHub issue URL)
+        #[arg(long)]
+        source_url: Option<String>,
+
+        /// Source type (e.g., "github", "jira")
+        #[arg(long)]
+        source_type: Option<String>,
+    },
+
+    /// List cards for a repo
+    List {
+        /// Repository name
+        #[arg(long)]
+        repo: String,
+
+        /// Show outbound cards (created by this repo) instead of inbound
+        #[arg(long)]
+        from: bool,
+    },
+
+    /// Accept a pending card (move to in-progress)
+    Accept {
+        /// Card ID
+        #[arg(long)]
+        id: String,
+    },
+
+    /// Block a card (technical blocker)
+    Block {
+        /// Card ID
+        #[arg(long)]
+        id: String,
+
+        /// Reason for blocking
+        #[arg(long)]
+        reason: Option<String>,
+    },
+
+    /// Unblock a blocked card (returns to in-progress)
+    Unblock {
+        /// Card ID
+        #[arg(long)]
+        id: String,
+    },
+
+    /// Mark a card for review
+    Review {
+        /// Card ID
+        #[arg(long)]
+        id: String,
+    },
+
+    /// Mark a card as needing human input
+    NeedInput {
+        /// Card ID
+        #[arg(long)]
+        id: String,
+
+        /// What input is needed
+        #[arg(long)]
+        reason: Option<String>,
+    },
+
+    /// Resume a card from needs-input or in-review
+    Resume {
+        /// Card ID
+        #[arg(long)]
+        id: String,
+    },
+
+    /// Cancel a card
+    Cancel {
+        /// Card ID
+        #[arg(long)]
+        id: String,
+    },
+
+    /// Assign a backlog card to an agent
+    Assign {
+        /// Card ID
+        #[arg(long)]
+        id: String,
+
+        /// Target agent/repo
+        #[arg(long)]
+        to: String,
+    },
+
+    /// Reopen a done or cancelled card
+    Reopen {
+        /// Card ID
         #[arg(long)]
         id: String,
     },
@@ -864,10 +1013,16 @@ fn main() -> error::Result<()> {
             let items = status::get_needs(&database, &repo)?;
             print!("{}", status::format_needs(&repo, &items));
         }
-        Commands::Done { repo, text } => {
+        Commands::Done { repo, text, id } => {
             let base = data_dir()?;
             let database = db::Database::open(&base.join("legion.db"))?;
             let index = search::SearchIndex::open(&base.join("index"))?;
+
+            // Validate card transition BEFORE posting announcements
+            if let Some(ref card_id) = id {
+                kanban::transition_card(&database, card_id, kanban::Action::Done, Some(&text))?;
+                println!("{card_id}");
+            }
 
             let announcement = format!("{repo} completed: {text}");
             let reflection = database.insert_reflection_with_meta(
@@ -900,6 +1055,113 @@ fn main() -> error::Result<()> {
 
             if blocked_agents.is_empty() {
                 info!("[legion] no blocked agents found");
+            }
+        }
+        Commands::Work { repo, peek } => {
+            let base = data_dir()?;
+            let database = db::Database::open(&base.join("legion.db"))?;
+
+            let card = if peek {
+                kanban::peek_work(&database, &repo)?
+            } else {
+                kanban::next_work(&database, &repo)?
+            };
+
+            match card {
+                Some(c) => print!("{}", kanban::format_work_card(&c)),
+                None => info!("[legion] no pending work for {repo}"),
+            }
+        }
+        Commands::Kanban { action } => {
+            let base = data_dir()?;
+            let database = db::Database::open(&base.join("legion.db"))?;
+
+            match action {
+                KanbanAction::Create {
+                    from,
+                    to,
+                    text,
+                    context,
+                    priority,
+                    labels,
+                    parent,
+                    source_url,
+                    source_type,
+                } => {
+                    let id = kanban::create_card(
+                        &database,
+                        &from,
+                        &to,
+                        &text,
+                        context.as_deref(),
+                        &priority,
+                        labels.as_deref(),
+                        parent.as_deref(),
+                        source_url.as_deref(),
+                        source_type.as_deref(),
+                    )?;
+                    println!("{id}");
+                }
+                KanbanAction::List { repo, from } => {
+                    let direction = if from {
+                        kanban::Direction::Outbound
+                    } else {
+                        kanban::Direction::Inbound
+                    };
+                    let cards = kanban::list_cards(&database, &repo, direction)?;
+                    let output = kanban::format_card_list(&cards, &repo, direction);
+                    if output.is_empty() {
+                        info!("[legion] no cards found");
+                    } else {
+                        print!("{output}");
+                    }
+                }
+                KanbanAction::Accept { id } => {
+                    kanban::transition_card(&database, &id, kanban::Action::Accept, None)?;
+                    println!("{id}");
+                }
+                KanbanAction::Block { id, reason } => {
+                    kanban::transition_card(
+                        &database,
+                        &id,
+                        kanban::Action::Block,
+                        reason.as_deref(),
+                    )?;
+                    println!("{id}");
+                }
+                KanbanAction::Unblock { id } => {
+                    kanban::transition_card(&database, &id, kanban::Action::Unblock, None)?;
+                    println!("{id}");
+                }
+                KanbanAction::Review { id } => {
+                    kanban::transition_card(&database, &id, kanban::Action::Review, None)?;
+                    println!("{id}");
+                }
+                KanbanAction::NeedInput { id, reason } => {
+                    kanban::transition_card(
+                        &database,
+                        &id,
+                        kanban::Action::NeedInput,
+                        reason.as_deref(),
+                    )?;
+                    println!("{id}");
+                }
+                KanbanAction::Resume { id } => {
+                    kanban::transition_card(&database, &id, kanban::Action::Resume, None)?;
+                    println!("{id}");
+                }
+                KanbanAction::Cancel { id } => {
+                    kanban::transition_card(&database, &id, kanban::Action::Cancel, None)?;
+                    println!("{id}");
+                }
+                KanbanAction::Assign { id, to } => {
+                    database.assign_card(&id, &to)?;
+                    println!("{id}");
+                }
+                KanbanAction::Reopen { id } => {
+                    kanban::transition_card(&database, &id, kanban::Action::Reopen, None)?;
+                    println!("{id}");
+                }
             }
         }
         Commands::Task { action } => {

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1339,3 +1339,346 @@ fn task_surface_shows_pending() {
         "expected task attribution, got: {stdout}"
     );
 }
+
+// --- Kanban CLI tests ---
+
+#[test]
+fn kanban_create_and_list() {
+    let dir = tempfile::tempdir().unwrap();
+
+    let out = legion_cmd(dir.path())
+        .args([
+            "kanban",
+            "create",
+            "--from",
+            "sean",
+            "--to",
+            "kelex",
+            "--text",
+            "implement search",
+            "--priority",
+            "high",
+            "--labels",
+            "backend,search",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "kanban create failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let id = String::from_utf8_lossy(&out.stdout).trim().to_string();
+    assert_eq!(id.len(), 36, "expected UUID, got: {id}");
+
+    let out = legion_cmd(dir.path())
+        .args(["kanban", "list", "--repo", "kelex"])
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("implement search"),
+        "expected card text, got: {stdout}"
+    );
+    assert!(
+        stdout.contains("[high]"),
+        "expected priority, got: {stdout}"
+    );
+    assert!(
+        stdout.contains("{backend,search}"),
+        "expected labels, got: {stdout}"
+    );
+}
+
+#[test]
+fn kanban_work_picks_up_card() {
+    let dir = tempfile::tempdir().unwrap();
+
+    // Create two cards with different priorities
+    legion_cmd(dir.path())
+        .args([
+            "kanban",
+            "create",
+            "--from",
+            "sean",
+            "--to",
+            "kelex",
+            "--text",
+            "low prio",
+            "--priority",
+            "low",
+        ])
+        .output()
+        .unwrap();
+    legion_cmd(dir.path())
+        .args([
+            "kanban",
+            "create",
+            "--from",
+            "sean",
+            "--to",
+            "kelex",
+            "--text",
+            "high prio",
+            "--priority",
+            "high",
+        ])
+        .output()
+        .unwrap();
+
+    // Work should pick up the high priority card
+    let out = legion_cmd(dir.path())
+        .args(["work", "--repo", "kelex"])
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("high prio"),
+        "expected high prio card, got: {stdout}"
+    );
+    assert!(
+        stdout.contains("Priority: high"),
+        "expected priority line, got: {stdout}"
+    );
+}
+
+#[test]
+fn kanban_work_empty_queue() {
+    let dir = tempfile::tempdir().unwrap();
+
+    // Init DB
+    legion_cmd(dir.path())
+        .args(["reflect", "--repo", "test", "--text", "setup"])
+        .output()
+        .unwrap();
+
+    let out = legion_cmd(dir.path())
+        .args(["--verbose", "work", "--repo", "kelex"])
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("no pending work"),
+        "expected no-work message, got: {stderr}"
+    );
+}
+
+#[test]
+fn kanban_work_peek_does_not_accept() {
+    let dir = tempfile::tempdir().unwrap();
+
+    legion_cmd(dir.path())
+        .args([
+            "kanban",
+            "create",
+            "--from",
+            "sean",
+            "--to",
+            "kelex",
+            "--text",
+            "peek test",
+            "--priority",
+            "med",
+        ])
+        .output()
+        .unwrap();
+
+    // Peek should show card but not accept
+    let out = legion_cmd(dir.path())
+        .args(["work", "--repo", "kelex", "--peek"])
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("peek test"), "expected card, got: {stdout}");
+
+    // Card should still be pending (work without peek should still get it)
+    let out = legion_cmd(dir.path())
+        .args(["work", "--repo", "kelex"])
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("peek test"),
+        "card should still be available, got: {stdout}"
+    );
+}
+
+#[test]
+fn kanban_full_lifecycle() {
+    let dir = tempfile::tempdir().unwrap();
+
+    // Create
+    let out = legion_cmd(dir.path())
+        .args([
+            "kanban",
+            "create",
+            "--from",
+            "sean",
+            "--to",
+            "kelex",
+            "--text",
+            "lifecycle test",
+        ])
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+    let id = String::from_utf8_lossy(&out.stdout).trim().to_string();
+
+    // Accept
+    let out = legion_cmd(dir.path())
+        .args(["kanban", "accept", "--id", &id])
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "accept failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    // Review
+    let out = legion_cmd(dir.path())
+        .args(["kanban", "review", "--id", &id])
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "review failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    // Done via kanban
+    let out = legion_cmd(dir.path())
+        .args(["done", "--repo", "kelex", "--text", "shipped", "--id", &id])
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "done failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+#[test]
+fn kanban_block_unblock() {
+    let dir = tempfile::tempdir().unwrap();
+
+    let out = legion_cmd(dir.path())
+        .args([
+            "kanban",
+            "create",
+            "--from",
+            "sean",
+            "--to",
+            "kelex",
+            "--text",
+            "block test",
+        ])
+        .output()
+        .unwrap();
+    let id = String::from_utf8_lossy(&out.stdout).trim().to_string();
+
+    legion_cmd(dir.path())
+        .args(["kanban", "accept", "--id", &id])
+        .output()
+        .unwrap();
+
+    let out = legion_cmd(dir.path())
+        .args([
+            "kanban",
+            "block",
+            "--id",
+            &id,
+            "--reason",
+            "waiting on upstream",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "block failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let out = legion_cmd(dir.path())
+        .args(["kanban", "unblock", "--id", &id])
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "unblock failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+#[test]
+fn kanban_invalid_transition() {
+    let dir = tempfile::tempdir().unwrap();
+
+    let out = legion_cmd(dir.path())
+        .args([
+            "kanban",
+            "create",
+            "--from",
+            "sean",
+            "--to",
+            "kelex",
+            "--text",
+            "invalid test",
+        ])
+        .output()
+        .unwrap();
+    let id = String::from_utf8_lossy(&out.stdout).trim().to_string();
+
+    // Try to review a pending card (should fail -- must accept first)
+    let out = legion_cmd(dir.path())
+        .args(["kanban", "review", "--id", &id])
+        .output()
+        .unwrap();
+    assert!(!out.status.success(), "review of pending card should fail");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("InvalidCardTransition"),
+        "expected transition error, got: {stderr}"
+    );
+}
+
+#[test]
+fn kanban_with_source_url() {
+    let dir = tempfile::tempdir().unwrap();
+
+    let out = legion_cmd(dir.path())
+        .args([
+            "kanban",
+            "create",
+            "--from",
+            "sean",
+            "--to",
+            "kelex",
+            "--text",
+            "github issue",
+            "--source-url",
+            "https://github.com/ssilvius/legion/issues/42",
+            "--source-type",
+            "github",
+        ])
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+    let id = String::from_utf8_lossy(&out.stdout).trim().to_string();
+    assert_eq!(id.len(), 36);
+
+    let out = legion_cmd(dir.path())
+        .args(["kanban", "list", "--repo", "kelex"])
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("github.com"),
+        "expected source URL in output, got: {stdout}"
+    );
+}


### PR DESCRIPTION
## Summary

Closes #99

- `legion work --repo X [--peek]` -- scheduler picks next card by priority, auto-accepts
- `legion done --repo X --text "..." [--id <card>]` -- validates card transition BEFORE posting announcements
- `legion kanban create/list/accept/block/unblock/review/need-input/resume/cancel/assign/reopen`
- Atomic `assign_card` in db.rs (backlog status guard + to_repo update in one statement)
- CLAUDE.md updated with full kanban command reference
- Old `legion task` commands kept for backwards compat

## Test plan

- [x] 304 tests pass (264 unit + 40 integration)
- [x] 8 new kanban integration tests (create, list, work, peek, lifecycle, block/unblock, invalid transitions, source URLs)
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt -- --check` clean
- [x] Simplify review: assign bug fixed (was bypassing state machine)
- [x] PR review (code + silent-failure): 2 critical findings fixed (assign atomicity, done ordering)
- [x] Pre-commit hook passed
- [x] Pre-push hook passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)