### PR TITLE
v0.6.2: Phase D daemon post-merge review fixes

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
     {
       "name": "legion",
       "description": "Agent memory layer with recall, reflect, consult, bullpen, and cross-agent coordination. Includes health monitoring and auto-wake. Hooks wire legion into every session automatically.",
-      "version": "0.6.1",
+      "version": "0.6.2",
       "author": {
         "name": "Sean Silvius",
         "email": "sean@silvius.me"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1204,7 +1204,7 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "legion"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "async-stream",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "legion"
-version = "0.6.1"
+version = "0.6.2"
 edition = "2024"
 description = "Agent specialization through deliberate practice"
 

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "legion",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Institutional memory for Claude Code agents with real-time team channel.",
   "author": {
     "name": "Sean Silvius",

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Legion Changelog
 
+## 0.6.2
+
+### Phase D daemon post-merge review fixes
+
+Addresses findings from the pr-review-toolkit run on #201 that were deferred to ship the merge. Closes #202.
+
+### Bug Fixes
+- **Daemon task supervision** (`src/daemon.rs`): `run_daemon_async` now races the HTTP server, watch task, and MCP task via `tokio::select!`. Any task exiting (success, error, or panic) triggers the others to stop. Previously background task failures were silently ignored until SIGINT, so a crashing watch loop or panicking MCP handler would leave the daemon running in a half-broken state.
+- **SIGINT hang on MCP stdin** (`src/daemon.rs`): `run_daemon` now calls `runtime.shutdown_timeout(Duration::from_secs(2))` after `block_on` returns, giving the blocking MCP stdin thread up to 2 seconds to exit cleanly. Without this, a `spawn_blocking` task parked on `read_until()` held the OS thread alive and blocked process exit.
+- **`shutdown_signal` ctrl_c install failure now parks instead of returning** (`src/daemon.rs`): a return in the `ctrl_c` arm would cause the outer `select!` to fire immediately on daemon startup, shutting the daemon down. The failure branch now logs and parks via `std::future::pending()`.
+- **MCP tool errors use `isError: true`** (`src/mcp.rs`): per MCP 2024-11-05 spec, tool execution failures go in the success envelope with `isError: true`, not as JSON-RPC `-32603` responses. JSON-RPC errors are reserved for protocol-level failures (parse errors, method not found, invalid request envelope). Added the `tool_error` helper and three tests asserting the correct envelope shape for unknown tools and `McpInvalidArgument` errors.
+- **MCP error messages are sanitized** (`src/mcp.rs`): non-argument errors show `"internal error: <msg>"` instead of leaking file paths or DB internals. `McpInvalidArgument` still shows the full validation message since it is a contract error for the caller.
+- **`api_post` uses `board::post_from_text_with_meta`** (`src/channel.rs`): matches the MCP handlers and propagates index failures as 500s instead of silently swallowing them with an `eprintln!`. A post that cannot be indexed is unsearchable, which is a half-broken state -- callers should see the failure and retry.
+- **SSE broadcast `Lagged`/`Closed` handled explicitly** (`src/channel.rs`): previously the `Ok(_) = rx.recv()` select arm used a refutable match that silently did not fire on `Lagged(n)` (subscriber fell behind the ring buffer) or `Closed` (sender dropped). `Lagged` now logs the dropped-event count and forces a DB re-read to catch up; `Closed` ends the stream. Added two tests guarding the `TryRecvError::Lagged` and `TryRecvError::Closed` paths.
+
+### Features
+- **Embed model absence warning at daemon startup**: logs `"note: embed model not loaded -- posts via /api/post and MCP will not be similarity-searchable until card 019d7991-2eab lands"` so operators are not surprised when daemon-side posts do not appear in cosine recall results.
+- **TODO comments on each `post_from_text_with_meta` call site** (`src/mcp.rs`, `src/channel.rs`): reference card `019d7991-2eab` for the embed model threading follow-up.
+
 ## 0.6.1
 
 ### Phase D: Channel + Watch + MCP unified daemon
@@ -8,9 +27,9 @@ Ports `plugin/channel/*.ts` (TypeScript + Bun) to three tokio tasks in one Rust 
 
 ### Features
 - **`legion daemon` subcommand**: one process hosts the channel (SSE pub/sub + HTTP endpoints at `/api/feed`, `/api/tasks`, `/api/post`, `/sse`), an optional MCP stdio server (`legion daemon --mcp`), and the watch poll loop that was previously a separate `legion watch` process
-- **`src/channel.rs`** (~532 lines): SSE broadcast channel, HTTP endpoints matching the legacy TS JSON shapes byte-for-byte so existing consumers (dashboard, sse-client, any external tooling) continue to work through the transition. Opens DB once per SSE subscriber lifetime and queries only on broadcast notifications, not on every tick.
-- **`src/mcp.rs`** (~700 lines): hand-rolled JSON-RPC 2.0 stdio server. Implements `initialize`, `tools/list`, `tools/call` per MCP 2024-11-05 spec. Four legion tools: `legion_post`, `legion_reply`, `legion_signal`, `legion_task_respond`. Each handler calls existing Rust primitives (`board::post_from_text_with_meta`, `sig::*`, `task::*`) instead of re-implementing. Bounded stdin buffer (1 MB per line) to prevent resource exhaustion. UTF-8 safe response truncation.
-- **`src/daemon.rs`**: task orchestration with shared `Arc<Database>`. Watch task holds a `watch::PidLockGuard` for RAII cleanup on SIGINT/abort. Graceful shutdown via `select!` on Ctrl+C + SIGTERM (with logged fallback if signal handler install fails instead of panicking).
+- **`src/channel.rs`**: SSE broadcast channel, HTTP endpoints matching the legacy JSON shapes so existing consumers (dashboard, any external tooling that scraped the legacy endpoints) continue to work. Opens DB once per SSE subscriber lifetime and queries only on broadcast notifications, not on every tick.
+- **`src/mcp.rs`**: hand-rolled JSON-RPC 2.0 stdio server. Implements `initialize`, `tools/list`, `tools/call` per MCP 2024-11-05 spec. Four legion tools: `legion_post`, `legion_reply`, `legion_signal`, `legion_task_respond`. Each handler calls existing Rust primitives (`board::post_from_text_with_meta`, `sig::*`, `task::*`) instead of re-implementing. Bounded stdin buffer (1 MB per line) to prevent resource exhaustion. UTF-8 safe response truncation.
+- **`src/daemon.rs`**: task orchestration; each handler opens its own DB connection consistent with the CLI pattern (follow-up card 019d7991-2eb4 tracks deduplication between channel.rs and serve.rs). Watch task holds a `watch::PidLockGuard` for RAII cleanup on SIGINT/abort. Graceful shutdown via `select!` races HTTP server, watch task, and MCP task -- any task exiting triggers the others to stop. Ctrl+C install failure uses `pending()` instead of returning, preventing spurious instant shutdown.
 - **New error variant**: `LegionError::McpInvalidArgument(String)` replaces the `LegionError::Io` abuse that was previously used for MCP argument validation errors.
 
 ### Deleted

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -377,8 +377,7 @@ mod tests {
 
     #[test]
     fn feed_endpoint_matches_legacy_shape() {
-        let (db, index, dir) = test_storage();
-        let _data_dir = dir.path().to_path_buf();
+        let (db, index, _dir) = test_storage();
 
         // Insert a team post
         let reflection = db

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -10,6 +10,7 @@ use axum::routing::{get, post};
 use axum::{Json, Router};
 use tokio::sync::broadcast;
 
+use crate::board;
 use crate::db::{Database, ReflectionMeta};
 use crate::error::LegionError;
 use crate::search::SearchIndex;
@@ -45,7 +46,8 @@ pub struct ChannelState {
     pub tx: broadcast::Sender<ChannelEvent>,
 }
 
-/// Feed item returned by GET /api/feed -- matches the legacy TS shape exactly.
+/// Feed item returned by GET /api/feed. Field names (snake_case) and is_signal flag are part of the
+/// public JSON contract -- changing them breaks dashboard and external tooling.
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone)]
 pub struct FeedItem {
     pub id: String,
@@ -101,7 +103,7 @@ fn json_error(status: StatusCode, message: &str) -> Response {
 
 /// GET /api/feed -- bullpen posts with optional repo and signal/musing filter.
 ///
-/// Matches the legacy TypeScript API shape exactly:
+/// Query shape is part of the public JSON contract: repo, filter=signals|musings, unread_for=<repo>.
 /// - `repo`: filter by source repo
 /// - `filter`: "signals" | "musings" | (all)
 /// - `unread_for`: atomic unread-and-mark for the channel backlog
@@ -193,11 +195,15 @@ pub struct PostRequest {
 }
 
 /// POST /api/post -- broadcast a message to the bullpen and notify SSE subscribers.
+///
+/// Index failures are treated as errors (500) rather than silently swallowed -- a post
+/// that cannot be indexed is unsearchable, which is a half-broken state. Callers should
+/// retry if they get a 500.
 pub async fn api_post(
     State(state): State<ChannelState>,
     Json(body): Json<PostRequest>,
 ) -> Response {
-    let trimmed = body.text.trim();
+    let trimmed = body.text.trim().to_string();
     if trimmed.is_empty() {
         return json_error(StatusCode::BAD_REQUEST, "text is required");
     }
@@ -217,29 +223,25 @@ pub async fn api_post(
         }
     };
 
-    let reflection = match db.insert_reflection_with_meta(
+    // TODO(019d7991-2eab): compute and store embedding so this post is similarity-searchable
+    let id = match board::post_from_text_with_meta(
+        &db,
+        &index,
         &body.repo,
-        trimmed,
-        "team",
+        &trimmed,
         &ReflectionMeta::default(),
     ) {
-        Ok(r) => r,
+        Ok(id) => id,
         Err(e) => {
-            return json_error(
-                StatusCode::INTERNAL_SERVER_ERROR,
-                &format!("insert error: {e}"),
-            );
+            eprintln!("[legion channel] api_post failed: {e}");
+            return json_error(StatusCode::INTERNAL_SERVER_ERROR, "failed to store post");
         }
     };
-
-    if let Err(e) = index.add(&reflection.id, &reflection.repo, trimmed) {
-        eprintln!("[legion channel] search index add failed: {e}");
-    }
 
     // Notify SSE subscribers (best-effort; no SSE listeners is not an error).
     let _ = state.tx.send(ChannelEvent::Feed);
 
-    Json(reflection).into_response()
+    Json(serde_json::json!({ "id": id })).into_response()
 }
 
 /// SSE handler -- streams feed, tasks, and ping events to subscribers.
@@ -275,8 +277,22 @@ pub async fn sse_handler(
         loop {
             // Wait for a broadcast notification or a ping timeout.
             tokio::select! {
-                Ok(_) = rx.recv() => {
-                    // Something changed -- fall through to emit events.
+                result = rx.recv() => {
+                    match result {
+                        Ok(_) => {
+                            // Something changed -- fall through to emit events.
+                        }
+                        Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
+                            // Subscriber fell behind the broadcast ring buffer. Events were
+                            // dropped, so force a re-read of the DB to catch up.
+                            eprintln!("[legion channel] sse subscriber lagged {n} events; forcing re-check");
+                            // Fall through to re-query the DB for latest state.
+                        }
+                        Err(tokio::sync::broadcast::error::RecvError::Closed) => {
+                            eprintln!("[legion channel] sse broadcast closed; ending stream");
+                            return;
+                        }
+                    }
                 }
                 _ = tokio::time::sleep(ping_interval) => {
                     // No change notification for a while -- emit keepalive only.
@@ -362,7 +378,7 @@ mod tests {
     #[test]
     fn feed_endpoint_matches_legacy_shape() {
         let (db, index, dir) = test_storage();
-        let data_dir = dir.path().to_path_buf();
+        let _data_dir = dir.path().to_path_buf();
 
         // Insert a team post
         let reflection = db
@@ -395,8 +411,6 @@ mod tests {
         assert!(json.get("text").is_some());
         assert!(json.get("created_at").is_some());
         assert!(json.get("is_signal").is_some());
-        // Drop to make usage clear.
-        drop(data_dir);
     }
 
     #[test]
@@ -444,5 +458,43 @@ mod tests {
         let parsed: serde_json::Value = serde_json::from_str(&json).expect("parse");
         assert!(parsed.is_array());
         assert_eq!(parsed.as_array().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn broadcast_lag_produces_recv_error() {
+        // A subscriber that falls behind the ring buffer capacity gets TryRecvError::Lagged,
+        // not a silent drop. This guards the M2 fix -- the SSE handler must handle Lagged
+        // explicitly (force re-read) rather than letting the select! arm silently not fire.
+        use tokio::sync::broadcast::error::TryRecvError;
+
+        // Tiny capacity to force lag.
+        let (tx, mut rx) = broadcast::channel::<ChannelEvent>(1);
+
+        // Fill past capacity without the subscriber reading.
+        tx.send(ChannelEvent::Feed).expect("send 1");
+        tx.send(ChannelEvent::Feed).expect("send 2");
+
+        // The first recv should be Lagged since we overflowed the 1-slot buffer.
+        let result = rx.try_recv();
+        assert!(
+            matches!(result, Err(TryRecvError::Lagged(_))),
+            "expected TryRecvError::Lagged, got: {result:?}"
+        );
+    }
+
+    #[test]
+    fn broadcast_closed_produces_recv_error() {
+        // When the sender is dropped the subscriber gets TryRecvError::Closed on next recv.
+        // Guards the M2 fix -- SSE handler must return on Closed, not loop forever.
+        use tokio::sync::broadcast::error::TryRecvError;
+
+        let (tx, mut rx) = broadcast::channel::<ChannelEvent>(8);
+        drop(tx); // close the channel
+
+        let result = rx.try_recv();
+        assert!(
+            matches!(result, Err(TryRecvError::Closed)),
+            "expected TryRecvError::Closed, got: {result:?}"
+        );
     }
 }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -101,44 +101,36 @@ async fn run_daemon_async(config: DaemonConfig) -> Result<()> {
     // Build the axum server future.
     let serve_future = axum::serve(listener, app).with_graceful_shutdown(shutdown_signal());
 
-    // Race the HTTP server, watch task, MCP task (if present), and shutdown signal.
-    // Any task exiting (success or failure) triggers the others to be cancelled.
-    // This ensures panics or early returns in background tasks don't go undetected.
-    if let Some(mcp) = mcp_handle {
-        tokio::select! {
-            result = serve_future => {
-                if let Err(e) = result {
-                    eprintln!("[legion daemon] http server error: {e}");
-                }
-                eprintln!("[legion daemon] http server exited; shutting down");
+    // Unify the mcp arm: when mcp is disabled, the future parks forever so the
+    // select! never fires it. This avoids duplicating the whole select! block.
+    let mcp_future = async move {
+        match mcp_handle {
+            Some(h) => h.await,
+            None => std::future::pending().await,
+        }
+    };
+
+    // Race the HTTP server, watch task, and MCP task (if enabled). Any task
+    // exiting -- success, error, or panic -- triggers the others to stop so
+    // background failures surface immediately instead of silently continuing.
+    tokio::select! {
+        result = serve_future => {
+            if let Err(e) = result {
+                eprintln!("[legion daemon] http server error: {e}");
             }
-            result = watch_handle => {
-                match result {
-                    Ok(()) => eprintln!("[legion daemon] watch task exited; shutting down"),
-                    Err(e) => eprintln!("[legion daemon] watch task exited: {e}; shutting down"),
-                }
-            }
-            result = mcp => {
-                match result {
-                    Ok(Ok(())) => eprintln!("[legion daemon] mcp loop exited; shutting down"),
-                    Ok(Err(e)) => eprintln!("[legion daemon] mcp loop error: {e}; shutting down"),
-                    Err(e) => eprintln!("[legion daemon] mcp task panic: {e}; shutting down"),
-                }
+            eprintln!("[legion daemon] http server exited; shutting down");
+        }
+        result = watch_handle => {
+            match result {
+                Ok(()) => eprintln!("[legion daemon] watch task exited; shutting down"),
+                Err(e) => eprintln!("[legion daemon] watch task exited: {e}; shutting down"),
             }
         }
-    } else {
-        tokio::select! {
-            result = serve_future => {
-                if let Err(e) = result {
-                    eprintln!("[legion daemon] http server error: {e}");
-                }
-                eprintln!("[legion daemon] http server exited; shutting down");
-            }
-            result = watch_handle => {
-                match result {
-                    Ok(()) => eprintln!("[legion daemon] watch task exited; shutting down"),
-                    Err(e) => eprintln!("[legion daemon] watch task exited: {e}; shutting down"),
-                }
+        result = mcp_future => {
+            match result {
+                Ok(Ok(())) => eprintln!("[legion daemon] mcp loop exited; shutting down"),
+                Ok(Err(e)) => eprintln!("[legion daemon] mcp loop error: {e}; shutting down"),
+                Err(e) => eprintln!("[legion daemon] mcp task panic: {e}; shutting down"),
             }
         }
     }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -6,6 +6,7 @@
 ///
 /// The daemon starts all tasks and shuts down cleanly on SIGINT/SIGTERM.
 use std::path::{Path, PathBuf};
+use std::time::Duration;
 
 use crate::channel;
 use crate::error::{LegionError, Result};
@@ -34,7 +35,14 @@ pub fn run_daemon(config: DaemonConfig) -> Result<()> {
     let runtime = tokio::runtime::Runtime::new()
         .map_err(|e| LegionError::Server(format!("failed to create runtime: {e}")))?;
 
-    runtime.block_on(run_daemon_async(config))
+    let result = runtime.block_on(run_daemon_async(config));
+
+    // Give blocking threads (e.g. MCP stdin loop) up to 2 seconds to exit before
+    // the runtime forcibly drops them. Without this, a blocking task stuck on
+    // read_until() holds the OS thread alive until the process exits.
+    runtime.shutdown_timeout(Duration::from_secs(2));
+
+    result
 }
 
 async fn run_daemon_async(config: DaemonConfig) -> Result<()> {
@@ -46,10 +54,15 @@ async fn run_daemon_async(config: DaemonConfig) -> Result<()> {
         port, config.enable_mcp
     );
 
+    // Embed model is not loaded in daemon mode. Posts via /api/post and MCP tools will have
+    // NULL embedding columns and won't be similarity-searchable until card 019d7991-2eab lands.
+    eprintln!(
+        "[legion daemon] note: embed model not loaded -- posts via /api/post and MCP will not be similarity-searchable until card 019d7991-2eab lands"
+    );
+
     // Build the broadcast channel for SSE notifications.
     let (tx, _rx) = channel::new_broadcast();
 
-    // Build the channel HTTP router directly -- no passthrough wrapper needed.
     let channel_state = channel::ChannelState {
         data_dir: data_dir.clone(),
         tx: tx.clone(),
@@ -71,7 +84,7 @@ async fn run_daemon_async(config: DaemonConfig) -> Result<()> {
     });
 
     // Spawn the MCP stdio server if requested.
-    let mcp_handle = if config.enable_mcp {
+    let mcp_handle: Option<tokio::task::JoinHandle<Result<()>>> = if config.enable_mcp {
         let mcp_data_dir = data_dir.clone();
         let mcp_tx = tx.clone();
         let version = env!("CARGO_PKG_VERSION").to_string();
@@ -85,20 +98,52 @@ async fn run_daemon_async(config: DaemonConfig) -> Result<()> {
         None
     };
 
-    // Run the axum server until SIGINT/SIGTERM.
-    axum::serve(listener, app)
-        .with_graceful_shutdown(shutdown_signal())
-        .await
-        .map_err(|e| LegionError::Server(format!("server error: {e}")))?;
+    // Build the axum server future.
+    let serve_future = axum::serve(listener, app).with_graceful_shutdown(shutdown_signal());
 
-    eprintln!("[legion daemon] shutting down");
-
-    // Abort background tasks on shutdown.
-    watch_handle.abort();
-    if let Some(h) = mcp_handle {
-        h.abort();
+    // Race the HTTP server, watch task, MCP task (if present), and shutdown signal.
+    // Any task exiting (success or failure) triggers the others to be cancelled.
+    // This ensures panics or early returns in background tasks don't go undetected.
+    if let Some(mcp) = mcp_handle {
+        tokio::select! {
+            result = serve_future => {
+                if let Err(e) = result {
+                    eprintln!("[legion daemon] http server error: {e}");
+                }
+                eprintln!("[legion daemon] http server exited; shutting down");
+            }
+            result = watch_handle => {
+                match result {
+                    Ok(()) => eprintln!("[legion daemon] watch task exited; shutting down"),
+                    Err(e) => eprintln!("[legion daemon] watch task exited: {e}; shutting down"),
+                }
+            }
+            result = mcp => {
+                match result {
+                    Ok(Ok(())) => eprintln!("[legion daemon] mcp loop exited; shutting down"),
+                    Ok(Err(e)) => eprintln!("[legion daemon] mcp loop error: {e}; shutting down"),
+                    Err(e) => eprintln!("[legion daemon] mcp task panic: {e}; shutting down"),
+                }
+            }
+        }
+    } else {
+        tokio::select! {
+            result = serve_future => {
+                if let Err(e) = result {
+                    eprintln!("[legion daemon] http server error: {e}");
+                }
+                eprintln!("[legion daemon] http server exited; shutting down");
+            }
+            result = watch_handle => {
+                match result {
+                    Ok(()) => eprintln!("[legion daemon] watch task exited; shutting down"),
+                    Err(e) => eprintln!("[legion daemon] watch task exited: {e}; shutting down"),
+                }
+            }
+        }
     }
 
+    eprintln!("[legion daemon] shutdown complete");
     Ok(())
 }
 
@@ -223,8 +268,15 @@ async fn shutdown_signal() {
     use tokio::signal;
 
     let ctrl_c = async {
-        if let Err(e) = signal::ctrl_c().await {
-            eprintln!("[legion daemon] failed to install Ctrl+C handler: {e}");
+        match signal::ctrl_c().await {
+            Ok(()) => {}
+            Err(e) => {
+                // Log the failure but never return -- returning here would cause
+                // the select! to fire the ctrl_c arm on startup, shutting down
+                // the daemon immediately. Instead park until SIGTERM arrives.
+                eprintln!("[legion daemon] failed to install Ctrl+C handler, ignoring: {e}");
+                std::future::pending::<()>().await;
+            }
         }
     };
 

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -27,7 +27,7 @@ const PROTOCOL_VERSION: &str = "2024-11-05";
 /// Maximum tool result content length before truncation.
 const MAX_TOOL_RESULT_LEN: usize = 2000;
 
-/// Tool definitions -- match the TypeScript tools.ts shapes exactly.
+/// Tool definitions returned by tools/list. Shape is a public contract -- external MCP clients pin to these field names.
 fn tool_definitions() -> Value {
     json!([
         {
@@ -163,6 +163,27 @@ fn tool_result(text: &str) -> Value {
     })
 }
 
+/// Build a tool error response per MCP spec 2024-11-05.
+///
+/// Tool execution errors are returned in the SUCCESS envelope with `isError: true`,
+/// not as JSON-RPC error responses. JSON-RPC errors are reserved for protocol-level
+/// failures (parse errors, method not found, invalid request envelope).
+fn tool_error(id: &Value, err: &LegionError) -> Value {
+    // Avoid leaking internal details (file paths, DB internals) for non-argument errors.
+    let msg = match err {
+        LegionError::McpInvalidArgument(m) => m.clone(),
+        _ => format!("internal error: {err}"),
+    };
+    json!({
+        "jsonrpc": "2.0",
+        "id": id,
+        "result": {
+            "content": [{"type": "text", "text": msg}],
+            "isError": true
+        }
+    })
+}
+
 /// Truncate content to MAX_TOOL_RESULT_LEN with a trailing hint.
 ///
 /// Cuts at a UTF-8 codepoint boundary to avoid panicking on multi-byte chars.
@@ -209,6 +230,7 @@ fn handle_tool_call(
             let db = Database::open(&data_dir.join("legion.db"))?;
             let index = SearchIndex::open(&data_dir.join("index"))?;
 
+            // TODO(019d7991-2eab): compute and store embedding so this post is similarity-searchable
             let id = board::post_from_text_with_meta(
                 &db,
                 &index,
@@ -230,12 +252,13 @@ fn handle_tool_call(
             let text = get_str("text")
                 .ok_or_else(|| LegionError::McpInvalidArgument("text is required".into()))?;
 
-            // Format: re:<post_id> -- <text>  (matches TS tools.ts::legion_reply)
+            // Reply format "re:<post_id> -- <text>" is part of the bullpen text protocol; other agents parse this prefix.
             let reply_text = format!("re:{} -- {}", post_id, text.trim());
 
             let db = Database::open(&data_dir.join("legion.db"))?;
             let index = SearchIndex::open(&data_dir.join("index"))?;
 
+            // TODO(019d7991-2eab): compute and store embedding so this post is similarity-searchable
             let id = board::post_from_text_with_meta(
                 &db,
                 &index,
@@ -286,6 +309,7 @@ fn handle_tool_call(
             let db = Database::open(&data_dir.join("legion.db"))?;
             let index = SearchIndex::open(&data_dir.join("index"))?;
 
+            // TODO(019d7991-2eab): compute and store embedding so this post is similarity-searchable
             let id = board::post_from_text_with_meta(
                 &db,
                 &index,
@@ -391,7 +415,9 @@ pub fn dispatch(
                     let truncated = truncate(&text);
                     Some(success_response(&id, tool_result(&truncated)))
                 }
-                Err(e) => Some(error_response(&id, -32603, &e.to_string())),
+                // Per MCP spec 2024-11-05: tool execution errors go in the success
+                // envelope with isError:true, not as JSON-RPC error responses.
+                Err(e) => Some(tool_error(&id, &e)),
             }
         }
 
@@ -665,7 +691,7 @@ mod tests {
     }
 
     #[test]
-    fn unknown_tool_returns_error() {
+    fn unknown_tool_returns_is_error() {
         let (db, dir) = mcp_test_dir();
         drop(db);
 
@@ -679,7 +705,21 @@ mod tests {
         );
 
         let resp = dispatch(&req, dir.path(), "0.6.0", &tx).expect("response");
-        assert!(resp.get("error").is_some(), "expected error response");
+        // Per MCP spec: tool errors go in the success envelope with isError:true,
+        // NOT as a JSON-RPC error response.
+        assert!(
+            resp.get("error").is_none(),
+            "tool errors must not be JSON-RPC errors"
+        );
+        assert_eq!(
+            resp["result"]["isError"], true,
+            "expected isError: true in result"
+        );
+        let text = resp["result"]["content"][0]["text"].as_str().unwrap_or("");
+        assert!(
+            text.contains("nonexistent_tool"),
+            "error text should name the tool"
+        );
     }
 
     #[test]
@@ -708,7 +748,7 @@ mod tests {
     }
 
     #[test]
-    fn legion_post_missing_repo_returns_error() {
+    fn legion_post_missing_repo_returns_is_error() {
         let (db, dir) = mcp_test_dir();
         drop(db);
 
@@ -724,15 +764,54 @@ mod tests {
         );
 
         let resp = dispatch(&req, dir.path(), "0.6.0", &tx).expect("response");
+        // Per MCP spec: McpInvalidArgument is a tool error, not a protocol error.
+        // Must be in the success envelope with isError:true.
         assert!(
-            resp.get("error").is_some(),
-            "expected error for missing repo"
+            resp.get("error").is_none(),
+            "tool argument errors must not be JSON-RPC errors; got: {:?}",
+            resp.get("error")
         );
+        assert_eq!(
+            resp["result"]["isError"], true,
+            "expected isError: true in result"
+        );
+        let text = resp["result"]["content"][0]["text"].as_str().unwrap_or("");
         assert!(
-            resp["error"]["message"]
-                .as_str()
-                .unwrap_or("")
-                .contains("repo is required")
+            text.contains("repo is required"),
+            "expected 'repo is required' in error text, got: {text}"
+        );
+    }
+
+    #[test]
+    fn mcp_invalid_argument_is_not_json_rpc_error() {
+        // Specifically assert McpInvalidArgument produces isError:true, not -32603.
+        let (db, dir) = mcp_test_dir();
+        drop(db);
+
+        let tx = make_tx();
+        // legion_signal requires "repo", "to", and "verb".
+        let req = make_request(
+            "tools/call",
+            Some(json!({
+                "name": "legion_signal",
+                "arguments": {
+                    "repo": "kelex"
+                    // missing "to" and "verb"
+                }
+            })),
+        );
+
+        let resp = dispatch(&req, dir.path(), "0.6.0", &tx).expect("response");
+        assert!(
+            resp.get("error").is_none(),
+            "McpInvalidArgument must not produce a JSON-RPC error envelope"
+        );
+        assert_eq!(resp["result"]["isError"], true);
+        // The error text should describe what is missing (not internal server error).
+        let text = resp["result"]["content"][0]["text"].as_str().unwrap_or("");
+        assert!(
+            !text.starts_with("internal error:"),
+            "McpInvalidArgument should show the validation message, not 'internal error'"
         );
     }
 


### PR DESCRIPTION
Closes #202.

## Summary

Addresses findings from the pr-review-toolkit run on #201 (Phase D daemon) that were deferred to ship the merge.

### daemon.rs
- **Task supervision via tokio::select!** -- race the HTTP server, watch task, and MCP task so a panic or early return in any background task surfaces immediately instead of being silently ignored until Ctrl+C. Unified both mcp-enabled/disabled cases into one select! via an mcp_future that parks forever when mcp is disabled.
- **SIGINT hang fix** -- runtime.shutdown_timeout(2s) after block_on so the blocking MCP stdin thread gets time to exit cleanly instead of holding the process open.
- **shutdown_signal ctrl_c fix** -- on handler install failure, park via pending() instead of returning. A return would fire the select! arm on startup, shutting the daemon down immediately.
- **Embed model absence warning** -- log at daemon startup so operators see upfront that posts via /api/post and MCP will not be similarity-searchable until card 019d7991-2eab lands.

### mcp.rs
- **Tool errors return isError:true per MCP 2024-11-05 spec** -- tool execution failures go in the success envelope with isError:true, not as JSON-RPC -32603 responses. JSON-RPC errors are reserved for protocol-level failures.
- **Sanitize internal error messages** -- non-argument errors show "internal error: ..." without leaking file paths or DB internals. McpInvalidArgument still shows the full validation message (it is a contract error for the caller).
- **TODO comments** for card 019d7991-2eab on each post_from_text_with_meta call site.
- **Three tests** covering the isError:true behavior for unknown tools and McpInvalidArgument.

### channel.rs
- **api_post uses board::post_from_text_with_meta** -- matches the MCP handlers, and index failures are now propagated as 500s instead of silently swallowed.
- **SSE broadcast Lagged/Closed handled explicitly** -- Lagged forces a DB re-read to catch up; Closed ends the stream. Previously the refutable match in the select! arm silently did not fire on these.
- **Two tests** guarding the TryRecvError::Lagged and TryRecvError::Closed paths.

## Simplify gate

Ran the simplify skill manually. Two findings both fixed in this branch:

- **HIGH**: duplicated select! blocks for with-mcp and without-mcp cases. Fixed by wrapping mcp_handle in a future that parks via pending() when disabled, allowing one unified select!.
- **LOW**: dead _data_dir binding in feed_endpoint_matches_legacy_shape test. Removed.

## Out of scope

Three follow-up cards remain from the Phase D simplify review, tracked separately:
- 019d7991-2eab HIGH: embed model in daemon (non-trivial, threads Arc<Option<EmbedModel>> through)
- 019d7991-2eb4 MED: FeedItem/build_feed_json dedup between channel.rs and serve.rs
- 019d7991-2ebc MED: watch loop dedup between daemon::run_watch_task and watch::run

## Test plan

- [x] cargo build (clean)
- [x] cargo clippy --all-targets -- -D warnings (clean)
- [x] cargo fmt -- --check (clean)
- [x] cargo test --bin legion: 381 passed, 0 failed
- [ ] Windows/macOS/Linux CI green