### PR TITLE
feat(#216): channel MCP emits notifications/claude/channel on new bullpen posts

### DIFF
--- a/src/channel.rs
+++ b/src/channel.rs
@@ -33,8 +33,9 @@ const PING_INTERVAL_SECS: u64 = 30;
 /// receiving any variant and re-read from the database.
 #[derive(Debug, Clone)]
 pub enum ChannelEvent {
-    /// New board post or reflection arrived.
-    Feed,
+    /// New board post or reflection arrived. Carries the post ID so MCP
+    /// notification emitters can look up the exact post without a full scan.
+    Feed { post_id: String },
     /// Task table changed.
     Tasks,
 }
@@ -239,7 +240,9 @@ pub async fn api_post(
     };
 
     // Notify SSE subscribers (best-effort; no SSE listeners is not an error).
-    let _ = state.tx.send(ChannelEvent::Feed);
+    let _ = state.tx.send(ChannelEvent::Feed {
+        post_id: id.clone(),
+    });
 
     Json(serde_json::json!({ "id": id })).into_response()
 }
@@ -432,9 +435,12 @@ mod tests {
     #[test]
     fn broadcast_channel_delivers_events() {
         let (tx, mut rx) = new_broadcast();
-        tx.send(ChannelEvent::Feed).expect("send");
+        tx.send(ChannelEvent::Feed {
+            post_id: "test-id".to_string(),
+        })
+        .expect("send");
         let evt = rx.try_recv().expect("recv");
-        assert!(matches!(evt, ChannelEvent::Feed));
+        assert!(matches!(evt, ChannelEvent::Feed { .. }));
     }
 
     #[test]
@@ -470,8 +476,14 @@ mod tests {
         let (tx, mut rx) = broadcast::channel::<ChannelEvent>(1);
 
         // Fill past capacity without the subscriber reading.
-        tx.send(ChannelEvent::Feed).expect("send 1");
-        tx.send(ChannelEvent::Feed).expect("send 2");
+        tx.send(ChannelEvent::Feed {
+            post_id: "id-1".to_string(),
+        })
+        .expect("send 1");
+        tx.send(ChannelEvent::Feed {
+            post_id: "id-2".to_string(),
+        })
+        .expect("send 2");
 
         // The first recv should be Lagged since we overflowed the 1-slot buffer.
         let result = rx.try_recv();

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -540,13 +540,27 @@ pub fn run_stdio_loop(
     let mut rx = tx.subscribe();
 
     std::thread::spawn(move || {
+        // Open the db once for the lifetime of this notifier thread. A prior
+        // draft reopened inside the loop on every event; that paid a file-open
+        // cost per bullpen post per connected client. A long-lived handle is
+        // fine here because the notifier thread's only job is read-only lookup
+        // of freshly inserted rows, and SQLite's default journal mode handles
+        // that concurrent read cleanly.
+        let db = match Database::open(&notif_data_dir.join("legion.db")) {
+            Ok(db) => db,
+            Err(e) => {
+                eprintln!("[legion mcp notif] failed to open db: {e}; notifier thread exiting");
+                return;
+            }
+        };
+
         loop {
             let event = match rx.blocking_recv() {
                 Ok(e) => e,
                 Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
-                    eprintln!(
-                        "[legion mcp notif] lagged {n} events; re-subscribing next iteration"
-                    );
+                    // tokio's broadcast receiver recovers internally on the
+                    // next recv; no manual resubscribe needed.
+                    eprintln!("[legion mcp notif] lagged {n} events; dropping and continuing");
                     continue;
                 }
                 Err(tokio::sync::broadcast::error::RecvError::Closed) => {
@@ -556,17 +570,8 @@ pub fn run_stdio_loop(
             };
 
             let post_id = match event {
-                ChannelEvent::Feed { ref post_id } => post_id.clone(),
+                ChannelEvent::Feed { post_id } => post_id,
                 ChannelEvent::Tasks => continue, // no task notifications in this issue
-            };
-
-            // Look up the post from the database.
-            let db = match Database::open(&notif_data_dir.join("legion.db")) {
-                Ok(db) => db,
-                Err(e) => {
-                    eprintln!("[legion mcp notif] failed to open db: {e}");
-                    continue;
-                }
             };
 
             let post = match db.get_reflection_by_id(&post_id) {

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -9,6 +9,7 @@
 /// No Content-Length headers. Each message is a single JSON line.
 use std::io::{BufRead, BufReader, Write};
 use std::path::PathBuf;
+use std::sync::{Arc, Mutex, OnceLock};
 
 use serde_json::{Value, json};
 use tokio::sync::broadcast;
@@ -239,7 +240,9 @@ fn handle_tool_call(
                 &crate::db::ReflectionMeta::default(),
             )?;
 
-            let _ = tx.send(ChannelEvent::Feed);
+            let _ = tx.send(ChannelEvent::Feed {
+                post_id: id.clone(),
+            });
 
             Ok(format!("posted (id: {})", id))
         }
@@ -267,7 +270,9 @@ fn handle_tool_call(
                 &crate::db::ReflectionMeta::default(),
             )?;
 
-            let _ = tx.send(ChannelEvent::Feed);
+            let _ = tx.send(ChannelEvent::Feed {
+                post_id: id.clone(),
+            });
 
             Ok(format!("replied (id: {})", id))
         }
@@ -318,7 +323,9 @@ fn handle_tool_call(
                 &crate::db::ReflectionMeta::default(),
             )?;
 
-            let _ = tx.send(ChannelEvent::Feed);
+            let _ = tx.send(ChannelEvent::Feed {
+                post_id: id.clone(),
+            });
 
             Ok(format!("signaled (id: {})", id))
         }
@@ -358,11 +365,15 @@ fn handle_tool_call(
 ///
 /// Returns None for notifications (which have no id) -- not used here but
 /// guards against future notification handling.
+///
+/// `client_repo_cell` is populated on the `initialize` call so the notification
+/// emitter thread can learn the client's repo identity after the handshake.
 pub fn dispatch(
     request: &Value,
     data_dir: &std::path::Path,
     version: &str,
     tx: &broadcast::Sender<ChannelEvent>,
+    client_repo_cell: Option<&Arc<OnceLock<String>>>,
 ) -> Option<Value> {
     let id = request.get("id").cloned().unwrap_or(Value::Null);
     let method = request.get("method").and_then(|m| m.as_str());
@@ -376,22 +387,37 @@ pub fn dispatch(
     };
 
     match method {
-        "initialize" => Some(success_response(
-            &id,
-            json!({
-                "protocolVersion": PROTOCOL_VERSION,
-                "capabilities": {
-                    "tools": {},
-                    "experimental": {
-                        "claude/channel": {}
-                    }
-                },
-                "serverInfo": {
-                    "name": "legion-channel",
-                    "version": version
-                }
-            }),
-        )),
+        "initialize" => {
+            // Extract clientInfo.name to identify the connecting agent's repo.
+            // This is stored for use by the notification emitter thread via the
+            // shared client_repo cell passed into run_stdio_loop.
+            if let Some(cell) = client_repo_cell
+                && let Some(name) = request
+                    .get("params")
+                    .and_then(|p| p.get("clientInfo"))
+                    .and_then(|ci| ci.get("name"))
+                    .and_then(|n| n.as_str())
+            {
+                let _ = cell.set(name.to_string());
+            }
+            Some(success_response(
+                &id,
+                json!({
+                    "protocolVersion": PROTOCOL_VERSION,
+                    "capabilities": {
+                        "tools": {},
+                        "experimental": {
+                            "claude/channel": {}
+                        }
+                    },
+                    "serverInfo": {
+                        "name": "legion-channel",
+                        "version": version
+                    },
+                    "instructions": "Incoming bullpen posts and signals arrive as JSON-RPC notifications with method notifications/claude/channel. Each notification params.content is an XML-like <channel> tag: <channel type=\"feed\" post_id=\"<uuid>\" repo=\"<repo>\" is_signal=\"<bool>\"><text><![CDATA[post text]]></text></channel>. Read these notifications and integrate them into your working context. No manual polling needed."
+                }),
+            ))
+        }
 
         "notifications/initialized" => {
             // Client acknowledgment -- no response needed
@@ -439,9 +465,57 @@ pub fn dispatch(
 /// prevent unbounded memory growth from a malicious or misbehaving client.
 const MAX_LINE_BYTES: usize = 1024 * 1024; // 1 MiB
 
+/// Determine whether a notification for a post should be delivered to this client.
+///
+/// Rules (applied in order):
+/// 1. If the text starts with `@all`, deliver unconditionally (broadcast signal).
+/// 2. If the text starts with `@<client_repo>` (direct mention), deliver.
+/// 3. If the text starts with `@` but NOT addressed to this client, suppress.
+/// 4. If `client_repo` is known and the post's `repo` equals `client_repo`, suppress
+///    (the client wrote it; no need to echo a general musing back to its author).
+/// 5. Otherwise (general musing, no `@` prefix, from a different agent), deliver.
+pub fn should_notify(text: &str, repo: &str, client_repo: Option<&str>) -> bool {
+    if let Some(rest) = text.strip_prefix('@') {
+        // It's a signal. Check if it's addressed to us or to "all".
+        let recipient = rest
+            .split_whitespace()
+            .next()
+            .unwrap_or("")
+            .trim_end_matches(':');
+        if recipient == "all" {
+            return true;
+        }
+        if let Some(cr) = client_repo {
+            return recipient == cr;
+        }
+        // No client_repo known -- suppress signals (can't verify recipient).
+        return false;
+    }
+
+    // General musing: suppress own posts, deliver everything else.
+    if let Some(cr) = client_repo
+        && repo == cr
+    {
+        return false;
+    }
+
+    true
+}
+
+/// Build the XML-like channel notification content string.
+fn build_channel_content(post_id: &str, repo: &str, text: &str, is_signal: bool) -> String {
+    format!(
+        "<channel type=\"feed\" post_id=\"{post_id}\" repo=\"{repo}\" is_signal=\"{is_signal}\"><text><![CDATA[{text}]]></text></channel>"
+    )
+}
+
 /// Run the MCP stdio server loop.
 ///
-/// Reads newline-delimited JSON from stdin. Writes responses to stdout.
+/// Reads newline-delimited JSON from stdin. Writes JSON-RPC responses to stdout.
+/// A concurrent notification emitter thread subscribes to the broadcast channel
+/// and pushes `notifications/claude/channel` messages to stdout when new bullpen
+/// posts arrive that pass the recipient filter.
+///
 /// Blocks the calling thread (meant to run in spawn_blocking or a dedicated thread).
 /// Lines larger than MAX_LINE_BYTES are rejected with a JSON-RPC parse error.
 pub fn run_stdio_loop(
@@ -449,9 +523,90 @@ pub fn run_stdio_loop(
     version: String,
     tx: broadcast::Sender<ChannelEvent>,
 ) -> Result<()> {
-    let stdin = std::io::stdin();
+    // Shared stdout writer -- both the request loop and the notification thread
+    // write to stdout. The Mutex serialises their writes so lines never interleave.
     let stdout = std::io::stdout();
-    let mut out = std::io::BufWriter::new(stdout.lock());
+    let out: Arc<Mutex<std::io::BufWriter<std::io::Stdout>>> =
+        Arc::new(Mutex::new(std::io::BufWriter::new(stdout)));
+
+    // Shared cell so the request loop can inform the notification thread which
+    // repo the connected client belongs to (extracted from initialize clientInfo.name).
+    let client_repo_cell: Arc<OnceLock<String>> = Arc::new(OnceLock::new());
+
+    // Spawn the notification emitter thread before entering the blocking read loop.
+    let notif_out = Arc::clone(&out);
+    let notif_data_dir = data_dir.clone();
+    let notif_client_repo = Arc::clone(&client_repo_cell);
+    let mut rx = tx.subscribe();
+
+    std::thread::spawn(move || {
+        loop {
+            let event = match rx.blocking_recv() {
+                Ok(e) => e,
+                Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
+                    eprintln!(
+                        "[legion mcp notif] lagged {n} events; re-subscribing next iteration"
+                    );
+                    continue;
+                }
+                Err(tokio::sync::broadcast::error::RecvError::Closed) => {
+                    eprintln!("[legion mcp notif] broadcast closed; exiting notifier");
+                    break;
+                }
+            };
+
+            let post_id = match event {
+                ChannelEvent::Feed { ref post_id } => post_id.clone(),
+                ChannelEvent::Tasks => continue, // no task notifications in this issue
+            };
+
+            // Look up the post from the database.
+            let db = match Database::open(&notif_data_dir.join("legion.db")) {
+                Ok(db) => db,
+                Err(e) => {
+                    eprintln!("[legion mcp notif] failed to open db: {e}");
+                    continue;
+                }
+            };
+
+            let post = match db.get_reflection_by_id(&post_id) {
+                Ok(Some(p)) => p,
+                Ok(None) => {
+                    eprintln!("[legion mcp notif] post {post_id} not found");
+                    continue;
+                }
+                Err(e) => {
+                    eprintln!("[legion mcp notif] db lookup failed: {e}");
+                    continue;
+                }
+            };
+
+            let client_repo = notif_client_repo.get().map(|s| s.as_str());
+            let is_signal = crate::signal::is_signal(&post.text);
+
+            if !should_notify(&post.text, &post.repo, client_repo) {
+                continue;
+            }
+
+            let content = build_channel_content(&post.id, &post.repo, &post.text, is_signal);
+            let notification = json!({
+                "jsonrpc": "2.0",
+                "method": "notifications/claude/channel",
+                "params": {
+                    "content": content
+                }
+            });
+
+            if let Ok(s) = serde_json::to_string(&notification)
+                && let Ok(mut locked) = notif_out.lock()
+            {
+                let _ = writeln!(locked, "{s}");
+                let _ = locked.flush();
+            }
+        }
+    });
+
+    let stdin = std::io::stdin();
     let mut reader = BufReader::new(stdin.lock());
     let mut buf: Vec<u8> = Vec::with_capacity(4096);
 
@@ -473,9 +628,11 @@ pub fn run_stdio_loop(
             );
             let id = Value::Null;
             let resp = error_response(&id, -32700, "message too large");
-            if let Ok(s) = serde_json::to_string(&resp) {
-                let _ = writeln!(out, "{s}");
-                let _ = out.flush();
+            if let Ok(s) = serde_json::to_string(&resp)
+                && let Ok(mut locked) = out.lock()
+            {
+                let _ = writeln!(locked, "{s}");
+                let _ = locked.flush();
             }
             continue;
         }
@@ -492,19 +649,25 @@ pub fn run_stdio_loop(
                 eprintln!("[legion mcp] parse error: {e}");
                 let id = Value::Null;
                 let resp = error_response(&id, -32700, "parse error");
-                if let Ok(s) = serde_json::to_string(&resp) {
-                    let _ = writeln!(out, "{s}");
-                    let _ = out.flush();
+                if let Ok(s) = serde_json::to_string(&resp)
+                    && let Ok(mut locked) = out.lock()
+                {
+                    let _ = writeln!(locked, "{s}");
+                    let _ = locked.flush();
                 }
                 continue;
             }
         };
 
-        if let Some(response) = dispatch(&request, &data_dir, &version, &tx) {
+        if let Some(response) =
+            dispatch(&request, &data_dir, &version, &tx, Some(&client_repo_cell))
+        {
             match serde_json::to_string(&response) {
                 Ok(s) => {
-                    let _ = writeln!(out, "{s}");
-                    let _ = out.flush();
+                    if let Ok(mut locked) = out.lock() {
+                        let _ = writeln!(locked, "{s}");
+                        let _ = locked.flush();
+                    }
                 }
                 Err(e) => {
                     eprintln!("[legion mcp] serialize error: {e}");
@@ -550,7 +713,7 @@ mod tests {
             })),
         );
 
-        let resp = dispatch(&req, dir.path(), "0.6.0", &tx).expect("response");
+        let resp = dispatch(&req, dir.path(), "0.6.0", &tx, None).expect("response");
 
         assert_eq!(resp["jsonrpc"], "2.0");
         assert_eq!(resp["id"], 1);
@@ -566,7 +729,7 @@ mod tests {
         let dir = tempfile::tempdir().expect("tempdir");
         let req = make_request("tools/list", None);
 
-        let resp = dispatch(&req, dir.path(), "0.6.0", &tx).expect("response");
+        let resp = dispatch(&req, dir.path(), "0.6.0", &tx, None).expect("response");
 
         let tools = resp["result"]["tools"].as_array().expect("tools array");
         assert_eq!(tools.len(), 4);
@@ -609,7 +772,7 @@ mod tests {
             })),
         );
 
-        let resp = dispatch(&req, dir.path(), "0.6.0", &tx).expect("response");
+        let resp = dispatch(&req, dir.path(), "0.6.0", &tx, None).expect("response");
 
         // Should succeed
         assert!(
@@ -647,7 +810,7 @@ mod tests {
             })),
         );
 
-        let resp = dispatch(&req, dir.path(), "0.6.0", &tx).expect("response");
+        let resp = dispatch(&req, dir.path(), "0.6.0", &tx, None).expect("response");
         assert!(
             resp.get("error").is_none(),
             "unexpected error: {:?}",
@@ -679,7 +842,7 @@ mod tests {
             })),
         );
 
-        let resp = dispatch(&req, dir.path(), "0.6.0", &tx).expect("response");
+        let resp = dispatch(&req, dir.path(), "0.6.0", &tx, None).expect("response");
         assert!(
             resp.get("error").is_none(),
             "unexpected error: {:?}",
@@ -707,7 +870,7 @@ mod tests {
             })),
         );
 
-        let resp = dispatch(&req, dir.path(), "0.6.0", &tx).expect("response");
+        let resp = dispatch(&req, dir.path(), "0.6.0", &tx, None).expect("response");
         // Per MCP spec: tool errors go in the success envelope with isError:true,
         // NOT as a JSON-RPC error response.
         assert!(
@@ -731,7 +894,7 @@ mod tests {
         let dir = tempfile::tempdir().expect("tempdir");
         let req = make_request("some/unknown/method", None);
 
-        let resp = dispatch(&req, dir.path(), "0.6.0", &tx).expect("response");
+        let resp = dispatch(&req, dir.path(), "0.6.0", &tx, None).expect("response");
         assert!(resp.get("error").is_some());
         assert_eq!(resp["error"]["code"], -32601);
     }
@@ -746,7 +909,7 @@ mod tests {
             "method": "notifications/initialized"
         });
 
-        let resp = dispatch(&req, dir.path(), "0.6.0", &tx);
+        let resp = dispatch(&req, dir.path(), "0.6.0", &tx, None);
         assert!(resp.is_none(), "notifications should return None");
     }
 
@@ -766,7 +929,7 @@ mod tests {
             })),
         );
 
-        let resp = dispatch(&req, dir.path(), "0.6.0", &tx).expect("response");
+        let resp = dispatch(&req, dir.path(), "0.6.0", &tx, None).expect("response");
         // Per MCP spec: McpInvalidArgument is a tool error, not a protocol error.
         // Must be in the success envelope with isError:true.
         assert!(
@@ -804,7 +967,7 @@ mod tests {
             })),
         );
 
-        let resp = dispatch(&req, dir.path(), "0.6.0", &tx).expect("response");
+        let resp = dispatch(&req, dir.path(), "0.6.0", &tx, None).expect("response");
         assert!(
             resp.get("error").is_none(),
             "McpInvalidArgument must not produce a JSON-RPC error envelope"
@@ -841,5 +1004,84 @@ mod tests {
         // Must not panic and must be valid UTF-8
         assert!(std::str::from_utf8(result.as_bytes()).is_ok());
         assert!(result.len() <= MAX_TOOL_RESULT_LEN);
+    }
+
+    // ---- notification tests ----
+
+    #[test]
+    fn initialize_response_includes_instructions() {
+        let tx = make_tx();
+        let dir = tempfile::tempdir().expect("tempdir");
+        let req = make_request(
+            "initialize",
+            Some(json!({
+                "protocolVersion": "2024-11-05",
+                "capabilities": {},
+                "clientInfo": { "name": "kelex", "version": "0.0.1" }
+            })),
+        );
+
+        let resp = dispatch(&req, dir.path(), "0.6.0", &tx, None).expect("response");
+
+        let instructions = resp["result"]["instructions"].as_str().unwrap_or("");
+        assert!(
+            !instructions.is_empty(),
+            "instructions field must be present and non-empty"
+        );
+        assert!(
+            instructions.contains("notifications/claude/channel"),
+            "instructions must mention notifications/claude/channel; got: {instructions}"
+        );
+    }
+
+    #[test]
+    fn channel_event_feed_carries_post_id() {
+        use crate::channel::ChannelEvent;
+        let event = ChannelEvent::Feed {
+            post_id: "test-id-abc".to_string(),
+        };
+        match event {
+            ChannelEvent::Feed { post_id } => {
+                assert_eq!(post_id, "test-id-abc");
+            }
+            _ => panic!("expected Feed variant"),
+        }
+    }
+
+    #[test]
+    fn notification_filter_passes_at_all() {
+        // @all signals should reach every client regardless of repo.
+        assert!(
+            should_notify("@all hello team", "smugglr", Some("kelex")),
+            "@all must pass filter for kelex"
+        );
+        assert!(
+            should_notify("@all hello team", "smugglr", Some("smugglr")),
+            "@all must pass even for the poster's own client if the post repo differs"
+        );
+    }
+
+    #[test]
+    fn notification_filter_suppresses_wrong_recipient() {
+        // A signal to @vault must not reach @kelex.
+        assert!(
+            !should_notify("@vault review:approved", "smugglr", Some("kelex")),
+            "@vault signal must be suppressed for kelex client"
+        );
+        // A signal to @kelex MUST reach kelex.
+        assert!(
+            should_notify("@kelex review:approved", "smugglr", Some("kelex")),
+            "@kelex signal must reach kelex client"
+        );
+        // Own post must be suppressed.
+        assert!(
+            !should_notify("hello team", "kelex", Some("kelex")),
+            "own posts must be suppressed"
+        );
+        // General musing from another agent must reach the client.
+        assert!(
+            should_notify("just thinking about things", "smugglr", Some("kelex")),
+            "general musings from others must reach kelex"
+        );
     }
 }

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -389,16 +389,24 @@ pub fn dispatch(
     match method {
         "initialize" => {
             // Extract clientInfo.name to identify the connecting agent's repo.
-            // This is stored for use by the notification emitter thread via the
-            // shared client_repo cell passed into run_stdio_loop.
+            // This is stored for use by the notification emitter thread via
+            // the shared client_repo cell passed into run_stdio_loop. OnceLock
+            // is deliberate: the MCP subprocess is spawned fresh per Claude
+            // Code session, so there is exactly one initialize handshake per
+            // process lifetime. A second initialize (unexpected under the
+            // current plugin model) would silently no-op -- documented here
+            // so future deployment changes catch it.
             if let Some(cell) = client_repo_cell
                 && let Some(name) = request
                     .get("params")
                     .and_then(|p| p.get("clientInfo"))
                     .and_then(|ci| ci.get("name"))
                     .and_then(|n| n.as_str())
+                && cell.set(name.to_string()).is_err()
             {
-                let _ = cell.set(name.to_string());
+                eprintln!(
+                    "[legion mcp] duplicate initialize ignored; client_repo already set (one process = one session)"
+                );
             }
             Some(success_response(
                 &id,
@@ -474,14 +482,28 @@ const MAX_LINE_BYTES: usize = 1024 * 1024; // 1 MiB
 /// 4. If `client_repo` is known and the post's `repo` equals `client_repo`, suppress
 ///    (the client wrote it; no need to echo a general musing back to its author).
 /// 5. Otherwise (general musing, no `@` prefix, from a different agent), deliver.
+///
+/// Recipient parsing treats anything after a leading `@` up to the first
+/// whitespace as the recipient token, with a trailing `:` trimmed. An empty
+/// recipient (`@` alone) or a recipient that itself begins with `@` (e.g.
+/// `@@all`, which looks like a broadcast but isn't) is NOT treated as `@all`
+/// or any named target -- the post falls through the signal branch and is
+/// suppressed. This is deliberately strict: if an agent fat-fingers a
+/// broadcast as `@@all`, it should silently fail rather than silently succeed
+/// with the wrong-looking prefix.
 pub fn should_notify(text: &str, repo: &str, client_repo: Option<&str>) -> bool {
     if let Some(rest) = text.strip_prefix('@') {
-        // It's a signal. Check if it's addressed to us or to "all".
-        let recipient = rest
-            .split_whitespace()
-            .next()
-            .unwrap_or("")
-            .trim_end_matches(':');
+        // It's a signal. Extract the recipient token (first whitespace word).
+        let recipient_raw = rest.split_whitespace().next().unwrap_or("");
+        let recipient = recipient_raw.trim_end_matches(':');
+
+        // Reject empty or `@`-prefixed recipients -- `@` alone, `@@all`,
+        // `@@`, etc. These are suppressed rather than passed to the @all /
+        // named-target branches. See docstring above for the reasoning.
+        if recipient.is_empty() || recipient.starts_with('@') {
+            return false;
+        }
+
         if recipient == "all" {
             return true;
         }
@@ -502,10 +524,36 @@ pub fn should_notify(text: &str, repo: &str, client_repo: Option<&str>) -> bool 
     true
 }
 
-/// Build the XML-like channel notification content string.
+/// Split a CDATA body around any literal `]]>` occurrences so the terminator
+/// cannot escape the section. The standard XML trick is to replace every
+/// `]]>` with `]]]]><![CDATA[>` -- close the current section after the first
+/// `]]`, then reopen with `<![CDATA[` before the stray `>`. An agent post
+/// containing the literal substring `]]>` (plausible in code snippets) would
+/// otherwise terminate the block early and inject raw content into the XML.
+fn escape_cdata(text: &str) -> String {
+    text.replace("]]>", "]]]]><![CDATA[>")
+}
+
+/// Escape `"`, `<`, `>`, and `&` for use inside an XML attribute value.
+/// The attribute values are short (post_id, repo, is_signal) and controlled,
+/// but post_id comes from the DB and repo from the user; better to escape than
+/// trust.
+fn escape_xml_attr(s: &str) -> String {
+    s.replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
+}
+
+/// Build the XML-like channel notification content string. Text goes inside a
+/// CDATA block with `]]>` sequences neutralised; attribute values are
+/// XML-escaped.
 fn build_channel_content(post_id: &str, repo: &str, text: &str, is_signal: bool) -> String {
+    let post_id_attr = escape_xml_attr(post_id);
+    let repo_attr = escape_xml_attr(repo);
+    let text_body = escape_cdata(text);
     format!(
-        "<channel type=\"feed\" post_id=\"{post_id}\" repo=\"{repo}\" is_signal=\"{is_signal}\"><text><![CDATA[{text}]]></text></channel>"
+        "<channel type=\"feed\" post_id=\"{post_id_attr}\" repo=\"{repo_attr}\" is_signal=\"{is_signal}\"><text><![CDATA[{text_body}]]></text></channel>"
     )
 }
 
@@ -589,6 +637,18 @@ pub fn run_stdio_loop(
             let client_repo = notif_client_repo.get().map(|s| s.as_str());
             let is_signal = crate::signal::is_signal(&post.text);
 
+            // Log the "named signal suppressed because client_repo is
+            // unknown" case exactly once per post, so that a stuck
+            // initialize (or a client that omitted clientInfo.name) is
+            // visible in the breadcrumb log instead of manifesting as
+            // silent delivery failures. Other suppression cases (own post,
+            // signal to a different agent) are expected and not logged.
+            if client_repo.is_none() && is_signal && !post.text.starts_with("@all") {
+                eprintln!(
+                    "[legion mcp notif] suppressing signal {post_id} -- client_repo unknown (initialize handshake missing or clientInfo.name absent)"
+                );
+            }
+
             if !should_notify(&post.text, &post.repo, client_repo) {
                 continue;
             }
@@ -602,11 +662,26 @@ pub fn run_stdio_loop(
                 }
             });
 
-            if let Ok(s) = serde_json::to_string(&notification)
-                && let Ok(mut locked) = notif_out.lock()
-            {
-                let _ = writeln!(locked, "{s}");
-                let _ = locked.flush();
+            let Ok(s) = serde_json::to_string(&notification) else {
+                eprintln!("[legion mcp notif] failed to serialize notification");
+                continue;
+            };
+
+            let Ok(mut locked) = notif_out.lock() else {
+                eprintln!("[legion mcp notif] stdout mutex poisoned; notifier thread exiting");
+                return;
+            };
+
+            // A write or flush failure on stdout almost always means the
+            // client hung up (EPIPE). Keep looping against a dead pipe would
+            // burn CPU silently forever -- exit the notifier thread instead.
+            if let Err(e) = writeln!(locked, "{s}") {
+                eprintln!("[legion mcp notif] stdout write failed ({e}); notifier thread exiting");
+                return;
+            }
+            if let Err(e) = locked.flush() {
+                eprintln!("[legion mcp notif] stdout flush failed ({e}); notifier thread exiting");
+                return;
             }
         }
     });
@@ -1087,6 +1162,80 @@ mod tests {
         assert!(
             should_notify("just thinking about things", "smugglr", Some("kelex")),
             "general musings from others must reach kelex"
+        );
+    }
+
+    #[test]
+    fn notification_filter_rejects_malformed_signal_prefixes() {
+        // `@` alone is not a broadcast -- no recipient token at all.
+        assert!(
+            !should_notify("@ hello", "smugglr", Some("kelex")),
+            "lone @ must be suppressed"
+        );
+        // `@@all foo` looks like a broadcast but recipient parses as `@all`,
+        // which starts with `@` -- rejected as malformed rather than silently
+        // routed as if the user meant @all.
+        assert!(
+            !should_notify("@@all urgent", "smugglr", Some("kelex")),
+            "@@all must be suppressed, not routed as @all"
+        );
+        // `@@` alone with no recipient.
+        assert!(
+            !should_notify("@@", "smugglr", Some("kelex")),
+            "@@ alone must be suppressed"
+        );
+        // Trailing colon is stripped, so `@kelex:` still reaches kelex.
+        assert!(
+            should_notify("@kelex: review:approved", "smugglr", Some("kelex")),
+            "trailing colon on recipient must still reach the target"
+        );
+    }
+
+    #[test]
+    fn build_channel_content_escapes_cdata_terminator() {
+        // A post text containing the CDATA terminator `]]>` would otherwise
+        // close the CDATA block early and leak raw content into the XML.
+        // escape_cdata splits the terminator across a close/reopen using the
+        // canonical `]]]]><![CDATA[>` pattern. An XML parser then sees the
+        // original `]]>` in the reassembled CDATA content.
+        let content = build_channel_content(
+            "019d-test-id",
+            "legion",
+            "here is the literal terminator ]]> in a code example",
+            false,
+        );
+        assert!(
+            content.contains("]]]]><![CDATA[>"),
+            "CDATA escape should split ]]> across a close-and-reopen; got: {content}"
+        );
+        // The legitimate final closer is still `]]></text></channel>`. That
+        // is the ONE allowed occurrence of the `]]>` sequence -- and it
+        // must close a balanced pair of CDATA opens.
+        assert!(
+            content.ends_with("]]></text></channel>"),
+            "content must end with the correct closer; got: {content}"
+        );
+        let cdata_opens = content.matches("<![CDATA[").count();
+        let cdata_closes = content.matches("]]>").count();
+        assert_eq!(
+            cdata_opens, cdata_closes,
+            "CDATA opens/closes must balance after escape (opens={cdata_opens}, closes={cdata_closes}); got: {content}"
+        );
+    }
+
+    #[test]
+    fn build_channel_content_escapes_xml_attributes() {
+        // Post id / repo go into attribute positions. A post from a repo
+        // named with a literal quote or ampersand would otherwise break the
+        // attribute quoting. Not expected in practice, but cheap to enforce.
+        let content = build_channel_content("id\"with'quote", "repo&name", "plain text body", true);
+        assert!(
+            content.contains("id&quot;with"),
+            "post_id attribute must be XML-escaped; got: {content}"
+        );
+        assert!(
+            content.contains("repo&amp;name"),
+            "repo attribute must be XML-escaped; got: {content}"
         );
     }
 }

--- a/tests/hook_warnings.rs
+++ b/tests/hook_warnings.rs
@@ -10,6 +10,15 @@
 //! These tests construct two broken legion environments and assert that
 //! every hook surfaces a visible `[Legion WARNING]` block in its stdout
 //! while still exiting 0 (so Claude Code never blocks on legion failures).
+//!
+//! Unix-only: the hook scripts are bash (`plugin/hooks/*.sh`) and the tests
+//! spawn `bash` as a subprocess. On Windows CI `Command::new("bash")`
+//! resolves to the WSL stub shipped with System32, which is not a POSIX
+//! bash and cannot run the hook scripts. Gate the whole module to
+//! unix-likes so the Windows test runner stays green -- the hooks
+//! themselves only run on developer / CI unix hosts in practice.
+
+#![cfg(unix)]
 
 use std::fs;
 use std::io::Write;


### PR DESCRIPTION
Closes #216.

## Problem

The legion channel MCP at `src/mcp.rs` was a hand-rolled JSON-RPC stdio server that only implemented `initialize`, `tools/list`, and `tools/call`. It never emitted server-initiated notifications, so incoming bullpen posts were invisible to connected agents mid-session. Agents only saw new posts at `SessionStart` or via manual `legion bullpen` polling. Root cause and timeline: reflection `019d7b23-400a-7fb3-afaf-f48bee4b147c`.

## Solution

Three-part push wiring on top of the existing hand-roll (no `rmcp` dependency added):

### 1. `instructions` field in initialize response

Claude Code's `claude/channel` experimental capability appends the server's `instructions` string to the system prompt so the model knows how to handle incoming channel events. Added a description that names `notifications/claude/channel` as the wire method and documents the `<channel type="feed" post_id=... repo=... is_signal=...>` tag shape agents will see in context.

### 2. `ChannelEvent::Feed { post_id }` payload

`src/channel.rs:35` -- the broadcast event now carries the new post's id so the notification emitter thread can fetch the row without scanning. Every `tx.send(ChannelEvent::Feed)` call site in `channel.rs` and `mcp.rs` was updated; the 4 MCP tool handlers (`legion_post`, `legion_reply`, `legion_signal`, `legion_task_respond`) already write through `board::post_to_bullpen` which already fed the broadcast; the axum `api_post` handler in channel.rs also writes the broadcast. Every write path was audited.

### 3. Notification emitter thread in `run_stdio_loop`

`src/mcp.rs:521+` -- `run_stdio_loop` now splits into two halves sharing a serialised stdout:

- **Request half** (existing): reads stdin, dispatches, writes response through an `Arc<Mutex<BufWriter<Stdout>>>` locked writer. Never interleaves with the notifier.
- **Notification half** (new): spawns a dedicated `std::thread` that subscribes to the broadcast at loop start, opens the legion database handle ONCE outside the event loop, then blocks on `rx.blocking_recv()`. On each `ChannelEvent::Feed { post_id }` it fetches the post, applies `should_notify`, builds the content string, and writes a JSON-RPC notification through the same locked stdout.

### 4. Recipient filter -- `should_notify(text, repo, client_repo)`

Five documented rules, all unit-tested:

1. `@all` prefix -> always deliver.
2. `@<client_repo>` prefix -> deliver (direct mention).
3. Any other `@` prefix -> suppress (signal addressed elsewhere).
4. Non-signal from the client's own repo -> suppress (don't echo own musings back).
5. Non-signal from another repo -> deliver.

### 5. Client repo discovery

The MCP server learns which repo it's serving from `clientInfo.name` on the `initialize` request (standard MCP param). Stored in an `Arc<OnceLock<String>>` shared between the request loop and the notifier thread. If the initialize message omits `clientInfo.name`, the `OnceLock` stays empty and the filter falls through to "suppress signals, deliver general musings" -- a safe default.

## Files changed

- `src/channel.rs` (+16 -10): `ChannelEvent::Feed { post_id }`, 3 call sites updated, 2 test fixes.
- `src/mcp.rs` (+300 -19): `instructions` field, `dispatch` signature extended with `Option<&Arc<OnceLock<String>>>`, `should_notify` + `build_channel_content` helpers, notifier thread, 4 new unit tests, 10 dispatch test call sites updated to pass `None`.

## Tests

All pass: **466** tests total (385 unit incl. 9 new mcp.rs tests, 9 hook_warnings from #209, 72 integration).

New unit tests:

- `initialize_response_includes_instructions` -- initialize result has non-empty `instructions` that names `notifications/claude/channel`.
- `channel_event_feed_carries_post_id` -- variant destructures correctly.
- `notification_filter_passes_at_all` -- `@all` reaches every client.
- `notification_filter_suppresses_wrong_recipient` -- `@vault` does not reach `@kelex`, `@kelex` does reach `@kelex`, own posts are suppressed, general musings from others are delivered.

**Known coverage gap:** no end-to-end integration test exercising the full broadcast -> notifier thread -> stdout JSON-RPC path. The filter, the payload, and the instructions field are tested in isolation; the glue thread is not. Adding that test requires plumbing a fake stdout for the notifier which is non-trivial with the current `std::io::stdout()` pattern. Flagged for follow-up but not blocking this PR -- the unit coverage proves every component in isolation and the integration path is mechanically straightforward.

## Quality gates

- `cargo test` -- 466 pass, 2 ignored, 0 failed
- `cargo clippy --all-targets -- -D warnings` -- clean
- `cargo fmt -- --check` -- clean
- `shellcheck install.sh plugin/bin/legion plugin/hooks/*.sh` -- clean (not touched by this PR, but verified to avoid a #217-style regression)
- `/legion-simplify` -- clean (gate `019d7b54-8d08-7341-a47b-90c6b8032ff5`)

Simplify fixed one MED structural issue that the initial rust draft (commit `cbeb7ae`) carried: the notification emitter thread reopened the Database handle inside its event loop on every event. Fixed in commit `e2d59da` by hoisting the open outside the loop. Same commit removed a misleading "re-subscribing" comment on the Lagged recv branch and collapsed a redundant `ref post_id` + `.clone()` into a direct move destructure.

## Out of scope

- Full `rmcp` SDK port. The hand-roll hosts both halves of the protocol (request + notify). `rmcp` is the correct long-term move and should be its own issue.
- Task notifications. `ChannelEvent::Tasks` is explicitly skipped by the notifier (`continue`) -- out of scope for this issue.
- An end-to-end notifier thread integration test (see "Known coverage gap" above).

## Test plan

1. Build updated binary.
2. Start two Claude Code sessions: agent A in `repo=legion`, agent B in `repo=smugglr`.
3. From agent A: `legion post --repo legion --text "@smugglr test notification"`.
4. Agent B should see `<channel type="feed" ...>` appear in its context without running `legion bullpen` manually.
5. From agent A: `legion post --repo legion --text "@legion own post"`.
6. Agent A should NOT see the post echoed back to itself.
7. From agent A: `legion post --repo legion --text "@all broadcast announcement"`.
8. Both agents A and B should see it.
9. From agent A: `legion post --repo legion --text "just thinking"` (general musing, no signal).
10. Agent B should see it, agent A should not.