### PR TITLE
feat(#192): legion CLI gap rework -- issue close/reopen/edit, kanban delete/reconcile, auto-propagation

### DIFF
--- a/plugin/worksources/github
+++ b/plugin/worksources/github
@@ -33,13 +33,42 @@ case "${1:-}" in
 
   close)
     NUMBER="${2:-}"
+    COMMENT="${LEGION_WS_COMMENT:-}"
     if [ -z "$REPO" ] || [ -z "$NUMBER" ]; then
+      echo '{"error":"LEGION_WS_REPO and number required"}' >&2
       exit 1
     fi
     if ! command -v gh &>/dev/null; then
+      echo '{"error":"gh CLI not found"}' >&2
       exit 1
     fi
-    gh issue close "$NUMBER" --repo "$REPO" 2>/dev/null
+    if [ -n "$COMMENT" ]; then
+      gh issue comment "$NUMBER" --repo "$REPO" --body "$COMMENT" >/dev/null \
+        || { echo '{"error":"gh issue comment failed"}' >&2; exit 1; }
+    fi
+    gh issue close "$NUMBER" --repo "$REPO" \
+      || { echo '{"error":"gh issue close failed"}' >&2; exit 1; }
+    echo '{"ok":true}'
+    ;;
+
+  reopen)
+    NUMBER="${2:-}"
+    COMMENT="${LEGION_WS_COMMENT:-}"
+    if [ -z "$REPO" ] || [ -z "$NUMBER" ]; then
+      echo '{"error":"LEGION_WS_REPO and number required"}' >&2
+      exit 1
+    fi
+    if ! command -v gh &>/dev/null; then
+      echo '{"error":"gh CLI not found"}' >&2
+      exit 1
+    fi
+    gh issue reopen "$NUMBER" --repo "$REPO" \
+      || { echo '{"error":"gh issue reopen failed"}' >&2; exit 1; }
+    if [ -n "$COMMENT" ]; then
+      gh issue comment "$NUMBER" --repo "$REPO" --body "$COMMENT" >/dev/null \
+        || { echo '{"error":"gh issue comment failed"}' >&2; exit 1; }
+    fi
+    echo '{"ok":true}'
     ;;
 
   detect)

--- a/plugin/worksources/github
+++ b/plugin/worksources/github
@@ -71,6 +71,30 @@ case "${1:-}" in
     echo '{"ok":true}'
     ;;
 
+  edit-issue)
+    NUMBER="${LEGION_WS_NUMBER:-}"
+    TITLE="${LEGION_WS_TITLE:-}"
+    BODY="${LEGION_WS_BODY:-}"
+    if [ -z "$REPO" ] || [ -z "$NUMBER" ]; then
+      echo '{"error":"LEGION_WS_REPO and LEGION_WS_NUMBER required"}' >&2
+      exit 1
+    fi
+    if [ -z "$TITLE" ] && [ -z "$BODY" ]; then
+      echo '{"error":"at least one of LEGION_WS_TITLE or LEGION_WS_BODY required"}' >&2
+      exit 1
+    fi
+    if ! command -v gh &>/dev/null; then
+      echo '{"error":"gh CLI not found"}' >&2
+      exit 1
+    fi
+    ARGS=(issue edit "$NUMBER" --repo "$REPO")
+    [ -n "$TITLE" ] && ARGS+=(--title "$TITLE")
+    [ -n "$BODY" ] && ARGS+=(--body "$BODY")
+    gh "${ARGS[@]}" >/dev/null \
+      || { echo '{"error":"gh issue edit failed"}' >&2; exit 1; }
+    echo '{"ok":true}'
+    ;;
+
   detect)
     # Try to detect the GitHub repo from the workdir
     if [ -n "$WORKDIR" ] && [ -d "$WORKDIR/.git" ]; then

--- a/src/db.rs
+++ b/src/db.rs
@@ -1651,6 +1651,25 @@ impl Database {
         Ok(())
     }
 
+    /// Permanently remove a kanban card from the database.
+    ///
+    /// Unlike `transition_card` with `Cancel`, which moves the card to a
+    /// terminal `cancelled` state where it still appears in `legion kanban
+    /// list`, this drops the row entirely. Used to hard-remove a card
+    /// filed in error (e.g. a card created from a mistaken
+    /// `legion kanban create`) that should never have existed. Returns
+    /// `CardNotFound` if the id does not match any row so the caller can
+    /// surface a clear error rather than silently no-op.
+    pub fn delete_card(&self, id: &str) -> Result<()> {
+        let rows = self
+            .conn
+            .execute("DELETE FROM tasks WHERE id = ?1", rusqlite::params![id])?;
+        if rows == 0 {
+            return Err(LegionError::CardNotFound(id.to_string()));
+        }
+        Ok(())
+    }
+
     /// Get per-agent workload summary.
     pub fn get_agent_workloads(&self) -> Result<Vec<crate::kanban::AgentWorkload>> {
         let mut stmt = self.conn.prepare(
@@ -3380,5 +3399,39 @@ mod tests {
             .unwrap()
             .unwrap();
         assert_eq!(fetched.details.as_deref(), Some(details));
+    }
+
+    #[test]
+    fn delete_card_removes_row_and_reports_not_found() {
+        let db = test_db();
+
+        // Insert a minimal card and confirm it is visible before delete.
+        let id = db
+            .insert_card(
+                "legion",
+                "legion",
+                "test card to delete",
+                None,
+                "med",
+                None,
+                None,
+                None,
+                None,
+                None,
+            )
+            .unwrap();
+        assert!(db.get_card_by_id(&id).unwrap().is_some());
+
+        // Delete the card and confirm it is gone.
+        db.delete_card(&id).expect("delete existing card");
+        assert!(db.get_card_by_id(&id).unwrap().is_none());
+
+        // Deleting a non-existent card returns CardNotFound, not a silent
+        // no-op.
+        let result = db.delete_card(&id);
+        assert!(
+            matches!(result, Err(LegionError::CardNotFound(_))),
+            "expected CardNotFound for missing card, got: {result:?}"
+        );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -807,6 +807,35 @@ enum KanbanAction {
         #[arg(long)]
         id: String,
     },
+
+    /// Reconcile kanban done/cancelled cards with their linked GitHub
+    /// issue state.
+    ///
+    /// Finds every card whose local state is `done` or `cancelled` but
+    /// whose linked GitHub issue is still `OPEN`, and reports the
+    /// mismatches. Used to backfill the stale-open drift that
+    /// accumulated before the `cancel`/`reopen` auto-propagation
+    /// shipped.
+    ///
+    /// `--dry-run` (default) only prints the mismatches. `--close-stale`
+    /// additionally calls `legion issue close` on every mismatched
+    /// issue with a canned reconciliation comment.
+    Reconcile {
+        /// Optional repo filter -- only reconcile cards owned by this
+        /// agent. Default is all cards across all repos.
+        #[arg(long)]
+        repo: Option<String>,
+
+        /// Dry-run (default). Report mismatches without changing any
+        /// GitHub state.
+        #[arg(long, default_value_t = true)]
+        dry_run: bool,
+
+        /// Actually close the stale GitHub issues. Without this flag,
+        /// the command is read-only and safe to run repeatedly.
+        #[arg(long)]
+        close_stale: bool,
+    },
 }
 
 #[derive(Subcommand)]
@@ -2442,6 +2471,154 @@ fn run() -> error::Result<()> {
                         details: None,
                         outcome: "success",
                     });
+                }
+                KanbanAction::Reconcile {
+                    repo,
+                    dry_run: _,
+                    close_stale,
+                } => {
+                    // `dry_run` is true by default from clap; the
+                    // meaningful flag is `close_stale`. When
+                    // `close_stale` is set, we actually close stale
+                    // issues; otherwise we only print mismatches.
+                    let cards = kanban::board_cards(&database)?;
+                    let mut stale: Vec<(kanban::Card, u64, String)> = Vec::new();
+
+                    for card in cards {
+                        // Only done/cancelled cards are candidates for
+                        // reconciliation. Active cards are expected to
+                        // have open issues.
+                        if !matches!(
+                            card.status,
+                            kanban::CardStatus::Done | kanban::CardStatus::Cancelled
+                        ) {
+                            continue;
+                        }
+
+                        if let Some(ref filter) = repo
+                            && card.to_repo != *filter
+                        {
+                            continue;
+                        }
+
+                        let Some(ref source_url) = card.source_url else {
+                            continue;
+                        };
+                        let Some(number) = worksource::extract_issue_number(source_url) else {
+                            continue;
+                        };
+                        let Some(source) = card.source_type.as_deref() else {
+                            continue;
+                        };
+                        let Some((_, source_repo, _)) = worksource::resolve_config(&card.to_repo)
+                        else {
+                            eprintln!(
+                                "[legion] reconcile: skipping card {} -- to_repo '{}' has no work source configured",
+                                card.id, card.to_repo
+                            );
+                            continue;
+                        };
+
+                        // Query the live issue state. view_issue returns
+                        // ExternalIssue with a `state` field that is
+                        // "OPEN" or "CLOSED" for GitHub. Any other
+                        // value is treated as "unknown" and skipped
+                        // with a warning so a plugin that returns a
+                        // non-standard state does not silently get
+                        // reported as stale-open.
+                        let state = match worksource::view_issue(source, &source_repo, number) {
+                            Ok(issue) => issue.state,
+                            Err(e) => {
+                                eprintln!(
+                                    "[legion] reconcile: failed to view {} issue #{}: {}",
+                                    source_repo, number, e
+                                );
+                                continue;
+                            }
+                        };
+
+                        if state == "OPEN" {
+                            stale.push((card.clone(), number, source_repo.clone()));
+                        }
+                    }
+
+                    if stale.is_empty() {
+                        println!("[legion] reconcile: no stale-open issues found");
+                    } else {
+                        println!(
+                            "[legion] reconcile: {} stale-open issue(s) found",
+                            stale.len()
+                        );
+                        for (card, number, source_repo) in &stale {
+                            println!(
+                                "  card={} status={} source={}#{} to_repo={}",
+                                card.id,
+                                card.status.label(),
+                                source_repo,
+                                number,
+                                card.to_repo
+                            );
+                        }
+                    }
+
+                    if close_stale && !stale.is_empty() {
+                        println!("[legion] reconcile: closing {} stale issue(s)", stale.len());
+                        let mut closed = 0_u64;
+                        let mut failed = 0_u64;
+                        for (card, number, source_repo) in &stale {
+                            let Some(source) = card.source_type.as_deref() else {
+                                continue;
+                            };
+                            let reconcile_comment = format!(
+                                "Closed by legion reconcile: local card {} is {} but this issue was left open. Reconciling to match the local state.",
+                                card.id,
+                                card.status.label()
+                            );
+                            match worksource::close_issue(
+                                source,
+                                source_repo,
+                                *number,
+                                Some(&reconcile_comment),
+                            ) {
+                                Ok(()) => {
+                                    closed += 1;
+                                    eprintln!(
+                                        "[legion] reconcile: closed {} issue #{}",
+                                        source_repo, number
+                                    );
+                                    let details = serde_json::json!({
+                                        "card_id": card.id,
+                                        "propagation": "reconcile",
+                                    });
+                                    let details_str = details.to_string();
+                                    audit(&db::AuditInput {
+                                        agent: &card.to_repo,
+                                        action: "close-issue",
+                                        target_type: "issue",
+                                        target_ref: &number.to_string(),
+                                        task_id: Some(&card.id),
+                                        source_type: source,
+                                        details: Some(&details_str),
+                                        outcome: "success",
+                                    });
+                                }
+                                Err(e) => {
+                                    failed += 1;
+                                    eprintln!(
+                                        "[legion] reconcile: failed to close {} issue #{}: {}",
+                                        source_repo, number, e
+                                    );
+                                }
+                            }
+                        }
+                        println!("[legion] reconcile: {} closed, {} failed", closed, failed);
+                    } else if close_stale {
+                        println!("[legion] reconcile: nothing to close");
+                    } else if !stale.is_empty() {
+                        println!(
+                            "[legion] reconcile: dry-run -- pass --close-stale to actually close these issues"
+                        );
+                    }
                 }
             }
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -430,7 +430,12 @@ enum Commands {
         #[arg(long)]
         repo: Option<String>,
 
-        /// Filter by action type (create-issue, create-pr, review, merge, comment, close)
+        /// Filter by action type. Known verbs:
+        /// create-issue, close-issue, reopen-issue, edit-issue,
+        /// create-pr, close-pr, review, merge, comment,
+        /// delete-card, update-card.
+        /// Filter is an exact string match; additional verbs
+        /// introduced by future subcommands work automatically.
         #[arg(long)]
         action: Option<String>,
 
@@ -817,19 +822,15 @@ enum KanbanAction {
     /// accumulated before the `cancel`/`reopen` auto-propagation
     /// shipped.
     ///
-    /// `--dry-run` (default) only prints the mismatches. `--close-stale`
-    /// additionally calls `legion issue close` on every mismatched
-    /// issue with a canned reconciliation comment.
+    /// Default mode is read-only: the command scans and reports
+    /// without changing any GitHub state. Pass `--close-stale` to
+    /// actually close each mismatched issue via the work source
+    /// plugin with a canned reconciliation comment.
     Reconcile {
         /// Optional repo filter -- only reconcile cards owned by this
         /// agent. Default is all cards across all repos.
         #[arg(long)]
         repo: Option<String>,
-
-        /// Dry-run (default). Report mismatches without changing any
-        /// GitHub state.
-        #[arg(long, default_value_t = true)]
-        dry_run: bool,
 
         /// Actually close the stale GitHub issues. Without this flag,
         /// the command is read-only and safe to run repeatedly.
@@ -2472,15 +2473,9 @@ fn run() -> error::Result<()> {
                         outcome: "success",
                     });
                 }
-                KanbanAction::Reconcile {
-                    repo,
-                    dry_run: _,
-                    close_stale,
-                } => {
-                    // `dry_run` is true by default from clap; the
-                    // meaningful flag is `close_stale`. When
-                    // `close_stale` is set, we actually close stale
-                    // issues; otherwise we only print mismatches.
+                KanbanAction::Reconcile { repo, close_stale } => {
+                    // Default mode is read-only. `--close-stale` is the
+                    // only flag that actually touches GitHub.
                     let cards = kanban::board_cards(&database)?;
                     let mut stale: Vec<(kanban::Card, u64, String)> = Vec::new();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -870,6 +870,42 @@ enum IssueAction {
         #[arg(long)]
         number: u64,
     },
+    /// Close an issue via the configured work source
+    ///
+    /// Used to reconcile a shipped kanban card with its public GitHub state
+    /// when the card was closed through a path other than `pr merge --task`
+    /// (which already auto-closes the linked issue). The optional `--comment`
+    /// is posted on the issue before it transitions to closed.
+    Close {
+        /// Repository name (resolves work source config from watch.toml)
+        #[arg(long)]
+        repo: String,
+
+        /// Issue number
+        #[arg(long)]
+        number: u64,
+
+        /// Optional closing comment posted before the close
+        #[arg(long)]
+        comment: Option<String>,
+    },
+    /// Reopen a previously closed issue via the configured work source
+    ///
+    /// Symmetrical with `close` for reverting a kanban transition that
+    /// already propagated to GitHub.
+    Reopen {
+        /// Repository name (resolves work source config from watch.toml)
+        #[arg(long)]
+        repo: String,
+
+        /// Issue number
+        #[arg(long)]
+        number: u64,
+
+        /// Optional reopening comment posted after the reopen
+        #[arg(long)]
+        comment: Option<String>,
+    },
 }
 
 #[derive(Subcommand, Debug)]
@@ -1894,11 +1930,14 @@ fn run() -> error::Result<()> {
                     kanban::transition_card(&database, card_id, kanban::Action::Done, Some(&text))?;
                 println!("{card_id}");
 
-                // Close linked external issue if present
+                // Close the linked external issue if present, using the
+                // done-text as the closing comment so the GitHub issue thread
+                // records why it was closed.
                 if let (Some(url), Some(source)) = (&card.source_url, &card.source_type)
                     && let Some(number) = worksource::extract_issue_number(url)
                     && let Some((_, source_repo, _)) = worksource::resolve_config(&repo)
-                    && let Err(e) = worksource::close_issue(source, &source_repo, number)
+                    && let Err(e) =
+                        worksource::close_issue(source, &source_repo, number, Some(&text))
                 {
                     eprintln!("[legion] failed to close {source} issue #{number}: {e}");
                 }
@@ -2371,6 +2410,66 @@ fn run() -> error::Result<()> {
                 println!("State: {}", issue.state);
                 println!("URL: {}", issue.url);
             }
+            IssueAction::Close {
+                repo,
+                number,
+                comment,
+            } => {
+                let (plugin_name, source_repo, _workdir) = worksource::resolve_config(&repo)
+                    .ok_or_else(|| {
+                        error::LegionError::WorkSource(format!(
+                            "no work source configured for repo '{}' in watch.toml",
+                            repo
+                        ))
+                    })?;
+
+                worksource::close_issue(&plugin_name, &source_repo, number, comment.as_deref())?;
+
+                let details = serde_json::json!({ "comment": comment });
+                let details_str = details.to_string();
+                audit(&db::AuditInput {
+                    agent: &repo,
+                    action: "close-issue",
+                    target_type: "issue",
+                    target_ref: &number.to_string(),
+                    task_id: None,
+                    source_type: &plugin_name,
+                    details: Some(&details_str),
+                    outcome: "success",
+                });
+
+                println!("closed issue #{} on {}", number, source_repo);
+            }
+            IssueAction::Reopen {
+                repo,
+                number,
+                comment,
+            } => {
+                let (plugin_name, source_repo, _workdir) = worksource::resolve_config(&repo)
+                    .ok_or_else(|| {
+                        error::LegionError::WorkSource(format!(
+                            "no work source configured for repo '{}' in watch.toml",
+                            repo
+                        ))
+                    })?;
+
+                worksource::reopen_issue(&plugin_name, &source_repo, number, comment.as_deref())?;
+
+                let details = serde_json::json!({ "comment": comment });
+                let details_str = details.to_string();
+                audit(&db::AuditInput {
+                    agent: &repo,
+                    action: "reopen-issue",
+                    target_type: "issue",
+                    target_ref: &number.to_string(),
+                    task_id: None,
+                    source_type: &plugin_name,
+                    details: Some(&details_str),
+                    outcome: "success",
+                });
+
+                println!("reopened issue #{} on {}", number, source_repo);
+            }
         },
         Commands::Pr { action } => match action {
             PrAction::Create {
@@ -2635,13 +2734,22 @@ fn run() -> error::Result<()> {
                         ),
                     }
 
-                    // Close linked issue if the card has a source URL
+                    // Close the linked issue if the card has a source URL,
+                    // using a generated merge comment so the GitHub issue
+                    // records which PR merge closed it.
                     if let Some(card) = database.get_card_by_id(task_id)?
                         && let Some(ref url) = card.source_url
                         && let Some(issue_num) = worksource::extract_issue_number(url)
                         && let Some(ref source) = card.source_type
                     {
-                        if let Err(e) = worksource::close_issue(source, &source_repo, issue_num) {
+                        let merge_comment =
+                            format!("Closed by PR #{number} merge via legion kanban propagation.");
+                        if let Err(e) = worksource::close_issue(
+                            source,
+                            &source_repo,
+                            issue_num,
+                            Some(&merge_comment),
+                        ) {
                             eprintln!(
                                 "[legion] warning: could not close issue #{}: {}",
                                 issue_num, e

--- a/src/main.rs
+++ b/src/main.rs
@@ -952,6 +952,29 @@ enum IssueAction {
         #[arg(long)]
         comment: Option<String>,
     },
+    /// Edit the title and/or body of an existing issue
+    ///
+    /// At least one of `--title` or `--body` must be provided. Used for
+    /// scope amendments and stale-content fixes after a sync, so agents
+    /// do not have to drop scope addenda into comment threads where they
+    /// are buried below fold on the public GitHub view.
+    Edit {
+        /// Repository name (resolves work source config from watch.toml)
+        #[arg(long)]
+        repo: String,
+
+        /// Issue number
+        #[arg(long)]
+        number: u64,
+
+        /// Replace the issue title
+        #[arg(long)]
+        title: Option<String>,
+
+        /// Replace the issue body
+        #[arg(long)]
+        body: Option<String>,
+    },
 }
 
 #[derive(Subcommand, Debug)]
@@ -2722,6 +2745,52 @@ fn run() -> error::Result<()> {
                 });
 
                 println!("reopened issue #{} on {}", number, source_repo);
+            }
+            IssueAction::Edit {
+                repo,
+                number,
+                title,
+                body,
+            } => {
+                if title.is_none() && body.is_none() {
+                    return Err(error::LegionError::WorkSource(
+                        "legion issue edit requires at least one of --title or --body".to_string(),
+                    ));
+                }
+
+                let (plugin_name, source_repo, _workdir) = worksource::resolve_config(&repo)
+                    .ok_or_else(|| {
+                        error::LegionError::WorkSource(format!(
+                            "no work source configured for repo '{}' in watch.toml",
+                            repo
+                        ))
+                    })?;
+
+                worksource::edit_issue(
+                    &plugin_name,
+                    &source_repo,
+                    number,
+                    title.as_deref(),
+                    body.as_deref(),
+                )?;
+
+                let details = serde_json::json!({
+                    "title_set": title.is_some(),
+                    "body_set": body.is_some(),
+                });
+                let details_str = details.to_string();
+                audit(&db::AuditInput {
+                    agent: &repo,
+                    action: "edit-issue",
+                    target_type: "issue",
+                    target_ref: &number.to_string(),
+                    task_id: None,
+                    source_type: &plugin_name,
+                    details: Some(&details_str),
+                    outcome: "success",
+                });
+
+                println!("edited issue #{} on {}", number, source_repo);
             }
         },
         Commands::Pr { action } => match action {

--- a/src/main.rs
+++ b/src/main.rs
@@ -738,10 +738,27 @@ enum KanbanAction {
     },
 
     /// Cancel a card
+    ///
+    /// When the card has a linked external issue (`source_url`), the
+    /// corresponding GitHub issue is automatically closed as
+    /// "not-planned" via the work source plugin. Pass `--no-propagate`
+    /// to transition only the local card state without touching
+    /// GitHub.
     Cancel {
         /// Card ID
         #[arg(long)]
         id: String,
+
+        /// Optional cancel reason, posted as a comment on the GitHub
+        /// issue before the close
+        #[arg(long)]
+        reason: Option<String>,
+
+        /// Transition the card locally without closing the linked
+        /// GitHub issue. Use this when the kanban state needs to
+        /// diverge from the external issue state deliberately.
+        #[arg(long)]
+        no_propagate: bool,
     },
 
     /// Assign a backlog card to an agent
@@ -756,10 +773,25 @@ enum KanbanAction {
     },
 
     /// Reopen a done or cancelled card
+    ///
+    /// When the card has a linked external issue that was previously
+    /// closed by a kanban transition, the corresponding GitHub issue
+    /// is automatically reopened via the work source plugin. Pass
+    /// `--no-propagate` to transition only the local card state.
     Reopen {
         /// Card ID
         #[arg(long)]
         id: String,
+
+        /// Optional reopen reason, posted as a comment on the GitHub
+        /// issue after the reopen
+        #[arg(long)]
+        reason: Option<String>,
+
+        /// Transition the card locally without reopening the linked
+        /// GitHub issue
+        #[arg(long)]
+        no_propagate: bool,
     },
 }
 
@@ -1266,6 +1298,164 @@ fn audit(input: &db::AuditInput<'_>) {
         && let Err(e) = database.insert_audit_entry(input)
     {
         eprintln!("[legion] warning: audit log failed: {}", e);
+    }
+}
+
+/// Close the GitHub issue linked to a kanban card via the work source
+/// plugin, and write an audit entry describing the propagation. Called by
+/// `legion kanban cancel` (and in the future `legion kanban done` /
+/// `legion done`) to keep the public GitHub state consistent with the local
+/// kanban state.
+///
+/// A card with no `source_url` is a pure local card and is skipped
+/// silently. A card whose `to_repo` has no work source configured in
+/// `watch.toml` is also skipped, with a warning -- the agent can still
+/// transition the card locally, they just have to reconcile GitHub state
+/// manually. All other failure modes log to stderr and do not abort the
+/// calling handler, because the card transition has already happened and
+/// returning an error here would leave the agent with an inconsistent
+/// understanding of local state.
+///
+/// `comment` is the closing comment posted on the GitHub issue before the
+/// state transition. When `None`, the plugin closes the issue without a
+/// comment.
+fn propagate_card_close_to_worksource(
+    database: &db::Database,
+    card_id: &str,
+    comment: Option<&str>,
+) {
+    let card = match database.get_card_by_id(card_id) {
+        Ok(Some(c)) => c,
+        Ok(None) => {
+            eprintln!("[legion] propagate: card {card_id} not found; skipping");
+            return;
+        }
+        Err(e) => {
+            eprintln!("[legion] propagate: lookup of card {card_id} failed: {e}; skipping");
+            return;
+        }
+    };
+
+    let Some(ref source_url) = card.source_url else {
+        // Pure local card with no linked issue -- nothing to propagate.
+        return;
+    };
+
+    let Some(number) = worksource::extract_issue_number(source_url) else {
+        eprintln!(
+            "[legion] propagate: card {card_id} has source_url {source_url} but no extractable issue number; skipping"
+        );
+        return;
+    };
+
+    let Some(source) = card.source_type.as_deref() else {
+        eprintln!(
+            "[legion] propagate: card {card_id} has source_url {source_url} but no source_type; skipping"
+        );
+        return;
+    };
+
+    let Some((_, source_repo, _)) = worksource::resolve_config(&card.to_repo) else {
+        eprintln!(
+            "[legion] propagate: to_repo '{}' for card {card_id} has no work source configured in watch.toml; skipping GitHub close",
+            card.to_repo
+        );
+        return;
+    };
+
+    match worksource::close_issue(source, &source_repo, number, comment) {
+        Ok(()) => {
+            eprintln!("[legion] closed {source} issue #{number}");
+            let details = serde_json::json!({
+                "card_id": card_id,
+                "propagation": "kanban-transition",
+                "comment": comment,
+            });
+            let details_str = details.to_string();
+            audit(&db::AuditInput {
+                agent: &card.to_repo,
+                action: "close-issue",
+                target_type: "issue",
+                target_ref: &number.to_string(),
+                task_id: Some(card_id),
+                source_type: source,
+                details: Some(&details_str),
+                outcome: "success",
+            });
+        }
+        Err(e) => {
+            eprintln!("[legion] propagate: failed to close {source} issue #{number}: {e}");
+        }
+    }
+}
+
+/// Reopen the GitHub issue linked to a kanban card via the work source
+/// plugin. Symmetrical with `propagate_card_close_to_worksource`. Called by
+/// `legion kanban reopen` so a card being moved back to in-progress reopens
+/// its public GitHub issue.
+fn propagate_card_reopen_to_worksource(
+    database: &db::Database,
+    card_id: &str,
+    comment: Option<&str>,
+) {
+    let card = match database.get_card_by_id(card_id) {
+        Ok(Some(c)) => c,
+        Ok(None) => {
+            eprintln!("[legion] propagate: card {card_id} not found; skipping");
+            return;
+        }
+        Err(e) => {
+            eprintln!("[legion] propagate: lookup of card {card_id} failed: {e}; skipping");
+            return;
+        }
+    };
+
+    let Some(ref source_url) = card.source_url else {
+        return;
+    };
+    let Some(number) = worksource::extract_issue_number(source_url) else {
+        eprintln!(
+            "[legion] propagate: card {card_id} has source_url {source_url} but no extractable issue number; skipping"
+        );
+        return;
+    };
+    let Some(source) = card.source_type.as_deref() else {
+        eprintln!(
+            "[legion] propagate: card {card_id} has source_url {source_url} but no source_type; skipping"
+        );
+        return;
+    };
+    let Some((_, source_repo, _)) = worksource::resolve_config(&card.to_repo) else {
+        eprintln!(
+            "[legion] propagate: to_repo '{}' for card {card_id} has no work source configured in watch.toml; skipping GitHub reopen",
+            card.to_repo
+        );
+        return;
+    };
+
+    match worksource::reopen_issue(source, &source_repo, number, comment) {
+        Ok(()) => {
+            eprintln!("[legion] reopened {source} issue #{number}");
+            let details = serde_json::json!({
+                "card_id": card_id,
+                "propagation": "kanban-transition",
+                "comment": comment,
+            });
+            let details_str = details.to_string();
+            audit(&db::AuditInput {
+                agent: &card.to_repo,
+                action: "reopen-issue",
+                target_type: "issue",
+                target_ref: &number.to_string(),
+                task_id: Some(card_id),
+                source_type: source,
+                details: Some(&details_str),
+                outcome: "success",
+            });
+        }
+        Err(e) => {
+            eprintln!("[legion] propagate: failed to reopen {source} issue #{number}: {e}");
+        }
     }
 }
 
@@ -2155,17 +2345,41 @@ fn run() -> error::Result<()> {
                     kanban::transition_card(&database, &id, kanban::Action::Resume, None)?;
                     println!("{id}");
                 }
-                KanbanAction::Cancel { id } => {
-                    kanban::transition_card(&database, &id, kanban::Action::Cancel, None)?;
+                KanbanAction::Cancel {
+                    id,
+                    reason,
+                    no_propagate,
+                } => {
+                    kanban::transition_card(
+                        &database,
+                        &id,
+                        kanban::Action::Cancel,
+                        reason.as_deref(),
+                    )?;
                     println!("{id}");
+                    if !no_propagate {
+                        propagate_card_close_to_worksource(&database, &id, reason.as_deref());
+                    }
                 }
                 KanbanAction::Assign { id, to } => {
                     database.assign_card(&id, &to)?;
                     println!("{id}");
                 }
-                KanbanAction::Reopen { id } => {
-                    kanban::transition_card(&database, &id, kanban::Action::Reopen, None)?;
+                KanbanAction::Reopen {
+                    id,
+                    reason,
+                    no_propagate,
+                } => {
+                    kanban::transition_card(
+                        &database,
+                        &id,
+                        kanban::Action::Reopen,
+                        reason.as_deref(),
+                    )?;
                     println!("{id}");
+                    if !no_propagate {
+                        propagate_card_reopen_to_worksource(&database, &id, reason.as_deref());
+                    }
                 }
             }
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -793,6 +793,20 @@ enum KanbanAction {
         #[arg(long)]
         no_propagate: bool,
     },
+
+    /// Permanently delete a card from the kanban board.
+    ///
+    /// Unlike `cancel` (which transitions to a terminal `cancelled`
+    /// state where the card still appears in `legion kanban list`),
+    /// `delete` removes the row entirely. Used to hard-remove a card
+    /// filed in error. Does NOT touch the linked GitHub issue; use
+    /// `legion issue close` or `legion issue reopen` separately if the
+    /// public state needs to change.
+    Delete {
+        /// Card ID
+        #[arg(long)]
+        id: String,
+    },
 }
 
 #[derive(Subcommand)]
@@ -2380,6 +2394,31 @@ fn run() -> error::Result<()> {
                     if !no_propagate {
                         propagate_card_reopen_to_worksource(&database, &id, reason.as_deref());
                     }
+                }
+                KanbanAction::Delete { id } => {
+                    // Capture the card's to_repo before the delete so the
+                    // audit entry records which agent owned it. A card
+                    // that does not exist at delete time is a hard error
+                    // from the DB layer, matching the shape of the other
+                    // id-targeted kanban subcommands.
+                    let agent_repo = database
+                        .get_card_by_id(&id)?
+                        .map(|c| c.to_repo)
+                        .unwrap_or_else(|| "unknown".to_string());
+
+                    database.delete_card(&id)?;
+                    println!("{id}");
+
+                    audit(&db::AuditInput {
+                        agent: &agent_repo,
+                        action: "delete-card",
+                        target_type: "card",
+                        target_ref: &id,
+                        task_id: Some(&id),
+                        source_type: "legion",
+                        details: None,
+                        outcome: "success",
+                    });
                 }
             }
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1368,11 +1368,44 @@ fn audit(input: &db::AuditInput<'_>) {
     }
 }
 
+/// Outcome of a kanban-to-worksource propagation attempt.
+///
+/// Returned by `propagate_card_close_to_worksource` and
+/// `propagate_card_reopen_to_worksource` so the caller can make the
+/// success/failure state visible on stdout in addition to the stderr
+/// breadcrumbs emitted by the helpers. Scripts piping legion output can
+/// detect `Failed` and surface partial-success errors; humans reading the
+/// terminal see either the silent success or the explicit warning line.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PropagateOutcome {
+    /// Plugin call succeeded and the GitHub issue state changed.
+    Propagated,
+    /// Card had no linked external issue (pure local card), or its
+    /// `to_repo` has no work source configured. Nothing to propagate.
+    /// Safe to no-op without caller intervention.
+    Skipped,
+    /// Plugin call was attempted and failed, OR a card-level precondition
+    /// was not met (e.g. source_url present but no extractable issue
+    /// number, or source_type missing). The local card transition has
+    /// already completed; the caller should surface a visible warning so
+    /// scripted consumers can detect partial success.
+    Failed,
+}
+
 /// Close the GitHub issue linked to a kanban card via the work source
 /// plugin, and write an audit entry describing the propagation. Called by
-/// `legion kanban cancel` (and in the future `legion kanban done` /
-/// `legion done`) to keep the public GitHub state consistent with the local
-/// kanban state.
+/// `legion kanban cancel` to keep the public GitHub state consistent with
+/// the local kanban state.
+///
+/// NOT called by `legion done --id`, which has an equivalent inline
+/// propagation at its own call site in `Commands::Done` (search for the
+/// `// Close the linked external issue if present` block). The two paths
+/// are functionally equivalent today; folding `Commands::Done` through
+/// this helper is tracked as post-#192 cleanup.
+///
+/// Returns a `PropagateOutcome` so the caller can emit a visible warning
+/// to stdout on failure. Stderr breadcrumbs explain the failure; stdout
+/// visibility is what lets scripted pipelines detect partial success.
 ///
 /// A card with no `source_url` is a pure local card and is skipped
 /// silently. A card whose `to_repo` has no work source configured in
@@ -1390,36 +1423,36 @@ fn propagate_card_close_to_worksource(
     database: &db::Database,
     card_id: &str,
     comment: Option<&str>,
-) {
+) -> PropagateOutcome {
     let card = match database.get_card_by_id(card_id) {
         Ok(Some(c)) => c,
         Ok(None) => {
             eprintln!("[legion] propagate: card {card_id} not found; skipping");
-            return;
+            return PropagateOutcome::Failed;
         }
         Err(e) => {
             eprintln!("[legion] propagate: lookup of card {card_id} failed: {e}; skipping");
-            return;
+            return PropagateOutcome::Failed;
         }
     };
 
     let Some(ref source_url) = card.source_url else {
         // Pure local card with no linked issue -- nothing to propagate.
-        return;
+        return PropagateOutcome::Skipped;
     };
 
     let Some(number) = worksource::extract_issue_number(source_url) else {
         eprintln!(
             "[legion] propagate: card {card_id} has source_url {source_url} but no extractable issue number; skipping"
         );
-        return;
+        return PropagateOutcome::Failed;
     };
 
     let Some(source) = card.source_type.as_deref() else {
         eprintln!(
             "[legion] propagate: card {card_id} has source_url {source_url} but no source_type; skipping"
         );
-        return;
+        return PropagateOutcome::Failed;
     };
 
     let Some((_, source_repo, _)) = worksource::resolve_config(&card.to_repo) else {
@@ -1427,7 +1460,11 @@ fn propagate_card_close_to_worksource(
             "[legion] propagate: to_repo '{}' for card {card_id} has no work source configured in watch.toml; skipping GitHub close",
             card.to_repo
         );
-        return;
+        // Missing watch.toml entry is treated as Skipped (not Failed)
+        // because it is a configuration-level "not applicable here"
+        // rather than an attempt-and-fail. Scripted consumers that
+        // care about this case should rely on the stderr warning.
+        return PropagateOutcome::Skipped;
     };
 
     match worksource::close_issue(source, &source_repo, number, comment) {
@@ -1449,9 +1486,11 @@ fn propagate_card_close_to_worksource(
                 details: Some(&details_str),
                 outcome: "success",
             });
+            PropagateOutcome::Propagated
         }
         Err(e) => {
             eprintln!("[legion] propagate: failed to close {source} issue #{number}: {e}");
+            PropagateOutcome::Failed
         }
     }
 }
@@ -1464,40 +1503,40 @@ fn propagate_card_reopen_to_worksource(
     database: &db::Database,
     card_id: &str,
     comment: Option<&str>,
-) {
+) -> PropagateOutcome {
     let card = match database.get_card_by_id(card_id) {
         Ok(Some(c)) => c,
         Ok(None) => {
             eprintln!("[legion] propagate: card {card_id} not found; skipping");
-            return;
+            return PropagateOutcome::Failed;
         }
         Err(e) => {
             eprintln!("[legion] propagate: lookup of card {card_id} failed: {e}; skipping");
-            return;
+            return PropagateOutcome::Failed;
         }
     };
 
     let Some(ref source_url) = card.source_url else {
-        return;
+        return PropagateOutcome::Skipped;
     };
     let Some(number) = worksource::extract_issue_number(source_url) else {
         eprintln!(
             "[legion] propagate: card {card_id} has source_url {source_url} but no extractable issue number; skipping"
         );
-        return;
+        return PropagateOutcome::Failed;
     };
     let Some(source) = card.source_type.as_deref() else {
         eprintln!(
             "[legion] propagate: card {card_id} has source_url {source_url} but no source_type; skipping"
         );
-        return;
+        return PropagateOutcome::Failed;
     };
     let Some((_, source_repo, _)) = worksource::resolve_config(&card.to_repo) else {
         eprintln!(
             "[legion] propagate: to_repo '{}' for card {card_id} has no work source configured in watch.toml; skipping GitHub reopen",
             card.to_repo
         );
-        return;
+        return PropagateOutcome::Skipped;
     };
 
     match worksource::reopen_issue(source, &source_repo, number, comment) {
@@ -1519,9 +1558,11 @@ fn propagate_card_reopen_to_worksource(
                 details: Some(&details_str),
                 outcome: "success",
             });
+            PropagateOutcome::Propagated
         }
         Err(e) => {
             eprintln!("[legion] propagate: failed to reopen {source} issue #{number}: {e}");
+            PropagateOutcome::Failed
         }
     }
 }
@@ -2425,7 +2466,23 @@ fn run() -> error::Result<()> {
                     )?;
                     println!("{id}");
                     if !no_propagate {
-                        propagate_card_close_to_worksource(&database, &id, reason.as_deref());
+                        match propagate_card_close_to_worksource(&database, &id, reason.as_deref())
+                        {
+                            PropagateOutcome::Propagated | PropagateOutcome::Skipped => {}
+                            PropagateOutcome::Failed => {
+                                // Emit a visible warning line on stdout so
+                                // scripted callers (`legion kanban cancel |
+                                // ...`) can detect partial success. The
+                                // card transition has already succeeded --
+                                // the first println of {id} above is still
+                                // the authoritative success marker -- but
+                                // the linked GitHub issue was NOT closed
+                                // and the caller needs to know.
+                                println!(
+                                    "[legion] WARNING: card {id} cancelled locally but linked github issue propagation FAILED -- run `legion kanban reconcile --close-stale` to retry"
+                                );
+                            }
+                        }
                     }
                 }
                 KanbanAction::Assign { id, to } => {
@@ -2445,7 +2502,21 @@ fn run() -> error::Result<()> {
                     )?;
                     println!("{id}");
                     if !no_propagate {
-                        propagate_card_reopen_to_worksource(&database, &id, reason.as_deref());
+                        match propagate_card_reopen_to_worksource(&database, &id, reason.as_deref())
+                        {
+                            PropagateOutcome::Propagated | PropagateOutcome::Skipped => {}
+                            PropagateOutcome::Failed => {
+                                // Same stdout-visibility pattern as
+                                // KanbanAction::Cancel above. The card
+                                // is reopened locally but the linked
+                                // GitHub issue was not reopened, and
+                                // scripted callers need to see this on
+                                // stdout, not buried in stderr.
+                                println!(
+                                    "[legion] WARNING: card {id} reopened locally but linked github issue propagation FAILED -- the public issue may still be closed"
+                                );
+                            }
+                        }
                     }
                 }
                 KanbanAction::Delete { id } => {
@@ -2603,6 +2674,33 @@ fn run() -> error::Result<()> {
                                         "[legion] reconcile: failed to close {} issue #{}: {}",
                                         source_repo, number, e
                                     );
+                                    // Record the failure in the audit log
+                                    // so a human operator running
+                                    // `legion audit --action close-issue`
+                                    // can see exactly which stale issues
+                                    // reconcile could not close. Without
+                                    // this, a reconcile run that fails
+                                    // on 3 of 10 issues leaves no durable
+                                    // record of which 3 -- same class of
+                                    // invisibility the PR is fixing for
+                                    // the direct cancel path.
+                                    let err_msg = e.to_string();
+                                    let details = serde_json::json!({
+                                        "card_id": card.id,
+                                        "propagation": "reconcile",
+                                        "error": err_msg,
+                                    });
+                                    let details_str = details.to_string();
+                                    audit(&db::AuditInput {
+                                        agent: &card.to_repo,
+                                        action: "close-issue",
+                                        target_type: "issue",
+                                        target_ref: &number.to_string(),
+                                        task_id: Some(&card.id),
+                                        source_type: source,
+                                        details: Some(&details_str),
+                                        outcome: "failure",
+                                    });
                                 }
                             }
                         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2523,12 +2523,16 @@ fn run() -> error::Result<()> {
                     // Capture the card's to_repo before the delete so the
                     // audit entry records which agent owned it. A card
                     // that does not exist at delete time is a hard error
-                    // from the DB layer, matching the shape of the other
-                    // id-targeted kanban subcommands.
+                    // from the DB layer (CardNotFound), matching the
+                    // shape of the other id-targeted kanban subcommands;
+                    // the lookup here therefore either returns a real
+                    // repo or propagates the error before we ever reach
+                    // the audit call, so there is no need for a fallback
+                    // value.
                     let agent_repo = database
                         .get_card_by_id(&id)?
-                        .map(|c| c.to_repo)
-                        .unwrap_or_else(|| "unknown".to_string());
+                        .ok_or_else(|| error::LegionError::CardNotFound(id.clone()))?
+                        .to_repo;
 
                     database.delete_card(&id)?;
                     println!("{id}");

--- a/src/worksource.rs
+++ b/src/worksource.rs
@@ -275,6 +275,49 @@ pub fn reopen_issue(
     Ok(())
 }
 
+/// Edit an existing issue's title and/or body via a work source plugin.
+///
+/// At least one of `title` or `body` must be set; passing both `None` is
+/// rejected as a caller bug rather than silently no-opping. The plugin
+/// reads `LEGION_WS_TITLE` and `LEGION_WS_BODY` env vars and is expected
+/// to no-op on any field whose env var is empty or absent.
+///
+/// Used for scope amendments and stale-content fixes after a sync, so
+/// agents do not have to drop scope addenda into comment threads where
+/// they are buried below fold on the public GitHub view.
+pub fn edit_issue(
+    plugin_name: &str,
+    github_repo: &str,
+    number: u64,
+    title: Option<&str>,
+    body: Option<&str>,
+) -> Result<()> {
+    if title.is_none() && body.is_none() {
+        return Err(LegionError::WorkSource(
+            "edit_issue: at least one of title or body must be provided".to_string(),
+        ));
+    }
+
+    let plugin_path = find_plugin(plugin_name)
+        .ok_or_else(|| LegionError::WorkSource(format!("plugin not found: {plugin_name}")))?;
+
+    let number_str = number.to_string();
+    let mut env: Vec<(&str, &str)> = vec![
+        ("LEGION_WS_REPO", github_repo),
+        ("LEGION_WS_NUMBER", &number_str),
+    ];
+    if let Some(t) = title {
+        env.push(("LEGION_WS_TITLE", t));
+    }
+    if let Some(b) = body {
+        env.push(("LEGION_WS_BODY", b));
+    }
+
+    call_plugin(&plugin_path, &["edit-issue"], &env)?;
+
+    Ok(())
+}
+
 /// Result of creating an issue via a work source plugin.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct CreatedIssue {

--- a/src/worksource.rs
+++ b/src/worksource.rs
@@ -725,6 +725,95 @@ mod tests {
         );
     }
 
+    /// Regression guard for the PR #227 silent-fallthrough fix.
+    ///
+    /// A prior revision of `close_issue` had `None => return Ok(())` on the
+    /// `find_plugin` branch, silently no-opping when the plugin was not
+    /// installed. That made every caller believe the close had succeeded
+    /// when in fact nothing had happened, and was the root cause of
+    /// kanban-done-but-github-open drift observed in practice.
+    ///
+    /// If a future PR restores the silent fallthrough on `close_issue`,
+    /// `reopen_issue`, or `edit_issue`, this test must fail.
+    #[test]
+    fn close_issue_returns_worksource_error_when_plugin_missing() {
+        let result = close_issue("nonexistent-plugin-xyz", "owner/repo", 1, None);
+        assert!(
+            matches!(result, Err(LegionError::WorkSource(_))),
+            "expected WorkSource error, got {:?}",
+            result
+        );
+    }
+
+    #[test]
+    fn close_issue_returns_worksource_error_when_plugin_missing_with_comment() {
+        // Same regression guard with a non-None comment, so a future change
+        // that routes the comment through a different path and loses the
+        // plugin check still fails this test.
+        let result = close_issue(
+            "nonexistent-plugin-xyz",
+            "owner/repo",
+            1,
+            Some("closed by legion reconcile"),
+        );
+        assert!(
+            matches!(result, Err(LegionError::WorkSource(_))),
+            "expected WorkSource error, got {:?}",
+            result
+        );
+    }
+
+    #[test]
+    fn reopen_issue_returns_worksource_error_when_plugin_missing() {
+        let result = reopen_issue("nonexistent-plugin-xyz", "owner/repo", 1, None);
+        assert!(
+            matches!(result, Err(LegionError::WorkSource(_))),
+            "expected WorkSource error, got {:?}",
+            result
+        );
+    }
+
+    #[test]
+    fn edit_issue_returns_worksource_error_when_plugin_missing() {
+        let result = edit_issue(
+            "nonexistent-plugin-xyz",
+            "owner/repo",
+            1,
+            Some("new title"),
+            None,
+        );
+        assert!(
+            matches!(result, Err(LegionError::WorkSource(_))),
+            "expected WorkSource error, got {:?}",
+            result
+        );
+    }
+
+    /// Regression guard for the `edit_issue` empty-args defense-in-depth.
+    ///
+    /// The function rejects `title.is_none() && body.is_none()` before
+    /// attempting any plugin call. The CLI handler in `main.rs` also
+    /// performs the same check, but this guard is load-bearing for
+    /// programmatic callers (propagation helpers, reconcile paths,
+    /// future auto-propagation sites) that might bypass the CLI layer.
+    /// If someone deletes the worksource check thinking the CLI check is
+    /// sufficient, this test fails.
+    #[test]
+    fn edit_issue_rejects_empty_args_before_plugin_lookup() {
+        // Uses a plugin name that would otherwise cause a plugin-lookup
+        // failure. The assertion on the error message proves the
+        // validation fired BEFORE the lookup rather than the lookup
+        // happening to succeed with None args.
+        let result = edit_issue("any-plugin-name", "owner/repo", 1, None, None);
+        let Err(LegionError::WorkSource(msg)) = result else {
+            panic!("expected WorkSource error, got {:?}", result);
+        };
+        assert!(
+            msg.contains("at least one of title or body"),
+            "expected validation error message, got: {msg}"
+        );
+    }
+
     #[test]
     fn parse_semver_orders_versions() {
         assert!(parse_semver("0.4.7") > parse_semver("0.4.3"));

--- a/src/worksource.rs
+++ b/src/worksource.rs
@@ -209,17 +209,68 @@ pub fn view_issue(plugin_name: &str, github_repo: &str, number: u64) -> Result<E
 }
 
 /// Close an issue via a work source plugin.
-pub fn close_issue(plugin_name: &str, github_repo: &str, number: u64) -> Result<()> {
-    let plugin_path = match find_plugin(plugin_name) {
-        Some(p) => p,
-        None => return Ok(()),
-    };
+///
+/// When `comment` is provided, the plugin posts it as a closing comment on
+/// the issue before transitioning state. The plugin reads the comment from
+/// the `LEGION_WS_COMMENT` environment variable and is expected to no-op on
+/// the comment step if the variable is empty or absent.
+///
+/// A missing plugin is a hard error. A previous revision silently returned
+/// `Ok(())` when the plugin could not be found, which looked like a
+/// successful close from the caller's perspective and let kanban-done
+/// transitions claim they had closed the GitHub issue when in fact nothing
+/// had happened. That quiet-failure mode was the root cause of #190 sitting
+/// open on GitHub for days after its card was marked done.
+pub fn close_issue(
+    plugin_name: &str,
+    github_repo: &str,
+    number: u64,
+    comment: Option<&str>,
+) -> Result<()> {
+    let plugin_path = find_plugin(plugin_name)
+        .ok_or_else(|| LegionError::WorkSource(format!("plugin not found: {plugin_name}")))?;
 
-    call_plugin(
-        &plugin_path,
-        &["close", &number.to_string()],
-        &[("LEGION_WS_REPO", github_repo)],
-    )?;
+    let number_str = number.to_string();
+    let mut env: Vec<(&str, &str)> = vec![
+        ("LEGION_WS_REPO", github_repo),
+        ("LEGION_WS_NUMBER", &number_str),
+    ];
+    if let Some(c) = comment {
+        env.push(("LEGION_WS_COMMENT", c));
+    }
+
+    call_plugin(&plugin_path, &["close", &number_str], &env)?;
+
+    Ok(())
+}
+
+/// Reopen a previously closed issue via a work source plugin.
+///
+/// Symmetrical with `close_issue`. When `comment` is provided, the plugin
+/// posts it as a reopening comment on the issue after transitioning state
+/// back to open. Used to revert a kanban transition that already propagated
+/// to GitHub (e.g. a card moved from `done` back to `in-progress`).
+///
+/// A missing plugin is a hard error, matching the close path.
+pub fn reopen_issue(
+    plugin_name: &str,
+    github_repo: &str,
+    number: u64,
+    comment: Option<&str>,
+) -> Result<()> {
+    let plugin_path = find_plugin(plugin_name)
+        .ok_or_else(|| LegionError::WorkSource(format!("plugin not found: {plugin_name}")))?;
+
+    let number_str = number.to_string();
+    let mut env: Vec<(&str, &str)> = vec![
+        ("LEGION_WS_REPO", github_repo),
+        ("LEGION_WS_NUMBER", &number_str),
+    ];
+    if let Some(c) = comment {
+        env.push(("LEGION_WS_COMMENT", c));
+    }
+
+    call_plugin(&plugin_path, &["reopen", &number_str], &env)?;
 
     Ok(())
 }


### PR DESCRIPTION
## Summary

Closes the legion CLI gap rework tracked in #192. Ships six commits on \`feat/192-worksource-cli-gaps\` that let agents run the full issue / PR / kanban lifecycle from inside legion without reaching for \`gh\` and without leaving stale state behind when kanban transitions happen.

The driving observations from tonight's session:

1. **#190** (kanban done 2026-04-11, still OPEN on GitHub) and **#225** (kanban cancelled tonight, still OPEN) were the concrete symptoms of kanban-done-but-github-open drift. Direct kanban transitions never called the work source plugin, and the existing \`worksource::close_issue\` silently returned \`Ok(())\` when the plugin was not found, making every caller believe the close had succeeded.
2. **Tonight's scope amendments on #192 had to be posted as comments** instead of proper body edits because \`legion issue edit\` did not exist. An implementer reading \`legion issue view\` saw the original body first and only found the amendments if they scrolled through conversation.
3. **No way to hard-remove a wrongly-filed kanban card.** The \`cancel\` state transition leaves a row in \`legion kanban list\` forever.

## What ships

All six sections of the #192 scope are covered. Sections B, C.update, and G turned out to already be implemented at the start of the rework (see discovery notes below); only the genuinely-missing pieces were built.

### Section A: Issue lifecycle

\`\`\`
legion issue close   --repo <name> --number <n> [--comment <text>]
legion issue reopen  --repo <name> --number <n> [--comment <text>]
legion issue edit    --repo <name> --number <n> [--title <text>] [--body <text>]
\`\`\`

- **Silent fallthrough fix.** Before this PR, \`worksource::close_issue\` returned \`Ok(())\` when \`find_plugin\` returned \`None\`. Every caller (\`Commands::Done\`, \`PrAction::Merge --task\`) believed the close had succeeded when in fact the plugin had never been invoked. Hard error now, matching the shape of \`create_issue\` / \`create_pr\` / \`review_pr\` / \`merge_pr\` / \`close_pr\`.
- **Optional closing comment.** \`close_issue\` now takes an \`Option<&str>\` fourth parameter. The plugin reads it from \`LEGION_WS_COMMENT\` and posts it via \`gh issue comment\` before \`gh issue close\`.
- **\`close_issue\` / \`reopen_issue\` / \`edit_issue\`** in \`src/worksource.rs\` are symmetrical, each with matching audit entries on the handler side.
- **Plugin protocol additions** in \`plugin/worksources/github\`: \`close\` handler reads LEGION_WS_COMMENT, new \`reopen\` subcommand, new \`edit-issue\` subcommand. All emit \`{\"ok\":true}\` on success.

### Section D: Auto-propagation on direct kanban transitions

\`\`\`
legion kanban cancel --id <id> [--reason <text>] [--no-propagate]
legion kanban reopen --id <id> [--reason <text>] [--no-propagate]
\`\`\`

- New \`propagate_card_close_to_worksource\` and \`propagate_card_reopen_to_worksource\` helpers in \`main.rs\`. Each fetches the card, extracts the linked issue number from \`source_url\`, resolves the work source config from \`card.to_repo\`, and calls \`close_issue\` / \`reopen_issue\` with the optional comment.
- **\`--reason\`** becomes the closing/reopening comment posted on the GitHub issue before the state transition, AND is passed to \`kanban::transition_card\` so the note is also recorded on the local card.
- **\`--no-propagate\`** is the explicit-override escape hatch for rare cases where the agent deliberately wants the local kanban state to diverge from the external issue state.
- Failure modes are degraded gracefully: missing source_url = skip silently, non-extractable issue number = warn and skip, no watch.toml entry = warn and skip, plugin error = warn and skip. Card transition always happens; propagation is best-effort.
- Commit 2 also fixes the Commands::Done auto-propagation at \`main.rs:1894-1905\` and \`PrAction::Merge --task\` at \`main.rs:2641-2656\` to pass meaningful close comments instead of None.

### Section C: Kanban delete

\`\`\`
legion kanban delete --id <card-id>
\`\`\`

- New \`Database::delete_card\` executes \`DELETE FROM tasks WHERE id = ?1\` and returns \`CardNotFound\` on zero rows affected. Hard error, not silent no-op.
- Used to hard-remove cards filed in error (like the #225 card I invented tonight) without leaving them cluttering \`legion kanban list --from\` output in the \`cancelled\` state.
- Deliberately does NOT touch the linked GitHub issue. Delete is pure local-state hard-remove. When the GitHub side also needs to change, the agent runs \`legion issue close\` or \`legion issue reopen\` separately.
- Unit test \`delete_card_removes_row_and_reports_not_found\` covers happy path + CardNotFound semantics.

### Section E: Kanban reconcile

\`\`\`
legion kanban reconcile [--repo <name>] [--close-stale]
\`\`\`

- Scans every kanban card in \`done\` or \`cancelled\` state, fetches each linked GitHub issue state via \`worksource::view_issue\`, and reports the ones that are still \`OPEN\` (stale-open drift).
- Default mode is read-only. Pass \`--close-stale\` to actually close each mismatched issue via the work source plugin with a canned reconciliation comment. Safe to run repeatedly.
- Optional \`--repo\` filter to scope to a single agent's cards.
- Every successful close writes an audit entry with \`details: {\"card_id\": ..., \"propagation\": \"reconcile\"}\` so the repair is traceable in \`legion audit --action close-issue\`.
- Used to backfill the stale-open backlog that accumulated before this PR shipped. Tonight's #190 and #225 are the known stale-open items.

### Section F: Audit filter help text refresh

- Updated \`legion audit --action\` help text to list the real set of known verbs: \`create-issue, close-issue, reopen-issue, edit-issue, create-pr, close-pr, review, merge, comment, delete-card, update-card\`. No behavior change (the filter was always a string match) -- the old help text listed \`close\` (stale) and omitted everything added in tonight's work.

## Discovery notes: what was already implemented

A significant chunk of the original #192 scope amendment turned out to already be built when I started reading the source. Documenting here so future contributors do not re-do work already shipped:

- **Section B: \`legion pr close --reason <text>\`** already exists. Flag is named \`--reason\` not \`--body\` or \`--comment\`. When I tried \`legion pr close --repo legion --number 221 --body ...\` earlier tonight and got \"error: unexpected argument '--body' found\", the real answer was \"use --reason\". No code change needed.
- **Section C.update: \`legion kanban update\`** already supports \`--text\`, \`--body\`, \`--priority\`, \`--labels\`, \`--add-labels\`, \`--remove-labels\`. The original #192 concern (reprioritize after sync) was already solved.
- **Section G: \`legion pr review --comments <path>\`** already accepts a JSON file with inline comments per the GitHub Reviews API schema and submits them as one review event via \`gh api repos/{owner}/{repo}/pulls/{N}/reviews --method POST --input $FILE\` (plugin/worksources/github:178-184). End-to-end inline PR review tooling was already fully built.

## Gate results

- \`cargo test --bin legion\`: **393 passed**, 0 failed, 2 ignored (393 = 392 baseline + 1 new \`delete_card_removes_row_and_reports_not_found\`)
- \`cargo test --test integration\`: 73 passed, 0 failed, 2 ignored
- \`cargo clippy --all-targets -- -D warnings\`: clean
- \`cargo fmt -- --check\`: clean
- \`/legion-simplify\` quality gate: recorded clean at each of the six commits
- Pre-push review on the full branch: flagged \"doc/behavior drift, silent-failure ergonomics, thin test coverage on new surface\" as expected categories -- addressed in \`/review-pr\` pass after PR creation

## What this does NOT do

- **No TS/Bun test harness for the plugin shell script.** The \`plugin/worksources/github\` additions (close --comment, reopen, edit-issue) are exercised through the Rust integration path but the shell script itself has no unit tests. That's a separate concern tracked across all worksource handlers, not scoped to this PR.
- **No self-approval override** for PRs where author == reviewer. Tonight I hit this on PR #222 and PR #224 and had to wait on a second reviewer (eavesdrop). Still a gap, deferred to a policy decision.
- **No workflow run visibility** (\`legion workflow list\`). Different plugin surface, separate issue.
- **No reflection edit/delete**. Different subsystem, separate issue.

## Test plan

- [x] Every new subcommand has a unit test or an adjacent existing call site that exercises the same plugin path
- [x] \`delete_card_removes_row_and_reports_not_found\` regression test locks the delete semantics
- [x] Rust gates green
- [ ] Live smoke test after merge: run \`legion kanban reconcile --repo legion\` against the real legion data dir and verify #190 and #225 show up as stale-open. Then run \`legion kanban reconcile --repo legion --close-stale\` to reconcile them in one pass.
- [ ] Live smoke test: run \`legion issue close --repo legion --number <some-open-card-issue> --comment \"shipped in PR #<this-pr>\"\` end-to-end once this PR itself merges.

Closes #192.