### PR TITLE
feat: auto-signal review agent on PR creation

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -788,6 +788,16 @@ fn data_dir() -> error::Result<PathBuf> {
     Ok(path)
 }
 
+/// Best-effort audit log entry. Failures warn to stderr, never abort.
+fn audit(input: &db::AuditInput<'_>) {
+    if let Ok(base) = data_dir()
+        && let Ok(database) = db::Database::open(&base.join("legion.db"))
+        && let Err(e) = database.insert_audit_entry(input)
+    {
+        eprintln!("[legion] warning: audit log failed: {}", e);
+    }
+}
+
 /// Run a compound command (text or transcript) across multiple repos with metadata.
 ///
 /// Prints each stored ID to stdout (one per repo) so callers and scripts
@@ -1618,29 +1628,20 @@ fn main() -> error::Result<()> {
                     assignee.as_deref(),
                 )?;
 
-                // Audit log (best-effort)
-                if let Ok(db_base) = data_dir()
-                    && let Ok(database) = db::Database::open(&db_base.join("legion.db"))
-                {
-                    let details = serde_json::json!({
-                        "title": title,
-                        "labels": labels,
-                        "assignee": assignee,
-                    });
-                    let details_str = details.to_string();
-                    if let Err(e) = database.insert_audit_entry(&db::AuditInput {
-                        agent: &repo,
-                        action: "create-issue",
-                        target_type: "issue",
-                        target_ref: &created.number.to_string(),
-                        task_id: None,
-                        source_type: &plugin_name,
-                        details: Some(&details_str),
-                        outcome: "success",
-                    }) {
-                        eprintln!("[legion] warning: audit log failed: {}", e);
-                    }
-                }
+                let details = serde_json::json!({
+                    "title": title, "labels": labels, "assignee": assignee,
+                });
+                let details_str = details.to_string();
+                audit(&db::AuditInput {
+                    agent: &repo,
+                    action: "create-issue",
+                    target_type: "issue",
+                    target_ref: &created.number.to_string(),
+                    task_id: None,
+                    source_type: &plugin_name,
+                    details: Some(&details_str),
+                    outcome: "success",
+                });
 
                 println!("{}", created.url);
                 eprintln!(
@@ -1691,28 +1692,48 @@ fn main() -> error::Result<()> {
                     }
                 }
 
-                // Audit log (best-effort)
-                if let Ok(db_base) = data_dir()
-                    && let Ok(database) = db::Database::open(&db_base.join("legion.db"))
+                let details = serde_json::json!({
+                    "title": title, "base": base, "head": head, "draft": draft,
+                });
+                let details_str = details.to_string();
+                audit(&db::AuditInput {
+                    agent: &repo,
+                    action: "create-pr",
+                    target_type: "pr",
+                    target_ref: &created.number.to_string(),
+                    task_id: task.as_deref(),
+                    source_type: &plugin_name,
+                    details: Some(&details_str),
+                    outcome: "success",
+                });
+
+                // Auto-signal review agent if configured
+                if let Some(review_cfg) = worksource::resolve_review_config()
+                    && review_cfg.auto_signal
                 {
-                    let details = serde_json::json!({
-                        "title": title,
-                        "base": base,
-                        "head": head,
-                        "draft": draft,
-                    });
-                    let details_str = details.to_string();
-                    if let Err(e) = database.insert_audit_entry(&db::AuditInput {
-                        agent: &repo,
-                        action: "create-pr",
-                        target_type: "pr",
-                        target_ref: &created.number.to_string(),
-                        task_id: task.as_deref(),
-                        source_type: &plugin_name,
-                        details: Some(&details_str),
-                        outcome: "success",
-                    }) {
-                        eprintln!("[legion] warning: audit log failed: {}", e);
+                    let signal_text = format!(
+                        "@{} review:ready -- repo:{},pr:{},source:{}",
+                        review_cfg.agent, repo, created.number, source_repo
+                    );
+                    if let Ok(db_base) = data_dir()
+                        && let Ok(database) = db::Database::open(&db_base.join("legion.db"))
+                        && let Ok(index) = search::SearchIndex::open(&db_base.join("index"))
+                    {
+                        let meta = db::ReflectionMeta::default();
+                        match board::post_from_text_with_meta(
+                            &database,
+                            &index,
+                            &repo,
+                            &signal_text,
+                            &meta,
+                        ) {
+                            Ok(_) => {
+                                eprintln!("[legion] signaled @{} for review", review_cfg.agent)
+                            }
+                            Err(e) => {
+                                eprintln!("[legion] warning: review signal failed: {}", e)
+                            }
+                        }
                     }
                 }
 
@@ -1781,6 +1802,19 @@ fn main() -> error::Result<()> {
                     comments.as_deref(),
                 )?;
 
+                let details = serde_json::json!({ "event": event });
+                let details_str = details.to_string();
+                audit(&db::AuditInput {
+                    agent: &repo,
+                    action: "review",
+                    target_type: "pr",
+                    target_ref: &number.to_string(),
+                    task_id: None,
+                    source_type: &plugin_name,
+                    details: Some(&details_str),
+                    outcome: "success",
+                });
+
                 eprintln!(
                     "[legion] posted {} review on PR #{} on {}",
                     event, number, source_repo
@@ -1837,6 +1871,21 @@ fn main() -> error::Result<()> {
                     }
                 }
 
+                let details = serde_json::json!({
+                    "strategy": strategy, "delete_branch": !keep_branch,
+                });
+                let details_str = details.to_string();
+                audit(&db::AuditInput {
+                    agent: &repo,
+                    action: "merge",
+                    target_type: "pr",
+                    target_ref: &number.to_string(),
+                    task_id: task.as_deref(),
+                    source_type: &plugin_name,
+                    details: Some(&details_str),
+                    outcome: "success",
+                });
+
                 println!("PR #{} merged on {}", number, source_repo);
             }
         },
@@ -1851,22 +1900,16 @@ fn main() -> error::Result<()> {
 
             worksource::comment(&plugin_name, &source_repo, number, &body)?;
 
-            // Audit log (best-effort)
-            if let Ok(db_base) = data_dir()
-                && let Ok(database) = db::Database::open(&db_base.join("legion.db"))
-                && let Err(e) = database.insert_audit_entry(&db::AuditInput {
-                    agent: &repo,
-                    action: "comment",
-                    target_type: "comment",
-                    target_ref: &number.to_string(),
-                    task_id: None,
-                    source_type: &plugin_name,
-                    details: None,
-                    outcome: "success",
-                })
-            {
-                eprintln!("[legion] warning: audit log failed: {}", e);
-            }
+            audit(&db::AuditInput {
+                agent: &repo,
+                action: "comment",
+                target_type: "comment",
+                target_ref: &number.to_string(),
+                task_id: None,
+                source_type: &plugin_name,
+                details: None,
+                outcome: "success",
+            });
 
             eprintln!("[legion] commented on #{} on {}", number, source_repo);
         }

--- a/src/worksource.rs
+++ b/src/worksource.rs
@@ -442,6 +442,29 @@ pub fn resolve_config(legion_repo: &str) -> Option<(String, String, String)> {
     None
 }
 
+/// Review agent configuration from watch.toml.
+pub struct ReviewConfig {
+    pub agent: String,
+    pub auto_signal: bool,
+}
+
+/// Read the review agent configuration from watch.toml.
+pub fn resolve_review_config() -> Option<ReviewConfig> {
+    let data_dir = crate::data_dir().ok()?;
+    let config_path = data_dir.join("watch.toml");
+    let content = std::fs::read_to_string(&config_path).ok()?;
+    let config: toml::Table = content.parse().ok()?;
+
+    let review = config.get("review")?;
+    let agent = review.get("agent")?.as_str()?.to_string();
+    let auto_signal = review
+        .get("auto_signal")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+
+    Some(ReviewConfig { agent, auto_signal })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
## Summary
- `legion pr create` auto-signals the configured review agent when `[review]` section exists in watch.toml with `auto_signal = true`
- Adds audit logging to review and merge commands (completing audit coverage for all work source actions)
- Extracts `audit()` helper to eliminate 5 duplicate DB-open-and-log patterns
- Adds `resolve_review_config()` to read review agent config from watch.toml

### watch.toml config
```toml
[review]
agent = "vault-2026"
auto_signal = true
```

Closes #149.

## Test plan
- [x] 275 unit + 40 integration tests pass
- [x] clippy clean, fmt clean
- [ ] Manual: add `[review]` to watch.toml, run `legion pr create`, verify signal appears on bullpen
- [ ] Manual: `legion audit --action review` shows review entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)