### PR TITLE
feat(#209): surface legion hook failures via visible warnings

### DIFF
--- a/plugin/hooks/.shellcheckrc
+++ b/plugin/hooks/.shellcheckrc
@@ -1,0 +1,2 @@
+external-sources=true
+source-path=SCRIPTDIR

--- a/plugin/hooks/_legion-warn.sh
+++ b/plugin/hooks/_legion-warn.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+# Shared helper for legion hooks. Tracks failed legion invocations and
+# renders a visible warning block so agents notice when legion is degraded
+# instead of silently losing context.
+#
+# Usage from a hook script:
+#
+#   source "${CLAUDE_PLUGIN_ROOT}/hooks/_legion-warn.sh"
+#
+#   SOME_OUTPUT=$("$LEGION" recall --repo "$REPO" ... 2>>"$LOG")
+#   legion_check $? "recall"
+#
+#   # ... later, when building additionalContext:
+#   WARN=$(legion_warnings_block)
+#   if [ -n "$WARN" ]; then
+#     OUTPUT="${WARN}"$'\n\n'"${OUTPUT}"
+#   fi
+#
+# The helper never exits the calling script and never writes to stderr on
+# its own -- it only accumulates state and renders a string on request.
+
+# Accumulator for failed actions (one per line, "- <action>").
+# Hooks source this file fresh each invocation, so the empty init is safe.
+LEGION_WARNINGS=""
+
+# Record a failure if the exit code is nonzero.
+#   $1 -- exit code from the most recent command (pass $? immediately after it)
+#   $2 -- short action name ("recall", "sync", "bullpen", etc)
+legion_check() {
+  if [ "${1:-0}" -ne 0 ]; then
+    LEGION_WARNINGS="${LEGION_WARNINGS}- ${2} failed (exit ${1})"$'\n'
+  fi
+}
+
+# Render the warning block. Empty string if no failures were recorded.
+# The sentinel "[Legion WARNING]" is load-bearing -- integration tests
+# grep for it to confirm visible degradation surfacing.
+legion_warnings_block() {
+  if [ -z "$LEGION_WARNINGS" ]; then
+    return 0
+  fi
+  printf '%s' "[Legion WARNING] Legion is degraded. One or more hook commands failed:
+${LEGION_WARNINGS}Details: /tmp/legion-hook-errors.log
+Common causes: missing binary at \${CLAUDE_PLUGIN_ROOT}/bin/legion, DB schema mismatch, corrupted embedding column (TEXT instead of BLOB), data_dir split-brain between ~/Library/Application Support/legion and ~/.claude/plugins/data/legion-legion, wrong CLAUDE_PLUGIN_ROOT in hook subshell.
+Recall and bullpen context is missing from this session until legion recovers."
+}

--- a/plugin/hooks/bullpen-check.sh
+++ b/plugin/hooks/bullpen-check.sh
@@ -6,6 +6,11 @@
 # Hook subshells do not inherit the plugin bin dir on PATH -- only the Bash
 # tool does. Invoke via full CLAUDE_PLUGIN_ROOT path (fixes #204).
 LEGION="${CLAUDE_PLUGIN_ROOT}/bin/legion"
+LOG=/tmp/legion-hook-errors.log
+
+# Shared warning helper -- surfaces legion degradation via additionalContext
+# instead of silently dropping bullpen notifications. See #209.
+source "${CLAUDE_PLUGIN_ROOT}/hooks/_legion-warn.sh"
 
 INPUT=$(cat)
 CWD=$(echo "$INPUT" | jq -r '.cwd // empty')
@@ -21,10 +26,27 @@ if [ -f "/tmp/legion-channel-${REPO}" ]; then
   exit 0
 fi
 
-# Check board for unread posts
-BOARD_COUNT=$("$LEGION" bullpen --count --repo "$REPO" 2>/dev/null)
-if [ -n "$BOARD_COUNT" ]; then
-  jq -n --arg ctx "[Legion] ${BOARD_COUNT}. Run legion bullpen --repo ${REPO} to read them." '{
+# Check board for unread posts. Route stderr to the breadcrumb log (was /dev/null)
+# so broken-legion failures leave a trace instead of disappearing.
+BOARD_COUNT=$("$LEGION" bullpen --count --repo "$REPO" 2>>"$LOG")
+legion_check $? "bullpen --count"
+
+WARN=$(legion_warnings_block)
+
+if [ -n "$BOARD_COUNT" ] || [ -n "$WARN" ]; then
+  if [ -n "$BOARD_COUNT" ]; then
+    CTX="[Legion] ${BOARD_COUNT}. Run legion bullpen --repo ${REPO} to read them."
+  else
+    CTX=""
+  fi
+  if [ -n "$WARN" ]; then
+    if [ -n "$CTX" ]; then
+      CTX="${WARN}"$'\n\n'"${CTX}"
+    else
+      CTX="$WARN"
+    fi
+  fi
+  jq -n --arg ctx "$CTX" '{
     "hookSpecificOutput": {
       "hookEventName": "PreToolUse",
       "permissionDecision": "allow",

--- a/plugin/hooks/bullpen-check.sh
+++ b/plugin/hooks/bullpen-check.sh
@@ -10,6 +10,7 @@ LOG=/tmp/legion-hook-errors.log
 
 # Shared warning helper -- surfaces legion degradation via additionalContext
 # instead of silently dropping bullpen notifications. See #209.
+# shellcheck source=_legion-warn.sh
 source "${CLAUDE_PLUGIN_ROOT}/hooks/_legion-warn.sh"
 
 INPUT=$(cat)

--- a/plugin/hooks/post-compact.sh
+++ b/plugin/hooks/post-compact.sh
@@ -11,6 +11,7 @@ LOG=/tmp/legion-hook-errors.log
 # post-compact silently failed because the checkpoint DB was corrupted. Never
 # again. Every legion call now feeds legion_check, and the warning block is
 # rendered at the top of the re-orientation output. See #209.
+# shellcheck source=_legion-warn.sh
 source "${CLAUDE_PLUGIN_ROOT}/hooks/_legion-warn.sh"
 
 INPUT=$(cat)

--- a/plugin/hooks/post-compact.sh
+++ b/plugin/hooks/post-compact.sh
@@ -5,6 +5,13 @@
 # Hook subshells do not inherit the plugin bin dir on PATH -- only the Bash
 # tool does. Invoke via full CLAUDE_PLUGIN_ROOT path (fixes #204).
 LEGION="${CLAUDE_PLUGIN_ROOT}/bin/legion"
+LOG=/tmp/legion-hook-errors.log
+
+# Shared warning helper -- the original incident (2026-04-11) happened here:
+# post-compact silently failed because the checkpoint DB was corrupted. Never
+# again. Every legion call now feeds legion_check, and the warning block is
+# rendered at the top of the re-orientation output. See #209.
+source "${CLAUDE_PLUGIN_ROOT}/hooks/_legion-warn.sh"
 
 INPUT=$(cat)
 CWD=$(echo "$INPUT" | jq -r '.cwd // empty')
@@ -14,10 +21,20 @@ if [ -z "$CWD" ]; then
 fi
 
 REPO=$(basename "$CWD")
+CWD_HASH=$(echo "$CWD" | md5 -q 2>/dev/null || echo "$CWD" | md5sum 2>/dev/null | cut -d' ' -f1)
 
 # Clean up stop-hook marker so reflect prompt fires fresh
-MARKER="/tmp/legion-reflected-$(echo "$CWD" | md5 -q 2>/dev/null || echo "$CWD" | md5sum 2>/dev/null | cut -d' ' -f1)"
+MARKER="/tmp/legion-reflected-${CWD_HASH}"
 rm -f "$MARKER" 2>/dev/null
+
+# Read and consume the precompact checkpoint-failed marker, if any.
+# precompact.sh touches this when its reflect call fails, so the failure
+# propagates into this hook's re-orientation output.
+CHECKPOINT_MARKER="/tmp/legion-checkpoint-failed-${CWD_HASH}"
+if [ -f "$CHECKPOINT_MARKER" ]; then
+  legion_check 1 "precompact reflect (checkpoint not saved)"
+  rm -f "$CHECKPOINT_MARKER" 2>/dev/null
+fi
 
 OUTPUT="[Legion] POST-COMPACTION RE-ORIENTATION
 IMPORTANT: You just compacted. The compaction summary may be stale or incomplete.
@@ -47,7 +64,8 @@ fi
 # Recall: checkpoint reflection from PreCompact hook + branch context
 OUTPUT="$OUTPUT"$'\n\n'"--- LEGION CHECKPOINT (stored before compaction) ---"
 
-CHECKPOINT=$("$LEGION" recall --repo "$REPO" --context "compact checkpoint" --limit 1 2>/dev/null)
+CHECKPOINT=$("$LEGION" recall --repo "$REPO" --context "compact checkpoint" --limit 1 2>>"$LOG")
+legion_check $? "recall (checkpoint)"
 if [ -n "$CHECKPOINT" ]; then
   OUTPUT="$OUTPUT"$'\n'"$CHECKPOINT"
 else
@@ -56,20 +74,23 @@ fi
 
 # Branch-specific recall if on a feature branch
 if [ -n "$GIT_BRANCH" ] && [ "$GIT_BRANCH" != "main" ] && [ "$GIT_BRANCH" != "master" ]; then
-  BRANCH_RECALL=$("$LEGION" recall --repo "$REPO" --context "$GIT_BRANCH" 2>/dev/null)
+  BRANCH_RECALL=$("$LEGION" recall --repo "$REPO" --context "$GIT_BRANCH" 2>>"$LOG")
+  legion_check $? "recall (branch)"
   if [ -n "$BRANCH_RECALL" ]; then
     OUTPUT="$OUTPUT"$'\n\n'"--- BRANCH CONTEXT ($GIT_BRANCH) ---"$'\n'"$BRANCH_RECALL"
   fi
 fi
 
 # Surface: cross-repo highlights, board posts, pending tasks
-SURFACE=$("$LEGION" surface --repo "$REPO" 2>/dev/null)
+SURFACE=$("$LEGION" surface --repo "$REPO" 2>>"$LOG")
+legion_check $? "surface"
 if [ -n "$SURFACE" ]; then
   OUTPUT="$OUTPUT"$'\n\n'"$SURFACE"
 fi
 
 # Unread bullpen
-BOARD_COUNT=$("$LEGION" bullpen --count --repo "$REPO" 2>/dev/null)
+BOARD_COUNT=$("$LEGION" bullpen --count --repo "$REPO" 2>>"$LOG")
+legion_check $? "bullpen --count"
 if [ -n "$BOARD_COUNT" ]; then
   OUTPUT="$OUTPUT"$'\n\n'"[Legion] ${BOARD_COUNT}. Run: legion bullpen --repo ${REPO}"
 fi
@@ -81,6 +102,15 @@ OUTPUT="$OUTPUT"$'\n\n'"--- ACTION REQUIRED ---
 4. THEN resume work."
 
 OUTPUT="$OUTPUT"$'\n\n'"[Legion] consult --context <problem> to search all agents | signal --to <agent> --verb question to ask directly | boost --id <id> when a reflection helps"
+
+# Prepend the warning block above everything else if any legion call failed.
+# This is the highest-priority surface for degraded legion -- agents MUST
+# see this immediately after compaction because a missing checkpoint or
+# broken recall makes post-compact recovery impossible. See #209.
+WARN=$(legion_warnings_block)
+if [ -n "$WARN" ]; then
+  OUTPUT="${WARN}"$'\n\n'"${OUTPUT}"
+fi
 
 jq -n --arg ctx "$OUTPUT" '{
   "hookSpecificOutput": {

--- a/plugin/hooks/precompact.sh
+++ b/plugin/hooks/precompact.sh
@@ -45,8 +45,7 @@ fi
 # marker that post-compact.sh reads and surfaces via its own warning block.
 # This propagates the failure to the first hook that CAN surface context.
 # See #209 -- losing a checkpoint silently is what caused the original incident.
-"$LEGION" reflect --repo "$REPO" --text "[COMPACT CHECKPOINT] Work in progress before compaction: ${CONTEXT}" --domain "checkpoint" --tags "auto,precompact" 2>>"$LOG"
-if [ $? -ne 0 ]; then
+if ! "$LEGION" reflect --repo "$REPO" --text "[COMPACT CHECKPOINT] Work in progress before compaction: ${CONTEXT}" --domain "checkpoint" --tags "auto,precompact" 2>>"$LOG"; then
   touch "$CHECKPOINT_MARKER" 2>/dev/null
 else
   # Previous run may have left a stale marker; clear it on successful reflect.

--- a/plugin/hooks/precompact.sh
+++ b/plugin/hooks/precompact.sh
@@ -6,6 +6,7 @@
 # Hook subshells do not inherit the plugin bin dir on PATH -- only the Bash
 # tool does. Invoke via full CLAUDE_PLUGIN_ROOT path (fixes #204).
 LEGION="${CLAUDE_PLUGIN_ROOT}/bin/legion"
+LOG=/tmp/legion-hook-errors.log
 
 INPUT=$(cat)
 CWD=$(echo "$INPUT" | jq -r '.cwd // empty')
@@ -16,6 +17,8 @@ if [ -z "$CWD" ]; then
 fi
 
 REPO=$(basename "$CWD")
+CWD_HASH=$(echo "$CWD" | md5 -q 2>/dev/null || echo "$CWD" | md5sum 2>/dev/null | cut -d' ' -f1)
+CHECKPOINT_MARKER="/tmp/legion-checkpoint-failed-${CWD_HASH}"
 
 # Extract recent assistant text from transcript JSONL
 CONTEXT=""
@@ -37,7 +40,17 @@ if [ -z "$CONTEXT" ]; then
   CONTEXT="(no transcript context extracted)"
 fi
 
-# Save checkpoint reflection
-"$LEGION" reflect --repo "$REPO" --text "[COMPACT CHECKPOINT] Work in progress before compaction: ${CONTEXT}" --domain "checkpoint" --tags "auto,precompact" 2>/dev/null
+# Save checkpoint reflection. PreCompact cannot emit additionalContext (the
+# session is about to be compacted, not resumed), so on failure we touch a
+# marker that post-compact.sh reads and surfaces via its own warning block.
+# This propagates the failure to the first hook that CAN surface context.
+# See #209 -- losing a checkpoint silently is what caused the original incident.
+"$LEGION" reflect --repo "$REPO" --text "[COMPACT CHECKPOINT] Work in progress before compaction: ${CONTEXT}" --domain "checkpoint" --tags "auto,precompact" 2>>"$LOG"
+if [ $? -ne 0 ]; then
+  touch "$CHECKPOINT_MARKER" 2>/dev/null
+else
+  # Previous run may have left a stale marker; clear it on successful reflect.
+  rm -f "$CHECKPOINT_MARKER" 2>/dev/null
+fi
 
 exit 0

--- a/plugin/hooks/recall-first.sh
+++ b/plugin/hooks/recall-first.sh
@@ -18,6 +18,10 @@
 LEGION="${CLAUDE_PLUGIN_ROOT}/bin/legion"
 LOG=/tmp/legion-hook-errors.log
 
+# Shared warning helper -- surfaces legion degradation instead of letting
+# it silently hide recall context from the agent. See #209.
+source "${CLAUDE_PLUGIN_ROOT}/hooks/_legion-warn.sh"
+
 INPUT=$(cat)
 CWD=$(echo "$INPUT" | jq -r '.cwd // empty')
 TOOL=$(echo "$INPUT" | jq -r '.tool_name // empty')
@@ -55,17 +59,29 @@ fi
 
 # Run recall. Short limit + preview truncation keep injected context compact.
 HITS=$("$LEGION" recall --repo "$REPO" --context "$QUERY" --limit 3 --preview 200 2>>"$LOG")
+legion_check $? "recall"
 
-# No hits -- don't inject anything, let the tool fire as normal
-if [ -z "$HITS" ]; then
+WARN=$(legion_warnings_block)
+
+# No hits and no warning -- don't inject anything, let the tool fire as normal.
+# If there's a warning, surface it even without hits so the agent knows recall
+# is degraded and shouldn't trust the absence of reflections as "nothing relevant".
+if [ -z "$HITS" ] && [ -z "$WARN" ]; then
   exit 0
 fi
 
-CTX="[Legion] Before ${TOOL}, recall hits for: ${QUERY}
+if [ -z "$HITS" ]; then
+  CTX="$WARN"
+else
+  CTX="[Legion] Before ${TOOL}, recall hits for: ${QUERY}
 
 ${HITS}
 
 If these answer your question, skip the ${TOOL}. Otherwise continue -- but consider whether the reflection explains WHY before you search for WHAT."
+  if [ -n "$WARN" ]; then
+    CTX="${WARN}"$'\n\n'"${CTX}"
+  fi
+fi
 
 jq -n --arg ctx "$CTX" '{
   "hookSpecificOutput": {

--- a/plugin/hooks/recall-first.sh
+++ b/plugin/hooks/recall-first.sh
@@ -20,6 +20,7 @@ LOG=/tmp/legion-hook-errors.log
 
 # Shared warning helper -- surfaces legion degradation instead of letting
 # it silently hide recall context from the agent. See #209.
+# shellcheck source=_legion-warn.sh
 source "${CLAUDE_PLUGIN_ROOT}/hooks/_legion-warn.sh"
 
 INPUT=$(cat)

--- a/plugin/hooks/session-start.sh
+++ b/plugin/hooks/session-start.sh
@@ -19,6 +19,10 @@
 LEGION="${CLAUDE_PLUGIN_ROOT}/bin/legion"
 LOG=/tmp/legion-hook-errors.log
 
+# Shared warning helper -- tracks degraded legion calls and renders a
+# visible block when any legion invocation exits nonzero. See #209.
+source "${CLAUDE_PLUGIN_ROOT}/hooks/_legion-warn.sh"
+
 INPUT=$(cat)
 CWD=$(echo "$INPUT" | jq -r '.cwd // empty')
 
@@ -41,12 +45,18 @@ touch "/tmp/legion-work-${CWD_HASH}"
 
 # Sync GitHub issues into kanban before session starts (5-second timeout to avoid blocking).
 # Opt-out via LEGION_NO_SYNC=1 (for environments without network access or to avoid latency).
+# A timeout exit is treated as "no sync this session" not a legion breakage -- don't surface it.
 if [ "${LEGION_NO_SYNC:-}" != "1" ]; then
   # Use gtimeout if available (macOS via homebrew), otherwise fall back to perl idiom.
   if command -v gtimeout >/dev/null 2>&1; then
     gtimeout 5 "$LEGION" sync --repo "$REPO" >/dev/null 2>>"$LOG"
   else
     perl -e 'alarm 5; exec @ARGV' -- "$LEGION" sync --repo "$REPO" >/dev/null 2>>"$LOG"
+  fi
+  SYNC_RC=$?
+  # 124 = gtimeout/perl SIGALRM; treat as informational, not a failure.
+  if [ "$SYNC_RC" -ne 0 ] && [ "$SYNC_RC" -ne 124 ] && [ "$SYNC_RC" -ne 142 ]; then
+    legion_check "$SYNC_RC" "sync"
   fi
 fi
 
@@ -56,13 +66,16 @@ BRANCH=$(cd "$CWD" && git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
 OUTPUT=""
 if [ -n "$BRANCH" ] && [ "$BRANCH" != "main" ] && [ "$BRANCH" != "master" ]; then
   OUTPUT=$("$LEGION" recall --repo "$REPO" --context "$BRANCH" --limit 2 --preview 240 2>>"$LOG")
+  legion_check $? "recall (branch)"
 fi
 if [ -z "$OUTPUT" ]; then
   OUTPUT=$("$LEGION" recall --repo "$REPO" --latest --limit 2 --preview 240 2>>"$LOG")
+  legion_check $? "recall (latest)"
 fi
 
 # Compact status counts from the JSON summary instead of full status text
 STATUS_JSON=$("$LEGION" status --repo "$REPO" --json 2>>"$LOG")
+legion_check $? "status --json"
 if [ -n "$STATUS_JSON" ]; then
   TASKS=$(echo "$STATUS_JSON" | jq -r '.tasks // 0')
   BLOCKED=$(echo "$STATUS_JSON" | jq -r '.blocked // 0')
@@ -91,6 +104,17 @@ if [ -n "$STATUS_JSON" ]; then
     else
       OUTPUT="$STATUS_LINE"
     fi
+  fi
+fi
+
+# Prepend a visible warning block if any legion call above failed.
+# The block is load-bearing for agent awareness of legion degradation -- see #209.
+WARN=$(legion_warnings_block)
+if [ -n "$WARN" ]; then
+  if [ -n "$OUTPUT" ]; then
+    OUTPUT="${WARN}"$'\n\n'"${OUTPUT}"
+  else
+    OUTPUT="$WARN"
   fi
 fi
 

--- a/plugin/hooks/session-start.sh
+++ b/plugin/hooks/session-start.sh
@@ -21,6 +21,7 @@ LOG=/tmp/legion-hook-errors.log
 
 # Shared warning helper -- tracks degraded legion calls and renders a
 # visible block when any legion invocation exits nonzero. See #209.
+# shellcheck source=_legion-warn.sh
 source "${CLAUDE_PLUGIN_ROOT}/hooks/_legion-warn.sh"
 
 INPUT=$(cat)

--- a/tests/hook_warnings.rs
+++ b/tests/hook_warnings.rs
@@ -190,74 +190,77 @@ fn assert_warned(hook: &str, stdout: &str, exit_code: i32) {
     );
 }
 
-// --- TEST 1: corrupted embedding column (the regression from 2026-04-11) ---
+/// One of the two broken-legion scenarios exercised by the tests.
+enum Corruption {
+    /// legion.db replaced with a directory -- every sqlite open fails.
+    Schema,
+    /// LEGION_DATA_DIR is a file where a directory is expected.
+    MissingDataDir,
+}
+
+/// Stdin JSON shape expected by the hook under test.
+enum InputKind {
+    /// `{"cwd": "..."}` -- session-start, bullpen-check, post-compact.
+    Cwd,
+    /// `{"cwd": "...", "tool_name": "Grep", "tool_input": {"pattern": "..."}}` -- recall-first.
+    Grep,
+}
+
+/// Build the hook test environment inside `temp`, applying the requested
+/// corruption, and return the `(plugin_root, legion_data_dir, cwd)` triple
+/// that `run_hook` needs. `temp` must outlive the returned paths.
+fn build_env(temp: &Path, corruption: Corruption) -> (PathBuf, PathBuf, PathBuf) {
+    let plugin_root = setup_plugin_root(temp);
+    let data_dir = match corruption {
+        Corruption::Schema => {
+            let d = temp.join("data");
+            fs::create_dir_all(&d).unwrap();
+            poison_schema(&d);
+            d
+        }
+        Corruption::MissingDataDir => broken_data_dir_as_file(temp),
+    };
+    let cwd = temp.join("legion");
+    fs::create_dir_all(&cwd).unwrap();
+    (plugin_root, data_dir, cwd)
+}
+
+/// Run the common "hook warns under broken legion" assertion. Drives the
+/// two corruption scenarios through the four surfaceable hooks without
+/// duplicating setup code across eight near-identical test bodies.
+fn assert_hook_warns(hook: &str, corruption: Corruption, input: InputKind) {
+    let temp = tempfile::tempdir().unwrap();
+    let (plugin_root, data_dir, cwd) = build_env(temp.path(), corruption);
+
+    let stdin = match input {
+        InputKind::Cwd => cwd_json(&cwd),
+        InputKind::Grep => grep_tool_json(&cwd),
+    };
+
+    let (stdout, _stderr, exit) = run_hook(hook, &plugin_root, &data_dir, &stdin);
+    assert_warned(hook, &stdout, exit);
+}
+
+// --- TEST 1: corrupted schema (the regression class from 2026-04-11) ---
 
 #[test]
 fn session_start_warns_on_corrupted_schema() {
-    let temp = tempfile::tempdir().unwrap();
-    let plugin_root = setup_plugin_root(temp.path());
-    let data_dir = temp.path().join("data");
-    fs::create_dir_all(&data_dir).unwrap();
-    poison_schema(&data_dir);
-
-    let cwd = temp.path().join("legion");
-    fs::create_dir_all(&cwd).unwrap();
-
-    let (stdout, _stderr, exit) =
-        run_hook("session-start.sh", &plugin_root, &data_dir, &cwd_json(&cwd));
-    assert_warned("session-start.sh", &stdout, exit);
+    assert_hook_warns("session-start.sh", Corruption::Schema, InputKind::Cwd);
 }
 
 #[test]
 fn recall_first_warns_on_corrupted_schema() {
-    let temp = tempfile::tempdir().unwrap();
-    let plugin_root = setup_plugin_root(temp.path());
-    let data_dir = temp.path().join("data");
-    fs::create_dir_all(&data_dir).unwrap();
-    poison_schema(&data_dir);
-
-    let cwd = temp.path().join("legion");
-    fs::create_dir_all(&cwd).unwrap();
-
-    let (stdout, _stderr, exit) = run_hook(
-        "recall-first.sh",
-        &plugin_root,
-        &data_dir,
-        &grep_tool_json(&cwd),
-    );
-    assert_warned("recall-first.sh", &stdout, exit);
+    assert_hook_warns("recall-first.sh", Corruption::Schema, InputKind::Grep);
 }
 
 #[test]
 fn bullpen_check_warns_on_corrupted_schema() {
-    let temp = tempfile::tempdir().unwrap();
-    let plugin_root = setup_plugin_root(temp.path());
-    let data_dir = temp.path().join("data");
-    fs::create_dir_all(&data_dir).unwrap();
-    poison_schema(&data_dir);
-
-    let cwd = temp.path().join("legion");
-    fs::create_dir_all(&cwd).unwrap();
-
-    let (stdout, _stderr, exit) =
-        run_hook("bullpen-check.sh", &plugin_root, &data_dir, &cwd_json(&cwd));
-    assert_warned("bullpen-check.sh", &stdout, exit);
+    assert_hook_warns("bullpen-check.sh", Corruption::Schema, InputKind::Cwd);
 }
 
 #[test]
 fn post_compact_warns_on_corrupted_schema() {
-    let temp = tempfile::tempdir().unwrap();
-    let plugin_root = setup_plugin_root(temp.path());
-    let data_dir = temp.path().join("data");
-    fs::create_dir_all(&data_dir).unwrap();
-    poison_schema(&data_dir);
-
-    let cwd = temp.path().join("legion");
-    fs::create_dir_all(&cwd).unwrap();
-
-    let (stdout, _stderr, exit) =
-        run_hook("post-compact.sh", &plugin_root, &data_dir, &cwd_json(&cwd));
-    assert_warned("post-compact.sh", &stdout, exit);
+    assert_hook_warns("post-compact.sh", Corruption::Schema, InputKind::Cwd);
 }
 
 #[test]
@@ -265,15 +268,11 @@ fn precompact_failure_propagates_to_post_compact_warning() {
     // precompact.sh cannot surface additionalContext itself -- the session
     // is about to compact. When its reflect call fails it touches a marker
     // that post-compact.sh reads on the next invocation and surfaces via
-    // its own warning block. This is the end-to-end path.
+    // its own warning block. This is the only end-to-end hook chain that
+    // needs bespoke setup (transcript_path + two sequential invocations),
+    // so it doesn't go through assert_hook_warns.
     let temp = tempfile::tempdir().unwrap();
-    let plugin_root = setup_plugin_root(temp.path());
-    let data_dir = temp.path().join("data");
-    fs::create_dir_all(&data_dir).unwrap();
-    poison_schema(&data_dir);
-
-    let cwd = temp.path().join("legion");
-    fs::create_dir_all(&cwd).unwrap();
+    let (plugin_root, data_dir, cwd) = build_env(temp.path(), Corruption::Schema);
     let transcript = temp.path().join("transcript.jsonl");
     fs::write(&transcript, b"").unwrap();
 
@@ -287,11 +286,11 @@ fn precompact_failure_propagates_to_post_compact_warning() {
     );
     assert_eq!(pre_exit, 0, "precompact must exit 0");
 
-    // The marker path is /tmp/legion-checkpoint-failed-<md5(cwd)>. We can't
-    // easily recompute the hash cross-platform here, so assert by running
-    // post-compact and inspecting its output -- if the marker was dropped,
-    // post-compact will include "precompact reflect (checkpoint not saved)"
-    // in its warning block.
+    // Marker path is /tmp/legion-checkpoint-failed-<md5(cwd)>. Recomputing
+    // the hash cross-platform would couple the test to the shell md5 tool;
+    // instead, run post-compact and assert its output surfaces the
+    // "precompact reflect (checkpoint not saved)" action string that
+    // post-compact only emits when the marker file is present.
     let (stdout, _stderr, exit) =
         run_hook("post-compact.sh", &plugin_root, &data_dir, &cwd_json(&cwd));
     assert_warned("post-compact.sh", &stdout, exit);
@@ -305,60 +304,36 @@ fn precompact_failure_propagates_to_post_compact_warning() {
 
 #[test]
 fn session_start_warns_on_missing_data_dir() {
-    let temp = tempfile::tempdir().unwrap();
-    let plugin_root = setup_plugin_root(temp.path());
-    let broken = broken_data_dir_as_file(temp.path());
-
-    let cwd = temp.path().join("legion");
-    fs::create_dir_all(&cwd).unwrap();
-
-    let (stdout, _stderr, exit) =
-        run_hook("session-start.sh", &plugin_root, &broken, &cwd_json(&cwd));
-    assert_warned("session-start.sh", &stdout, exit);
+    assert_hook_warns(
+        "session-start.sh",
+        Corruption::MissingDataDir,
+        InputKind::Cwd,
+    );
 }
 
 #[test]
 fn recall_first_warns_on_missing_data_dir() {
-    let temp = tempfile::tempdir().unwrap();
-    let plugin_root = setup_plugin_root(temp.path());
-    let broken = broken_data_dir_as_file(temp.path());
-
-    let cwd = temp.path().join("legion");
-    fs::create_dir_all(&cwd).unwrap();
-
-    let (stdout, _stderr, exit) = run_hook(
+    assert_hook_warns(
         "recall-first.sh",
-        &plugin_root,
-        &broken,
-        &grep_tool_json(&cwd),
+        Corruption::MissingDataDir,
+        InputKind::Grep,
     );
-    assert_warned("recall-first.sh", &stdout, exit);
 }
 
 #[test]
 fn bullpen_check_warns_on_missing_data_dir() {
-    let temp = tempfile::tempdir().unwrap();
-    let plugin_root = setup_plugin_root(temp.path());
-    let broken = broken_data_dir_as_file(temp.path());
-
-    let cwd = temp.path().join("legion");
-    fs::create_dir_all(&cwd).unwrap();
-
-    let (stdout, _stderr, exit) =
-        run_hook("bullpen-check.sh", &plugin_root, &broken, &cwd_json(&cwd));
-    assert_warned("bullpen-check.sh", &stdout, exit);
+    assert_hook_warns(
+        "bullpen-check.sh",
+        Corruption::MissingDataDir,
+        InputKind::Cwd,
+    );
 }
 
 #[test]
 fn post_compact_warns_on_missing_data_dir() {
-    let temp = tempfile::tempdir().unwrap();
-    let plugin_root = setup_plugin_root(temp.path());
-    let broken = broken_data_dir_as_file(temp.path());
-
-    let cwd = temp.path().join("legion");
-    fs::create_dir_all(&cwd).unwrap();
-
-    let (stdout, _stderr, exit) =
-        run_hook("post-compact.sh", &plugin_root, &broken, &cwd_json(&cwd));
-    assert_warned("post-compact.sh", &stdout, exit);
+    assert_hook_warns(
+        "post-compact.sh",
+        Corruption::MissingDataDir,
+        InputKind::Cwd,
+    );
 }

--- a/tests/hook_warnings.rs
+++ b/tests/hook_warnings.rs
@@ -1,0 +1,364 @@
+//! Integration tests for legion hook warnings (#209).
+//!
+//! Regression guard: prior to #209 every legion hook piped stderr to
+//! /tmp/legion-hook-errors.log (or /dev/null) and silently exited 0 on
+//! failure. When legion itself was broken (corrupted embedding column,
+//! missing data dir, schema mismatch) the agent lost recall + bullpen
+//! context mid-session with zero visible signal. Compounding incidents
+//! masked as agent idiocy for days.
+//!
+//! These tests construct two broken legion environments and assert that
+//! every hook surfaces a visible `[Legion WARNING]` block in its stdout
+//! while still exiting 0 (so Claude Code never blocks on legion failures).
+
+use std::fs;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+
+const WARNING_SENTINEL: &str = "[Legion WARNING]";
+
+/// Build a self-contained test CLAUDE_PLUGIN_ROOT in `temp` containing:
+///   - bin/legion -- a wrapper script that execs the cargo-built test binary
+///   - hooks/<all-under-test>.sh + _legion-warn.sh copied from source tree
+fn setup_plugin_root(temp: &Path) -> PathBuf {
+    let plugin_root = temp.join("plugin");
+    fs::create_dir_all(plugin_root.join("bin")).expect("mkdir bin");
+    fs::create_dir_all(plugin_root.join("hooks")).expect("mkdir hooks");
+
+    let legion_bin = plugin_root.join("bin").join("legion");
+    let test_binary = env!("CARGO_BIN_EXE_legion");
+    fs::write(
+        &legion_bin,
+        format!("#!/bin/bash\nexec \"{}\" \"$@\"\n", test_binary),
+    )
+    .expect("write legion wrapper");
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut perms = fs::metadata(&legion_bin)
+            .expect("stat wrapper")
+            .permissions();
+        perms.set_mode(0o755);
+        fs::set_permissions(&legion_bin, perms).expect("chmod wrapper");
+    }
+
+    let src_hooks = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("plugin")
+        .join("hooks");
+    for hook in [
+        "_legion-warn.sh",
+        "session-start.sh",
+        "recall-first.sh",
+        "bullpen-check.sh",
+        "post-compact.sh",
+        "precompact.sh",
+    ] {
+        fs::copy(src_hooks.join(hook), plugin_root.join("hooks").join(hook))
+            .unwrap_or_else(|e| panic!("copy {}: {}", hook, e));
+    }
+
+    plugin_root
+}
+
+/// Invoke a hook by name, write `stdin_json` to its stdin, and return
+/// (stdout, stderr, exit_code). The hook is run under bash with the
+/// supplied CLAUDE_PLUGIN_ROOT and LEGION_DATA_DIR environment.
+/// LEGION_NO_SYNC=1 is set to skip the sync path that would otherwise
+/// hit the network and muddy the test.
+fn run_hook(
+    hook: &str,
+    plugin_root: &Path,
+    data_dir: &Path,
+    stdin_json: &str,
+) -> (String, String, i32) {
+    let hook_path = plugin_root.join("hooks").join(hook);
+    let mut child = Command::new("bash")
+        .arg(&hook_path)
+        .env("CLAUDE_PLUGIN_ROOT", plugin_root)
+        .env("LEGION_DATA_DIR", data_dir)
+        .env("LEGION_NO_SYNC", "1")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap_or_else(|e| panic!("spawn {}: {}", hook, e));
+
+    child
+        .stdin
+        .as_mut()
+        .expect("stdin handle")
+        .write_all(stdin_json.as_bytes())
+        .expect("write stdin");
+
+    let output = child.wait_with_output().expect("wait hook");
+    (
+        String::from_utf8_lossy(&output.stdout).into_owned(),
+        String::from_utf8_lossy(&output.stderr).into_owned(),
+        output.status.code().unwrap_or(-1),
+    )
+}
+
+/// Create a broken LEGION_DATA_DIR by writing a regular file where a
+/// directory is expected. Every legion invocation that tries to read or
+/// create subpaths inside will fail.
+fn broken_data_dir_as_file(temp: &Path) -> PathBuf {
+    let path = temp.join("broken-data-dir");
+    fs::write(&path, b"not-a-directory").expect("write decoy file");
+    path
+}
+
+/// Initialize a legion data dir via a real `legion reflect` call, then
+/// corrupt it catastrophically by replacing `legion.db` with a directory
+/// of the same name. Every subsequent SQLite open fails because sqlite3
+/// cannot treat a directory as a database file.
+///
+/// Less catastrophic corruption (DROP TABLE, UPDATE to wrong type, write
+/// junk bytes) did not work reliably: legion's `init_schema` re-runs on
+/// every open with `CREATE TABLE IF NOT EXISTS`, so schema-level damage
+/// silently heals itself. Type-affinity damage only triggers on paths
+/// that actually deserialize the embedding column as BLOB, which is a
+/// subset of legion reads. The directory-in-place-of-file trick is
+/// path-independent and survives every legion recovery attempt -- the
+/// same failure class as the 2026-04-11 incident where a data dir was
+/// unusable but legion hooks gave no visible signal. See #209.
+fn poison_schema(data_dir: &Path) {
+    let init = Command::new(env!("CARGO_BIN_EXE_legion"))
+        .env("LEGION_DATA_DIR", data_dir)
+        .args([
+            "reflect",
+            "--repo",
+            "legion",
+            "--text",
+            "sentinel reflection so the data dir is fully initialized",
+        ])
+        .output()
+        .expect("spawn legion reflect");
+    assert!(
+        init.status.success(),
+        "legion reflect init failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&init.stdout),
+        String::from_utf8_lossy(&init.stderr)
+    );
+
+    let db_path = data_dir.join("legion.db");
+    assert!(
+        db_path.exists(),
+        "legion.db missing after reflect -- schema changed?"
+    );
+
+    // Remove the db and its WAL/SHM sidecars, then put a directory in
+    // place of the main file. Legion cannot open a directory as a db.
+    fs::remove_file(&db_path).expect("rm legion.db");
+    let _ = fs::remove_file(data_dir.join("legion.db-shm"));
+    let _ = fs::remove_file(data_dir.join("legion.db-wal"));
+    fs::create_dir(&db_path).expect("mkdir in place of legion.db");
+}
+
+/// Build stdin JSON shaped for a hook that only needs `cwd`.
+fn cwd_json(cwd: &Path) -> String {
+    format!(r#"{{"cwd": "{}"}}"#, cwd.display())
+}
+
+/// Build stdin JSON for recall-first.sh: cwd + tool metadata.
+fn grep_tool_json(cwd: &Path) -> String {
+    format!(
+        r#"{{"cwd": "{}", "tool_name": "Grep", "tool_input": {{"pattern": "some-query-longer-than-four"}}}}"#,
+        cwd.display()
+    )
+}
+
+/// Build stdin JSON for precompact.sh: cwd + transcript_path.
+fn precompact_json(cwd: &Path, transcript: &Path) -> String {
+    format!(
+        r#"{{"cwd": "{}", "transcript_path": "{}"}}"#,
+        cwd.display(),
+        transcript.display()
+    )
+}
+
+/// Assert that hook output contains the warning sentinel and the hook
+/// still exited 0 (never break Claude Code).
+fn assert_warned(hook: &str, stdout: &str, exit_code: i32) {
+    assert_eq!(
+        exit_code, 0,
+        "{hook} must exit 0 even on legion failure (got {exit_code})\nstdout: {stdout}"
+    );
+    assert!(
+        stdout.contains(WARNING_SENTINEL),
+        "{hook} stdout missing {WARNING_SENTINEL}:\n{stdout}"
+    );
+}
+
+// --- TEST 1: corrupted embedding column (the regression from 2026-04-11) ---
+
+#[test]
+fn session_start_warns_on_corrupted_schema() {
+    let temp = tempfile::tempdir().unwrap();
+    let plugin_root = setup_plugin_root(temp.path());
+    let data_dir = temp.path().join("data");
+    fs::create_dir_all(&data_dir).unwrap();
+    poison_schema(&data_dir);
+
+    let cwd = temp.path().join("legion");
+    fs::create_dir_all(&cwd).unwrap();
+
+    let (stdout, _stderr, exit) =
+        run_hook("session-start.sh", &plugin_root, &data_dir, &cwd_json(&cwd));
+    assert_warned("session-start.sh", &stdout, exit);
+}
+
+#[test]
+fn recall_first_warns_on_corrupted_schema() {
+    let temp = tempfile::tempdir().unwrap();
+    let plugin_root = setup_plugin_root(temp.path());
+    let data_dir = temp.path().join("data");
+    fs::create_dir_all(&data_dir).unwrap();
+    poison_schema(&data_dir);
+
+    let cwd = temp.path().join("legion");
+    fs::create_dir_all(&cwd).unwrap();
+
+    let (stdout, _stderr, exit) = run_hook(
+        "recall-first.sh",
+        &plugin_root,
+        &data_dir,
+        &grep_tool_json(&cwd),
+    );
+    assert_warned("recall-first.sh", &stdout, exit);
+}
+
+#[test]
+fn bullpen_check_warns_on_corrupted_schema() {
+    let temp = tempfile::tempdir().unwrap();
+    let plugin_root = setup_plugin_root(temp.path());
+    let data_dir = temp.path().join("data");
+    fs::create_dir_all(&data_dir).unwrap();
+    poison_schema(&data_dir);
+
+    let cwd = temp.path().join("legion");
+    fs::create_dir_all(&cwd).unwrap();
+
+    let (stdout, _stderr, exit) =
+        run_hook("bullpen-check.sh", &plugin_root, &data_dir, &cwd_json(&cwd));
+    assert_warned("bullpen-check.sh", &stdout, exit);
+}
+
+#[test]
+fn post_compact_warns_on_corrupted_schema() {
+    let temp = tempfile::tempdir().unwrap();
+    let plugin_root = setup_plugin_root(temp.path());
+    let data_dir = temp.path().join("data");
+    fs::create_dir_all(&data_dir).unwrap();
+    poison_schema(&data_dir);
+
+    let cwd = temp.path().join("legion");
+    fs::create_dir_all(&cwd).unwrap();
+
+    let (stdout, _stderr, exit) =
+        run_hook("post-compact.sh", &plugin_root, &data_dir, &cwd_json(&cwd));
+    assert_warned("post-compact.sh", &stdout, exit);
+}
+
+#[test]
+fn precompact_failure_propagates_to_post_compact_warning() {
+    // precompact.sh cannot surface additionalContext itself -- the session
+    // is about to compact. When its reflect call fails it touches a marker
+    // that post-compact.sh reads on the next invocation and surfaces via
+    // its own warning block. This is the end-to-end path.
+    let temp = tempfile::tempdir().unwrap();
+    let plugin_root = setup_plugin_root(temp.path());
+    let data_dir = temp.path().join("data");
+    fs::create_dir_all(&data_dir).unwrap();
+    poison_schema(&data_dir);
+
+    let cwd = temp.path().join("legion");
+    fs::create_dir_all(&cwd).unwrap();
+    let transcript = temp.path().join("transcript.jsonl");
+    fs::write(&transcript, b"").unwrap();
+
+    // Run precompact first -- reflect should fail on the poisoned DB and
+    // the marker file should get dropped. precompact exits 0 with no stdout.
+    let (_pre_stdout, _pre_stderr, pre_exit) = run_hook(
+        "precompact.sh",
+        &plugin_root,
+        &data_dir,
+        &precompact_json(&cwd, &transcript),
+    );
+    assert_eq!(pre_exit, 0, "precompact must exit 0");
+
+    // The marker path is /tmp/legion-checkpoint-failed-<md5(cwd)>. We can't
+    // easily recompute the hash cross-platform here, so assert by running
+    // post-compact and inspecting its output -- if the marker was dropped,
+    // post-compact will include "precompact reflect (checkpoint not saved)"
+    // in its warning block.
+    let (stdout, _stderr, exit) =
+        run_hook("post-compact.sh", &plugin_root, &data_dir, &cwd_json(&cwd));
+    assert_warned("post-compact.sh", &stdout, exit);
+    assert!(
+        stdout.contains("precompact reflect"),
+        "post-compact stdout should surface the precompact failure chain:\n{stdout}"
+    );
+}
+
+// --- TEST 2: missing / broken data directory (file where dir expected) ---
+
+#[test]
+fn session_start_warns_on_missing_data_dir() {
+    let temp = tempfile::tempdir().unwrap();
+    let plugin_root = setup_plugin_root(temp.path());
+    let broken = broken_data_dir_as_file(temp.path());
+
+    let cwd = temp.path().join("legion");
+    fs::create_dir_all(&cwd).unwrap();
+
+    let (stdout, _stderr, exit) =
+        run_hook("session-start.sh", &plugin_root, &broken, &cwd_json(&cwd));
+    assert_warned("session-start.sh", &stdout, exit);
+}
+
+#[test]
+fn recall_first_warns_on_missing_data_dir() {
+    let temp = tempfile::tempdir().unwrap();
+    let plugin_root = setup_plugin_root(temp.path());
+    let broken = broken_data_dir_as_file(temp.path());
+
+    let cwd = temp.path().join("legion");
+    fs::create_dir_all(&cwd).unwrap();
+
+    let (stdout, _stderr, exit) = run_hook(
+        "recall-first.sh",
+        &plugin_root,
+        &broken,
+        &grep_tool_json(&cwd),
+    );
+    assert_warned("recall-first.sh", &stdout, exit);
+}
+
+#[test]
+fn bullpen_check_warns_on_missing_data_dir() {
+    let temp = tempfile::tempdir().unwrap();
+    let plugin_root = setup_plugin_root(temp.path());
+    let broken = broken_data_dir_as_file(temp.path());
+
+    let cwd = temp.path().join("legion");
+    fs::create_dir_all(&cwd).unwrap();
+
+    let (stdout, _stderr, exit) =
+        run_hook("bullpen-check.sh", &plugin_root, &broken, &cwd_json(&cwd));
+    assert_warned("bullpen-check.sh", &stdout, exit);
+}
+
+#[test]
+fn post_compact_warns_on_missing_data_dir() {
+    let temp = tempfile::tempdir().unwrap();
+    let plugin_root = setup_plugin_root(temp.path());
+    let broken = broken_data_dir_as_file(temp.path());
+
+    let cwd = temp.path().join("legion");
+    fs::create_dir_all(&cwd).unwrap();
+
+    let (stdout, _stderr, exit) =
+        run_hook("post-compact.sh", &plugin_root, &broken, &cwd_json(&cwd));
+    assert_warned("post-compact.sh", &stdout, exit);
+}


### PR DESCRIPTION
Closes #209.

## Problem

Every legion hook piped stderr to /tmp/legion-hook-errors.log (or /dev/null in bullpen-check.sh) and silently exited 0 on failure. When legion itself was broken -- corrupted embedding column, missing data dir, schema mismatch, wrong CLAUDE_PLUGIN_ROOT -- the agent lost recall + bullpen context mid-session with no visible signal. The 2026-04-11 incident was a compounding failure chain that cost roughly an hour because post-compact silently hit a corrupted DB and the agent had no way to know. Reflection 019d7a6d-4042-7b93-9c89-8d88bef36905 documents the full chain.

## Solution

Every plugin hook now runs its legion invocations through a shared `plugin/hooks/_legion-warn.sh` helper that tracks failed calls and renders a visible `[Legion WARNING]` block in `additionalContext`. Hooks still exit 0 on legion failure -- Claude Code never blocks -- but the agent sees exactly which legion commands failed and is pointed at /tmp/legion-hook-errors.log plus the common root causes.

## Changed files

- `plugin/hooks/_legion-warn.sh` (new): `legion_check` + `legion_warnings_block`, sentinel string `[Legion WARNING]` grepped by the integration tests.
- `plugin/hooks/session-start.sh`: checks sync, recall (branch + latest), status. Treats gtimeout exit codes 124/142 as non-failures so a legitimate 5-second sync timeout doesn't masquerade as legion breakage.
- `plugin/hooks/recall-first.sh`: checks recall. Surfaces the warning even when HITS is empty so the agent knows absence is degradation, not legitimate no-match.
- `plugin/hooks/bullpen-check.sh`: checks bullpen --count. Routes stderr to LOG (was /dev/null).
- `plugin/hooks/post-compact.sh`: checks recall (checkpoint + branch), surface, bullpen. Warning block is prepended to the re-orientation output -- this is the critical path per the original incident.
- `plugin/hooks/precompact.sh`: PreCompact cannot surface additionalContext (session is about to compact). On reflect failure it touches /tmp/legion-checkpoint-failed-<cwd-hash> which post-compact.sh reads on its next run and surfaces via its own warning block. The marker gets cleaned up on successful reflect to prevent stale carryover.

## Tests

`tests/hook_warnings.rs` -- 9 integration tests covering:

**Corrupted schema** (directory-in-place-of-db-file, the only corruption that survives legion's self-healing `init_schema` migration path):
- session-start.sh warns
- recall-first.sh warns (with Grep tool input)
- bullpen-check.sh warns
- post-compact.sh warns
- precompact -> post-compact marker chain: run precompact on poisoned data dir, then run post-compact, assert its output contains "precompact reflect (checkpoint not saved)"

**Missing / broken data dir** (file-in-place-of-dir):
- session-start.sh warns
- recall-first.sh warns
- bullpen-check.sh warns
- post-compact.sh warns

Every test asserts the hook still exits 0 (Claude Code must never block on legion failure). Tests use a sandboxed CLAUDE_PLUGIN_ROOT tempdir with a wrapper bin/legion pointing at CARGO_BIN_EXE_legion, so the suite is hermetic.

An initial spec-literal corruption (embedding column UPDATE to TEXT) only broke legion paths that actually deserialize embedding as BLOB -- not all of them. DROP TABLE reflections was too gentle: legion's `init_schema` recreates the table on next open. Directory-in-place-of-sqlite-file is the only corruption that reliably breaks every legion invocation, and it represents the same failure class as the 2026-04-11 incident (an unusable data dir). Test comment documents the reasoning.

## Quality gates

- `cargo test` -- 81 pass (72 pre-existing + 9 new, 2 ignored)
- `cargo clippy --all-targets -- -D warnings` -- clean
- `cargo fmt -- --check` -- clean
- `/legion-simplify` -- clean (gate 019d7b3a-1ff0-7110-9b33-585e9f3d022e); one MED finding about test body duplication was fixed in commit 86d5547 before recording clean

## Audit of write paths

No changes to ChannelEvent broadcast or similar -- this PR is hook-only. All edits are on explicit file paths, no `git add -A`. The branch carries exactly 7 files: 5 modified hooks, 1 new helper, 1 new test module.

## Out of scope

- rmcp port of src/mcp.rs (covered separately by #216)
- gitignore addition for `.claude/worktrees/` (orthogonal cleanup)

## Test plan

1. Build updated binary.
2. Start a fresh Claude Code session with LEGION_DATA_DIR pointing at a file (not a directory).
3. Verify session-start injects a `[Legion WARNING]` additionalContext block naming the failed actions (sync / recall / status).
4. With a healthy LEGION_DATA_DIR, verify no warning block appears (baseline).
5. Corrupt the healthy data dir mid-session (replace the sqlite file with a directory of the same name) and run a Grep tool call -- recall-first.sh should emit the warning.