### PR TITLE
fix: add .mcp.json for MCP server registration

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
     {
       "name": "legion",
       "description": "Agent memory layer with recall, reflect, consult, bullpen, and cross-agent coordination. Includes health monitoring and auto-wake. Hooks wire legion into every session automatically.",
-      "version": "0.4.3",
+      "version": "0.4.4",
       "author": {
         "name": "Sean Silvius",
         "email": "sean@silvius.me"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "legion"
-version = "0.4.3"
+version = "0.4.4"
 edition = "2024"
 description = "Agent specialization through deliberate practice"
 

--- a/plugin/.claude-plugin/.mcp.json
+++ b/plugin/.claude-plugin/.mcp.json
@@ -1,0 +1,9 @@
+{
+  "legion": {
+    "command": "bun",
+    "args": ["run", "${CLAUDE_PLUGIN_ROOT}/channel/index.ts"],
+    "env": {
+      "LEGION_PORT": "3131"
+    }
+  }
+}

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "legion",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "Institutional memory for Claude Code agents with real-time team channel.",
   "author": {
     "name": "Sean Silvius",

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Legion Changelog
 
+## 0.4.4
+
+### MCP Server Registration
+- Added `.mcp.json` to plugin root so Claude Code discovers the channel MCP server
+- Without this file, legion_post, legion_reply, legion_signal, and legion_task_respond tools were invisible
+- The `channel` field in plugin.json is a separate mechanism; `.mcp.json` is how plugins register MCP servers
+
 ## 0.4.3
 
 ### Structured Card Storage


### PR DESCRIPTION
## Summary
- Added plugin/.claude-plugin/.mcp.json so Claude Code discovers the channel MCP server
- Bumped version to 0.4.4 across Cargo.toml, plugin.json, marketplace.json
- Updated CHANGELOG.md

## Context
Plugins register MCP servers via .mcp.json at the plugin root. Without it, legion_post, legion_reply, legion_signal, legion_task_respond tools were invisible despite the channel process running.

## Test plan
- [x] cargo test -- 40 passed
- [x] cargo clippy -- clean
- [x] cargo fmt -- clean
- [ ] New session verifies mcp__legion__* tools appear