### PR TITLE
fix: SessionStart hook reliability, status --json, service startup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1204,7 +1204,7 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "legion"
-version = "0.4.6"
+version = "0.4.7"
 dependencies = [
  "async-stream",
  "axum",

--- a/plugin/hooks/hooks.json
+++ b/plugin/hooks/hooks.json
@@ -3,7 +3,6 @@
   "hooks": {
     "SessionStart": [
       {
-        "matcher": "startup",
         "hooks": [
           {
             "type": "command",
@@ -14,16 +13,6 @@
             "type": "command",
             "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/session-start.sh",
             "timeout": 10
-          }
-        ]
-      },
-      {
-        "matcher": "compact",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/post-compact.sh",
-            "timeout": 15
           }
         ]
       }
@@ -46,6 +35,11 @@
             "type": "command",
             "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/precompact.sh",
             "timeout": 10
+          },
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/post-compact.sh",
+            "timeout": 15
           }
         ]
       }

--- a/plugin/hooks/session-start.sh
+++ b/plugin/hooks/session-start.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Legion SessionStart hook: last reflection + status + channel server
+# Legion SessionStart hook: last reflection + status
 INPUT=$(cat)
 CWD=$(echo "$INPUT" | jq -r '.cwd // empty')
 
@@ -19,28 +19,6 @@ rm -f "/tmp/legion-channel-${REPO}" 2>/dev/null
 # Mark session as having done work (used by stop hook)
 touch "/tmp/legion-work-${CWD_HASH}"
 
-# -- Long-lived services -------------------------------------------------------
-# Channel MCP and watch should always be running. They outlive agent sessions
-# so signals can wake sleeping agents even when no session is active.
-LEGION_PORT="${LEGION_PORT:-3131}"
-PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-}"
-
-# Channel MCP server
-if [ -n "$PLUGIN_ROOT" ] && [ -f "$PLUGIN_ROOT/channel/index.ts" ]; then
-  if ! lsof -iTCP:"$LEGION_PORT" -sTCP:LISTEN -t >/dev/null 2>&1; then
-    if command -v bun >/dev/null 2>&1; then
-      nohup bun run "$PLUGIN_ROOT/channel/index.ts" >/dev/null 2>&1 &
-    fi
-  fi
-fi
-
-# Watch (auto-wake agents on signal arrival)
-if command -v legion >/dev/null 2>&1; then
-  if ! pgrep -f "legion watch" >/dev/null 2>&1; then
-    nohup legion watch >/dev/null 2>&1 &
-  fi
-fi
-
 # Append non-empty text to OUTPUT, separated by double newlines
 append() {
   local text="$1"
@@ -59,8 +37,33 @@ OUTPUT=""
 LAST=$(legion recall --repo "$REPO" --latest --limit 1 2>/dev/null)
 append "$LAST"
 
-# 2. Status -- task count, direct signals, what changed
-append "$(legion status --repo "$REPO" 2>/dev/null)"
+# 2. Status -- compact one-liner with counts
+STATUS_JSON=$(legion status --repo "$REPO" --json 2>/dev/null)
+if [ -n "$STATUS_JSON" ]; then
+  TASKS=$(echo "$STATUS_JSON" | jq -r '.tasks // 0')
+  BLOCKED=$(echo "$STATUS_JSON" | jq -r '.blocked // 0')
+  NEEDS=$(echo "$STATUS_JSON" | jq -r '.team_needs // 0')
+  CHANGED=$(echo "$STATUS_JSON" | jq -r '.what_changed // 0')
+  PARTS=""
+  if [ "$TASKS" -gt 0 ]; then
+    if [ "$BLOCKED" -gt 0 ]; then
+      PARTS="${TASKS} tasks (${BLOCKED} blocked)"
+    else
+      PARTS="${TASKS} tasks"
+    fi
+  fi
+  if [ "$NEEDS" -gt 0 ]; then
+    [ -n "$PARTS" ] && PARTS="${PARTS}, "
+    PARTS="${PARTS}${NEEDS} unread @${REPO}"
+  fi
+  if [ "$CHANGED" -gt 0 ]; then
+    [ -n "$PARTS" ] && PARTS="${PARTS}, "
+    PARTS="${PARTS}${CHANGED} updates"
+  fi
+  if [ -n "$PARTS" ]; then
+    append "[Legion] ${PARTS} -- legion bullpen for details"
+  fi
+fi
 
 if [ -n "$OUTPUT" ]; then
   jq -n --arg ctx "$OUTPUT" '{

--- a/plugin/hooks/setup-binary.sh
+++ b/plugin/hooks/setup-binary.sh
@@ -177,3 +177,24 @@ Work source commands (required -- direct `gh` is blocked):
 LEGION_EOF
   echo "[legion] added instructions to ${CLAUDE_MD}" >&2
 fi
+
+# -- Long-lived services -------------------------------------------------------
+# Channel MCP and watch should always be running. They outlive agent sessions
+# so signals can wake sleeping agents even when no session is active.
+LEGION_PORT="${LEGION_PORT:-3131}"
+
+# Channel MCP server
+if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -f "${CLAUDE_PLUGIN_ROOT}/channel/index.ts" ]; then
+  if ! lsof -iTCP:"$LEGION_PORT" -sTCP:LISTEN -t >/dev/null 2>&1; then
+    if command -v bun >/dev/null 2>&1; then
+      nohup bun run "${CLAUDE_PLUGIN_ROOT}/channel/index.ts" >/dev/null 2>&1 &
+    fi
+  fi
+fi
+
+# Watch (auto-wake agents on signal arrival)
+if command -v legion >/dev/null 2>&1; then
+  if ! pgrep -f "legion watch" >/dev/null 2>&1; then
+    nohup legion watch >/dev/null 2>&1 &
+  fi
+fi

--- a/src/main.rs
+++ b/src/main.rs
@@ -269,6 +269,10 @@ enum Commands {
         /// Repository name
         #[arg(long)]
         repo: String,
+
+        /// Output as JSON with counts only (for hooks/scripts)
+        #[arg(long)]
+        json: bool,
     },
 
     /// Show what the team needs help with
@@ -1327,18 +1331,25 @@ fn run() -> error::Result<()> {
             }
             serve::run_server(port, base)?;
         }
-        Commands::Status { repo } => {
+        Commands::Status { repo, json } => {
             let base = data_dir()?;
             let database = db::Database::open(&base.join("legion.db"))?;
             let output = status::get_status(&database, &repo)?;
-            let formatted = status::format_status(&output);
-            if formatted.is_empty() {
+            if json {
                 println!(
-                    "[Legion] Status for {}: all clear. Check `gh issue list` for GitHub issues.",
-                    repo
+                    "{}",
+                    serde_json::to_string(&status::format_summary(&output))?
                 );
             } else {
-                print!("{formatted}");
+                let formatted = status::format_status(&output);
+                if formatted.is_empty() {
+                    println!(
+                        "[Legion] Status for {}: all clear. Check `gh issue list` for GitHub issues.",
+                        repo
+                    );
+                } else {
+                    print!("{formatted}");
+                }
             }
         }
         Commands::Needs { repo } => {

--- a/src/status.rs
+++ b/src/status.rs
@@ -104,6 +104,44 @@ pub fn format_needs(repo: &str, items: &[StatusItem]) -> String {
     out
 }
 
+/// JSON-friendly summary with counts only. Used by hooks to inject minimal context.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct StatusSummary {
+    pub repo: String,
+    pub tasks: usize,
+    pub blocked: usize,
+    pub team_needs: usize,
+    pub what_changed: usize,
+}
+
+/// Produce a compact summary with counts only.
+pub fn format_summary(output: &StatusOutput) -> StatusSummary {
+    let blocked: usize = output
+        .your_work
+        .iter()
+        .filter(|i| i.text.contains("[BLOCKED]"))
+        .count();
+    let tasks: usize = output
+        .your_work
+        .first()
+        .and_then(|i| {
+            if i.category == "TASKS" {
+                i.text.split_whitespace().next()?.parse::<usize>().ok()
+            } else {
+                None
+            }
+        })
+        .unwrap_or(0);
+
+    StatusSummary {
+        repo: output.repo.clone(),
+        tasks,
+        blocked,
+        team_needs: output.team_needs.len(),
+        what_changed: output.what_changed.len(),
+    }
+}
+
 /// Format status output for terminal display.
 pub fn format_status(output: &StatusOutput) -> String {
     if output.your_work.is_empty() && output.team_needs.is_empty() && output.what_changed.is_empty()


### PR DESCRIPTION
## Summary

- Remove `matcher` field from SessionStart hooks in hooks.json (silently fails for SessionStart events)
- Move post-compact.sh from SessionStart(compact) to PreCompact where it belongs
- Relocate channel MCP and watch startup from session-start.sh to setup-binary.sh
- Add `--json` flag to `legion status` for compact hook output
- Version bump to 0.4.7

Fixes #190

## Test plan

- [x] `cargo test` -- 40 passed
- [x] `cargo clippy -- -D warnings` -- clean
- [x] `cargo fmt -- --check` -- clean
- [ ] Verify SessionStart hooks fire on fresh session
- [ ] Verify `legion status --repo legion --json` outputs compact JSON