### PR TITLE
feat: legion forget <id> to permanently delete a reflection

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -750,6 +750,41 @@ impl Database {
         }
     }
 
+    /// Permanently remove a reflection from the database by id.
+    ///
+    /// Returns the deleted reflection so the caller can confirm what was
+    /// removed (repo, audience, first 80 chars of text, etc). Returns
+    /// `LegionError::ReflectionNotFound` if the id does not match any
+    /// row.
+    ///
+    /// This is a HARD delete from SQLite only. Callers must also call
+    /// `SearchIndex::delete(id)` to remove the matching document from
+    /// the tantivy index, or subsequent BM25 queries will still return
+    /// the deleted reflection as a "ghost" until the next reindex.
+    ///
+    /// Destructive. No soft-delete, no undo. Used by `legion forget` to
+    /// retire stale workaround reflections, bad reflections, or personal
+    /// data that should not persist in the corpus.
+    pub fn delete_reflection(&self, id: &str) -> Result<Reflection> {
+        // Fetch first so we can return it and so a missing id produces a
+        // clear error rather than a silent zero-row delete.
+        let reflection = self
+            .get_reflection_by_id(id)?
+            .ok_or_else(|| LegionError::ReflectionNotFound(id.to_string()))?;
+
+        let rows = self.conn.execute(
+            "DELETE FROM reflections WHERE id = ?1",
+            rusqlite::params![id],
+        )?;
+        if rows == 0 {
+            // Race: reflection existed at the fetch above but was
+            // deleted before our delete ran. Surface as NotFound rather
+            // than success.
+            return Err(LegionError::ReflectionNotFound(id.to_string()));
+        }
+        Ok(reflection)
+    }
+
     /// Retrieve reflections by a list of IDs. Returns them in the order found
     /// (not necessarily the input order). Missing IDs are silently skipped.
     pub fn get_reflections_by_ids(&self, ids: &[&str]) -> Result<Vec<Reflection>> {
@@ -3399,6 +3434,38 @@ mod tests {
             .unwrap()
             .unwrap();
         assert_eq!(fetched.details.as_deref(), Some(details));
+    }
+
+    #[test]
+    fn delete_reflection_removes_row_and_returns_deleted() {
+        let db = test_db();
+
+        // Insert a reflection via the real path so the schema columns
+        // are all populated exactly as production would.
+        let inserted = db
+            .insert_reflection("shingle", "stale workaround doctrine", "self")
+            .unwrap();
+
+        // Confirm it is visible before the delete.
+        assert!(db.get_reflection_by_id(&inserted.id).unwrap().is_some());
+
+        // Delete, confirm the returned row matches what was stored.
+        let deleted = db.delete_reflection(&inserted.id).expect("delete");
+        assert_eq!(deleted.id, inserted.id);
+        assert_eq!(deleted.repo, "shingle");
+        assert_eq!(deleted.text, "stale workaround doctrine");
+
+        // Gone from the table.
+        assert!(db.get_reflection_by_id(&inserted.id).unwrap().is_none());
+
+        // Second delete on the same id returns ReflectionNotFound,
+        // not silent success.
+        let result = db.delete_reflection(&inserted.id);
+        assert!(
+            matches!(result, Err(LegionError::ReflectionNotFound(_))),
+            "expected ReflectionNotFound, got {:?}",
+            result
+        );
     }
 
     #[test]

--- a/src/error.rs
+++ b/src/error.rs
@@ -42,6 +42,9 @@ pub enum LegionError {
     #[error("card not found: {0}")]
     CardNotFound(String),
 
+    #[error("reflection not found: {0}")]
+    ReflectionNotFound(String),
+
     #[error("invalid card transition: cannot {action} a card in status '{current}'")]
     InvalidCardTransition { action: String, current: String },
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -45,6 +45,15 @@ pub enum LegionError {
     #[error("reflection not found: {0}")]
     ReflectionNotFound(String),
 
+    #[error(
+        "repo safety check failed: reflection {id} belongs to '{actual}', not '{expected}' -- re-run without --repo or with the correct value"
+    )]
+    ReflectionRepoMismatch {
+        id: String,
+        actual: String,
+        expected: String,
+    },
+
     #[error("invalid card transition: cannot {action} a card in status '{current}'")]
     InvalidCardTransition { action: String, current: String },
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -106,6 +106,29 @@ enum Commands {
         dedupe_mode: DedupeMode,
     },
 
+    /// Permanently delete a reflection by id.
+    ///
+    /// Destructive. No soft-delete, no undo. Removes the row from both
+    /// the SQLite reflections table and the tantivy search index. Used
+    /// to retire stale workaround reflections, demonstrably-wrong
+    /// reflections, or personal data that should not persist in the
+    /// corpus.
+    ///
+    /// The optional `--repo` flag is a safety check: when provided,
+    /// the delete is refused unless the reflection's actual repo
+    /// matches. Prevents accidentally nuking the wrong reflection when
+    /// working with a similarly-shaped id.
+    Forget {
+        /// Reflection id to delete.
+        #[arg(long)]
+        id: String,
+
+        /// Optional safety check: refuse the delete unless the
+        /// reflection's repo matches this value.
+        #[arg(long)]
+        repo: Option<String>,
+    },
+
     /// Recall relevant reflections for the current context
     Recall {
         /// Repository name
@@ -1799,6 +1822,57 @@ fn run() -> error::Result<()> {
                     info!("[legion] embedded {} reflections", n);
                 }
             }
+        }
+        Commands::Forget { id, repo } => {
+            let base = data_dir()?;
+            let database = db::Database::open(&base.join("legion.db"))?;
+            let index = search::SearchIndex::open(&base.join("index"))?;
+
+            // Peek at the reflection first so we can run the optional
+            // --repo safety check AND print a summary of what is about
+            // to be deleted. The actual delete goes through
+            // `delete_reflection` which re-verifies the id exists.
+            let existing = database
+                .get_reflection_by_id(&id)?
+                .ok_or_else(|| error::LegionError::ReflectionNotFound(id.clone()))?;
+
+            if let Some(ref expected_repo) = repo
+                && existing.repo != *expected_repo
+            {
+                return Err(error::LegionError::WorkSource(format!(
+                    "repo safety check failed: reflection {} belongs to '{}', not '{}' -- re-run without --repo or with the correct value",
+                    id, existing.repo, expected_repo
+                )));
+            }
+
+            // Delete from SQLite first. If this fails, the index is
+            // untouched. If this succeeds but the index delete fails,
+            // the next `legion reindex` run will reconcile -- the
+            // index rebuild drops everything and re-seeds from the db.
+            let deleted = database.delete_reflection(&id)?;
+            index.delete(&id)?;
+
+            audit(&db::AuditInput {
+                agent: &deleted.repo,
+                action: "delete-reflection",
+                target_type: "reflection",
+                target_ref: &id,
+                task_id: None,
+                source_type: "legion",
+                details: None,
+                outcome: "success",
+            });
+
+            let preview: String = deleted.text.chars().take(80).collect();
+            let ellipsis = if deleted.text.chars().count() > 80 {
+                "..."
+            } else {
+                ""
+            };
+            println!(
+                "forgot reflection {} ({}): {}{}",
+                id, deleted.repo, preview, ellipsis
+            );
         }
         Commands::Recall {
             repo,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1836,32 +1836,64 @@ fn run() -> error::Result<()> {
                 .get_reflection_by_id(&id)?
                 .ok_or_else(|| error::LegionError::ReflectionNotFound(id.clone()))?;
 
+            // Every audit row for this command shares action/target_type/
+            // target_ref/task_id/source_type. Build them through one closure
+            // so the three call sites (rejected / success / partial) only
+            // name the three things that actually differ.
+            let write_audit = |agent: &str, outcome: &str, details: Option<&str>| {
+                audit(&db::AuditInput {
+                    agent,
+                    action: "delete-reflection",
+                    target_type: "reflection",
+                    target_ref: &id,
+                    task_id: None,
+                    source_type: "legion",
+                    details,
+                    outcome,
+                });
+            };
+
             if let Some(ref expected_repo) = repo
                 && existing.repo != *expected_repo
             {
-                return Err(error::LegionError::WorkSource(format!(
-                    "repo safety check failed: reflection {} belongs to '{}', not '{}' -- re-run without --repo or with the correct value",
-                    id, existing.repo, expected_repo
-                )));
+                // Audit the rejection BEFORE returning. Destructive-command
+                // rejections are forensically relevant -- we want a trace
+                // of every attempted forget, not just successful ones.
+                let details = format!("expected={} actual={}", expected_repo, existing.repo);
+                write_audit(&existing.repo, "rejected", Some(&details));
+                return Err(error::LegionError::ReflectionRepoMismatch {
+                    id: id.clone(),
+                    actual: existing.repo.clone(),
+                    expected: expected_repo.clone(),
+                });
             }
 
-            // Delete from SQLite first. If this fails, the index is
-            // untouched. If this succeeds but the index delete fails,
-            // the next `legion reindex` run will reconcile -- the
-            // index rebuild drops everything and re-seeds from the db.
+            // Delete from SQLite first. The audit entry is written AFTER
+            // the SQLite delete succeeds but BEFORE the index delete,
+            // so even if the tantivy side fails we still have a record
+            // that the db-side delete happened. The two-store write is
+            // not transactional -- if index.delete fails, the next
+            // `legion reindex` run will reconcile.
             let deleted = database.delete_reflection(&id)?;
-            index.delete(&id)?;
+            write_audit(&deleted.repo, "success", None);
 
-            audit(&db::AuditInput {
-                agent: &deleted.repo,
-                action: "delete-reflection",
-                target_type: "reflection",
-                target_ref: &id,
-                task_id: None,
-                source_type: "legion",
-                details: None,
-                outcome: "success",
-            });
+            if let Err(e) = index.delete(&id) {
+                // SQLite row is gone; tantivy still has the document.
+                // Tell the operator exactly what state the system is in
+                // and how to recover. Do not silently succeed.
+                eprintln!(
+                    "[legion forget] WARNING: SQLite delete succeeded but tantivy index delete failed for {id}.\n\
+                     The reflection is gone from the database but may still appear in BM25 recall results\n\
+                     as a ghost document until the index is rebuilt. Run `legion reindex` to reconcile.\n\
+                     Underlying error: {e}"
+                );
+                write_audit(
+                    &deleted.repo,
+                    "partial",
+                    Some("index-orphan: SQLite row deleted, tantivy index delete failed"),
+                );
+                return Err(e);
+            }
 
             let preview: String = deleted.text.chars().take(80).collect();
             let ellipsis = if deleted.text.chars().count() > 80 {

--- a/src/search.rs
+++ b/src/search.rs
@@ -152,6 +152,29 @@ impl SearchIndex {
         ))
     }
 
+    /// Delete a document from the search index by reflection id.
+    ///
+    /// Constructs a term matching the exact `id` field value and removes
+    /// every document with that term (there should be at most one, since
+    /// `id` is the primary key in the reflections table). Commits
+    /// immediately so a subsequent recall does not return the deleted
+    /// document.
+    ///
+    /// No error if the id is not present in the index -- tantivy's
+    /// `delete_term` is a no-op when nothing matches. The caller's
+    /// database-layer check is the authoritative "does this reflection
+    /// exist" source; this method's job is to remove any trace from the
+    /// index regardless.
+    pub fn delete(&self, id: &str) -> Result<()> {
+        let mut writer: IndexWriter = self.acquire_writer()?;
+        let term = Term::from_field_text(self.id_field, id);
+        writer.delete_term(term);
+        writer
+            .commit()
+            .map_err(|e| LegionError::Search(e.to_string()))?;
+        Ok(())
+    }
+
     /// Rebuild the index from a set of reflections in a single commit.
     ///
     /// Clears the existing index contents first, then bulk-inserts all

--- a/src/search.rs
+++ b/src/search.rs
@@ -435,6 +435,46 @@ mod tests {
     }
 
     #[test]
+    fn delete_removes_document_from_index() {
+        let (idx, _dir) = test_index();
+        idx.add(
+            "id-keep",
+            "kelex",
+            "keep this reflection about mapping rules",
+        )
+        .unwrap();
+        idx.add(
+            "id-gone",
+            "kelex",
+            "doomed reflection about mapping rules that should vanish",
+        )
+        .unwrap();
+
+        // Both documents visible before the delete.
+        let before = idx.search("kelex", "mapping rules", 10).unwrap();
+        assert_eq!(before.len(), 2);
+
+        idx.delete("id-gone").unwrap();
+
+        // After delete, only the kept document surfaces -- no ghost for id-gone.
+        let after = idx.search("kelex", "mapping rules", 10).unwrap();
+        assert_eq!(after.len(), 1);
+        assert_eq!(after[0].id, "id-keep");
+    }
+
+    #[test]
+    fn delete_nonexistent_id_is_noop() {
+        let (idx, _dir) = test_index();
+        idx.add("id-1", "kelex", "reflection one").unwrap();
+        // Deleting a term that never existed should not error.
+        idx.delete("id-does-not-exist").unwrap();
+        // Existing document still retrievable.
+        let results = idx.search("kelex", "reflection", 5).unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].id, "id-1");
+    }
+
+    #[test]
     fn rebuild_replaces_index_contents() {
         let (idx, _dir) = test_index();
         idx.add("id-old", "test", "old reflection that should be gone")

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -119,8 +119,8 @@ fn forget_rejects_wrong_repo_safety_check() {
     );
     let stderr = String::from_utf8_lossy(&out.stderr);
     assert!(
-        stderr.contains("repo safety check failed"),
-        "expected safety check error, got: {stderr}"
+        stderr.contains("ReflectionRepoMismatch"),
+        "expected safety check error variant, got: {stderr}"
     );
     assert!(
         stderr.contains("kelex"),
@@ -144,6 +144,27 @@ fn forget_rejects_wrong_repo_safety_check() {
         "reflection should still be intact after rejected forget, got: {stdout}"
     );
 
+    // Rejected forget attempts must be traceable in the audit log.
+    // Destructive-command rejections are forensically relevant.
+    let out = legion_cmd(dir.path())
+        .args(["audit", "--action", "delete-reflection", "--json"])
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+    let audit_stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        audit_stdout.contains("\"outcome\": \"rejected\""),
+        "rejected forget should be audited, got: {audit_stdout}"
+    );
+    assert!(
+        audit_stdout.contains("expected=rafters"),
+        "audit details should name the mismatched expected repo, got: {audit_stdout}"
+    );
+    assert!(
+        audit_stdout.contains("actual=kelex"),
+        "audit details should name the actual repo, got: {audit_stdout}"
+    );
+
     // Forget with the CORRECT --repo must succeed.
     let out = legion_cmd(dir.path())
         .args(["forget", "--id", &id, "--repo", "kelex"])
@@ -158,6 +179,18 @@ fn forget_rejects_wrong_repo_safety_check() {
     assert!(
         stdout.contains("forgot reflection"),
         "expected forget confirmation, got: {stdout}"
+    );
+
+    // The successful delete also produces an audit entry with outcome=success.
+    let out = legion_cmd(dir.path())
+        .args(["audit", "--action", "delete-reflection", "--json"])
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+    let audit_stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        audit_stdout.contains("\"outcome\": \"success\""),
+        "successful forget should be audited, got: {audit_stdout}"
     );
 }
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -84,6 +84,84 @@ fn quiet_by_default() {
 }
 
 #[test]
+fn forget_rejects_wrong_repo_safety_check() {
+    let dir = tempfile::tempdir().unwrap();
+
+    // Warm the db with a reflection on repo "kelex".
+    let out = legion_cmd(dir.path())
+        .args([
+            "reflect",
+            "--repo",
+            "kelex",
+            "--text",
+            "doomed reflection about mapping rules",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "reflect failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let id = String::from_utf8_lossy(&out.stdout).trim().to_string();
+    assert_uuid_format(&id);
+
+    // Forget with the WRONG --repo must refuse the delete and exit nonzero.
+    let out = legion_cmd(dir.path())
+        .args(["forget", "--id", &id, "--repo", "rafters"])
+        .output()
+        .unwrap();
+    assert!(
+        !out.status.success(),
+        "forget should have failed the safety check, stdout: {}, stderr: {}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("repo safety check failed"),
+        "expected safety check error, got: {stderr}"
+    );
+    assert!(
+        stderr.contains("kelex"),
+        "expected actual repo in error, got: {stderr}"
+    );
+    assert!(
+        stderr.contains("rafters"),
+        "expected expected repo in error, got: {stderr}"
+    );
+
+    // Reflection must still be recallable -- the rejected delete must not
+    // have touched the db or the index.
+    let out = legion_cmd(dir.path())
+        .args(["recall", "--repo", "kelex", "--context", "mapping rules"])
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("doomed reflection"),
+        "reflection should still be intact after rejected forget, got: {stdout}"
+    );
+
+    // Forget with the CORRECT --repo must succeed.
+    let out = legion_cmd(dir.path())
+        .args(["forget", "--id", &id, "--repo", "kelex"])
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "forget with correct repo failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("forgot reflection"),
+        "expected forget confirmation, got: {stdout}"
+    );
+}
+
+#[test]
 fn verbose_shows_confirmation() {
     let dir = tempfile::tempdir().unwrap();
 


### PR DESCRIPTION
## Summary

Adds `legion forget --id <reflection-id> [--repo <safety>]` to permanently
remove a reflection from both the SQLite `reflections` table and the tantivy
search index in a single command. Destructive. No soft-delete, no undo.

## Motivation

Reflections age. A reflection written as "workaround for bug X" is valid only
until bug X is fixed. When bug X ships a fix, the workaround reflection becomes
actively harmful -- it directs the agent to keep doing the workaround after it
is no longer needed. The agent has no way to know the bug was fixed unless a
later reflection explicitly retires the old one.

Concrete example: the shingle agent carried reflection
`019d573e-e508-79d2-84ed-fdbcf5545cf8` ("RAFTERS DARK MODE TOKEN GAP") which
authorized two workarounds for a persistence bug in the rafters MCP. The
reflection was written during a real bug, confirmed by the rafters agent, and
was correct at the time. Rafters shipped v0.0.39 which fixed the bug. The
reflection was never retired. Shingle has a later reflection that says
"v0.0.39 fixes the persistence bug," but BM25 returned the stale one first
for color-related queries because it had more topical surface. Shingle ended
up inside the rafters repo trying to edit `DEFAULT_SEMANTIC_COLOR_MAPPINGS` in
`defaults.ts` -- the exact file the stale reflection named -- because the
outdated doctrine was winning the recall fight.

Before this PR there was no way to delete a reflection via the legion CLI. The
`no-direct-db` hook also blocks agents from running SQL directly. The only
options were (a) post a superseding reflection and hope BM25 outranks the old
one, or (b) edit the database outside legion's control. Both are bad. The
correct answer is "retire the bomb surgically."

`legion forget --id 019d573e-...` removes the reflection cleanly. Used live to
retire the shingle time bomb in one command.

## New surface

### CLI
```
legion forget --id <reflection-id> [--repo <safety-check>]
```

- `--id`: reflection id to delete. Returns `ReflectionNotFound` if the id is
  not present.
- `--repo`: optional safety check. When set, the delete is refused unless the
  reflection's actual repo matches. Prevents nuking the wrong reflection when
  working with similarly-shaped ids.
- Prints a confirmation line on success with the repo and the first 80 chars
  of the deleted text so the operator can verify what was removed.
- Writes an audit entry with `action="delete-reflection"` so deletions are
  traceable in `legion audit`.

### Database
```rust
pub fn delete_reflection(&self, id: &str) -> Result<Reflection>
```

Returns the deleted row so the caller can confirm what was removed. Returns
`LegionError::ReflectionNotFound` if the id does not match. SQLite-only.
Callers MUST also call `SearchIndex::delete(id)` or the tantivy index will
return the deleted reflection as a ghost on the next BM25 query.

### SearchIndex
```rust
pub fn delete(&self, id: &str) -> Result<()>
```

Uses `Term::from_field_text(self.id_field, id)` + tantivy `delete_term` to
remove the matching document. Commits immediately so the next recall does not
return the ghost. No error if the id is not present -- `delete_term` is a
no-op on empty matches. The database-layer check is the authoritative
existence source.

### Error type
```rust
LegionError::ReflectionNotFound(String)
```

New thiserror variant paralleling `CardNotFound`.

## Test plan

- [x] `delete_reflection_removes_row_and_returns_deleted` (src/db.rs) -- insert,
  verify visible, delete, assert returned row matches, verify gone,
  double-delete returns `ReflectionNotFound`
- [x] `delete_removes_document_from_index` (src/search.rs) -- add two docs,
  delete one, confirm the remaining doc still surfaces and the deleted one is
  gone from BM25 results (no ghost)
- [x] `delete_nonexistent_id_is_noop` (src/search.rs) -- delete a term that
  never existed must not error; existing docs unaffected
- [x] `forget_rejects_wrong_repo_safety_check` (tests/integration.rs) --
  reflect on "kelex", call forget with `--repo rafters`, assert exit nonzero
  with "repo safety check failed" in stderr naming both repos, verify the
  reflection is still recallable after the rejected delete, then verify a
  forget with the correct `--repo` succeeds
- [x] 401 bin tests + 74 integration tests + 9 others passing
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt -- --check` clean
- [x] legion-simplify gate: clean

## Out of scope

- Sweep / batch deletion (`legion forget --all-matching "workaround"`). One-at-
  a-time delete with a safety check is the right first step; batch deletion
  needs a preview-first design to avoid accidents.
- Automatic workaround-reflection retirement tied to GitHub issue close state.
  Better long-term fix but requires cross-agent issue-close coordination.
  Separate issue territory.
- Boundary enforcement. The incident that motivated this was only possible
  because shingle's tools let it navigate outside its workdir. Deleting the
  stale reflection retires the time bomb but does not prevent a future stale
  reflection from producing the same outcome. That fix is at the hook layer,
  tracked separately.