### PR TITLE
fix: update plugin.json repo URL to runlegion/legion

### DIFF
--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -6,7 +6,7 @@
     "name": "Sean Silvius",
     "email": "sean@silvius.me"
   },
-  "repository": "https://github.com/ssilvius/legion",
+  "repository": "https://github.com/runlegion/legion",
   "license": "MIT",
   "channel": {
     "name": "legion",


### PR DESCRIPTION
## Summary
- Fix stale ssilvius/legion reference in plugin/.claude-plugin/plugin.json

Closes #117

## Test plan
- [ ] plugin.json points to runlegion/legion

Generated with [Claude Code](https://claude.com/claude-code)