### PR TITLE
feat(#236): focused session bootstrap -- identity + snooze + kanban only

### DIFF
--- a/plugin/hooks/hooks.json
+++ b/plugin/hooks/hooks.json
@@ -97,6 +97,16 @@
         ]
       },
       {
+        "matcher": "Agent",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/recall-first.sh",
+            "timeout": 5
+          }
+        ]
+      },
+      {
         "matcher": "Bash",
         "hooks": [
           {

--- a/plugin/hooks/recall-clamp.conf
+++ b/plugin/hooks/recall-clamp.conf
@@ -1,0 +1,12 @@
+# recall-clamp.conf -- tools to SKIP PreToolUse recall on
+# One tool name per line. Lines starting with # are ignored.
+# Edit this to tune token spend vs recall coverage.
+#
+# recall-first.sh handles: WebFetch, WebSearch, Agent (Explore)
+# pre-grep-recall.sh handles: Grep, Glob (separate hook)
+#
+# Uncomment a line to skip recall for that tool.
+
+WebSearch
+# WebFetch
+# Agent

--- a/plugin/hooks/recall-first.sh
+++ b/plugin/hooks/recall-first.sh
@@ -2,8 +2,12 @@
 # Legion PreToolUse hook: run recall on the search query and inject matching
 # reflections as additionalContext before the search tool fires.
 #
-# Fires on Grep, Glob, WebFetch, WebSearch. The agent may decide not to run
-# the search after seeing the reflections -- that is the point.
+# Fires on WebFetch, WebSearch, and Agent (Explore only). Grep and Glob are
+# handled by pre-grep-recall.sh which has better query sanitization for those.
+#
+# For Explore agent spawns: if recall has strong hits (score >= threshold),
+# the hook DENIES the spawn and returns recall results instead. This prevents
+# agents from burning tokens on Explore when legion already has the answer.
 #
 # Relies on session-start.sh having warmed the Tantivy index; cold ~2.2s,
 # warm ~170ms per call.
@@ -33,20 +37,34 @@ fi
 
 REPO=$(basename "$CWD")
 
+# Check the clamp list -- skip recall for tools that burn tokens without value
+CLAMP_FILE="${CLAUDE_PLUGIN_ROOT}/hooks/recall-clamp.conf"
+if [ -f "$CLAMP_FILE" ] && grep -qx "$TOOL" "$CLAMP_FILE"; then
+  exit 0
+fi
+
 # Extract the search query based on the tool
 QUERY=""
+IS_EXPLORE=false
 case "$TOOL" in
-  Grep|Glob)
-    QUERY=$(echo "$INPUT" | jq -r '.tool_input.pattern // empty')
-    ;;
   WebFetch)
-    # Use the URL path components as the query -- the domain + path usually
-    # carries the topic better than the full URL
-    QUERY=$(echo "$INPUT" | jq -r '.tool_input.url // empty' \
-      | sed -E 's|https?://||; s|[/?#&=]| |g')
+    # Use the prompt (user intent), not the URL -- URL path components
+    # produce garbage BM25 matches. The prompt carries actual topic signal.
+    QUERY=$(echo "$INPUT" | jq -r '.tool_input.prompt // empty')
     ;;
   WebSearch)
     QUERY=$(echo "$INPUT" | jq -r '.tool_input.query // empty')
+    ;;
+  Agent)
+    # For Explore agents, try recall first and deny the spawn if we have
+    # strong hits. Other agent types pass through.
+    AGENT_TYPE=$(echo "$INPUT" | jq -r '.tool_input.subagent_type // empty')
+    if [ "$AGENT_TYPE" = "Explore" ]; then
+      IS_EXPLORE=true
+      QUERY=$(echo "$INPUT" | jq -r '.tool_input.prompt // empty')
+    else
+      exit 0
+    fi
     ;;
   *)
     exit 0
@@ -84,11 +102,30 @@ If these answer your question, skip the ${TOOL}. Otherwise continue -- but consi
   fi
 fi
 
-jq -n --arg ctx "$CTX" '{
+# For Explore agents: deny the spawn if recall has a strong hit.
+# Extract the top score -- format is "score: 0.XX)" at end of each hit line.
+# If top score >= threshold, deny and return recall results instead.
+DECISION="allow"
+REASON="legion recall hits for the query"
+if [ "$IS_EXPLORE" = true ] && [ -n "$HITS" ]; then
+  TOP_SCORE=$(echo "$HITS" | grep -oE 'score: [0-9]+\.[0-9]+' | head -1 | awk '{print $2}')
+  THRESHOLD="${LEGION_EXPLORE_THRESHOLD:-0.60}"
+  if [ -n "$TOP_SCORE" ] && awk "BEGIN{exit !($TOP_SCORE >= $THRESHOLD)}"; then
+    DECISION="deny"
+    REASON="legion recall answered this (score: ${TOP_SCORE}). Use the recall results instead of spawning Explore."
+    CTX="[Legion] Explore BLOCKED -- recall already has what you need:
+
+${HITS}
+
+Use these results directly. If they are genuinely insufficient, rephrase your question and try a direct Grep or Read instead of Explore."
+  fi
+fi
+
+jq -n --arg ctx "$CTX" --arg decision "$DECISION" --arg reason "$REASON" '{
   "hookSpecificOutput": {
     "hookEventName": "PreToolUse",
-    "permissionDecision": "allow",
-    "permissionDecisionReason": "legion recall hits for the query",
+    "permissionDecision": $decision,
+    "permissionDecisionReason": $reason,
     "additionalContext": $ctx
   }
 }'

--- a/plugin/hooks/session-start.sh
+++ b/plugin/hooks/session-start.sh
@@ -1,26 +1,21 @@
 #!/bin/bash
-# Legion SessionStart hook: inject recall hits + compact status counts.
+# Legion SessionStart hook: focused bootstrap.
 #
-# Only injects what requires a DB read: recent reflections and a one-line
-# status summary. Everything else (instructions, command reference) lives
-# in the plugin's own documentation surfaces.
+# Injects exactly three things:
+#   1. Identity  -- who am I (domain: identity)
+#   2. Last snooze -- what was I doing (domain: snooze)
+#   3. Work source -- what's on my plate (kanban list)
+#
+# Everything else (bulk recall, surface, bullpen) is pulled on demand
+# during the session via recall/consult/bullpen commands.
 #
 # Also warms the Tantivy index in the background so the first PreToolUse
-# recall-first.sh hit is fast (cold ~2.2s, warm ~170ms).
-#
-# Error handling: legion invocations append stderr to /tmp/legion-hook-errors.log
-# instead of dropping it so a silently-broken legion (missing binary, bad
-# migration, DB schema mismatch) leaves a breadcrumb. The hook still exits 0
-# and degrades to "no context" so Claude Code does not block on a legion bug.
+# recall hit is fast (cold ~2.2s, warm ~170ms).
 
-# Hook subshells do not inherit the plugin bin dir on PATH -- only the Bash
-# tool does. Invoke the plugin binary by full path via CLAUDE_PLUGIN_ROOT
-# (exported to hook processes per plugins-reference). Fixes #204.
 LEGION="${CLAUDE_PLUGIN_ROOT}/bin/legion"
 LOG=/tmp/legion-hook-errors.log
 
-# Shared warning helper -- tracks degraded legion calls and renders a
-# visible block when any legion invocation exits nonzero. See #209.
+# Shared warning helper -- see #209.
 # shellcheck source=_legion-warn.sh
 source "${CLAUDE_PLUGIN_ROOT}/hooks/_legion-warn.sh"
 
@@ -40,76 +35,56 @@ rm -f "/tmp/legion-reflected-${CWD_HASH}" 2>/dev/null
 # Mark session as having done work (used by Stop hook to decide if reflect prompt fires)
 touch "/tmp/legion-work-${CWD_HASH}"
 
-# Warm the Tantivy index in the background -- makes PreToolUse recall-first.sh
-# fast on the first tool call instead of paying a 2s cold-start cost
+# Warm the Tantivy index in the background
 ("$LEGION" recall --repo "$REPO" --context warmup --limit 1 >/dev/null 2>&1 &)
 
-# Sync GitHub issues into kanban before session starts (5-second timeout to avoid blocking).
-# Opt-out via LEGION_NO_SYNC=1 (for environments without network access or to avoid latency).
-# A timeout exit is treated as "no sync this session" not a legion breakage -- don't surface it.
+# Sync GitHub issues into kanban (5-second timeout, opt-out via LEGION_NO_SYNC=1)
 if [ "${LEGION_NO_SYNC:-}" != "1" ]; then
-  # Use gtimeout if available (macOS via homebrew), otherwise fall back to perl idiom.
   if command -v gtimeout >/dev/null 2>&1; then
     gtimeout 5 "$LEGION" sync --repo "$REPO" >/dev/null 2>>"$LOG"
   else
     perl -e 'alarm 5; exec @ARGV' -- "$LEGION" sync --repo "$REPO" >/dev/null 2>>"$LOG"
   fi
   SYNC_RC=$?
-  # 124 = gtimeout/perl SIGALRM; treat as informational, not a failure.
   if [ "$SYNC_RC" -ne 0 ] && [ "$SYNC_RC" -ne 124 ] && [ "$SYNC_RC" -ne 142 ]; then
     legion_check "$SYNC_RC" "sync"
   fi
 fi
 
-# Branch-context recall first, fallback to latest if nothing matched.
-# --preview 240 keeps each hit compact so the session start stays small.
-BRANCH=$(cd "$CWD" && git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
 OUTPUT=""
-if [ -n "$BRANCH" ] && [ "$BRANCH" != "main" ] && [ "$BRANCH" != "master" ]; then
-  OUTPUT=$("$LEGION" recall --repo "$REPO" --context "$BRANCH" --limit 2 --preview 240 2>>"$LOG")
-  legion_check $? "recall (branch)"
+
+# 1. Identity -- who am I
+IDENTITY=$("$LEGION" recall --repo "$REPO" --domain identity --limit 1 2>>"$LOG")
+legion_check $? "recall (identity)"
+if [ -n "$IDENTITY" ]; then
+  OUTPUT="$IDENTITY"
 fi
-if [ -z "$OUTPUT" ]; then
-  OUTPUT=$("$LEGION" recall --repo "$REPO" --latest --limit 2 --preview 240 2>>"$LOG")
-  legion_check $? "recall (latest)"
-fi
 
-# Compact status counts from the JSON summary instead of full status text
-STATUS_JSON=$("$LEGION" status --repo "$REPO" --json 2>>"$LOG")
-legion_check $? "status --json"
-if [ -n "$STATUS_JSON" ]; then
-  TASKS=$(echo "$STATUS_JSON" | jq -r '.tasks // 0')
-  BLOCKED=$(echo "$STATUS_JSON" | jq -r '.blocked // 0')
-  TEAM_NEEDS=$(echo "$STATUS_JSON" | jq -r '.team_needs // 0')
-  CHANGED=$(echo "$STATUS_JSON" | jq -r '.what_changed // 0')
-
-  PARTS=()
-  if [ "$TASKS" -gt 0 ]; then
-    if [ "$BLOCKED" -gt 0 ]; then
-      PARTS+=("$TASKS tasks ($BLOCKED blocked)")
-    else
-      PARTS+=("$TASKS tasks")
-    fi
-  fi
-  if [ "$TEAM_NEEDS" -gt 0 ]; then
-    PARTS+=("$TEAM_NEEDS unread @$REPO")
-  fi
-  if [ "$CHANGED" -gt 0 ]; then
-    PARTS+=("$CHANGED updates")
-  fi
-
-  if [ ${#PARTS[@]} -gt 0 ]; then
-    STATUS_LINE="[Legion] $(IFS=', '; echo "${PARTS[*]}") -- legion bullpen for details"
-    if [ -n "$OUTPUT" ]; then
-      OUTPUT="${OUTPUT}"$'\n\n'"${STATUS_LINE}"
-    else
-      OUTPUT="$STATUS_LINE"
-    fi
+# 2. Last snooze -- what was I doing
+SNOOZE=$("$LEGION" recall --repo "$REPO" --domain snooze --limit 1 --preview 500 2>>"$LOG")
+legion_check $? "recall (snooze)"
+if [ -n "$SNOOZE" ]; then
+  if [ -n "$OUTPUT" ]; then
+    OUTPUT="${OUTPUT}"$'\n\n'"${SNOOZE}"
+  else
+    OUTPUT="$SNOOZE"
   fi
 fi
 
-# Prepend a visible warning block if any legion call above failed.
-# The block is load-bearing for agent awareness of legion degradation -- see #209.
+# 3. Work source -- what's on my plate
+KANBAN=$("$LEGION" kanban list --repo "$REPO" 2>>"$LOG")
+legion_check $? "kanban list"
+if [ -n "$KANBAN" ]; then
+  KANBAN_BLOCK="[Legion] Current work:
+${KANBAN}"
+  if [ -n "$OUTPUT" ]; then
+    OUTPUT="${OUTPUT}"$'\n\n'"${KANBAN_BLOCK}"
+  else
+    OUTPUT="$KANBAN_BLOCK"
+  fi
+fi
+
+# Prepend warning block if any legion call failed
 WARN=$(legion_warnings_block)
 if [ -n "$WARN" ]; then
   if [ -n "$OUTPUT" ]; then

--- a/src/db.rs
+++ b/src/db.rs
@@ -833,6 +833,27 @@ impl Database {
             .map_err(LegionError::Database)
     }
 
+    /// Retrieve latest reflections matching a specific domain for a repository.
+    ///
+    /// Bypasses search entirely -- pure SQL lookup by domain. Used for
+    /// reserved domains like `identity` and `snooze` that get injected
+    /// on every session start without needing a search query.
+    pub fn get_reflections_by_domain(
+        &self,
+        repo: &str,
+        domain: &str,
+        limit: usize,
+    ) -> Result<Vec<Reflection>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT id, repo, text, created_at, audience, domain, tags, recall_count, last_recalled_at, parent_id \
+             FROM reflections WHERE repo = ?1 AND domain = ?2 ORDER BY created_at DESC LIMIT ?3",
+        )?;
+
+        let rows = stmt.query_map(rusqlite::params![repo, domain, limit], map_reflection_row)?;
+        rows.collect::<std::result::Result<Vec<_>, _>>()
+            .map_err(LegionError::Database)
+    }
+
     /// Retrieve active (non-archived) bullpen posts, ordered newest first.
     pub fn get_board_posts(&self) -> Result<Vec<Reflection>> {
         let mut stmt = self.conn.prepare(

--- a/src/main.rs
+++ b/src/main.rs
@@ -159,6 +159,10 @@ enum Commands {
         /// Filter out results with a final score below this threshold
         #[arg(long)]
         min_score: Option<f32>,
+
+        /// Return latest reflections matching this domain (bypasses search)
+        #[arg(long, conflicts_with_all = ["latest", "cosine_only", "context"])]
+        domain: Option<String>,
     },
 
     /// Find reflections similar to a given reflection by cosine similarity
@@ -1914,11 +1918,14 @@ fn run() -> error::Result<()> {
             preview,
             cosine_only,
             min_score,
+            domain,
         } => {
             let base = data_dir()?;
             let database = db::Database::open(&base.join("legion.db"))?;
 
-            let mut result = if latest {
+            let mut result = if let Some(ref dom) = domain {
+                recall::recall_by_domain(&database, &repo, dom, limit)?
+            } else if latest {
                 recall::recall_latest(&database, &repo, limit)?
             } else if cosine_only {
                 // --cosine-only requires the embed model; error if unavailable.

--- a/src/recall.rs
+++ b/src/recall.rs
@@ -290,6 +290,36 @@ pub fn recall_latest(db: &Database, repo: &str, limit: usize) -> Result<RecallRe
     })
 }
 
+/// Return reflections matching a specific domain for a repo, bypassing search.
+///
+/// Used for reserved domains like `identity` and `snooze` that are injected
+/// on every session start. Pure SQL lookup, no BM25 or cosine involved.
+pub fn recall_by_domain(
+    db: &Database,
+    repo: &str,
+    domain: &str,
+    limit: usize,
+) -> Result<RecallResult> {
+    let matched = db.get_reflections_by_domain(repo, domain, limit)?;
+
+    let reflections: Vec<RecalledReflection> = matched
+        .into_iter()
+        .map(|r| RecalledReflection {
+            id: r.id,
+            repo: r.repo,
+            text: r.text,
+            score: 0.0,
+            created_at: r.created_at,
+        })
+        .collect();
+
+    Ok(RecallResult {
+        reflections,
+        query: format!("(domain:{domain})"),
+        repo: repo.to_owned(),
+    })
+}
+
 /// Search reflections across all repositories for cross-agent consultation.
 ///
 /// Uses `index.search_all()` (no repo filter) and joins with the database

--- a/tests/hook_warnings.rs
+++ b/tests/hook_warnings.rs
@@ -170,9 +170,12 @@ fn cwd_json(cwd: &Path) -> String {
 }
 
 /// Build stdin JSON for recall-first.sh: cwd + tool metadata.
-fn grep_tool_json(cwd: &Path) -> String {
+/// Uses WebFetch (not Grep) because recall-first.sh no longer handles Grep --
+/// pre-grep-recall.sh does. The prompt field must be >= 4 chars to pass the
+/// trivial-query skip.
+fn webfetch_tool_json(cwd: &Path) -> String {
     format!(
-        r#"{{"cwd": "{}", "tool_name": "Grep", "tool_input": {{"pattern": "some-query-longer-than-four"}}}}"#,
+        r#"{{"cwd": "{}", "tool_name": "WebFetch", "tool_input": {{"url": "https://example.com", "prompt": "some query longer than four chars"}}}}"#,
         cwd.display()
     )
 }
@@ -211,8 +214,8 @@ enum Corruption {
 enum InputKind {
     /// `{"cwd": "..."}` -- session-start, bullpen-check, post-compact.
     Cwd,
-    /// `{"cwd": "...", "tool_name": "Grep", "tool_input": {"pattern": "..."}}` -- recall-first.
-    Grep,
+    /// `{"cwd": "...", "tool_name": "WebFetch", "tool_input": {...}}` -- recall-first.
+    WebFetch,
 }
 
 /// Build the hook test environment inside `temp`, applying the requested
@@ -243,7 +246,7 @@ fn assert_hook_warns(hook: &str, corruption: Corruption, input: InputKind) {
 
     let stdin = match input {
         InputKind::Cwd => cwd_json(&cwd),
-        InputKind::Grep => grep_tool_json(&cwd),
+        InputKind::WebFetch => webfetch_tool_json(&cwd),
     };
 
     let (stdout, _stderr, exit) = run_hook(hook, &plugin_root, &data_dir, &stdin);
@@ -259,7 +262,7 @@ fn session_start_warns_on_corrupted_schema() {
 
 #[test]
 fn recall_first_warns_on_corrupted_schema() {
-    assert_hook_warns("recall-first.sh", Corruption::Schema, InputKind::Grep);
+    assert_hook_warns("recall-first.sh", Corruption::Schema, InputKind::WebFetch);
 }
 
 #[test]
@@ -325,7 +328,7 @@ fn recall_first_warns_on_missing_data_dir() {
     assert_hook_warns(
         "recall-first.sh",
         Corruption::MissingDataDir,
-        InputKind::Grep,
+        InputKind::WebFetch,
     );
 }
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -42,6 +42,119 @@ fn reflect_and_recall_roundtrip() {
     );
 }
 
+#[test]
+fn recall_by_domain_filters_correctly() {
+    let dir = tempfile::tempdir().unwrap();
+
+    // Create two reflections: one with domain "identity", one with domain "checkpoint"
+    let out = legion_cmd(dir.path())
+        .args([
+            "reflect",
+            "--repo",
+            "test",
+            "--text",
+            "I am the test agent",
+            "--domain",
+            "identity",
+        ])
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+
+    let out = legion_cmd(dir.path())
+        .args([
+            "reflect",
+            "--repo",
+            "test",
+            "--text",
+            "checkpoint before compact",
+            "--domain",
+            "checkpoint",
+        ])
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+
+    // Also create one without a domain
+    let out = legion_cmd(dir.path())
+        .args([
+            "reflect",
+            "--repo",
+            "test",
+            "--text",
+            "generic reflection no domain",
+        ])
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+
+    // Recall with --domain identity should return only the identity reflection
+    let out = legion_cmd(dir.path())
+        .args([
+            "recall", "--repo", "test", "--domain", "identity", "--limit", "5",
+        ])
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+    let stdout = String::from_utf8(out.stdout).unwrap();
+    assert!(
+        stdout.contains("I am the test agent"),
+        "expected identity reflection, got: {stdout}"
+    );
+    assert!(
+        !stdout.contains("checkpoint before compact"),
+        "should not contain checkpoint reflection: {stdout}"
+    );
+    assert!(
+        !stdout.contains("generic reflection"),
+        "should not contain domainless reflection: {stdout}"
+    );
+
+    // Recall with --domain checkpoint should return only the checkpoint reflection
+    let out = legion_cmd(dir.path())
+        .args([
+            "recall",
+            "--repo",
+            "test",
+            "--domain",
+            "checkpoint",
+            "--limit",
+            "5",
+        ])
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+    let stdout = String::from_utf8(out.stdout).unwrap();
+    assert!(
+        stdout.contains("checkpoint before compact"),
+        "expected checkpoint reflection, got: {stdout}"
+    );
+    assert!(
+        !stdout.contains("I am the test agent"),
+        "should not contain identity reflection: {stdout}"
+    );
+
+    // Recall with --domain nonexistent should return nothing
+    let out = legion_cmd(dir.path())
+        .args([
+            "recall",
+            "--repo",
+            "test",
+            "--domain",
+            "nonexistent",
+            "--limit",
+            "5",
+        ])
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+    let stdout = String::from_utf8(out.stdout).unwrap();
+    assert!(
+        stdout.trim().is_empty(),
+        "expected empty output for nonexistent domain, got: {stdout}"
+    );
+}
+
 /// Validate that a string looks like a UUIDv7 (36 chars, 4 hyphens).
 fn assert_uuid_format(s: &str) {
     let trimmed = s.trim();


### PR DESCRIPTION
## Summary

- SessionStart now injects three things instead of bulk recall + surface + status:
  1. Identity reflection (`--domain identity`) -- persistent agent self-awareness
  2. Last snooze reflection (`--domain snooze`) -- session continuity
  3. Kanban list -- current work assignments
- Adds `--domain` flag to `legion recall` for direct SQL lookup by domain, bypassing BM25 search
- recall-first.sh gains Explore agent gating: denies Explore spawns when recall has strong hits (>= 0.60)
- WebFetch query extraction uses prompt field instead of URL path components
- recall-clamp.conf provides a tool-level skip list for PreToolUse recall

## Test plan

- [x] `cargo test` -- 75 passed, 0 failed
- [x] `cargo clippy -- -D warnings` -- clean
- [x] `cargo fmt -- --check` -- clean
- [x] New integration test `recall_by_domain_filters_correctly` covers domain filter
- [x] Hook warning tests updated for recall-first.sh tool change (Grep -> WebFetch)
- [x] Manual test: `legion recall --repo rafters --domain identity` returns identity reflection
- [ ] Deploy to plugin cache and verify session-start injects identity/snooze/kanban
- [ ] Verify Explore agent gate triggers on strong recall hit

Closes #236