### PR TITLE
fix: remove since filter from watch poll cycle

### DIFF
--- a/src/watch.rs
+++ b/src/watch.rs
@@ -567,7 +567,6 @@ pub fn run(data_dir: &Path) -> Result<()> {
     let poll_interval = Duration::from_secs(config.poll_interval_secs);
     let health_interval = Duration::from_secs(config.health_poll_secs);
     let retention_cutoff = chrono::Duration::days(config.retention_days as i64);
-    let start_time = chrono::Utc::now().to_rfc3339();
 
     let mut poll_timer = Instant::now() - poll_interval; // poll immediately on start
     let mut health_timer = Instant::now() - health_interval; // sample immediately on start
@@ -606,7 +605,7 @@ pub fn run(data_dir: &Path) -> Result<()> {
         // Spawn check on the poll interval
         if poll_timer.elapsed() >= poll_interval {
             if sampler.can_spawn(config.health_threshold_pct) {
-                match poll_cycle(&db, &config, &mut cooldown, &mut tracker, Some(&start_time)) {
+                match poll_cycle(&db, &config, &mut cooldown, &mut tracker, None) {
                     Ok(n) if n > 0 => {
                         eprintln!("[legion watch] cycle complete: {} agent(s) spawned", n);
                     }


### PR DESCRIPTION
## Summary
- Remove `start_time` filter from watch `poll_cycle` call
- Signals created before watch starts are now visible
- `watch_handled` table prevents re-processing (redundant filter removed)

Closes #123

## Test plan
- [ ] Watch picks up signals created before daemon started
- [ ] Watch doesn't re-process already-handled signals
- [ ] `cargo test` -- 40 pass
- [ ] `cargo clippy -- -D warnings` clean

Generated with [Claude Code](https://claude.com/claude-code)