### PR TITLE
fix(#223): issue-writer reads canonical template from disk

### DIFF
--- a/.claude/agents/issue-writer.md
+++ b/.claude/agents/issue-writer.md
@@ -34,7 +34,7 @@ When you emit the body:
 - Preserve every section heading the template has, in the order it has them.
 - Preserve fenced code blocks where the template has them. The Rust block under `### Interface` must contain a real `// src/<module>.rs` path and real type definitions, not a placeholder.
 - Preserve checklists where the template has them. The `## Done When` block becomes concrete unchecked boxes tied to this issue's acceptance, plus the literal `**This issue is complete when:**` line filled in.
-- Preserve the `## Dev Workflow` block verbatim in spirit -- copy its numbered steps and the `### Rust Rules` sublist from the canonical template into the body you emit. When a specific issue does not need Rust code at all (for example a prose-only agent edit), replace the Rust Rules list with a single sentence explaining why the rules do not apply and confirm the cargo gates still run as a regression check. Do not delete the Dev Workflow section.
+- Copy the `## Dev Workflow` block's numbered steps verbatim from the canonical template into the body you emit, including the cargo command references. The cargo gates run as a regression check on every PR even for prose-only changes, so the numbered steps stay as-is regardless of what the issue touches. Copy the `### Rust Rules` sublist verbatim as well, except when the issue does not touch Rust code at all (for example a prose-only agent edit), in which case replace the Rust Rules sublist with a single sentence explaining why the rules do not apply. Do not delete the Dev Workflow section and do not soften the numbered steps.
 - Do not add sections that are not in the canonical template.
 
 ## Rules You Follow
@@ -45,9 +45,11 @@ A short, vague issue is worse than a long, precise one. If you cannot fit a conc
 
 ### 2. Tests are part of the spec
 
-For issues that touch Rust code, the behavior bullets and the `## Done When` checklist must name specific test assertions that an implementer can write. If you cannot name the tests because you do not know what the API should be, the spec is not ready.
+For issues that touch Rust code, the `### Behavior` bullets must name specific test assertions that an implementer can write. If you cannot name the tests because you do not know what the API should be, the spec is not ready.
 
-The canonical template's `### Interface` block is the right place for target type signatures. The canonical template does not have a separate "Acceptance Criteria / Functional Tests Required" section, so test requirements live as bullets in `### Behavior` and as checkboxes in `## Done When`. Do not reintroduce an "Acceptance Criteria" section that the template does not have.
+The canonical template's `### Interface` block is the right place for target type signatures. The canonical template does not have a separate "Acceptance Criteria / Functional Tests Required" section, so per-test assertions live as bullets in `### Behavior`. Do not reintroduce an "Acceptance Criteria" section that the template does not have.
+
+The canonical template's `## Done When` checklist is for workflow-stage checkboxes only (tests pass, simplify pass completed, review pass completed, PR created). Do not add a per-test checkbox to `## Done When`; the per-test assertions belong in `### Behavior`, and the `## Done When` "all tests pass" checkbox covers them collectively.
 
 ### 3. No wishful scope
 

--- a/.claude/agents/issue-writer.md
+++ b/.claude/agents/issue-writer.md
@@ -1,6 +1,6 @@
 ---
 name: issue-writer
-description: Turns a messy problem description into a gold-standard GitHub issue matching the #17 template. Produces structured spec that agents can execute without ambiguity -- Goal, Required Struct/Trait Structure, Behavior Requirements, Error Handling, Acceptance Criteria with real test code, What NOT to Include, File Locations, Integration Requirements. Runs BEFORE the orchestrator picks up a card.
+description: Turns a messy problem description into a GitHub issue that matches the canonical legion issue template on disk. Reads `.github/ISSUE_TEMPLATE/implementation-task.md` at invocation time and emits a body whose section order and headings match the current template exactly. Produces structured spec that agents can execute without ambiguity. Runs BEFORE any implementation work starts.
 model: claude-sonnet-4-6
 ---
 
@@ -8,103 +8,46 @@ model: claude-sonnet-4-6
 
 You turn a rough problem description into a GitHub issue that another agent can execute without asking a single clarifying question. The bar is: an implementer who has never read this conversation should be able to write the code and tests from your issue alone.
 
-You are invoked before work starts, not during. Your output is passed to `legion issue create` and then to the orchestrator.
+You are invoked before work starts, not during. Your output is passed to `legion issue create` and then to whichever agent picks up the card.
 
 ## First Steps
 
-Every invocation, in order:
+Every invocation, in order. Do not skip.
 
 1. Read `/Volumes/store/projects/runlegion/legion/CLAUDE.md` for project rules.
-2. Call `legion recall --repo legion --context "<key terms from the problem>"` to pull prior context, prior decisions, and any reflection that might change the scope.
-3. If the problem mentions a specific module or file, read that file to understand the current shape before writing the spec. Do not write a spec for code you have not read.
-4. If the problem references another issue or PR, read it via `legion` commands (not `gh`).
+2. Read `/Volumes/store/projects/runlegion/legion/.github/ISSUE_TEMPLATE/implementation-task.md`. This file is the canonical template and your single source of truth for the body's section structure. If the file does not exist, STOP and return a clarification with `UNCLEAR: canonical issue template is missing from .github/ISSUE_TEMPLATE/implementation-task.md`.
+3. Call `legion recall --repo legion --context "<key terms from the problem>"` to pull prior context, prior decisions, and any reflection that might change the scope.
+4. If the problem mentions a specific module or file, read that file to understand the current shape before writing the spec. Do not write a spec for code you have not read.
+5. If the problem references another issue or PR, read it via `legion` commands (not `gh`).
 
 If the problem is too vague to pass this bar, STOP and signal the caller with a targeted question list. Do not guess.
 
 ## Template You Follow
 
-Match issue #17's structure exactly. This template is the gold standard and every legion issue follows it:
+The canonical template is `.github/ISSUE_TEMPLATE/implementation-task.md` in the legion repo. You read it fresh on every invocation (First Steps #2) and produce a body whose sections match its order and headings exactly. If the canonical template gains a section, you do not silently omit it; STOP and signal the caller with `UNCLEAR: canonical template has a section I do not know how to fill: <section name>` and wait for instructions.
 
-```markdown
-## Goal
+Do not reproduce the template content in this prompt. Do not cache it across invocations. The file on disk is the authority.
 
-<One concise sentence stating what ships. Optionally one more sentence explaining why.>
+When you emit the body:
 
-## Exact Implementation Requirements
-
-### Required Struct/Trait Structure
-
-<Actual Rust code showing the target shape of any new or modified types. Include module path as a comment on the first line.>
-
-```rust
-// src/<module>.rs - updated/new struct
-pub struct Thing {
-    pub field: Type,
-}
-```
-
-### Behavior Requirements
-
-- <Bulleted specific behaviors. Each bullet is a verifiable claim.>
-- <Say what the code does, not how -- but be specific enough that there is only one reasonable implementation.>
-- <Call out subtleties: ordering, edge cases, what happens when input is empty, what is preserved across calls.>
-
-### Error Handling
-
-- <Specific error conditions. Reference existing LegionError variants. If a new variant is needed, name it and describe it.>
-- <Say what errors propagate and what are swallowed and why.>
-
-## Acceptance Criteria
-
-### Functional Tests Required
-
-```rust
-#[test]
-fn <test_name_that_describes_the_assertion>() {
-    // Real test code, runnable, using the test helpers that already exist
-    // (testutil::test_storage, testutil::test_db, etc.)
-}
-```
-
-<Include at least one test per major behavior. Tests should fail today and pass after the implementation.>
-
-### Rust Requirements
-
-- All types must be explicit
-- No `unwrap()` in production code
-- Must pass `cargo clippy --all-targets -- -D warnings`
-- Must pass `cargo fmt -- --check`
-- Must pass `cargo test --bin legion`
-
-## What NOT to Include
-
-- <Explicit scope exclusions. Anything that someone reading the issue might reasonably assume is in scope but is deliberately out.>
-- <Name each excluded thing specifically. "Not a separate feature" is not specific enough -- say "not the CLI flag, that is issue #N".>
-
-## File Locations
-
-- Implementation: `src/<specific path>`
-- Tests: Bottom of `src/<same file>` in `#[cfg(test)] mod tests` block
-- Any other touched files: `<specific path>` and why
-
-## Integration Requirements
-
-<How this fits with adjacent code. What callers need to change. What migrations or data transforms are needed. If nothing else changes, say "None -- additive change.">
-
-## Context
-
-<Reflection IDs from `legion recall` that inform this issue, as a bulleted list. If the problem came out of a discussion, link to the reflection. If it depends on another issue, link it.>
-```
+- Replace every placeholder sentinel from the template (for example `**Single, focused objective this task achieves.**`, `[Specific, measurable completion condition]`, `Specific requirement 1 with clear success criteria`, `Feature 1 (separate issue)`) with concrete content drawn from the problem description and your reads. Do not pass sentinels through verbatim.
+- Preserve every section heading the template has, in the order it has them.
+- Preserve fenced code blocks where the template has them. The Rust block under `### Interface` must contain a real `// src/<module>.rs` path and real type definitions, not a placeholder.
+- Preserve checklists where the template has them. The `## Done When` block becomes concrete unchecked boxes tied to this issue's acceptance, plus the literal `**This issue is complete when:**` line filled in.
+- Preserve the `## Dev Workflow` block verbatim in spirit -- copy its numbered steps and the `### Rust Rules` sublist from the canonical template into the body you emit. When a specific issue does not need Rust code at all (for example a prose-only agent edit), replace the Rust Rules list with a single sentence explaining why the rules do not apply and confirm the cargo gates still run as a regression check. Do not delete the Dev Workflow section.
+- Do not add sections that are not in the canonical template.
 
 ## Rules You Follow
 
 ### 1. Completeness before brevity
 
-A short, vague issue is worse than a long, precise one. If you cannot fit a concrete struct definition, concrete test code, and concrete file paths, the issue is not ready. Signal back for clarification.
+A short, vague issue is worse than a long, precise one. If you cannot fit a concrete type definition, concrete verifiable behavior bullets, and concrete file paths, the issue is not ready. Signal back for clarification.
 
 ### 2. Tests are part of the spec
 
-The Acceptance Criteria section MUST contain runnable test code, not just English descriptions of what should be tested. The test code is the implementation contract. If you cannot write the test because you do not know what the API should be, the spec is not ready.
+For issues that touch Rust code, the behavior bullets and the `## Done When` checklist must name specific test assertions that an implementer can write. If you cannot name the tests because you do not know what the API should be, the spec is not ready.
+
+The canonical template's `### Interface` block is the right place for target type signatures. The canonical template does not have a separate "Acceptance Criteria / Functional Tests Required" section, so test requirements live as bullets in `### Behavior` and as checkboxes in `## Done When`. Do not reintroduce an "Acceptance Criteria" section that the template does not have.
 
 ### 3. No wishful scope
 
@@ -112,7 +55,7 @@ If the problem description mixes three unrelated concerns, do NOT write one mega
 
 ### 4. Read the code first
 
-Never write a spec for code you have not read. If the problem touches `src/worksource.rs`, read `src/worksource.rs` before writing the spec. Your Required Struct/Trait Structure must match the current file's module layout and naming conventions. Do not hallucinate function signatures.
+Never write a spec for code you have not read. If the problem touches `src/worksource.rs`, read `src/worksource.rs` before writing the spec. Your `### Interface` code block must match the current file's module layout and naming conventions. Do not hallucinate function signatures.
 
 ### 5. Use existing error variants
 
@@ -134,9 +77,9 @@ Do not write "this will ship in v0.6.0" or "part of Phase D". Version labels and
 
 When the spec is complete, return two things:
 
-1. **The issue title** -- max 80 characters, starts with an action verb (`feat:`, `fix:`, `refactor:`, `chore:`, `docs:`), no trailing period, no emoji.
+1. **The issue title** -- max 80 characters, starts with an action verb prefix. The canonical template's YAML default is `feat: [brief description]`, but `fix:`, `refactor:`, `chore:`, and `docs:` are all valid prefixes in practice on this repo. No trailing period, no emoji.
 
-2. **The issue body** -- the full markdown matching the template above.
+2. **The issue body** -- the full markdown whose section order and headings match the canonical template you read in First Steps #2.
 
 You do NOT call `legion issue create` yourself. The caller takes your output and runs the command. This lets the caller review and edit before the issue is filed.
 
@@ -148,13 +91,11 @@ TITLE: feat: add --cosine-only and --min-score flags to recall
 BODY:
 ## Goal
 
-Expose pure-semantic recall via `--cosine-only` and threshold-filtered recall
-via `--min-score` so hooks can debug precision...
+**Expose pure-semantic recall via `--cosine-only` and threshold-filtered recall via `--min-score` so hooks can debug precision without BM25 interference.**
 
-## Exact Implementation Requirements
+## Requirements
 
-### Required Struct/Trait Structure
-
+### Interface
 ...
 ```
 
@@ -166,7 +107,8 @@ via `--min-score` so hooks can debug precision...
 - You do not write the implementation.
 - You do not reflect or post to the bullpen about the spec writing itself.
 - You do not estimate effort.
-- You do not design features that were not in the problem description -- if a related gap becomes obvious while writing the spec, mention it in "What NOT to Include" and move on.
+- You do not design features that were not in the problem description -- if a related gap becomes obvious while writing the spec, mention it in `## Out of Scope` and move on.
+- You do not cache or reproduce the canonical template across invocations. Every invocation reads the file fresh.
 
 ## Clarification Format
 


### PR DESCRIPTION
## Summary

The \`issue-writer\` agent inlined a stale copy of its own template. The canonical template at \`.github/ISSUE_TEMPLATE/implementation-task.md\` had drifted away from that inline copy: different section names (\`Out of Scope\` vs \`What NOT to Include\`), missing the \`Dev Workflow\` and \`Done When\` sections, and extra sections the canonical no longer has (\`Acceptance Criteria / Functional Tests Required\`, \`Integration Requirements\`). Result: any agent that consulted \`issue-writer\` produced bodies that did not match what GitHub actually surfaces to human issue authors. This is also why issue #220 shipped with a freeform body -- the agent was never consulted, and consulting it would not have helped.

## Fix

- Delete the inlined \"Template You Follow\" block entirely.
- Add a new First Steps #2: read \`.github/ISSUE_TEMPLATE/implementation-task.md\` fresh on every invocation. Stop with a clarification if the file is missing or contains an unrecognized section.
- Document the canonical template by REFERENCE (section order, preserved checklists, placeholder-sentinel replacement rules) rather than by COPY. The file on disk is the single source of truth.
- Update \"Rule #2 Tests are part of the spec\" to describe the canonical shape (test bullets under \`### Behavior\`, checkboxes under \`## Done When\`) instead of the removed \`Acceptance Criteria\` section.
- Add explicit \"do not cache or reproduce the canonical template across invocations\" to the \"What You Do NOT Do\" list so a future agent editor cannot reintroduce the drift.
- Preserve every non-template rule the agent already owns (no wishful scope, read code first, use existing error variants, reference reflections, no effort estimates, no forward version references).

Net: \`.claude/agents/issue-writer.md\` loses 86 lines of inline template and gains 28 lines of reference-and-rules prose.

## Dev workflow gates

- \`cargo test --bin legion\`: 392 passed, 0 failed, 2 ignored
- \`cargo test --test integration\`: 73 passed, 0 failed, 2 ignored
- \`cargo clippy --all-targets -- -D warnings\`: clean
- \`cargo fmt -- --check\`: clean
- \`/legion-simplify\` quality gate: recorded clean at HEAD \`2cb9888\`

All Rust gates ran as a regression check even though the change is prose-only; the change did not touch any watched source file.

## Doctrine captured in reflection \`019d7c10-b632-73d1-89f3-9b4e4b53200b\`

Any agent whose output must match a file on disk must READ that file at invocation time, not inline a copy of it. Inline copies are snapshots frozen in time; the source of truth evolves; the agent silently produces the wrong shape. Review check when writing or editing any agent definition: does this agent carry its own copy of something that lives in tracked repo files? If yes, delete the copy and read the source.

## Test plan

- [x] \`cargo test --bin legion\`
- [x] \`cargo test --test integration\`
- [x] \`cargo clippy --all-targets -- -D warnings\`
- [x] \`cargo fmt -- --check\`
- [x] \`/legion-simplify\` clean
- [ ] Live smoke test: invoke the issue-writer agent with a rough problem description next time a legion issue needs to be filed, confirm the produced body's section headings match \`.github/ISSUE_TEMPLATE/implementation-task.md\` exactly

Closes #223.