### PR TITLE
feat(#210): wire sync-version.sh into tracked pre-commit hook

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,7 +1,31 @@
 #!/bin/bash
-# Pre-commit: run /simplify on staged changes via Claude Code.
-# Catches structural issues, dead code, and cleanup before every commit.
+# Pre-commit: enforce version invariants, then run /simplify on staged changes.
+#
+# Step 1 (always runs): scripts/sync-version.sh when any of Cargo.toml,
+#   plugin.json, marketplace.json, or plugin/CHANGELOG.md are staged.
+#   Cargo.toml is the source of truth for the version number. The script
+#   propagates Cargo.toml's version to plugin.json and marketplace.json (and
+#   stages the updates), refuses to downgrade if either is ahead of Cargo.toml,
+#   and requires plugin/CHANGELOG.md's top "## <version>" header to match.
+#   See scripts/sync-version.sh and runlegion/legion#210.
+#
+# Step 2: run Claude Code's /simplify on the staged diff to catch structural
+#   issues, dead code, and cleanup before every commit. Skipped silently if
+#   Claude Code is not available.
 
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+
+# Step 1: version sync. Only runs when a version-bearing file is staged;
+# noise-free on every other commit.
+STAGED=$(git diff --cached --name-only)
+if echo "$STAGED" | grep -qE '^(Cargo\.toml|plugin/\.claude-plugin/plugin\.json|\.claude-plugin/marketplace\.json|plugin/CHANGELOG\.md)$'; then
+  if ! "${REPO_ROOT}/scripts/sync-version.sh"; then
+    echo "[pre-commit] scripts/sync-version.sh failed -- fix the version/changelog and re-commit" >&2
+    exit 1
+  fi
+fi
+
+# Step 2: simplify review on the staged diff.
 DIFF=$(git diff --cached --diff-filter=ACMR)
 if [ -z "$DIFF" ]; then
   exit 0
@@ -9,9 +33,7 @@ fi
 
 echo "[pre-commit] Running simplify review on staged changes..."
 
-RESULT=$(echo "$DIFF" | claude -p "You are reviewing a diff for code quality. Check for: dead code, unnecessary abstractions, copy-paste patterns, missing error handling, and style violations. If you find issues that MUST be fixed before commit, start your response with BLOCK: and list them. If the code is acceptable, start with PASS: and optionally note minor suggestions. Be concise." 2>/dev/null)
-
-if [ $? -ne 0 ]; then
+if ! RESULT=$(echo "$DIFF" | claude -p "You are reviewing a diff for code quality. Check for: dead code, unnecessary abstractions, copy-paste patterns, missing error handling, and style violations. If you find issues that MUST be fixed before commit, start your response with BLOCK: and list them. If the code is acceptable, start with PASS: and optionally note minor suggestions. Be concise." 2>/dev/null); then
   echo "[pre-commit] Claude Code unavailable, skipping review"
   exit 0
 fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - run: shellcheck install.sh plugin/bin/legion plugin/hooks/*.sh
+      - run: shellcheck install.sh plugin/bin/legion plugin/hooks/*.sh scripts/*.sh
 
   test:
     name: Test

--- a/README.md
+++ b/README.md
@@ -51,6 +51,21 @@ in your shell or in the environment where Claude Code runs. This disables the au
 
 Full documentation, architecture, and the multi-node story at [runlegion.dev](https://runlegion.dev).
 
+## Contributing
+
+After cloning the repo, install the tracked git hooks once:
+
+```bash
+./scripts/install-hooks.sh
+```
+
+This points `core.hooksPath` at the tracked `.githooks/` directory. Two hooks run from there:
+
+- **pre-commit** enforces the "Cargo.toml is source of truth" version invariant via `scripts/sync-version.sh` (propagates the Cargo.toml version to `plugin/.claude-plugin/plugin.json` and `.claude-plugin/marketplace.json`, refuses to downgrade, requires the `plugin/CHANGELOG.md` top header to match), then runs Claude Code's `/simplify` review over the staged diff.
+- **pre-push** runs the full Claude Code PR review over the branch diff before it reaches the remote.
+
+Both hooks silently skip if Claude Code is not on `PATH`. The version sync is pure shell and runs unconditionally when a version-bearing file is staged.
+
 ## License
 
 MIT

--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# Install the tracked .githooks/ directory as the active git hooks path.
+#
+# Git hooks default to .git/hooks/, which is not tracked by the repo, so new
+# contributors who clone never get the hooks unless they run this script.
+# Setting core.hooksPath to .githooks/ makes every hook in that directory
+# active immediately, and because .githooks/ IS tracked, every commit ships
+# the current hook definitions.
+#
+# Idempotent: re-running this script against an already-configured repo is
+# safe and prints what is already in place. Run it once per fresh clone.
+
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+
+if [ ! -d "${REPO_ROOT}/.githooks" ]; then
+  echo "[install-hooks] ERROR: .githooks directory missing at ${REPO_ROOT}/.githooks" >&2
+  exit 1
+fi
+
+# Make every hook in .githooks/ executable. Idempotent -- git tracks the
+# executable bit, but contributors who checked out on a filesystem that does
+# not honor it (certain Windows + WSL setups) may arrive here without it set.
+find "${REPO_ROOT}/.githooks" -type f ! -name '.*' -exec chmod +x {} \;
+
+# Point git at the tracked hooks directory. core.hooksPath is a per-repo
+# setting that overrides the default .git/hooks location.
+git -C "${REPO_ROOT}" config core.hooksPath .githooks
+
+echo "[install-hooks] core.hooksPath -> .githooks"
+echo "[install-hooks] hooks installed:"
+find "${REPO_ROOT}/.githooks" -maxdepth 1 -type f ! -name '.*' -exec basename {} \; | sort | sed 's/^/  - /'

--- a/scripts/sync-version.sh
+++ b/scripts/sync-version.sh
@@ -73,8 +73,29 @@ check_not_ahead() {
   fi
 }
 
+# --- validation phase: everything that can reject the commit runs first ---
+# Rationale: if we mutated plugin.json before discovering a stale CHANGELOG,
+# the developer would land in a half-synced working tree that blocks the
+# commit without any obvious undo path. Validate all invariants up front,
+# exit 1 loudly, then mutate only once we know every check passes.
+
 check_not_ahead "$PLUGIN_JSON" "plugin.json"
 check_not_ahead "$MARKETPLACE_JSON" "marketplace.json"
+
+# Require CHANGELOG top header to match Cargo.toml. Changelog body is
+# human-authored -- we only enforce the header version tag.
+if [ -f "$CHANGELOG" ]; then
+  TOP_HEADER=$(grep -E '^## [0-9]' "$CHANGELOG" | head -1 | sed -E 's/^## //' | awk '{print $1}')
+  if [ -z "$TOP_HEADER" ]; then
+    echo "[sync-version] WARNING: no '## <version>' header found in ${CHANGELOG#"$REPO_ROOT/"}" >&2
+  elif [ "$TOP_HEADER" != "$CARGO_VERSION" ]; then
+    echo "[sync-version] ERROR: ${CHANGELOG#"$REPO_ROOT/"} top header is '## ${TOP_HEADER}', Cargo.toml is ${CARGO_VERSION}" >&2
+    echo "[sync-version] Add a new '## ${CARGO_VERSION}' section at the top of ${CHANGELOG#"$REPO_ROOT/"} describing what shipped in this release, then commit." >&2
+    exit 1
+  fi
+fi
+
+# --- mutation phase: every invariant above passed, safe to edit files ---
 
 UPDATED=false
 
@@ -91,35 +112,28 @@ fi
 
 # Update marketplace.json via python for precise JSON handling (avoids sed
 # ambiguity when multiple "version" fields are present at different depths).
+# Pass path + version via env vars, NOT shell interpolation into the python
+# string literal -- a path or version containing a single quote would
+# otherwise break the python source. The heredoc is single-quoted so bash
+# does not interpolate inside it; python reads from os.environ.
 if [ -f "$MARKETPLACE_JSON" ]; then
   CURRENT=$(extract_version "$MARKETPLACE_JSON")
   if [ -n "$CURRENT" ] && [ "$CURRENT" != "$CARGO_VERSION" ]; then
-    python3 -c "
-import json
-with open('$MARKETPLACE_JSON', 'r') as f:
+    MARKETPLACE_JSON="$MARKETPLACE_JSON" CARGO_VERSION="$CARGO_VERSION" python3 <<'PY'
+import json, os
+path = os.environ['MARKETPLACE_JSON']
+version = os.environ['CARGO_VERSION']
+with open(path, 'r') as f:
     data = json.load(f)
 for p in data.get('plugins', []):
-    p['version'] = '$CARGO_VERSION'
-with open('$MARKETPLACE_JSON', 'w') as f:
+    p['version'] = version
+with open(path, 'w') as f:
     json.dump(data, f, indent=2)
     f.write('\n')
-"
+PY
     git add "$MARKETPLACE_JSON"
     echo "[sync-version] marketplace.json: ${CURRENT} -> ${CARGO_VERSION}" >&2
     UPDATED=true
-  fi
-fi
-
-# Require CHANGELOG top header to match Cargo.toml. Changelog body is
-# human-authored -- we only enforce the header version tag.
-if [ -f "$CHANGELOG" ]; then
-  TOP_HEADER=$(grep -E '^## [0-9]' "$CHANGELOG" | head -1 | sed -E 's/^## //' | awk '{print $1}')
-  if [ -z "$TOP_HEADER" ]; then
-    echo "[sync-version] WARNING: no '## <version>' header found in ${CHANGELOG#"$REPO_ROOT/"}" >&2
-  elif [ "$TOP_HEADER" != "$CARGO_VERSION" ]; then
-    echo "[sync-version] ERROR: ${CHANGELOG#"$REPO_ROOT/"} top header is '## ${TOP_HEADER}', Cargo.toml is ${CARGO_VERSION}" >&2
-    echo "[sync-version] Add a new '## ${CARGO_VERSION}' section at the top of ${CHANGELOG#"$REPO_ROOT/"} describing what shipped in this release, then commit." >&2
-    exit 1
   fi
 fi
 

--- a/scripts/sync-version.sh
+++ b/scripts/sync-version.sh
@@ -1,55 +1,128 @@
 #!/bin/bash
 # Sync version from Cargo.toml to plugin.json and marketplace.json.
-# Run as a git pre-commit hook or manually.
+#
+# Cargo.toml is the single source of truth. This script:
+#   1. Reads the version from Cargo.toml.
+#   2. Refuses to proceed if plugin.json or marketplace.json carries a HIGHER
+#      version than Cargo.toml -- never auto-downgrades. Bump Cargo.toml first.
+#   3. Updates plugin.json and marketplace.json if they are at or behind Cargo.toml
+#      and stages the resulting changes into the in-flight commit.
+#   4. Requires plugin/CHANGELOG.md's top "## <version>" header to match
+#      Cargo.toml. Fails loudly if the developer forgot to log the bump.
+#
+# Safe to run manually; intended to run as a git pre-commit hook via
+# .githooks/pre-commit + scripts/install-hooks.sh.
 set -euo pipefail
 
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 CARGO_TOML="${REPO_ROOT}/Cargo.toml"
 PLUGIN_JSON="${REPO_ROOT}/plugin/.claude-plugin/plugin.json"
 MARKETPLACE_JSON="${REPO_ROOT}/.claude-plugin/marketplace.json"
+CHANGELOG="${REPO_ROOT}/plugin/CHANGELOG.md"
 
-VERSION=$(grep '^version' "$CARGO_TOML" | head -1 | sed 's/version = "\(.*\)"/\1/')
+# Extract a "x.y.z" version string from a supported file type.
+extract_version() {
+  local file="$1"
+  case "$file" in
+    *Cargo.toml)
+      grep '^version' "$file" | head -1 | sed 's/version = "\(.*\)"/\1/'
+      ;;
+    *plugin.json)
+      grep '"version"' "$file" | head -1 | sed 's/.*"\([0-9][0-9.]*\)".*/\1/'
+      ;;
+    *marketplace.json)
+      # Version inside the plugins[] array, NOT the top-level schema version.
+      grep -A20 '"plugins"' "$file" | grep '"version"' | head -1 | sed 's/.*"\([0-9][0-9.]*\)".*/\1/'
+      ;;
+  esac
+}
 
-if [ -z "$VERSION" ]; then
-  echo "[sync-version] could not read version from Cargo.toml" >&2
+# Return 0 if $1 <= $2 by semver ordering, 1 otherwise. Uses `sort -V`.
+version_leq() {
+  [ "$1" = "$2" ] || [ "$(printf '%s\n%s\n' "$1" "$2" | sort -V | head -1)" = "$1" ]
+}
+
+# Portable in-place sed that works on both macOS and GNU sed.
+# macOS sed -i requires an explicit backup suffix argument; GNU sed accepts
+# -i alone. -i.bak works on both platforms; we then remove the .bak file.
+portable_sed_inplace() {
+  local expr="$1"
+  local file="$2"
+  sed -i.bak "$expr" "$file"
+  rm -f "${file}.bak"
+}
+
+CARGO_VERSION=$(extract_version "$CARGO_TOML")
+if [ -z "$CARGO_VERSION" ]; then
+  echo "[sync-version] ERROR: could not read version from Cargo.toml" >&2
   exit 1
 fi
 
+# Abort if any tracked version file is AHEAD of Cargo.toml.
+check_not_ahead() {
+  local file="$1"
+  local label="$2"
+  [ -f "$file" ] || return 0
+  local other
+  other=$(extract_version "$file")
+  [ -n "$other" ] || return 0
+  if ! version_leq "$other" "$CARGO_VERSION"; then
+    echo "[sync-version] ERROR: ${label} is at ${other}, ahead of Cargo.toml at ${CARGO_VERSION}" >&2
+    echo "[sync-version] Refusing to downgrade ${label}. Bump Cargo.toml to >= ${other} first, then commit." >&2
+    exit 1
+  fi
+}
+
+check_not_ahead "$PLUGIN_JSON" "plugin.json"
+check_not_ahead "$MARKETPLACE_JSON" "marketplace.json"
+
 UPDATED=false
 
-# Update plugin.json
+# Update plugin.json to match Cargo.toml if needed.
 if [ -f "$PLUGIN_JSON" ]; then
-  CURRENT=$(grep '"version"' "$PLUGIN_JSON" | head -1 | sed 's/.*"\([0-9][0-9.]*\)".*/\1/')
-  if [ "$CURRENT" != "$VERSION" ]; then
-    sed -i '' "s/\"version\": \"${CURRENT}\"/\"version\": \"${VERSION}\"/" "$PLUGIN_JSON"
+  CURRENT=$(extract_version "$PLUGIN_JSON")
+  if [ -n "$CURRENT" ] && [ "$CURRENT" != "$CARGO_VERSION" ]; then
+    portable_sed_inplace "s/\"version\": \"${CURRENT}\"/\"version\": \"${CARGO_VERSION}\"/" "$PLUGIN_JSON"
     git add "$PLUGIN_JSON"
-    echo "[sync-version] plugin.json: ${CURRENT} -> ${VERSION}" >&2
+    echo "[sync-version] plugin.json: ${CURRENT} -> ${CARGO_VERSION}" >&2
     UPDATED=true
   fi
 fi
 
-# Update marketplace.json plugin version (not the top-level schema version)
+# Update marketplace.json via python for precise JSON handling (avoids sed
+# ambiguity when multiple "version" fields are present at different depths).
 if [ -f "$MARKETPLACE_JSON" ]; then
-  # Match the version inside the plugins array (indented line)
-  CURRENT=$(grep -A20 '"plugins"' "$MARKETPLACE_JSON" | grep '"version"' | head -1 | sed 's/.*"\([0-9][0-9.]*\)".*/\1/')
-  if [ -n "$CURRENT" ] && [ "$CURRENT" != "$VERSION" ]; then
-    # Use python for precise JSON update to avoid sed ambiguity with multiple version fields
+  CURRENT=$(extract_version "$MARKETPLACE_JSON")
+  if [ -n "$CURRENT" ] && [ "$CURRENT" != "$CARGO_VERSION" ]; then
     python3 -c "
-import json, sys
+import json
 with open('$MARKETPLACE_JSON', 'r') as f:
     data = json.load(f)
 for p in data.get('plugins', []):
-    p['version'] = '$VERSION'
+    p['version'] = '$CARGO_VERSION'
 with open('$MARKETPLACE_JSON', 'w') as f:
     json.dump(data, f, indent=2)
     f.write('\n')
 "
     git add "$MARKETPLACE_JSON"
-    echo "[sync-version] marketplace.json: ${CURRENT} -> ${VERSION}" >&2
+    echo "[sync-version] marketplace.json: ${CURRENT} -> ${CARGO_VERSION}" >&2
     UPDATED=true
   fi
 fi
 
+# Require CHANGELOG top header to match Cargo.toml. Changelog body is
+# human-authored -- we only enforce the header version tag.
+if [ -f "$CHANGELOG" ]; then
+  TOP_HEADER=$(grep -E '^## [0-9]' "$CHANGELOG" | head -1 | sed -E 's/^## //' | awk '{print $1}')
+  if [ -z "$TOP_HEADER" ]; then
+    echo "[sync-version] WARNING: no '## <version>' header found in ${CHANGELOG#"$REPO_ROOT/"}" >&2
+  elif [ "$TOP_HEADER" != "$CARGO_VERSION" ]; then
+    echo "[sync-version] ERROR: ${CHANGELOG#"$REPO_ROOT/"} top header is '## ${TOP_HEADER}', Cargo.toml is ${CARGO_VERSION}" >&2
+    echo "[sync-version] Add a new '## ${CARGO_VERSION}' section at the top of ${CHANGELOG#"$REPO_ROOT/"} describing what shipped in this release, then commit." >&2
+    exit 1
+  fi
+fi
+
 if [ "$UPDATED" = false ]; then
-  echo "[sync-version] all versions match ${VERSION}" >&2
+  echo "[sync-version] all versions match ${CARGO_VERSION}" >&2
 fi

--- a/scripts/test-sync-version.sh
+++ b/scripts/test-sync-version.sh
@@ -1,0 +1,145 @@
+#!/bin/bash
+# Smoke test for scripts/sync-version.sh.
+#
+# Builds a temporary fake-repo fixture with the same directory shape as legion
+# (Cargo.toml, plugin/.claude-plugin/plugin.json, .claude-plugin/marketplace.json,
+# plugin/CHANGELOG.md), runs sync-version.sh under four scenarios, and asserts
+# the expected exit code + output sentinels.
+#
+# Scenarios:
+#   1. All versions match   -> exit 0, "all versions match"
+#   2. Cargo ahead of others -> exit 0, plugin+marketplace auto-updated
+#   3. plugin.json AHEAD    -> exit 1, "Refusing to downgrade"
+#   4. CHANGELOG behind     -> exit 1, "top header" mismatch
+#
+# Run manually: bash scripts/test-sync-version.sh
+# Exits 0 if every scenario behaves as expected, 1 otherwise.
+
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+SYNC_SCRIPT="${REPO_ROOT}/scripts/sync-version.sh"
+
+if [ ! -f "$SYNC_SCRIPT" ]; then
+  echo "ERROR: $SYNC_SCRIPT not found" >&2
+  exit 1
+fi
+
+FAILS=0
+pass() { printf '  [PASS] %s\n' "$1"; }
+fail() {
+  printf '  [FAIL] %s\n' "$1" >&2
+  FAILS=$((FAILS + 1))
+}
+
+# Build a fake-repo fixture at $1 with the given versions.
+#   $1 -- fixture root
+#   $2 -- Cargo.toml version
+#   $3 -- plugin.json version
+#   $4 -- marketplace.json plugins[0].version
+#   $5 -- CHANGELOG top header version
+build_fixture() {
+  local root="$1"
+  local cargo_v="$2"
+  local plugin_v="$3"
+  local market_v="$4"
+  local changelog_v="$5"
+
+  mkdir -p "$root/plugin/.claude-plugin" "$root/.claude-plugin" "$root/plugin"
+  cat >"$root/Cargo.toml" <<EOF
+[package]
+name = "legion-fixture"
+version = "$cargo_v"
+edition = "2024"
+EOF
+
+  cat >"$root/plugin/.claude-plugin/plugin.json" <<EOF
+{
+  "name": "legion",
+  "version": "$plugin_v"
+}
+EOF
+
+  cat >"$root/.claude-plugin/marketplace.json" <<EOF
+{
+  "version": "1.0.0",
+  "plugins": [
+    {
+      "name": "legion",
+      "version": "$market_v"
+    }
+  ]
+}
+EOF
+
+  cat >"$root/plugin/CHANGELOG.md" <<EOF
+# Legion Changelog
+
+## $changelog_v
+
+Test fixture.
+EOF
+
+  # Minimal git init so git rev-parse + git add inside sync-version.sh work.
+  (
+    cd "$root"
+    git init -q
+    git add -A
+    git -c user.email=test@test -c user.name=test commit -q -m init
+  )
+}
+
+run_case() {
+  local name="$1"
+  local root="$2"
+  local expected_exit="$3"
+  local expected_sentinel="$4"
+
+  local stderr_file="$root/_stderr.log"
+  local actual_exit=0
+  ( cd "$root" && bash "$SYNC_SCRIPT" ) 2>"$stderr_file" || actual_exit=$?
+
+  if [ "$actual_exit" -ne "$expected_exit" ]; then
+    fail "$name: expected exit $expected_exit, got $actual_exit. stderr:"
+    sed 's/^/      /' <"$stderr_file" >&2
+    return
+  fi
+  if ! grep -q -- "$expected_sentinel" "$stderr_file"; then
+    fail "$name: expected stderr to contain '$expected_sentinel'. actual stderr:"
+    sed 's/^/      /' <"$stderr_file" >&2
+    return
+  fi
+  pass "$name"
+}
+
+echo "[test-sync-version] running 4 scenarios..."
+
+T1=$(mktemp -d)
+T2=$(mktemp -d)
+T3=$(mktemp -d)
+T4=$(mktemp -d)
+trap 'rm -rf "$T1" "$T2" "$T3" "$T4"' EXIT
+
+# Scenario 1: all versions match 0.6.5
+build_fixture "$T1" 0.6.5 0.6.5 0.6.5 0.6.5
+run_case "1: all match" "$T1" 0 "all versions match 0.6.5"
+
+# Scenario 2: Cargo ahead, plugin + marketplace behind, CHANGELOG matches Cargo
+build_fixture "$T2" 0.7.0 0.6.5 0.6.5 0.7.0
+run_case "2: Cargo ahead, sync down" "$T2" 0 "plugin.json: 0.6.5 -> 0.7.0"
+
+# Scenario 3: plugin.json ahead of Cargo.toml -- refuse to downgrade
+build_fixture "$T3" 0.6.5 0.7.0 0.6.5 0.6.5
+run_case "3: plugin ahead -> refuse" "$T3" 1 "Refusing to downgrade"
+
+# Scenario 4: Cargo matches plugin/marketplace but CHANGELOG top header is stale
+build_fixture "$T4" 0.7.0 0.7.0 0.7.0 0.6.5
+run_case "4: CHANGELOG behind" "$T4" 1 "top header"
+
+if [ "$FAILS" -eq 0 ]; then
+  echo "[test-sync-version] all scenarios passed"
+  exit 0
+else
+  echo "[test-sync-version] $FAILS scenario(s) failed" >&2
+  exit 1
+fi


### PR DESCRIPTION
Closes #210.

## Problem

Cargo.toml is the declared source of truth for the legion version (per CLAUDE.md), but until now nothing enforced propagation. `scripts/sync-version.sh` existed and worked but was never wired to run automatically -- `plugin/.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`, and `plugin/CHANGELOG.md`'s top header could silently drift from Cargo.toml on a release bump. The tracked `.githooks/pre-commit` and `.githooks/pre-push` hooks existed but `core.hooksPath` pointed at the default `.git/hooks`, so they were dormant.

## Solution

Wire enforcement end-to-end: rewrite `sync-version.sh` to cover the missing checks, invoke it from `.githooks/pre-commit`, activate `.githooks/` via a one-shot installer, document it in the README, and extend CI shellcheck coverage to the new scripts.

### `scripts/sync-version.sh` (rewritten)

- Semver comparison via `sort -V`. Refuses to downgrade if `plugin.json` or `marketplace.json` carry a higher version than Cargo.toml. Fails loud with a message telling the developer to bump Cargo.toml instead.
- Propagates Cargo.toml version to `plugin.json` and `marketplace.json` when they're at or behind, and stages the updates into the in-flight commit via `git add`.
- Requires `plugin/CHANGELOG.md` top `## <version>` header to match Cargo.toml. Fails loud with a message pointing the developer at the changelog if not. Changelog body is human-authored -- only the header version tag is enforced.
- Portable sed (`-i.bak` + `rm .bak`) replacing the macOS-only `sed -i ''` from the original script.
- Pure shell + python3 (already assumed by the original script for the marketplace.json JSON edit).

### `.githooks/pre-commit` (modified)

- **Step 1 (new):** if any of `Cargo.toml`, `plugin.json`, `marketplace.json`, or `plugin/CHANGELOG.md` are staged, run `scripts/sync-version.sh`. Hard-fail on sync-version failure -- the commit cannot proceed with a broken version invariant.
- **Step 2 (unchanged behavior, cleaned up):** run the existing Claude Code `/simplify` review on the staged diff. Fixed a preexisting SC2181 shellcheck warning on the `claude -p` exit check by rewriting it to the direct `if ! cmd; then` idiom. Pre-push is left alone.

### `scripts/install-hooks.sh` (new)

One-shot installer: `git config core.hooksPath .githooks`. Idempotent; `chmod +x` on every file in `.githooks/` to cover filesystems that don't honor the executable bit (certain Windows+WSL setups). Prints the configured state and the list of installed hooks. Run once per fresh clone.

### `scripts/test-sync-version.sh` (new)

Smoke test for `sync-version.sh`. Spins up 4 fake-repo fixtures in `mktemp -d` dirs with `git init`, covers 4 scenarios, asserts exit codes and stderr sentinels. Runs in ~1 second. Exits 0 only if all 4 pass. Not wired into `cargo test` (not Rust), but tracked in `scripts/` so developers can run `bash scripts/test-sync-version.sh` to verify any future edits to `sync-version.sh`.

### `README.md`

Added a "Contributing" section that documents `./scripts/install-hooks.sh` as the one-shot setup for new contributors. Explains what `pre-commit` and `pre-push` do.

### `.github/workflows/ci.yml`

Extended the shellcheck job glob to cover `scripts/*.sh` so regressions in `sync-version.sh` / `install-hooks.sh` / `test-sync-version.sh` are caught in CI. Existing glob (`install.sh`, `plugin/bin/legion`, `plugin/hooks/*.sh`) untouched.

## Manual verification

All 4 scenarios from `scripts/test-sync-version.sh` passed locally:

1. **All versions match 0.6.5** → exit 0, stderr `[sync-version] all versions match 0.6.5`
2. **Cargo 0.7.0, plugin.json 0.6.5, marketplace 0.6.5, CHANGELOG 0.7.0** → exit 0, stderr `[sync-version] plugin.json: 0.6.5 -> 0.7.0` + marketplace update
3. **Cargo 0.6.5, plugin.json 0.7.0** → exit 1, stderr `[sync-version] ERROR: plugin.json is at 0.7.0, ahead of Cargo.toml at 0.6.5` + `Refusing to downgrade`
4. **Cargo 0.7.0, CHANGELOG top header still 0.6.5** → exit 1, stderr `[sync-version] ERROR: plugin/CHANGELOG.md top header is '## 0.6.5', Cargo.toml is 0.7.0`

## Quality gates

- `shellcheck install.sh plugin/bin/legion plugin/hooks/*.sh scripts/*.sh` -- clean (exit 0)
- `bash scripts/test-sync-version.sh` -- all 4 scenarios pass
- `cargo test`, `cargo clippy`, `cargo fmt` unchanged (no Rust edits)
- Pre-commit hook fired on this PR's own commit and reported PASS

## Out of scope

- `.githooks/pre-push` is left alone. It has two pre-existing shellcheck findings (SC2034 unused `CHANGED_FILES`, SC2181 on `$?` check) which predate this PR; fixing them is orthogonal and belongs in its own cleanup commit.
- The CI shellcheck glob is NOT extended to cover `.githooks/` for the same reason -- doing so would fail on the pre-existing pre-push issues above.
- The embedded Python block in `sync-version.sh` uses shell interpolation (`'$MARKETPLACE_JSON'`, `'$CARGO_VERSION'`) rather than env vars. This is inherited from the original script and is not an injection risk in practice (both values are legion-controlled), but it could be cleaned up in a follow-up.

## Test plan

1. `bash scripts/test-sync-version.sh` → all 4 scenarios pass.
2. Fresh clone: `./scripts/install-hooks.sh` → prints hooks installed, sets `core.hooksPath`.
3. `git config core.hooksPath` → prints `.githooks`.
4. Manually bump `Cargo.toml` version, stage, commit → pre-commit hook fires, syncs plugin.json + marketplace.json, stages them, commit succeeds.
5. Manually set `plugin.json` version higher than Cargo.toml, stage Cargo.toml, commit → pre-commit hook fails with "Refusing to downgrade" message.
6. Manually set `plugin/CHANGELOG.md` top header to a version different from Cargo.toml, stage Cargo.toml, commit → pre-commit fails with "top header" mismatch message.