### PR TITLE
feat: add legion rename command

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -1571,6 +1571,81 @@ impl Database {
         )?;
         Ok(rows as u64)
     }
+
+    /// Rename a repo across all tables. Returns total rows updated.
+    pub fn rename_repo(&self, from: &str, to: &str) -> Result<RenameCounts> {
+        // unchecked_transaction because Database uses &self (shared ref),
+        // but rusqlite::Connection::transaction() requires &mut self.
+        // Safe here: no concurrent access within this function.
+        let tx = self.conn.unchecked_transaction()?;
+
+        let reflections = tx.execute(
+            "UPDATE reflections SET repo = ?1 WHERE repo = ?2",
+            [to, from],
+        )? as u64;
+
+        let tasks_from = tx.execute(
+            "UPDATE tasks SET from_repo = ?1 WHERE from_repo = ?2",
+            [to, from],
+        )? as u64;
+
+        let tasks_to = tx.execute(
+            "UPDATE tasks SET to_repo = ?1 WHERE to_repo = ?2",
+            [to, from],
+        )? as u64;
+
+        // Delete target rows first to avoid PRIMARY KEY collision,
+        // then rename. The old read-state for `to` is stale anyway.
+        tx.execute("DELETE FROM board_reads WHERE reader_repo = ?1", [to])?;
+        let board_reads = tx.execute(
+            "UPDATE board_reads SET reader_repo = ?1 WHERE reader_repo = ?2",
+            [to, from],
+        )? as u64;
+
+        // Same for watch_handled: delete target's rows first to
+        // avoid composite PK collision on (signal_id, repo_name).
+        tx.execute("DELETE FROM watch_handled WHERE repo_name = ?1", [to])?;
+        let watch_handled = tx.execute(
+            "UPDATE watch_handled SET repo_name = ?1 WHERE repo_name = ?2",
+            [to, from],
+        )? as u64;
+
+        let schedules =
+            tx.execute("UPDATE schedules SET repo = ?1 WHERE repo = ?2", [to, from])? as u64;
+
+        tx.commit()?;
+
+        Ok(RenameCounts {
+            reflections,
+            tasks_from,
+            tasks_to,
+            board_reads,
+            watch_handled,
+            schedules,
+        })
+    }
+}
+
+/// Counts of rows updated by a repo rename.
+#[derive(Debug)]
+pub struct RenameCounts {
+    pub reflections: u64,
+    pub tasks_from: u64,
+    pub tasks_to: u64,
+    pub board_reads: u64,
+    pub watch_handled: u64,
+    pub schedules: u64,
+}
+
+impl RenameCounts {
+    pub fn total(&self) -> u64 {
+        self.reflections
+            + self.tasks_from
+            + self.tasks_to
+            + self.board_reads
+            + self.watch_handled
+            + self.schedules
+    }
 }
 
 /// Map a database row to a HealthSample struct.

--- a/src/main.rs
+++ b/src/main.rs
@@ -227,6 +227,16 @@ enum Commands {
     /// Rebuild the search index from the database
     Reindex,
 
+    /// Rename a repo across all tables and watch config
+    Rename {
+        /// Current repo name
+        #[arg(long)]
+        from: String,
+        /// New repo name
+        #[arg(long)]
+        to: String,
+    },
+
     /// Compute embeddings for all reflections that are missing them
     Backfill,
 
@@ -968,6 +978,43 @@ fn main() -> error::Result<()> {
             let count = reflections.len();
             index.rebuild(&reflections)?;
             info!("[legion] reindexed {} reflections", count);
+        }
+        Commands::Rename { from, to } => {
+            if from == to {
+                eprintln!("[legion] source and destination are the same, nothing to do");
+                return Ok(());
+            }
+
+            let base = data_dir()?;
+            let database = db::Database::open(&base.join("legion.db"))?;
+            let index = search::SearchIndex::open(&base.join("index"))?;
+
+            let counts = database.rename_repo(&from, &to)?;
+            eprintln!(
+                "[legion] renamed '{}' -> '{}': {} reflections, {} tasks (from), {} tasks (to), {} board reads, {} watch handled, {} schedules",
+                from,
+                to,
+                counts.reflections,
+                counts.tasks_from,
+                counts.tasks_to,
+                counts.board_reads,
+                counts.watch_handled,
+                counts.schedules
+            );
+
+            // Reindex since repo name is in the search index
+            let reflections = database.get_all_for_reindex()?;
+            let reindex_count = reflections.len();
+            index.rebuild(&reflections)?;
+            eprintln!("[legion] reindexed {} reflections", reindex_count);
+
+            // Update watch.toml
+            let watch_path = base.join("watch.toml");
+            if watch::rename_in_config(&watch_path, &from, &to)? {
+                eprintln!("[legion] updated watch.toml: '{}' -> '{}'", from, to);
+            }
+
+            eprintln!("[legion] total: {} rows updated", counts.total());
         }
         Commands::Backfill => {
             let base = data_dir()?;

--- a/src/watch.rs
+++ b/src/watch.rs
@@ -107,6 +107,26 @@ impl Default for WatchConfig {
     }
 }
 
+/// Rename a repo in watch.toml. Does string replacement to preserve comments
+/// and formatting. Returns true if the file was modified.
+pub fn rename_in_config(path: &Path, from: &str, to: &str) -> Result<bool> {
+    if !path.exists() {
+        return Ok(false);
+    }
+
+    let contents = std::fs::read_to_string(path)?;
+    let needle = format!("name = \"{}\"", from);
+    let replacement = format!("name = \"{}\"", to);
+
+    if !contents.contains(&needle) {
+        return Ok(false);
+    }
+
+    let updated = contents.replace(&needle, &replacement);
+    std::fs::write(path, updated)?;
+    Ok(true)
+}
+
 /// Load watch config from the given path. Returns a default config if the
 /// file does not exist.
 pub fn load_config(path: &Path) -> Result<WatchConfig> {


### PR DESCRIPTION
## Summary
- `legion rename --from smuggler --to smugglr` atomically renames across all tables + watch.toml
- Handles PK collisions on board_reads and watch_handled by deleting target rows first
- Reindexes after rename since repo name is in Tantivy
- Guards against from == to no-op

Closes #113

## Test plan
- [ ] `legion rename --from testold --to testnew` updates reflections, tasks, board_reads, watch_handled, schedules
- [ ] Watch.toml updated if entry exists
- [ ] Reindex runs after rename
- [ ] `legion rename --from x --to x` exits cleanly with message
- [ ] `cargo test` -- 40 pass
- [ ] `cargo clippy -- -D warnings` clean

Generated with [Claude Code](https://claude.com/claude-code)