### PR TITLE
feat: plugin 1.2.2 -- work source workflow guide in session-start

### DIFF
--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "legion",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Institutional memory for Claude Code agents with real-time team channel.",
   "author": {
     "name": "Sean Silvius",

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Legion Plugin Changelog
 
+## 1.2.2
+
+- Add work source workflow guide to SessionStart hook context: agents get legion command reference on every session start, covering the gh -> legion migration and --task flag for kanban integration
+
 ## 1.2.1
 
 - Slim down Stop hook: removed TEAM FIRST checklist, bullpen count check, and boost reminders. Now just prompts for one reflection if the session did real work. Full wind-down belongs in /snooze.

--- a/plugin/hooks/session-start.sh
+++ b/plugin/hooks/session-start.sh
@@ -53,7 +53,16 @@ LEGION_HELP="[Legion] You are legion. You are not a solo agent with a specialty 
 
 Treat your teammates the way you would want to be treated. If you were blocked and asked for help, you would want someone to show up -- so show up. If you had a bad idea, you would want someone to say so -- so speak up. If there was work to do, you would not want to be asked permission to help -- so just do it. Do not be passive. Do not wait for assignments. Do not be polite when you should be useful. Check the bullpen -- it is a conversation, not a status feed. Talk to your teammates, not at them. Status goes in tasks.
 
-Before you grep, check legion. Your teammates have already solved problems you are about to waste time on. consult --context <problem> to search all agents | signal --to <agent> --verb question to ask directly | boost --id <id> when a reflection helps"
+Before you grep, check legion. Your teammates have already solved problems you are about to waste time on. consult --context <problem> to search all agents | signal --to <agent> --verb question to ask directly | boost --id <id> when a reflection helps
+
+Work source commands are required for all GitHub operations. Do not use gh directly -- the PreToolUse hook will block it. Use these instead:
+- legion issue create --repo <name> --title '...' --body '...'
+- legion pr create --repo <name> --title '...' --body '...'
+- legion pr list --repo <name>
+- legion pr review --repo <name> --number <n> --approve --body 'LGTM'
+- legion pr merge --repo <name> --number <n> --task <card-id>  (transitions kanban card to done)
+- legion comment --repo <name> --number <n> --body '...'
+These go through the audit log and feed the kanban board. The --task flag on merge closes your card automatically."
 
 # Surface cross-repo highlights (board posts, high-value reflections, chains)
 append "$(legion surface --repo "$REPO" 2>/dev/null)"


### PR DESCRIPTION
## Summary
- Add work source command reference to SessionStart hook context
- Agents get legion command cheatsheet on every session start (issue create, pr create, pr merge --task, etc.)
- Bumps plugin to 1.2.2 with changelog

## Test plan
- [ ] New session shows work source commands in context
- [ ] /plugin detects 1.2.2 as available update