### PR TITLE
feat: add create-issue work source subcommand

### DIFF
--- a/plugin/worksources/github
+++ b/plugin/worksources/github
@@ -60,8 +60,34 @@ case "${1:-}" in
     fi
     ;;
 
+  create-issue)
+    TITLE="${LEGION_WS_TITLE:-}"
+    BODY="${LEGION_WS_BODY:-}"
+    LABELS="${LEGION_WS_LABELS:-}"
+    ASSIGNEE="${LEGION_WS_ASSIGNEE:-}"
+    if [ -z "$REPO" ] || [ -z "$TITLE" ]; then
+      echo '{"error":"LEGION_WS_REPO and LEGION_WS_TITLE required"}' >&2
+      exit 1
+    fi
+    if ! command -v gh &>/dev/null; then
+      echo '{"error":"gh CLI not found"}' >&2
+      exit 1
+    fi
+    ARGS=(issue create --repo "$REPO" --title "$TITLE")
+    [ -n "$BODY" ] && ARGS+=(--body "$BODY")
+    [ -n "$LABELS" ] && ARGS+=(--label "$LABELS")
+    [ -n "$ASSIGNEE" ] && ARGS+=(--assignee "$ASSIGNEE")
+    URL=$(gh "${ARGS[@]}") || { echo "gh issue create failed" >&2; exit 1; }
+    if [ -z "$URL" ]; then
+      echo "gh returned empty URL" >&2
+      exit 1
+    fi
+    NUMBER=$(echo "$URL" | grep -oE '[0-9]+$' || echo "0")
+    jq -n --arg url "$URL" --argjson number "${NUMBER:-0}" '{"url":$url,"number":$number}'
+    ;;
+
   *)
-    echo "Usage: github <list|close N|detect>" >&2
+    echo "Usage: github <list|close N|detect|create-issue>" >&2
     exit 1
     ;;
 esac

--- a/src/main.rs
+++ b/src/main.rs
@@ -312,6 +312,12 @@ enum Commands {
         action: ScheduleAction,
     },
 
+    /// Manage issues via work source plugins
+    Issue {
+        #[command(subcommand)]
+        action: IssueAction,
+    },
+
     /// Watch for signals and auto-wake sleeping agents
     Watch,
 
@@ -602,6 +608,32 @@ enum ScheduleAction {
         /// Active window end time (HH:MM UTC)
         #[arg(long)]
         active_end: Option<String>,
+    },
+}
+
+#[derive(Subcommand, Debug)]
+enum IssueAction {
+    /// Create an issue via the configured work source
+    Create {
+        /// Repository name (used to resolve work source config from watch.toml)
+        #[arg(long)]
+        repo: String,
+
+        /// Issue title
+        #[arg(long)]
+        title: String,
+
+        /// Issue body
+        #[arg(long)]
+        body: Option<String>,
+
+        /// Comma-separated labels
+        #[arg(long)]
+        labels: Option<String>,
+
+        /// Assignee login
+        #[arg(long)]
+        assignee: Option<String>,
     },
 }
 
@@ -1422,6 +1454,38 @@ fn main() -> error::Result<()> {
                 }
             }
         }
+        Commands::Issue { action } => match action {
+            IssueAction::Create {
+                repo,
+                title,
+                body,
+                labels,
+                assignee,
+            } => {
+                let (plugin_name, source_repo, _workdir) = worksource::resolve_config(&repo)
+                    .ok_or_else(|| {
+                        error::LegionError::WorkSource(format!(
+                            "no work source configured for repo '{}' in watch.toml",
+                            repo
+                        ))
+                    })?;
+
+                let created = worksource::create_issue(
+                    &plugin_name,
+                    &source_repo,
+                    &title,
+                    body.as_deref(),
+                    labels.as_deref(),
+                    assignee.as_deref(),
+                )?;
+
+                println!("{}", created.url);
+                eprintln!(
+                    "[legion] created issue #{} on {}",
+                    created.number, source_repo
+                );
+            }
+        },
         Commands::Watch => {
             let base = data_dir()?;
             watch::run(&base)?;

--- a/src/worksource.rs
+++ b/src/worksource.rs
@@ -121,6 +121,44 @@ pub fn close_issue(plugin_name: &str, github_repo: &str, number: u64) -> Result<
     Ok(())
 }
 
+/// Result of creating an issue via a work source plugin.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct CreatedIssue {
+    pub url: String,
+    pub number: u64,
+}
+
+/// Create an issue via a work source plugin.
+pub fn create_issue(
+    plugin_name: &str,
+    github_repo: &str,
+    title: &str,
+    body: Option<&str>,
+    labels: Option<&str>,
+    assignee: Option<&str>,
+) -> Result<CreatedIssue> {
+    let plugin_path = find_plugin(plugin_name)
+        .ok_or_else(|| LegionError::WorkSource(format!("plugin not found: {plugin_name}")))?;
+
+    let mut env: Vec<(&str, &str)> =
+        vec![("LEGION_WS_REPO", github_repo), ("LEGION_WS_TITLE", title)];
+    if let Some(b) = body {
+        env.push(("LEGION_WS_BODY", b));
+    }
+    if let Some(l) = labels {
+        env.push(("LEGION_WS_LABELS", l));
+    }
+    if let Some(a) = assignee {
+        env.push(("LEGION_WS_ASSIGNEE", a));
+    }
+
+    let output = call_plugin(&plugin_path, &["create-issue"], &env)?;
+    let created: CreatedIssue =
+        serde_json::from_str(&output).map_err(|e| LegionError::WorkSource(e.to_string()))?;
+
+    Ok(created)
+}
+
 /// Detect the external repo identifier from a workdir.
 #[allow(dead_code)]
 pub fn detect_repo(plugin_name: &str, workdir: &str) -> Result<Option<String>> {


### PR DESCRIPTION
## Summary
- GitHub plugin: `create-issue` subcommand with safe JSON output via jq
- Rust wrapper: `worksource::create_issue()` + `CreatedIssue` struct  
- CLI: `legion issue create --repo <name> --title "..." [--body] [--labels] [--assignee]`
- Resolves work source config from watch.toml

Part of #141. Closes #143.

## Test plan
- [ ] `legion issue create --repo legion --title "test"` creates a GitHub issue
- [ ] Returns issue URL on stdout
- [ ] Fails cleanly when gh is not authenticated
- [ ] Fails cleanly when repo has no work source in watch.toml
- [ ] `cargo test` -- 40 pass
- [ ] `cargo clippy -- -D warnings` clean

Generated with [Claude Code](https://claude.com/claude-code)