### PR TITLE
fix: truncate long channel notifications with bullpen pointer

### DIFF
--- a/plugin/channel/event-bridge.ts
+++ b/plugin/channel/event-bridge.ts
@@ -1,20 +1,44 @@
 import type { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import type { LegionEvent } from "./types.js";
 
+// Maximum content length for channel notifications.
+// Claude Code truncates content beyond this limit silently.
+const MAX_NOTIFICATION_LENGTH = 2000;
+
+// Truncate long content with a pointer to the bullpen.
+// Reserves space for the hint so the total stays under the limit.
+function truncateIfNeeded(content: string, id?: string): string {
+  if (content.length <= MAX_NOTIFICATION_LENGTH) return content;
+  const hint = id
+    ? `\n\n[truncated -- full content on bullpen, id: ${id}]`
+    : "\n\n[truncated -- full content on bullpen]";
+  const maxContent = Math.max(0, MAX_NOTIFICATION_LENGTH - hint.length);
+  const truncated = content.slice(0, maxContent);
+  return truncated + hint;
+}
+
 // Format an event into a human-readable channel message.
 function formatEvent(event: LegionEvent): string {
   switch (event.type) {
     case "post":
-      return `[post] ${event.from}: ${event.text}`;
+      return truncateIfNeeded(`[post] ${event.from}: ${event.text}`, event.id);
     case "signal":
-      return `[signal] @${event.to} ${event.verb}${event.status ? ":" + event.status : ""} from ${event.from}${event.note ? " -- " + event.note : ""}`;
+      return truncateIfNeeded(
+        `[signal] @${event.to} ${event.verb}${event.status ? ":" + event.status : ""} from ${event.from}${event.note ? " -- " + event.note : ""}`,
+        event.id
+      );
     case "task": {
       const prio =
         event.priority !== "med" ? ` [${event.priority}]` : "";
-      return `[task${prio}] ${event.from} assigned: "${event.text}"${event.context ? " (context: " + event.context + ")" : ""}`;
+      return truncateIfNeeded(
+        `[task${prio}] ${event.from} assigned: "${event.text}"${event.context ? " (context: " + event.context + ")" : ""}`,
+        event.id
+      );
     }
     case "discord":
-      return `[discord #${event.channel}] ${event.author}: ${event.text}`;
+      return truncateIfNeeded(
+        `[discord #${event.channel}] ${event.author}: ${event.text}`
+      );
   }
 }
 


### PR DESCRIPTION
## Summary

Closes #107

Long signals and posts were being silently truncated by Claude Code's channel notification system. This caused repeated issues today with agents losing content mid-message.

Fix: `truncateIfNeeded()` in event-bridge.ts reserves space for the hint before slicing, so the total stays under 2000 chars and the pointer to the bullpen is always visible.

- All event types (post, signal, task, discord) get truncation handling
- Hint is computed first, content sliced to `MAX - hint.length`
- `Math.max(0, ...)` guard prevents negative slice on edge cases
- Full text always stored in SQLite -- only the notification is truncated

## Test plan

- [x] Simplify review: all findings fixed
- [x] Silent-failure review: critical bug found (hint exceeded limit) and fixed
- [x] Pre-commit passed
- [x] Pre-push passed (caught discord magic number and negative slice edge case, both fixed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)