### PR TITLE
feat: binary release infra + unified versioning (0.3.0)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1204,7 +1204,7 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "legion"
-version = "0.1.1"
+version = "0.3.0"
 dependencies = [
  "async-stream",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "legion"
-version = "0.1.1"
+version = "0.3.0"
 edition = "2024"
 description = "Agent specialization through deliberate practice"
 

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "legion",
-  "version": "1.2.2",
+  "version": "0.3.0",
   "description": "Institutional memory for Claude Code agents with real-time team channel.",
   "author": {
     "name": "Sean Silvius",

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -1,29 +1,10 @@
-# Legion Plugin Changelog
+# Legion Changelog
 
-## 1.2.2
+## 0.3.0
 
-- Add work source workflow guide to SessionStart hook context: agents get legion command reference on every session start, covering the gh -> legion migration and --task flag for kanban integration
-
-## 1.2.1
-
-- Slim down Stop hook: removed TEAM FIRST checklist, bullpen count check, and boost reminders. Now just prompts for one reflection if the session did real work. Full wind-down belongs in /snooze.
-
-## 1.2.0
-
-- Add MCP channel server for real-time team communication
-- Add legion-memory skill for recall-before-grep doctrine
-- Add legion-prime and dungeon-master agent definitions
-- Add slash commands: reflect, recall, boost, bullpen, consult, surface, snooze, watch-sync
-
-## 1.1.0
-
-- Add PreCompact and post-compact hooks for context re-orientation
-- Add no-gh PreToolUse hook to block direct gh usage
-- Add recall-first PreToolUse hook for Grep/Glob/WebFetch/WebSearch
-
-## 1.0.0
-
-- Initial plugin release
-- SessionStart hook: recall + surface context injection
-- Stop hook: reflect prompt with work mutex
-- Plugin binary caching via setup-binary.sh
+- Add `--version` flag to the legion binary
+- setup-binary.sh reads version from plugin.json dynamically -- binary auto-updates on version bump
+- One version number for binary and plugin (Cargo.toml = plugin.json)
+- Add work source workflow guide to SessionStart hook context
+- Slim Stop hook: just a reflect prompt, no checklist
+- GitHub Release workflow on `v*` tags builds linux-x64, macos-x64, macos-arm64, windows-x64 with SHA-256 checksums

--- a/plugin/hooks/setup-binary.sh
+++ b/plugin/hooks/setup-binary.sh
@@ -6,7 +6,13 @@ set -euo pipefail
 
 REPO="runlegion/legion"
 BINARY_NAME="legion"
-EXPECTED_VERSION="0.1.1"
+
+# Read version from plugin.json -- one version for binary and plugin.
+PLUGIN_JSON="${CLAUDE_PLUGIN_ROOT:-}/.claude-plugin/plugin.json"
+if [ -f "$PLUGIN_JSON" ]; then
+  EXPECTED_VERSION=$(grep '"version"' "$PLUGIN_JSON" | head -1 | sed 's/.*: *"\([^"]*\)".*/\1/')
+fi
+EXPECTED_VERSION="${EXPECTED_VERSION:-0.3.0}"
 
 # -- Channel dependencies ----------------------------------------------------
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,7 +40,8 @@ macro_rules! info {
 #[derive(Parser)]
 #[command(
     name = "legion",
-    about = "Agent specialization through deliberate practice"
+    about = "Agent specialization through deliberate practice",
+    version
 )]
 struct Cli {
     /// Show informational messages on stderr (quiet by default)


### PR DESCRIPTION
## Summary
- Unify Cargo.toml and plugin.json at version 0.3.0 (one version for binary + plugin)
- Add --version flag to CLI so setup-binary.sh can detect installed version
- setup-binary.sh reads version from plugin.json dynamically -- no more hardcoded version strings
- After merge: tag v0.3.0 to trigger release workflow and produce platform binaries

## Test plan
- [x] cargo test passes
- [x] cargo clippy clean
- [x] legion --version prints legion 0.3.0
- [ ] After tagging v0.3.0, GitHub Actions builds linux-x64, macos-x64, macos-arm64, windows-x64
- [ ] setup-binary.sh downloads correct binary on fresh install

🤖 Generated with [Claude Code](https://claude.com/claude-code)