### PR TITLE
feat: single network server via serve flag

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1043,7 +1043,18 @@ fn main() -> error::Result<()> {
             stats::stats(&database, repo.as_deref())?;
         }
         Commands::Serve { port } => {
-            serve::run_server(port, data_dir()?)?;
+            let base = data_dir()?;
+            let watch_path = base.join("watch.toml");
+            if watch_path.exists() {
+                let contents = std::fs::read_to_string(&watch_path)?;
+                let config: watch::WatchConfig = toml::from_str(&contents)?;
+                if !config.serve {
+                    return Err(error::LegionError::Server(
+                        "serve is not enabled on this node. Set serve = true in watch.toml to designate this machine as the dashboard server.".to_string(),
+                    ));
+                }
+            }
+            serve::run_server(port, base)?;
         }
         Commands::Status { repo } => {
             let base = data_dir()?;

--- a/src/watch.rs
+++ b/src/watch.rs
@@ -58,6 +58,11 @@ pub struct WatchConfig {
     #[serde(default = "default_retention_days")]
     pub retention_days: u64,
 
+    /// Whether this node serves the web dashboard.
+    /// Only one node per network should have this set to true.
+    #[serde(default)]
+    pub serve: bool,
+
     #[serde(default)]
     pub repos: Vec<WatchRepoConfig>,
 }
@@ -102,6 +107,7 @@ impl Default for WatchConfig {
             health_poll_secs: default_health_poll_secs(),
             health_window_size: default_health_window_size(),
             retention_days: default_retention_days(),
+            serve: false,
             repos: Vec::new(),
         }
     }


### PR DESCRIPTION
## Summary
- Adds `serve = true` flag to watch.toml
- `legion serve` checks the flag before starting -- refuses without it
- Dashboard-only nodes (serve = true, no repos) work correctly
- No watch.toml = server starts (backwards compat)

Closes #115

## Test plan
- [ ] `legion serve` with `serve = true` in watch.toml starts normally
- [ ] `legion serve` with `serve = false` or missing returns error with guidance
- [ ] `legion serve` with no watch.toml starts normally (backwards compat)
- [ ] `legion serve` with `serve = true` and no `[[repos]]` starts normally (dashboard-only node)
- [ ] `cargo test` -- 40 pass
- [ ] `cargo clippy -- -D warnings` clean

Generated with [Claude Code](https://claude.com/claude-code)