### PR TITLE
feat(#240): legion watch add/remove/list subcommands

### DIFF
--- a/plugin/commands/snooze.md
+++ b/plugin/commands/snooze.md
@@ -31,8 +31,10 @@ Every boost makes the system smarter. Do not skip this.
 Store a session reflection that captures what matters for future sessions. Focus on WHY, not WHAT:
 
 ```bash
-legion reflect --repo <your-repo> --text "<consolidated session summary>"
+legion reflect --repo <your-repo> --text "<consolidated session summary>" --domain snooze --tags session
 ```
+
+The `--domain snooze` tag is mandatory -- SessionStart pulls the most recent `--domain snooze` reflection on boot. Without the tag, your session summary is invisible to the next session.
 
 Good reflections answer: "What would I tell another agent who hits this same situation tomorrow?"
 

--- a/src/db.rs
+++ b/src/db.rs
@@ -1071,10 +1071,15 @@ impl Database {
     pub fn get_unhandled_signals_for_repo(
         &self,
         repo_name: &str,
+        recipient: &str,
         since: Option<&str>,
     ) -> Result<Vec<Reflection>> {
-        let pattern_start = format!("@{} %", repo_name);
-        let pattern_mid = format!("%@{} %", repo_name);
+        // `recipient` drives the @mention pattern matching (this is the agent name
+        // when configured, otherwise the repo name). `repo_name` is the stable key
+        // for the watch_handled table and for self-signal exclusion -- signals are
+        // stored by their source repo, not by any agent override.
+        let pattern_start = format!("@{} %", recipient);
+        let pattern_mid = format!("%@{} %", recipient);
         let pattern_all_start = "@all %";
         let pattern_all_mid = "%@all %";
         let since_clause = if since.is_some() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -3639,7 +3639,7 @@ fn run() -> error::Result<()> {
                                 .map(str::to_string)
                                 .ok_or_else(|| {
                                     error::LegionError::WatchConfig(format!(
-                                        "cannot derive repo name from path {}",
+                                        "cannot derive a repo name from path {} -- pass --name <name> explicitly",
                                         path.display()
                                     ))
                                 })?

--- a/src/main.rs
+++ b/src/main.rs
@@ -1191,12 +1191,13 @@ enum QualityGateAction {
 enum WatchAction {
     /// Add a working directory to watch.toml (idempotent by canonicalized path)
     Add {
-        /// Display name for this repo (used for cooldown tracking)
-        #[arg(long)]
-        name: String,
-
         /// Absolute or relative path to the working directory
         path: std::path::PathBuf,
+
+        /// Display name for this repo (used for cooldown tracking).
+        /// Defaults to the basename of the resolved path.
+        #[arg(long)]
+        name: Option<String>,
 
         /// Signal recipient name. Signals addressed to this value (e.g., @my-agent)
         /// will wake this repo. Defaults to --name when absent.
@@ -3620,18 +3621,49 @@ fn run() -> error::Result<()> {
                     );
                     watch::run(&base)?;
                 }
-                Some(WatchAction::Add { name, path, agent }) => {
+                Some(WatchAction::Add { path, name, agent }) => {
                     let config_path = base.join("watch.toml");
-                    let added =
-                        watch::add_repo_to_config(&config_path, &name, &path, agent.as_deref())?;
+                    let effective_name = match name {
+                        Some(n) => n,
+                        None => {
+                            let canonical = path.canonicalize().map_err(|e| {
+                                error::LegionError::WatchConfig(format!(
+                                    "path {} cannot be resolved: {}",
+                                    path.display(),
+                                    e
+                                ))
+                            })?;
+                            canonical
+                                .file_name()
+                                .and_then(std::ffi::OsStr::to_str)
+                                .map(str::to_string)
+                                .ok_or_else(|| {
+                                    error::LegionError::WatchConfig(format!(
+                                        "cannot derive repo name from path {}",
+                                        path.display()
+                                    ))
+                                })?
+                        }
+                    };
+                    let added = watch::add_repo_to_config(
+                        &config_path,
+                        &effective_name,
+                        &path,
+                        agent.as_deref(),
+                    )?;
                     if added {
                         let agent_note = agent
                             .as_deref()
                             .map(|a| format!(" (agent: {})", a))
                             .unwrap_or_default();
-                        println!("added: {} -> {}{}", name, path.display(), agent_note);
+                        println!(
+                            "added: {} -> {}{}",
+                            effective_name,
+                            path.display(),
+                            agent_note
+                        );
                     } else {
-                        println!("already present: {}", name);
+                        println!("already present: {}", effective_name);
                     }
                 }
                 Some(WatchAction::Remove { name }) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -475,8 +475,11 @@ enum Commands {
         json: bool,
     },
 
-    /// Watch for signals and auto-wake sleeping agents
-    Watch,
+    /// Watch for signals and auto-wake sleeping agents (daemon mode when run without a subcommand)
+    Watch {
+        #[command(subcommand)]
+        action: Option<WatchAction>,
+    },
 
     /// MCP stdio server for Claude Code channel integration
     Mcp,
@@ -1182,6 +1185,33 @@ enum QualityGateAction {
         #[arg(long)]
         details_json: Option<String>,
     },
+}
+
+#[derive(Subcommand, Debug)]
+enum WatchAction {
+    /// Add a working directory to watch.toml (idempotent by canonicalized path)
+    Add {
+        /// Display name for this repo (used for cooldown tracking)
+        #[arg(long)]
+        name: String,
+
+        /// Absolute or relative path to the working directory
+        path: std::path::PathBuf,
+
+        /// Signal recipient name. Signals addressed to this value (e.g., @my-agent)
+        /// will wake this repo. Defaults to --name when absent.
+        #[arg(long)]
+        agent: Option<String>,
+    },
+
+    /// Remove a repo entry from watch.toml by name
+    Remove {
+        /// Repo name to remove
+        name: String,
+    },
+
+    /// List all repos currently in watch.toml
+    List,
 }
 
 /// Resolve the legion data directory.
@@ -3581,12 +3611,55 @@ fn run() -> error::Result<()> {
                 }
             }
         }
-        Commands::Watch => {
+        Commands::Watch { action } => {
             let base = data_dir()?;
-            eprintln!(
-                "[legion] `legion watch` is deprecated -- use `legion daemon` to run channel + watch in one process"
-            );
-            watch::run(&base)?;
+            match action {
+                None => {
+                    eprintln!(
+                        "[legion] `legion watch` is deprecated -- use `legion daemon` to run channel + watch in one process"
+                    );
+                    watch::run(&base)?;
+                }
+                Some(WatchAction::Add { name, path, agent }) => {
+                    let config_path = base.join("watch.toml");
+                    let added =
+                        watch::add_repo_to_config(&config_path, &name, &path, agent.as_deref())?;
+                    if added {
+                        let agent_note = agent
+                            .as_deref()
+                            .map(|a| format!(" (agent: {})", a))
+                            .unwrap_or_default();
+                        println!("added: {} -> {}{}", name, path.display(), agent_note);
+                    } else {
+                        println!("already present: {}", name);
+                    }
+                }
+                Some(WatchAction::Remove { name }) => {
+                    let config_path = base.join("watch.toml");
+                    let removed = watch::remove_repo_from_config(&config_path, &name)?;
+                    if removed {
+                        println!("removed: {}", name);
+                    } else {
+                        println!("not found: {}", name);
+                    }
+                }
+                Some(WatchAction::List) => {
+                    let config_path = base.join("watch.toml");
+                    let repos = watch::list_repos_in_config(&config_path)?;
+                    if repos.is_empty() {
+                        println!("no repos in watch.toml");
+                    } else {
+                        for repo in &repos {
+                            let agent_note = repo
+                                .agent
+                                .as_deref()
+                                .map(|a| format!(" (agent: {})", a))
+                                .unwrap_or_default();
+                            println!("{}\t{}{}", repo.name, repo.workdir, agent_note);
+                        }
+                    }
+                }
+            }
         }
         Commands::Mcp => {
             let base = data_dir()?;

--- a/src/watch.rs
+++ b/src/watch.rs
@@ -26,10 +26,16 @@ pub struct WatchRepoConfig {
 }
 
 impl WatchRepoConfig {
-    /// Recipient name used for signal matching. Prefers `agent` when set, falls
-    /// back to `name`. Centralizes the fallback rule so callers never recompute it.
+    /// Recipient name used for signal matching. Prefers `agent` when set to a
+    /// non-empty value, falls back to `name`. Empty or whitespace-only `agent`
+    /// values are treated as absent so a hand-edited `agent = ""` cannot silently
+    /// route to nothing. Centralizes the fallback rule so callers never recompute it.
     pub fn recipient(&self) -> &str {
-        self.agent.as_deref().unwrap_or(&self.name)
+        self.agent
+            .as_deref()
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .unwrap_or(&self.name)
     }
 }
 
@@ -152,8 +158,10 @@ fn read_or_default(path: &Path) -> Result<WatchConfig> {
     if !path.exists() {
         return Ok(WatchConfig::default());
     }
-    let contents = std::fs::read_to_string(path)?;
-    let config: WatchConfig = toml::from_str(&contents)?;
+    let contents = std::fs::read_to_string(path)
+        .map_err(|e| LegionError::WatchConfig(format!("cannot read {}: {}", path.display(), e)))?;
+    let config: WatchConfig = toml::from_str(&contents)
+        .map_err(|e| LegionError::WatchConfig(format!("malformed {}: {}", path.display(), e)))?;
     Ok(config)
 }
 
@@ -162,11 +170,23 @@ fn read_or_default(path: &Path) -> Result<WatchConfig> {
 /// Creates parent directories if they do not exist.
 fn write_config(path: &Path, config: &WatchConfig) -> Result<()> {
     if let Some(parent) = path.parent() {
-        std::fs::create_dir_all(parent)?;
+        std::fs::create_dir_all(parent).map_err(|e| {
+            LegionError::WatchConfig(format!(
+                "cannot create parent dir for {}: {}",
+                path.display(),
+                e
+            ))
+        })?;
     }
-    let toml_str =
-        toml::to_string_pretty(config).map_err(|e| LegionError::WatchConfig(e.to_string()))?;
-    std::fs::write(path, toml_str)?;
+    let toml_str = toml::to_string_pretty(config).map_err(|e| {
+        LegionError::WatchConfig(format!(
+            "cannot serialize watch config for {}: {}",
+            path.display(),
+            e
+        ))
+    })?;
+    std::fs::write(path, toml_str)
+        .map_err(|e| LegionError::WatchConfig(format!("cannot write {}: {}", path.display(), e)))?;
     Ok(())
 }
 
@@ -188,7 +208,20 @@ pub fn add_repo_to_config(
         )));
     }
 
-    let canonical = std::fs::canonicalize(workdir)?;
+    // Trim empty/whitespace-only agent values to None so they never round-trip
+    // to disk or bypass the recipient() fallback.
+    let normalized_agent = agent
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string);
+
+    let canonical = std::fs::canonicalize(workdir).map_err(|e| {
+        LegionError::WatchConfig(format!(
+            "cannot resolve workdir {}: {}",
+            workdir.display(),
+            e
+        ))
+    })?;
     let canonical_str = canonical.to_string_lossy().into_owned();
 
     let mut config = read_or_default(path)?;
@@ -210,7 +243,7 @@ pub fn add_repo_to_config(
     config.repos.push(WatchRepoConfig {
         name: name.to_string(),
         workdir: canonical_str,
-        agent: agent.map(|s| s.to_string()),
+        agent: normalized_agent,
     });
 
     write_config(path, &config)?;
@@ -403,9 +436,10 @@ impl CooldownTracker {
 pub fn find_pending_signals(
     db: &Database,
     repo_name: &str,
+    recipient: &str,
     since: Option<&str>,
 ) -> Result<Vec<(String, String, String)>> {
-    let reflections = db.get_unhandled_signals_for_repo(repo_name, since)?;
+    let reflections = db.get_unhandled_signals_for_repo(repo_name, recipient, since)?;
 
     let mut signals: Vec<(String, String, String)> = Vec::new();
     for r in reflections {
@@ -585,8 +619,14 @@ pub fn poll_cycle(
 
     // Check for auto-unblock opportunities from recent signals
     for repo in &config.repos {
-        if let Ok(signals) = find_pending_signals(db, repo.recipient(), since) {
-            check_auto_unblock(db, &signals);
+        match find_pending_signals(db, &repo.name, repo.recipient(), since) {
+            Ok(signals) => {
+                check_auto_unblock(db, &signals);
+            }
+            Err(e) => eprintln!(
+                "[legion watch] auto-unblock signal lookup failed for {}: {}",
+                repo.name, e
+            ),
         }
     }
 
@@ -596,7 +636,7 @@ pub fn poll_cycle(
         }
 
         let recipient = repo.recipient();
-        let signals = find_pending_signals(db, recipient, since)?;
+        let signals = find_pending_signals(db, &repo.name, recipient, since)?;
         if signals.is_empty() {
             continue;
         }
@@ -618,11 +658,12 @@ pub fn poll_cycle(
                 // Mark ALL signals as handled for THIS repo (per-repo tracking).
                 // This includes @all broadcasts -- each repo marks its own copy,
                 // so other repos still see the signal on their next poll.
+                // Keyed by `repo.name` (stable) so future `agent=` edits do not replay.
                 for (id, _, _) in &signals {
-                    if db.mark_signal_handled_for_repo(id, recipient).is_err() {
+                    if let Err(e) = db.mark_signal_handled_for_repo(id, &repo.name) {
                         eprintln!(
-                            "[legion watch] failed to mark signal {} as handled for {}",
-                            id, repo.name
+                            "[legion watch] failed to mark signal {} as handled for {}: {}",
+                            id, repo.name, e
                         );
                     }
                 }
@@ -823,7 +864,7 @@ workdir = "/tmp"
         db.insert_reflection("rafters", "@all announce: shipped", "team")
             .expect("insert broadcast");
 
-        let signals = find_pending_signals(&db, "legion", None).expect("find signals");
+        let signals = find_pending_signals(&db, "legion", "legion", None).expect("find signals");
         assert_eq!(signals.len(), 2);
 
         // Verify the targeted signal is found
@@ -853,8 +894,9 @@ workdir = "/tmp"
         .expect("insert multi-recipient");
 
         // Both shingle and huttspawn should see it
-        let shingle = find_pending_signals(&db, "shingle", None).expect("shingle");
-        let huttspawn = find_pending_signals(&db, "huttspawn", None).expect("huttspawn");
+        let shingle = find_pending_signals(&db, "shingle", "shingle", None).expect("shingle");
+        let huttspawn =
+            find_pending_signals(&db, "huttspawn", "huttspawn", None).expect("huttspawn");
         assert_eq!(
             shingle.len(),
             1,
@@ -867,11 +909,11 @@ workdir = "/tmp"
         );
 
         // legion (sender) should NOT see it
-        let legion = find_pending_signals(&db, "legion", None).expect("legion");
+        let legion = find_pending_signals(&db, "legion", "legion", None).expect("legion");
         assert!(legion.is_empty(), "sender should not see own signal");
 
         // unrelated repo should NOT see it
-        let kelex = find_pending_signals(&db, "kelex", None).expect("kelex");
+        let kelex = find_pending_signals(&db, "kelex", "kelex", None).expect("kelex");
         assert!(kelex.is_empty(), "unmentioned repo should not see signal");
     }
 
@@ -883,8 +925,37 @@ workdir = "/tmp"
         db.insert_reflection("legion", "@legion review:approved", "team")
             .expect("insert self-signal");
 
-        let signals = find_pending_signals(&db, "legion", None).expect("find signals");
+        let signals = find_pending_signals(&db, "legion", "legion", None).expect("find signals");
         assert!(signals.is_empty(), "self-signals should be excluded");
+    }
+
+    #[test]
+    fn find_pending_signals_with_agent_excludes_self_signals_via_repo_name() {
+        // Regression guard: when agent != name (e.g., platform agent watches ledger repo),
+        // a signal posted FROM the ledger repo targeting @platform must still be excluded
+        // by the repo_name key, not by the recipient. Previously only recipient was passed,
+        // so `r.repo != 'platform'` vs. `r.repo = 'ledger'` produced a self-wake.
+        let (db, _index, _dir) = test_storage();
+
+        db.insert_reflection("ledger", "@platform review:approved", "team")
+            .expect("insert self-signal");
+
+        let signals = find_pending_signals(&db, "ledger", "platform", None).expect("find signals");
+        assert!(
+            signals.is_empty(),
+            "self-signals must be excluded by repo_name, not by recipient"
+        );
+    }
+
+    #[test]
+    fn find_pending_signals_with_agent_accepts_signals_from_other_repos() {
+        let (db, _index, _dir) = test_storage();
+
+        db.insert_reflection("kelex", "@platform review:approved", "team")
+            .expect("insert external signal");
+
+        let signals = find_pending_signals(&db, "ledger", "platform", None).expect("find signals");
+        assert_eq!(signals.len(), 1, "external signal to agent should be found");
     }
 
     #[test]
@@ -894,7 +965,7 @@ workdir = "/tmp"
         db.insert_reflection("kelex", "@legion review:approved", "team")
             .expect("insert signal");
 
-        let signals = find_pending_signals(&db, "legion", None).expect("first poll");
+        let signals = find_pending_signals(&db, "legion", "legion", None).expect("first poll");
         assert_eq!(signals.len(), 1);
 
         // Mark as handled for legion
@@ -903,7 +974,7 @@ workdir = "/tmp"
             .expect("mark handled");
 
         // Should not appear again for legion
-        let signals = find_pending_signals(&db, "legion", None).expect("second poll");
+        let signals = find_pending_signals(&db, "legion", "legion", None).expect("second poll");
         assert!(signals.is_empty());
     }
 
@@ -965,8 +1036,9 @@ workdir = "/tmp"
             .expect("insert broadcast");
 
         // Both legion and rafters should see it
-        let legion_signals = find_pending_signals(&db, "legion", None).expect("legion");
-        let rafters_signals = find_pending_signals(&db, "rafters", None).expect("rafters");
+        let legion_signals = find_pending_signals(&db, "legion", "legion", None).expect("legion");
+        let rafters_signals =
+            find_pending_signals(&db, "rafters", "rafters", None).expect("rafters");
         assert_eq!(legion_signals.len(), 1);
         assert_eq!(rafters_signals.len(), 1);
 
@@ -977,14 +1049,16 @@ workdir = "/tmp"
         }
 
         // legion should NOT see it anymore
-        let legion_after = find_pending_signals(&db, "legion", None).expect("legion after");
+        let legion_after =
+            find_pending_signals(&db, "legion", "legion", None).expect("legion after");
         assert!(
             legion_after.is_empty(),
             "legion should not see broadcast after handling"
         );
 
         // rafters should STILL see the broadcast
-        let rafters_after = find_pending_signals(&db, "rafters", None).expect("rafters after");
+        let rafters_after =
+            find_pending_signals(&db, "rafters", "rafters", None).expect("rafters after");
         assert_eq!(
             rafters_after.len(),
             1,
@@ -998,7 +1072,8 @@ workdir = "/tmp"
         }
 
         // Now rafters should not see it either
-        let rafters_final = find_pending_signals(&db, "rafters", None).expect("rafters final");
+        let rafters_final =
+            find_pending_signals(&db, "rafters", "rafters", None).expect("rafters final");
         assert!(
             rafters_final.is_empty(),
             "rafters should not see broadcast after handling"
@@ -1146,6 +1221,40 @@ workdir = "/nonexistent/path/that/does/not/exist"
             agent: None,
         };
         assert_eq!(repo_without_agent.recipient(), "legion");
+    }
+
+    #[test]
+    fn watch_repo_config_recipient_treats_empty_agent_as_absent() {
+        // Hand-edited watch.toml may set agent = "" or all-whitespace.
+        // recipient() must not return empty -- that would route no signals.
+        let empty = WatchRepoConfig {
+            name: "fallback".to_string(),
+            workdir: "/tmp".to_string(),
+            agent: Some("".to_string()),
+        };
+        assert_eq!(empty.recipient(), "fallback");
+
+        let whitespace = WatchRepoConfig {
+            name: "fallback".to_string(),
+            workdir: "/tmp".to_string(),
+            agent: Some("   ".to_string()),
+        };
+        assert_eq!(whitespace.recipient(), "fallback");
+    }
+
+    #[test]
+    fn add_repo_normalizes_empty_agent_to_none() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let config_path = dir.path().join("watch.toml");
+        let workdir = dir.path().to_path_buf();
+
+        add_repo_to_config(&config_path, "legion", &workdir, Some("")).expect("add");
+        let repos = list_repos_in_config(&config_path).expect("list");
+        assert_eq!(repos.len(), 1);
+        assert!(
+            repos[0].agent.is_none(),
+            "empty --agent should be normalized to None, not stored as Some(\"\")"
+        );
     }
 
     #[test]

--- a/src/watch.rs
+++ b/src/watch.rs
@@ -25,6 +25,14 @@ pub struct WatchRepoConfig {
     pub agent: Option<String>,
 }
 
+impl WatchRepoConfig {
+    /// Recipient name used for signal matching. Prefers `agent` when set, falls
+    /// back to `name`. Centralizes the fallback rule so callers never recompute it.
+    pub fn recipient(&self) -> &str {
+        self.agent.as_deref().unwrap_or(&self.name)
+    }
+}
+
 /// Top-level watch configuration.
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct WatchConfig {
@@ -185,13 +193,18 @@ pub fn add_repo_to_config(
 
     let mut config = read_or_default(path)?;
 
-    // Idempotent check: already present if the canonicalized workdir matches.
-    let already_present = config
-        .repos
-        .iter()
-        .any(|r| r.workdir == canonical_str || r.name == name);
-    if already_present {
+    // Idempotent by canonicalized path. A repeated add for the same path is a no-op.
+    if config.repos.iter().any(|r| r.workdir == canonical_str) {
         return Ok(false);
+    }
+
+    // Name collision with a different path is an error, not a silent no-op,
+    // so the caller sees the conflict instead of a misleading "already present".
+    if let Some(existing) = config.repos.iter().find(|r| r.name == name) {
+        return Err(LegionError::WatchConfig(format!(
+            "name '{}' already in use by {}",
+            name, existing.workdir
+        )));
     }
 
     config.repos.push(WatchRepoConfig {
@@ -227,12 +240,7 @@ pub fn remove_repo_from_config(path: &Path, name: &str) -> Result<bool> {
 ///
 /// Returns an empty vec if the file does not exist.
 pub fn list_repos_in_config(path: &Path) -> Result<Vec<WatchRepoConfig>> {
-    if !path.exists() {
-        return Ok(Vec::new());
-    }
-    let contents = std::fs::read_to_string(path)?;
-    let config: WatchConfig = toml::from_str(&contents)?;
-    Ok(config.repos)
+    Ok(read_or_default(path)?.repos)
 }
 
 /// Load watch config from the given path. Returns a default config if the
@@ -577,9 +585,7 @@ pub fn poll_cycle(
 
     // Check for auto-unblock opportunities from recent signals
     for repo in &config.repos {
-        // Prefer the agent name for signal lookup when configured.
-        let recipient = repo.agent.as_deref().unwrap_or(&repo.name);
-        if let Ok(signals) = find_pending_signals(db, recipient, since) {
+        if let Ok(signals) = find_pending_signals(db, repo.recipient(), since) {
             check_auto_unblock(db, &signals);
         }
     }
@@ -589,8 +595,7 @@ pub fn poll_cycle(
             continue;
         }
 
-        // Prefer the agent name for signal lookup when configured.
-        let recipient = repo.agent.as_deref().unwrap_or(&repo.name);
+        let recipient = repo.recipient();
         let signals = find_pending_signals(db, recipient, since)?;
         if signals.is_empty() {
             continue;
@@ -1093,7 +1098,7 @@ workdir = "/nonexistent/path/that/does/not/exist"
     }
 
     #[test]
-    fn add_repo_is_idempotent_by_name() {
+    fn add_repo_is_idempotent_by_canonical_path() {
         let dir = tempfile::tempdir().expect("tempdir");
         let config_path = dir.path().join("watch.toml");
         let workdir = dir.path().to_path_buf();
@@ -1102,10 +1107,45 @@ workdir = "/nonexistent/path/that/does/not/exist"
         assert!(first);
 
         let second = add_repo_to_config(&config_path, "rafters", &workdir, None).expect("second");
-        assert!(!second, "duplicate by name should return false");
+        assert!(!second, "duplicate by canonical path should return false");
 
         let repos = list_repos_in_config(&config_path).expect("list");
         assert_eq!(repos.len(), 1, "should still have only one entry");
+    }
+
+    #[test]
+    fn add_repo_errors_on_name_collision_with_different_path() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let config_path = dir.path().join("watch.toml");
+        let workdir_a = dir.path().join("a");
+        let workdir_b = dir.path().join("b");
+        std::fs::create_dir_all(&workdir_a).expect("create a");
+        std::fs::create_dir_all(&workdir_b).expect("create b");
+
+        add_repo_to_config(&config_path, "foo", &workdir_a, None).expect("add a");
+        let err = add_repo_to_config(&config_path, "foo", &workdir_b, None).unwrap_err();
+        assert!(
+            err.to_string().contains("already in use"),
+            "expected 'already in use' error, got: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn watch_repo_config_recipient_prefers_agent_over_name() {
+        let repo_with_agent = WatchRepoConfig {
+            name: "ledger".to_string(),
+            workdir: "/tmp".to_string(),
+            agent: Some("platform".to_string()),
+        };
+        assert_eq!(repo_with_agent.recipient(), "platform");
+
+        let repo_without_agent = WatchRepoConfig {
+            name: "legion".to_string(),
+            workdir: "/tmp".to_string(),
+            agent: None,
+        };
+        assert_eq!(repo_without_agent.recipient(), "legion");
     }
 
     #[test]

--- a/src/watch.rs
+++ b/src/watch.rs
@@ -4,7 +4,7 @@ use std::process::Child;
 use std::time::{Duration, Instant};
 
 use chrono::Timelike;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 use crate::db::Database;
 use crate::error::{LegionError, Result};
@@ -14,14 +14,19 @@ use crate::signal;
 // -- Config ------------------------------------------------------------------
 
 /// A watched repository entry from watch.toml.
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct WatchRepoConfig {
     pub name: String,
     pub workdir: String,
+    /// The recipient name used for signal matching. When set, signals addressed
+    /// to this value (e.g., `@my-agent`) wake this repo. Falls back to `name`
+    /// when absent, preserving backward compatibility with existing watch.toml files.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub agent: Option<String>,
 }
 
 /// Top-level watch configuration.
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct WatchConfig {
     #[serde(default = "default_poll_interval")]
     pub poll_interval_secs: u64,
@@ -35,11 +40,11 @@ pub struct WatchConfig {
     pub stagger_secs: u64,
 
     /// Work hours start (0-23, local time). No cooldown during work hours.
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub work_hours_start: Option<u8>,
 
     /// Work hours end (0-23, local time). No cooldown during work hours.
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub work_hours_end: Option<u8>,
 
     /// Pressure threshold (0-100). Spawning is skipped when exceeded.
@@ -131,6 +136,103 @@ pub fn rename_in_config(path: &Path, from: &str, to: &str) -> Result<bool> {
     let updated = contents.replace(&needle, &replacement);
     std::fs::write(path, updated)?;
     Ok(true)
+}
+
+/// Read the current config from disk, or return a fresh default if the file
+/// does not exist. Used by add/remove to do a read-modify-write.
+fn read_or_default(path: &Path) -> Result<WatchConfig> {
+    if !path.exists() {
+        return Ok(WatchConfig::default());
+    }
+    let contents = std::fs::read_to_string(path)?;
+    let config: WatchConfig = toml::from_str(&contents)?;
+    Ok(config)
+}
+
+/// Write a `WatchConfig` to disk as TOML.
+///
+/// Creates parent directories if they do not exist.
+fn write_config(path: &Path, config: &WatchConfig) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let toml_str =
+        toml::to_string_pretty(config).map_err(|e| LegionError::WatchConfig(e.to_string()))?;
+    std::fs::write(path, toml_str)?;
+    Ok(())
+}
+
+/// Add a repo entry to watch.toml. Idempotent by canonicalized path.
+///
+/// Returns `true` if a new entry was written, `false` if the path was already
+/// present (matched by canonicalized workdir). Errors if `workdir` is not an
+/// existing directory.
+pub fn add_repo_to_config(
+    path: &Path,
+    name: &str,
+    workdir: &Path,
+    agent: Option<&str>,
+) -> Result<bool> {
+    if !workdir.is_dir() {
+        return Err(LegionError::WatchConfig(format!(
+            "workdir is not a directory: {}",
+            workdir.display()
+        )));
+    }
+
+    let canonical = std::fs::canonicalize(workdir)?;
+    let canonical_str = canonical.to_string_lossy().into_owned();
+
+    let mut config = read_or_default(path)?;
+
+    // Idempotent check: already present if the canonicalized workdir matches.
+    let already_present = config
+        .repos
+        .iter()
+        .any(|r| r.workdir == canonical_str || r.name == name);
+    if already_present {
+        return Ok(false);
+    }
+
+    config.repos.push(WatchRepoConfig {
+        name: name.to_string(),
+        workdir: canonical_str,
+        agent: agent.map(|s| s.to_string()),
+    });
+
+    write_config(path, &config)?;
+    Ok(true)
+}
+
+/// Remove a repo entry from watch.toml by name.
+///
+/// Returns `true` if an entry was removed, `false` if no entry matched.
+pub fn remove_repo_from_config(path: &Path, name: &str) -> Result<bool> {
+    if !path.exists() {
+        return Ok(false);
+    }
+
+    let mut config = read_or_default(path)?;
+    let before = config.repos.len();
+    config.repos.retain(|r| r.name != name);
+    let removed = config.repos.len() < before;
+
+    if removed {
+        write_config(path, &config)?;
+    }
+    Ok(removed)
+}
+
+/// List all repo entries currently in watch.toml.
+///
+/// Returns an empty vec if the file does not exist.
+pub fn list_repos_in_config(path: &Path) -> Result<Vec<WatchRepoConfig>> {
+    if !path.exists() {
+        return Ok(Vec::new());
+    }
+    let contents = std::fs::read_to_string(path)?;
+    let config: WatchConfig = toml::from_str(&contents)?;
+    Ok(config.repos)
 }
 
 /// Load watch config from the given path. Returns a default config if the
@@ -475,7 +577,9 @@ pub fn poll_cycle(
 
     // Check for auto-unblock opportunities from recent signals
     for repo in &config.repos {
-        if let Ok(signals) = find_pending_signals(db, &repo.name, since) {
+        // Prefer the agent name for signal lookup when configured.
+        let recipient = repo.agent.as_deref().unwrap_or(&repo.name);
+        if let Ok(signals) = find_pending_signals(db, recipient, since) {
             check_auto_unblock(db, &signals);
         }
     }
@@ -485,7 +589,9 @@ pub fn poll_cycle(
             continue;
         }
 
-        let signals = find_pending_signals(db, &repo.name, since)?;
+        // Prefer the agent name for signal lookup when configured.
+        let recipient = repo.agent.as_deref().unwrap_or(&repo.name);
+        let signals = find_pending_signals(db, recipient, since)?;
         if signals.is_empty() {
             continue;
         }
@@ -496,7 +602,7 @@ pub fn poll_cycle(
             repo.name
         );
 
-        let prompt = build_wake_prompt(&repo.name, &signals);
+        let prompt = build_wake_prompt(recipient, &signals);
 
         if spawned > 0 && config.stagger_secs > 0 {
             std::thread::sleep(Duration::from_secs(config.stagger_secs));
@@ -508,7 +614,7 @@ pub fn poll_cycle(
                 // This includes @all broadcasts -- each repo marks its own copy,
                 // so other repos still see the signal on their next poll.
                 for (id, _, _) in &signals {
-                    if db.mark_signal_handled_for_repo(id, &repo.name).is_err() {
+                    if db.mark_signal_handled_for_repo(id, recipient).is_err() {
                         eprintln!(
                             "[legion watch] failed to mark signal {} as handled for {}",
                             id, repo.name
@@ -827,6 +933,7 @@ workdir = "/tmp"
             repos: vec![WatchRepoConfig {
                 name: "legion".to_string(),
                 workdir: "/tmp".to_string(),
+                agent: None,
             }],
             ..WatchConfig::default()
         };
@@ -952,5 +1059,165 @@ workdir = "/nonexistent/path/that/does/not/exist"
 
         // Should succeed because the process is not running
         acquire_pid_lock(&lock_path).expect("acquire lock over stale");
+    }
+
+    // -- Config management tests -----------------------------------------------
+
+    #[test]
+    fn add_repo_creates_file_when_missing() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let config_path = dir.path().join("watch.toml");
+        let workdir = dir.path().to_path_buf();
+
+        let added = add_repo_to_config(&config_path, "rafters", &workdir, None).expect("add");
+        assert!(added, "should report added=true for new entry");
+        assert!(config_path.exists(), "config file should be created");
+
+        let repos = list_repos_in_config(&config_path).expect("list");
+        assert_eq!(repos.len(), 1);
+        assert_eq!(repos[0].name, "rafters");
+        assert!(repos[0].agent.is_none());
+    }
+
+    #[test]
+    fn add_repo_with_agent_stores_agent_field() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let config_path = dir.path().join("watch.toml");
+        let workdir = dir.path().to_path_buf();
+
+        add_repo_to_config(&config_path, "legion", &workdir, Some("my-agent")).expect("add");
+
+        let repos = list_repos_in_config(&config_path).expect("list");
+        assert_eq!(repos.len(), 1);
+        assert_eq!(repos[0].agent.as_deref(), Some("my-agent"));
+    }
+
+    #[test]
+    fn add_repo_is_idempotent_by_name() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let config_path = dir.path().join("watch.toml");
+        let workdir = dir.path().to_path_buf();
+
+        let first = add_repo_to_config(&config_path, "rafters", &workdir, None).expect("first");
+        assert!(first);
+
+        let second = add_repo_to_config(&config_path, "rafters", &workdir, None).expect("second");
+        assert!(!second, "duplicate by name should return false");
+
+        let repos = list_repos_in_config(&config_path).expect("list");
+        assert_eq!(repos.len(), 1, "should still have only one entry");
+    }
+
+    #[test]
+    fn add_repo_rejects_nonexistent_workdir() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let config_path = dir.path().join("watch.toml");
+        let bad_path = std::path::Path::new("/nonexistent/path/that/does/not/exist");
+
+        let err = add_repo_to_config(&config_path, "test", bad_path, None).unwrap_err();
+        assert!(
+            err.to_string().contains("not a directory"),
+            "unexpected error: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn remove_repo_removes_existing_entry() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let config_path = dir.path().join("watch.toml");
+
+        // Use two distinct sub-directories so the idempotency check passes.
+        let workdir_a = dir.path().join("a");
+        let workdir_b = dir.path().join("b");
+        std::fs::create_dir_all(&workdir_a).expect("create a");
+        std::fs::create_dir_all(&workdir_b).expect("create b");
+
+        add_repo_to_config(&config_path, "rafters", &workdir_a, None).expect("add rafters");
+        add_repo_to_config(&config_path, "legion", &workdir_b, None).expect("add legion");
+
+        let removed = remove_repo_from_config(&config_path, "rafters").expect("remove");
+        assert!(removed);
+
+        let repos = list_repos_in_config(&config_path).expect("list");
+        assert_eq!(repos.len(), 1);
+        assert_eq!(repos[0].name, "legion");
+    }
+
+    #[test]
+    fn remove_repo_returns_false_when_not_found() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let config_path = dir.path().join("watch.toml");
+        let workdir = dir.path().to_path_buf();
+
+        add_repo_to_config(&config_path, "rafters", &workdir, None).expect("add");
+
+        let removed = remove_repo_from_config(&config_path, "nonexistent").expect("remove");
+        assert!(!removed, "unknown name should return false");
+    }
+
+    #[test]
+    fn remove_repo_returns_false_when_file_missing() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let config_path = dir.path().join("watch.toml");
+
+        let removed = remove_repo_from_config(&config_path, "anything").expect("remove");
+        assert!(!removed);
+    }
+
+    #[test]
+    fn list_repos_returns_empty_when_file_missing() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let config_path = dir.path().join("watch.toml");
+
+        let repos = list_repos_in_config(&config_path).expect("list");
+        assert!(repos.is_empty());
+    }
+
+    #[test]
+    fn add_repo_stores_canonicalized_path() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let config_path = dir.path().join("watch.toml");
+        let workdir = dir.path().to_path_buf();
+        let canonical = std::fs::canonicalize(&workdir).expect("canonicalize");
+
+        add_repo_to_config(&config_path, "test", &workdir, None).expect("add");
+
+        let repos = list_repos_in_config(&config_path).expect("list");
+        // The stored path must be the canonicalized form.
+        assert_eq!(
+            repos[0].workdir,
+            canonical.to_string_lossy().as_ref(),
+            "workdir should be canonical"
+        );
+    }
+
+    #[test]
+    fn existing_config_without_agent_field_deserializes_cleanly() {
+        // Ensures backward compatibility: old watch.toml files without agent= still parse.
+        let toml_str = r#"
+[[repos]]
+name = "rafters"
+workdir = "/tmp"
+"#;
+        let config: WatchConfig = toml::from_str(toml_str).expect("parse");
+        assert_eq!(config.repos[0].agent, None);
+    }
+
+    #[test]
+    fn config_with_agent_field_round_trips() {
+        let toml_str = r#"
+[[repos]]
+name = "legion"
+workdir = "/tmp"
+agent = "my-agent"
+"#;
+        let config: WatchConfig = toml::from_str(toml_str).expect("parse");
+        assert_eq!(config.repos[0].agent.as_deref(), Some("my-agent"));
+
+        // Serialize and re-parse to confirm round-trip.
+        let serialized = toml::to_string_pretty(&config).expect("serialize");
+        let reparsed: WatchConfig = toml::from_str(&serialized).expect("reparse");
+        assert_eq!(reparsed.repos[0].agent.as_deref(), Some("my-agent"));
     }
 }

--- a/src/watch.rs
+++ b/src/watch.rs
@@ -23,6 +23,12 @@ pub struct WatchRepoConfig {
     /// when absent, preserving backward compatibility with existing watch.toml files.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub agent: Option<String>,
+
+    /// Any additional per-repo fields the struct does not model explicitly
+    /// (e.g., `github`, `worksource`, `review`). These survive a read-modify-write
+    /// cycle so CRUD on one entry never strips integration config on another.
+    #[serde(flatten, default, skip_serializing_if = "toml::Table::is_empty")]
+    pub extra: toml::Table,
 }
 
 impl WatchRepoConfig {
@@ -244,6 +250,7 @@ pub fn add_repo_to_config(
         name: name.to_string(),
         workdir: canonical_str,
         agent: normalized_agent,
+        extra: toml::Table::new(),
     });
 
     write_config(path, &config)?;
@@ -1010,6 +1017,7 @@ workdir = "/tmp"
                 name: "legion".to_string(),
                 workdir: "/tmp".to_string(),
                 agent: None,
+                extra: toml::Table::new(),
             }],
             ..WatchConfig::default()
         };
@@ -1212,6 +1220,7 @@ workdir = "/nonexistent/path/that/does/not/exist"
             name: "ledger".to_string(),
             workdir: "/tmp".to_string(),
             agent: Some("platform".to_string()),
+            extra: toml::Table::new(),
         };
         assert_eq!(repo_with_agent.recipient(), "platform");
 
@@ -1219,6 +1228,7 @@ workdir = "/nonexistent/path/that/does/not/exist"
             name: "legion".to_string(),
             workdir: "/tmp".to_string(),
             agent: None,
+            extra: toml::Table::new(),
         };
         assert_eq!(repo_without_agent.recipient(), "legion");
     }
@@ -1231,6 +1241,7 @@ workdir = "/nonexistent/path/that/does/not/exist"
             name: "fallback".to_string(),
             workdir: "/tmp".to_string(),
             agent: Some("".to_string()),
+            extra: toml::Table::new(),
         };
         assert_eq!(empty.recipient(), "fallback");
 
@@ -1238,6 +1249,7 @@ workdir = "/nonexistent/path/that/does/not/exist"
             name: "fallback".to_string(),
             workdir: "/tmp".to_string(),
             agent: Some("   ".to_string()),
+            extra: toml::Table::new(),
         };
         assert_eq!(whitespace.recipient(), "fallback");
     }
@@ -1254,6 +1266,49 @@ workdir = "/nonexistent/path/that/does/not/exist"
         assert!(
             repos[0].agent.is_none(),
             "empty --agent should be normalized to None, not stored as Some(\"\")"
+        );
+    }
+
+    #[test]
+    fn add_repo_preserves_unknown_fields_on_existing_entries() {
+        // Regression guard: add/remove must NOT strip fields the struct does not
+        // model explicitly (github, worksource, review, etc). A silent round-trip
+        // that drops these breaks `legion pr create` for every repo.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let config_path = dir.path().join("watch.toml");
+
+        let seed = r#"
+[[repos]]
+name = "legion"
+workdir = "/tmp"
+github = "runlegion/legion"
+worksource = "github"
+
+[[repos]]
+name = "rafters"
+workdir = "/tmp"
+github = "rafters-studio/rafters"
+"#;
+        std::fs::write(&config_path, seed).expect("seed config");
+
+        // Add a new repo -- triggers full read-modify-write.
+        let new_workdir = dir.path().join("newrepo");
+        std::fs::create_dir_all(&new_workdir).expect("mkdir");
+        add_repo_to_config(&config_path, "newrepo", &new_workdir, None).expect("add");
+
+        // Both original repos must still carry their github field.
+        let contents = std::fs::read_to_string(&config_path).expect("reread");
+        assert!(
+            contents.contains(r#"github = "runlegion/legion""#),
+            "legion's github field was stripped: {contents}"
+        );
+        assert!(
+            contents.contains(r#"github = "rafters-studio/rafters""#),
+            "rafters's github field was stripped: {contents}"
+        );
+        assert!(
+            contents.contains(r#"worksource = "github""#),
+            "legion's worksource field was stripped: {contents}"
         );
     }
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -3518,6 +3518,39 @@ fn watch_add_creates_entry() {
 }
 
 #[test]
+fn watch_add_derives_name_from_path_basename() {
+    let dir = tempfile::tempdir().unwrap();
+    let workdir_parent = tempfile::tempdir().unwrap();
+    let workdir = workdir_parent.path().join("my-project");
+    std::fs::create_dir(&workdir).unwrap();
+
+    let out = legion_cmd(dir.path())
+        .args(["watch", "add", workdir.to_str().unwrap()])
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "watch add (no --name) failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("my-project"),
+        "expected derived name 'my-project' in output: {stdout}"
+    );
+
+    let listed = legion_cmd(dir.path())
+        .args(["watch", "list"])
+        .output()
+        .unwrap();
+    let listed_stdout = String::from_utf8_lossy(&listed.stdout);
+    assert!(
+        listed_stdout.contains("my-project"),
+        "expected 'my-project' in list output: {listed_stdout}"
+    );
+}
+
+#[test]
 fn watch_add_idempotent() {
     let dir = tempfile::tempdir().unwrap();
     let workdir = tempfile::tempdir().unwrap();

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -3483,3 +3483,220 @@ fn mcp_push_bridge_delivers_cross_process_post() {
         );
     }
 }
+
+// -- legion watch add / remove / list -----------------------------------------
+
+#[test]
+fn watch_add_creates_entry() {
+    let dir = tempfile::tempdir().unwrap();
+    let workdir = tempfile::tempdir().unwrap();
+
+    let out = legion_cmd(dir.path())
+        .args([
+            "watch",
+            "add",
+            "--name",
+            "rafters",
+            workdir.path().to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "watch add failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("added:"),
+        "expected 'added:' in output: {stdout}"
+    );
+    assert!(
+        stdout.contains("rafters"),
+        "expected name in output: {stdout}"
+    );
+}
+
+#[test]
+fn watch_add_idempotent() {
+    let dir = tempfile::tempdir().unwrap();
+    let workdir = tempfile::tempdir().unwrap();
+
+    let first = legion_cmd(dir.path())
+        .args([
+            "watch",
+            "add",
+            "--name",
+            "rafters",
+            workdir.path().to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+    assert!(first.status.success());
+
+    let second = legion_cmd(dir.path())
+        .args([
+            "watch",
+            "add",
+            "--name",
+            "rafters",
+            workdir.path().to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+    assert!(second.status.success());
+    let stdout = String::from_utf8_lossy(&second.stdout);
+    assert!(
+        stdout.contains("already present"),
+        "expected 'already present' for duplicate: {stdout}"
+    );
+}
+
+#[test]
+fn watch_add_with_agent_flag() {
+    let dir = tempfile::tempdir().unwrap();
+    let workdir = tempfile::tempdir().unwrap();
+
+    let out = legion_cmd(dir.path())
+        .args([
+            "watch",
+            "add",
+            "--name",
+            "legion",
+            "--agent",
+            "my-agent",
+            workdir.path().to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "watch add --agent failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("my-agent"),
+        "expected agent name in output: {stdout}"
+    );
+}
+
+#[test]
+fn watch_list_shows_entries() {
+    let dir = tempfile::tempdir().unwrap();
+    let workdir = tempfile::tempdir().unwrap();
+
+    // Empty list first.
+    let empty = legion_cmd(dir.path())
+        .args(["watch", "list"])
+        .output()
+        .unwrap();
+    assert!(empty.status.success());
+    let stdout = String::from_utf8_lossy(&empty.stdout);
+    assert!(
+        stdout.contains("no repos"),
+        "empty list should say 'no repos': {stdout}"
+    );
+
+    // Add one entry.
+    legion_cmd(dir.path())
+        .args([
+            "watch",
+            "add",
+            "--name",
+            "rafters",
+            workdir.path().to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+
+    let list = legion_cmd(dir.path())
+        .args(["watch", "list"])
+        .output()
+        .unwrap();
+    assert!(list.status.success());
+    let stdout = String::from_utf8_lossy(&list.stdout);
+    assert!(
+        stdout.contains("rafters"),
+        "list should show 'rafters': {stdout}"
+    );
+}
+
+#[test]
+fn watch_remove_removes_entry() {
+    let dir = tempfile::tempdir().unwrap();
+    let workdir = tempfile::tempdir().unwrap();
+
+    legion_cmd(dir.path())
+        .args([
+            "watch",
+            "add",
+            "--name",
+            "rafters",
+            workdir.path().to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+
+    let out = legion_cmd(dir.path())
+        .args(["watch", "remove", "rafters"])
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "watch remove failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("removed:"),
+        "expected 'removed:' in output: {stdout}"
+    );
+
+    // Verify it is gone from list.
+    let list = legion_cmd(dir.path())
+        .args(["watch", "list"])
+        .output()
+        .unwrap();
+    let list_out = String::from_utf8_lossy(&list.stdout);
+    assert!(
+        !list_out.contains("rafters"),
+        "entry should be gone after remove: {list_out}"
+    );
+}
+
+#[test]
+fn watch_remove_missing_entry_reports_not_found() {
+    let dir = tempfile::tempdir().unwrap();
+
+    let out = legion_cmd(dir.path())
+        .args(["watch", "remove", "nonexistent"])
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("not found"),
+        "expected 'not found' for unknown name: {stdout}"
+    );
+}
+
+#[test]
+fn watch_add_rejects_nonexistent_workdir() {
+    let dir = tempfile::tempdir().unwrap();
+
+    let out = legion_cmd(dir.path())
+        .args([
+            "watch",
+            "add",
+            "--name",
+            "test",
+            "/nonexistent/path/that/does/not/exist",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        !out.status.success(),
+        "watch add should fail for non-directory path"
+    );
+}


### PR DESCRIPTION
## Summary

Closes #240.

Three subcommands under \`legion watch\` for managing \`watch.toml\` from the CLI:

- \`legion watch add <path> [--name <name>] [--agent <agent>]\` -- idempotent by canonicalized path; name defaults to path basename; \`--agent\` decouples the signal recipient from the project name (e.g., the \`platform\` agent watching the \`ledger\` repo).
- \`legion watch remove <name>\`
- \`legion watch list\`

Bare \`legion watch\` keeps its daemon behavior unchanged.

Closes the credibility gap in the runlegion.dev hero -- \`legion watch\` could register repos from the CLI in the old Bun server and got dropped during the Rust port.

## Schema changes

\`WatchRepoConfig\` gains:

- Optional \`agent: Option<String>\` -- serde default + skip_serializing_if, backward compatible.
- \`extra: toml::Table\` via \`#[serde(flatten)]\` -- captures any per-repo fields the struct does not model (\`github\`, \`worksource\`, \`review\`, future fields) so CRUD never strips them. Regression test guards this.

## Signal routing

\`WatchRepoConfig::recipient()\` centralizes \"prefer agent, else name.\" \`poll_cycle\` uses it for @mention pattern matching. Self-exclusion and \`watch_handled\` lookups remain keyed on \`repo.name\` so:

- An agent \`platform\` watching the \`ledger\` repo does not wake on signals it posted itself.
- Editing \`agent =\` later does not replay previously handled signals.

## Review pass (pr-review-toolkit + /legion-simplify)

- **Self-signal routing**: \`get_unhandled_signals_for_repo\` now takes separate \`repo_name\` and \`recipient\`.
- **Empty-agent bypass**: \`agent = \"\"\` or whitespace in hand-edited config made \`recipient()\` return empty. Now trimmed/filtered; \`add_repo_to_config\` normalizes to \`None\`.
- **Data-loss footgun**: typed serde round-trip was dropping unknown fields. Fixed via flatten. Regression test seeds \`github =\` and asserts it survives.
- **IO/TOML error context**: all \`fs\` and \`toml\` calls wrap errors with operation and path.
- **Auto-unblock silent-failure**: now logs instead of swallowing signal-lookup errors.
- Simplify: \`list_repos_in_config\` delegates to \`read_or_default\`; idempotency is canonical-path only per spec; name collision returns an explicit error.

## Test plan

- [x] \`cargo test\` -- 511 tests pass (419 unit + 9 + 83 integration).
- [x] \`cargo clippy -- -D warnings\` and \`cargo fmt -- --check\` clean.
- [x] Manual smoke: add/remove/list work; bare \`legion watch\` unchanged.
- [x] Unknown-field preservation verified on real \`watch.toml\`: 14 \`github\` entries before and after round-trip.
- [x] Backward compat: configs without \`agent\` load and serialize without drift.

## Commits

- \`05d09a1\` -- initial subcommands, config schema, daemon routing change.
- \`831ee10\` -- \`--name\` optional, derive from basename.
- \`4acbb2f\` -- simplify pass: \`recipient()\` method, canonical-path-only idempotency, \`list_repos_in_config\` delegation.
- \`56da4b0\` -- review pass: self-signal routing, empty agent normalization, IO context, silent-failure logging.
- \`d759a99\` -- preserve unknown per-repo fields on read-modify-write (data-loss fix).

## Out of scope

Hero-copy update to runlegion.dev; \`watch remove\` by agent/path; \`watch edit\` subcommand; multi-agent-per-repo.