### PR TITLE
fix: update remaining ssilvius/legion references to runlegion/legion

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -18,7 +18,7 @@
       },
       "source": "./plugin",
       "category": "productivity",
-      "homepage": "https://github.com/ssilvius/legion"
+      "homepage": "https://github.com/runlegion/legion"
     }
   ]
 }

--- a/install.sh
+++ b/install.sh
@@ -1,14 +1,14 @@
 #!/usr/bin/env bash
-# install.sh: Installer for Legion (https://github.com/ssilvius/legion)
+# install.sh: Installer for Legion (https://github.com/runlegion/legion)
 #
 # Usage:
-#   curl -fsSL https://raw.githubusercontent.com/ssilvius/legion/main/install.sh | bash
+#   curl -fsSL https://raw.githubusercontent.com/runlegion/legion/main/install.sh | bash
 #   curl -fsSL ... | bash -s v0.1.1
 #   LEGION_VERSION=v0.1.1 bash install.sh
 
 set -euo pipefail
 
-REPO="ssilvius/legion"
+REPO="runlegion/legion"
 INSTALL_DIR="${HOME}/.local/bin"
 BINARY_NAME="legion"
 

--- a/plugin/bin/legion
+++ b/plugin/bin/legion
@@ -19,5 +19,5 @@ if [ -n "$SYSTEM_LEGION" ] && [ -x "$SYSTEM_LEGION" ]; then
 fi
 
 echo "[legion] binary not found. Run a new session to trigger auto-download, or install manually:" >&2
-echo "  cargo install --git https://github.com/ssilvius/legion" >&2
+echo "  cargo install --git https://github.com/runlegion/legion" >&2
 exit 1

--- a/plugin/hooks/setup-binary.sh
+++ b/plugin/hooks/setup-binary.sh
@@ -4,7 +4,7 @@
 # or version mismatch. Uses CLAUDE_PLUGIN_DATA for persistent storage.
 set -euo pipefail
 
-REPO="ssilvius/legion"
+REPO="runlegion/legion"
 BINARY_NAME="legion"
 EXPECTED_VERSION="0.1.1"
 

--- a/src/kanban.rs
+++ b/src/kanban.rs
@@ -585,7 +585,7 @@ mod tests {
             "high",
             Some("backend,search"),
             None,
-            Some("https://github.com/ssilvius/legion/issues/42"),
+            Some("https://github.com/runlegion/legion/issues/42"),
             Some("github"),
         )
         .expect("create");
@@ -596,7 +596,7 @@ mod tests {
         assert_eq!(card.labels.as_deref(), Some("backend,search"));
         assert_eq!(
             card.source_url.as_deref(),
-            Some("https://github.com/ssilvius/legion/issues/42")
+            Some("https://github.com/runlegion/legion/issues/42")
         );
         assert_eq!(card.source_type.as_deref(), Some("github"));
     }
@@ -849,7 +849,7 @@ mod tests {
             note: None,
             labels: Some("backend,search".to_string()),
             parent_card_id: None,
-            source_url: Some("https://github.com/ssilvius/legion/issues/42".to_string()),
+            source_url: Some("https://github.com/runlegion/legion/issues/42".to_string()),
             source_type: Some("github".to_string()),
             sort_order: 0,
             created_at: "2026-04-03T00:00:00Z".to_string(),

--- a/src/worksource.rs
+++ b/src/worksource.rs
@@ -257,7 +257,7 @@ mod tests {
     #[test]
     fn extract_issue_number_from_url() {
         assert_eq!(
-            extract_issue_number("https://github.com/ssilvius/legion/issues/42"),
+            extract_issue_number("https://github.com/runlegion/legion/issues/42"),
             Some(42)
         );
         assert_eq!(extract_issue_number("not-a-url"), None);

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1662,7 +1662,7 @@ fn kanban_with_source_url() {
             "--text",
             "github issue",
             "--source-url",
-            "https://github.com/ssilvius/legion/issues/42",
+            "https://github.com/runlegion/legion/issues/42",
             "--source-type",
             "github",
         ])


### PR DESCRIPTION
## Summary
- Updates all remaining `ssilvius/legion` references to `runlegion/legion` across plugin scripts, installer, marketplace manifest, and test fixtures
- PR #118 caught `plugin.json` but missed 7 other files
- Closes #121

## Test plan
- [x] `cargo test` -- 40 passed
- [x] `cargo clippy -- -D warnings` -- clean
- [x] `grep -r ssilvius/legion` -- zero matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)