### PR TITLE
chore(#231): correct legion-memory skill description from enforces to reminds

### DIFF
--- a/plugin/skills/legion-memory/SKILL.md
+++ b/plugin/skills/legion-memory/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: legion-memory
 description: |
-  Auto-triggered skill that enforces recall-before-grep doctrine. When an agent is about to search the codebase for answers, this skill reminds them to check legion memory first. Use this when the agent is researching a problem, looking for patterns, or trying to understand why something was built a certain way.
+  Auto-triggered skill that reminds agents of the recall-before-grep doctrine. When an agent is about to search the codebase for answers, this skill reminds them to check legion memory first. Use this when the agent is researching a problem, looking for patterns, or trying to understand why something was built a certain way.
 version: 1.0.0
 user-invocable: false
 allowed-tools: Bash, Read


### PR DESCRIPTION
## Summary

One-word fix in \`plugin/skills/legion-memory/SKILL.md\` frontmatter: replace \`enforces\` with \`reminds agents of the\`. Skills in Claude Code are advisory, not enforcing -- the word "enforces" was aspirational and created a credibility gap between what the skill claimed and what it actually did.

The sentence now reads: "Auto-triggered skill that **reminds agents of the** recall-before-grep doctrine. When an agent is about to search the codebase for answers, this skill **reminds** them to check legion memory first." Two uses of "reminds" in the same description match the actual behavior.

Structural enforcement of the same doctrine lives at the hook layer and is tracked separately in #230 (pre-grep hook refactor) and #232 (pre-write-memory hook + \`legion recall --domain\`). The skill and the hooks together produce the recall-before-grep behavior: hooks enforce via auto-injection, the skill explains the doctrine when the model surfaces it. Both layers are useful; the truth-in-advertising fix here just stops the skill claiming the hook's job.

## Test plan

- [x] \`cargo test --bin legion\` -- 398 passed, 0 failed, 2 ignored
- [x] \`cargo clippy --all-targets -- -D warnings\` -- clean
- [x] \`cargo fmt -- --check\` -- clean
- [x] \`/legion-simplify\` quality gate recorded clean at HEAD f04f36c

Closes #231.