### PR TITLE
feat: add comment and pr-list work source subcommands

### DIFF
--- a/plugin/worksources/github
+++ b/plugin/worksources/github
@@ -118,8 +118,37 @@ case "${1:-}" in
     jq -n --arg url "$URL" --argjson number "${NUMBER:-0}" '{"url":$url,"number":$number}'
     ;;
 
+  comment)
+    NUMBER="${LEGION_WS_NUMBER:-}"
+    BODY="${LEGION_WS_BODY:-}"
+    if [ -z "$REPO" ] || [ -z "$NUMBER" ] || [ -z "$BODY" ]; then
+      echo "LEGION_WS_REPO, LEGION_WS_NUMBER, and LEGION_WS_BODY required" >&2
+      exit 1
+    fi
+    if ! command -v gh &>/dev/null; then
+      echo "gh CLI not found" >&2
+      exit 1
+    fi
+    gh issue comment "$NUMBER" --repo "$REPO" --body "$BODY" >/dev/null || { echo "gh comment failed" >&2; exit 1; }
+    echo '{"ok":true}'
+    ;;
+
+  pr-list)
+    if [ -z "$REPO" ]; then
+      echo "[]"
+      exit 0
+    fi
+    if ! command -v gh &>/dev/null; then
+      echo "[]"
+      exit 0
+    fi
+    gh pr list --repo "$REPO" --state open \
+      --json number,title,createdAt,updatedAt,headRefName,reviewDecision,isDraft \
+      --limit 50 2>/dev/null || echo "[]"
+    ;;
+
   *)
-    echo "Usage: github <list|close N|detect|create-issue|create-pr>" >&2
+    echo "Usage: github <list|close|detect|create-issue|create-pr|comment|pr-list>" >&2
     exit 1
     ;;
 esac

--- a/src/main.rs
+++ b/src/main.rs
@@ -318,6 +318,21 @@ enum Commands {
         action: IssueAction,
     },
 
+    /// Post a comment on an issue or PR via work source plugins
+    Comment {
+        /// Repository name (resolves work source config from watch.toml)
+        #[arg(long)]
+        repo: String,
+
+        /// Issue or PR number
+        #[arg(long)]
+        number: u64,
+
+        /// Comment body
+        #[arg(long)]
+        body: String,
+    },
+
     /// Manage pull requests via work source plugins
     Pr {
         #[command(subcommand)]
@@ -682,6 +697,13 @@ enum PrAction {
         /// Kanban card ID to link (stores PR URL on the card)
         #[arg(long)]
         task: Option<String>,
+    },
+
+    /// List open pull requests with review status
+    List {
+        /// Repository name (resolves work source config from watch.toml)
+        #[arg(long)]
+        repo: String,
     },
 }
 
@@ -1579,7 +1601,42 @@ fn main() -> error::Result<()> {
                 println!("{}", created.url);
                 eprintln!("[legion] created PR #{} on {}", created.number, source_repo);
             }
+            PrAction::List { repo } => {
+                let (plugin_name, source_repo, _workdir) = worksource::resolve_config(&repo)
+                    .ok_or_else(|| {
+                        error::LegionError::WorkSource(format!(
+                            "no work source configured for repo '{}' in watch.toml",
+                            repo
+                        ))
+                    })?;
+
+                let prs = worksource::list_prs(&plugin_name, &source_repo)?;
+                if prs.is_empty() {
+                    eprintln!("[legion] no open PRs on {}", source_repo);
+                } else {
+                    for pr in &prs {
+                        let review = pr.review_decision.as_deref().unwrap_or("PENDING");
+                        let draft = if pr.is_draft { " [draft]" } else { "" };
+                        println!(
+                            "#{} {} ({}) {}{}",
+                            pr.number, pr.title, pr.head_ref_name, review, draft
+                        );
+                    }
+                }
+            }
         },
+        Commands::Comment { repo, number, body } => {
+            let (plugin_name, source_repo, _workdir) = worksource::resolve_config(&repo)
+                .ok_or_else(|| {
+                    error::LegionError::WorkSource(format!(
+                        "no work source configured for repo '{}' in watch.toml",
+                        repo
+                    ))
+                })?;
+
+            worksource::comment(&plugin_name, &source_repo, number, &body)?;
+            eprintln!("[legion] commented on #{} on {}", number, source_repo);
+        }
         Commands::Watch => {
             let base = data_dir()?;
             watch::run(&base)?;

--- a/src/worksource.rs
+++ b/src/worksource.rs
@@ -210,6 +210,56 @@ pub fn create_pr(
     Ok(created)
 }
 
+/// Post a comment on an issue or PR via a work source plugin.
+pub fn comment(plugin_name: &str, github_repo: &str, number: u64, body: &str) -> Result<()> {
+    let plugin_path = find_plugin(plugin_name)
+        .ok_or_else(|| LegionError::WorkSource(format!("plugin not found: {plugin_name}")))?;
+
+    call_plugin(
+        &plugin_path,
+        &["comment"],
+        &[
+            ("LEGION_WS_REPO", github_repo),
+            ("LEGION_WS_NUMBER", &number.to_string()),
+            ("LEGION_WS_BODY", body),
+        ],
+    )?;
+
+    Ok(())
+}
+
+/// A PR from an external tracker with review status.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ExternalPR {
+    pub number: u64,
+    pub title: String,
+    pub created_at: String,
+    pub updated_at: String,
+    pub head_ref_name: String,
+    pub review_decision: Option<String>,
+    pub is_draft: bool,
+}
+
+/// List open PRs from a work source plugin.
+pub fn list_prs(plugin_name: &str, github_repo: &str) -> Result<Vec<ExternalPR>> {
+    let plugin_path = match find_plugin(plugin_name) {
+        Some(p) => p,
+        None => return Ok(Vec::new()),
+    };
+
+    let output = call_plugin(
+        &plugin_path,
+        &["pr-list"],
+        &[("LEGION_WS_REPO", github_repo)],
+    )?;
+
+    let prs: Vec<ExternalPR> =
+        serde_json::from_str(&output).map_err(|e| LegionError::WorkSource(e.to_string()))?;
+
+    Ok(prs)
+}
+
 /// Detect the external repo identifier from a workdir.
 #[allow(dead_code)]
 pub fn detect_repo(plugin_name: &str, workdir: &str) -> Result<Option<String>> {


### PR DESCRIPTION
## Summary
- `legion comment --repo <name> --number 42 --body "..."` posts comments via work source
- `legion pr list --repo <name>` lists open PRs with review decision and draft status
- GitHub plugin: `comment` and `pr-list` subcommands

Part of #141. Closes #147, #148.

## Test plan
- [ ] `legion comment --repo legion --number 151 --body "test"` posts a comment
- [ ] `legion pr list --repo legion` shows open PRs with review status
- [ ] Both fail cleanly without work source config
- [ ] `cargo test` -- 40 pass
- [ ] `cargo clippy -- -D warnings` clean

Generated with [Claude Code](https://claude.com/claude-code)