### PR TITLE
feat: hard limit signal note to 280 chars

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -63,6 +63,11 @@ pub enum LegionError {
     #[error("schedule not found: {0}")]
     ScheduleNotFound(String),
 
+    #[error(
+        "signal note too long ({len} chars, max {max}). Signals are pings, not essays. Post the content first with `legion post`, then signal with a short note."
+    )]
+    SignalNoteTooLong { len: usize, max: usize },
+
     #[error("watch config error: {0}")]
     WatchConfig(String),
 
@@ -131,6 +136,15 @@ mod tests {
     fn error_display_no_data_dir() {
         let err = LegionError::NoDataDir;
         assert_eq!(err.to_string(), "data directory not available");
+    }
+
+    #[test]
+    fn error_display_signal_note_too_long() {
+        let err = LegionError::SignalNoteTooLong { len: 500, max: 280 };
+        let msg = err.to_string();
+        assert!(msg.contains("500 chars"));
+        assert!(msg.contains("max 280"));
+        assert!(msg.contains("legion post"));
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -846,6 +846,10 @@ fn main() -> error::Result<()> {
                 })
                 .unwrap_or_default();
 
+            if let Some(ref n) = note {
+                signal::validate_note(n)?;
+            }
+
             let text = signal::format_signal(
                 &to,
                 &verb,

--- a/src/signal.rs
+++ b/src/signal.rs
@@ -1,5 +1,21 @@
 use std::collections::HashMap;
 
+use crate::error;
+
+/// Maximum length for a signal note (bytes). Signals are pings, not content delivery.
+pub const MAX_SIGNAL_NOTE_LENGTH: usize = 280;
+
+/// Validate that a signal note is within the length limit.
+pub fn validate_note(note: &str) -> error::Result<()> {
+    if note.len() > MAX_SIGNAL_NOTE_LENGTH {
+        return Err(error::LegionError::SignalNoteTooLong {
+            len: note.len(),
+            max: MAX_SIGNAL_NOTE_LENGTH,
+        });
+    }
+    Ok(())
+}
+
 /// A parsed signal from a bullpen post.
 ///
 /// Signals follow the format: `@recipient verb:status {key: value, key: value}`
@@ -351,6 +367,21 @@ mod tests {
         assert_eq!(parsed.recipient, "platform");
         assert_eq!(parsed.verb, "request");
         assert_eq!(parsed.status.as_deref(), Some("help"));
+    }
+
+    #[test]
+    fn validate_note_rejects_long_notes() {
+        let long = "a".repeat(MAX_SIGNAL_NOTE_LENGTH + 1);
+        let result = validate_note(&long);
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("legion post"));
+    }
+
+    #[test]
+    fn validate_note_accepts_short_notes() {
+        assert!(validate_note("short note").is_ok());
+        assert!(validate_note(&"a".repeat(MAX_SIGNAL_NOTE_LENGTH)).is_ok());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Signal `--note` field now hard-errors at 280 chars with actionable message
- Validation in `signal::validate_note()` so any future signal path gets the check
- New `SignalNoteTooLong` error variant in `LegionError`

Closes #109

## Test plan
- [ ] `legion signal --note "short"` works normally
- [ ] `legion signal --note "<300+ chars>"` returns error with "legion post" guidance
- [ ] Boundary: exactly 280 chars passes, 281 fails
- [ ] `cargo test` -- 40 pass including new signal validation tests
- [ ] `cargo clippy -- -D warnings` clean

Generated with [Claude Code](https://claude.com/claude-code)