### PR TITLE
feat(#245): soft delete schema for multi-node sync

### DIFF
--- a/plugin/commands/snooze.md
+++ b/plugin/commands/snooze.md
@@ -31,8 +31,10 @@ Every boost makes the system smarter. Do not skip this.
 Store a session reflection that captures what matters for future sessions. Focus on WHY, not WHAT:
 
 ```bash
-legion reflect --repo <your-repo> --text "<consolidated session summary>"
+legion reflect --repo <your-repo> --text "<consolidated session summary>" --domain snooze --tags session
 ```
+
+The `--domain snooze` tag is mandatory -- SessionStart pulls the most recent `--domain snooze` reflection on boot. Without the tag, your session summary is invisible to the next session.
 
 Good reflections answer: "What would I tell another agent who hits this same situation tomorrow?"
 

--- a/src/db.rs
+++ b/src/db.rs
@@ -798,6 +798,21 @@ impl Database {
         Ok(reflection)
     }
 
+    /// Soft-delete a reflection by setting its deleted_at timestamp.
+    ///
+    /// Unlike `delete_reflection` (hard delete), this preserves the row for
+    /// multi-node sync tombstone propagation. The row becomes invisible to
+    /// normal queries but can still be synced to other nodes.
+    #[allow(dead_code)] // Used by sync module in #248
+    pub fn soft_delete_reflection(&self, id: &str) -> Result<bool> {
+        let now = Utc::now().to_rfc3339();
+        let rows = self.conn.execute(
+            "UPDATE reflections SET deleted_at = ?1 WHERE id = ?2 AND deleted_at IS NULL",
+            rusqlite::params![now, id],
+        )?;
+        Ok(rows > 0)
+    }
+
     /// Retrieve reflections by a list of IDs. Returns them in the order found
     /// (not necessarily the input order). Missing IDs are silently skipped.
     pub fn get_reflections_by_ids(&self, ids: &[&str]) -> Result<Vec<Reflection>> {
@@ -1749,6 +1764,21 @@ impl Database {
         Ok(())
     }
 
+    /// Soft-delete a card by setting its deleted_at timestamp.
+    ///
+    /// Unlike `delete_card` (hard delete), this preserves the row for
+    /// multi-node sync tombstone propagation. The row becomes invisible to
+    /// normal queries but can still be synced to other nodes.
+    #[allow(dead_code)] // Used by sync module in #248
+    pub fn soft_delete_card(&self, id: &str) -> Result<bool> {
+        let now = chrono::Utc::now().to_rfc3339();
+        let rows = self.conn.execute(
+            "UPDATE tasks SET deleted_at = ?1 WHERE id = ?2 AND deleted_at IS NULL",
+            rusqlite::params![now, id],
+        )?;
+        Ok(rows > 0)
+    }
+
     /// Get per-agent workload summary.
     pub fn get_agent_workloads(&self) -> Result<Vec<crate::kanban::AgentWorkload>> {
         let mut stmt = self.conn.prepare(
@@ -1756,7 +1786,7 @@ impl Database {
              SUM(CASE WHEN status IN ('accepted', 'in-review', 'needs-input') THEN 1 ELSE 0 END) as active, \
              SUM(CASE WHEN status = 'pending' THEN 1 ELSE 0 END) as pending, \
              SUM(CASE WHEN status = 'blocked' THEN 1 ELSE 0 END) as blocked \
-             FROM tasks WHERE status NOT IN ('done', 'cancelled') \
+             FROM tasks WHERE status NOT IN ('done', 'cancelled') AND deleted_at IS NULL \
              GROUP BY to_repo ORDER BY to_repo",
         )?;
         let rows = stmt.query_map([], |row| {
@@ -1955,6 +1985,21 @@ impl Database {
         let rows = self
             .conn
             .execute("DELETE FROM schedules WHERE id = ?1", [id])?;
+        Ok(rows > 0)
+    }
+
+    /// Soft-delete a schedule by setting its deleted_at timestamp.
+    ///
+    /// Unlike `delete_schedule` (hard delete), this preserves the row for
+    /// multi-node sync tombstone propagation. The row becomes invisible to
+    /// normal queries but can still be synced to other nodes.
+    #[allow(dead_code)] // Used by sync module in #248
+    pub fn soft_delete_schedule(&self, id: &str) -> Result<bool> {
+        let now = chrono::Utc::now().to_rfc3339();
+        let rows = self.conn.execute(
+            "UPDATE schedules SET deleted_at = ?1 WHERE id = ?2 AND deleted_at IS NULL",
+            rusqlite::params![now, id],
+        )?;
         Ok(rows > 0)
     }
 
@@ -3545,6 +3590,109 @@ mod tests {
         assert!(
             matches!(result, Err(LegionError::CardNotFound(_))),
             "expected CardNotFound for missing card, got: {result:?}"
+        );
+    }
+
+    #[test]
+    fn soft_delete_reflection_hides_from_queries() {
+        let db = test_db();
+
+        // Insert a reflection.
+        let r = db
+            .insert_reflection("test-repo", "soft delete test reflection", "self")
+            .unwrap();
+        let id = r.id;
+        assert!(db.get_reflection_by_id(&id).unwrap().is_some());
+
+        // Soft delete it.
+        let deleted = db.soft_delete_reflection(&id).unwrap();
+        assert!(deleted, "soft_delete_reflection should return true");
+
+        // The reflection should now be invisible to normal queries.
+        assert!(
+            db.get_reflection_by_id(&id).unwrap().is_none(),
+            "soft-deleted reflection should not be visible"
+        );
+
+        // Soft deleting again returns false (already deleted).
+        let deleted_again = db.soft_delete_reflection(&id).unwrap();
+        assert!(
+            !deleted_again,
+            "soft_delete_reflection on already-deleted should return false"
+        );
+    }
+
+    #[test]
+    fn soft_delete_card_hides_from_queries() {
+        let db = test_db();
+
+        // Insert a card.
+        let id = db
+            .insert_card(
+                "legion",
+                "legion",
+                "soft delete test card",
+                None,
+                "med",
+                None,
+                None,
+                None,
+                None,
+                None,
+            )
+            .unwrap();
+        assert!(db.get_card_by_id(&id).unwrap().is_some());
+
+        // Soft delete it.
+        let deleted = db.soft_delete_card(&id).unwrap();
+        assert!(deleted, "soft_delete_card should return true");
+
+        // The card should now be invisible to normal queries.
+        assert!(
+            db.get_card_by_id(&id).unwrap().is_none(),
+            "soft-deleted card should not be visible"
+        );
+
+        // Soft deleting again returns false (already deleted).
+        let deleted_again = db.soft_delete_card(&id).unwrap();
+        assert!(
+            !deleted_again,
+            "soft_delete_card on already-deleted should return false"
+        );
+    }
+
+    #[test]
+    fn soft_delete_schedule_hides_from_queries() {
+        let db = test_db();
+
+        // Insert a schedule (using */Nm interval format).
+        let id = db
+            .insert_schedule("test-schedule", "*/30m", "echo test", "legion", None, None)
+            .unwrap();
+
+        // Verify it appears in list.
+        let schedules = db.list_schedules().unwrap();
+        assert!(
+            schedules.iter().any(|s| s.id == id),
+            "schedule should appear in list"
+        );
+
+        // Soft delete it.
+        let deleted = db.soft_delete_schedule(&id).unwrap();
+        assert!(deleted, "soft_delete_schedule should return true");
+
+        // The schedule should now be invisible.
+        let schedules_after = db.list_schedules().unwrap();
+        assert!(
+            !schedules_after.iter().any(|s| s.id == id),
+            "soft-deleted schedule should not appear in list"
+        );
+
+        // Soft deleting again returns false.
+        let deleted_again = db.soft_delete_schedule(&id).unwrap();
+        assert!(
+            !deleted_again,
+            "soft_delete_schedule on already-deleted should return false"
         );
     }
 }

--- a/src/db.rs
+++ b/src/db.rs
@@ -874,7 +874,7 @@ impl Database {
     ) -> Result<Vec<Reflection>> {
         let mut stmt = self.conn.prepare(
             "SELECT id, repo, text, created_at, audience, domain, tags, recall_count, last_recalled_at, parent_id \
-             FROM reflections WHERE repo = ?1 AND domain = ?2 ORDER BY created_at DESC LIMIT ?3",
+             FROM reflections WHERE repo = ?1 AND domain = ?2 AND deleted_at IS NULL ORDER BY created_at DESC LIMIT ?3",
         )?;
 
         let rows = stmt.query_map(rusqlite::params![repo, domain, limit], map_reflection_row)?;
@@ -886,7 +886,7 @@ impl Database {
     pub fn get_board_posts(&self) -> Result<Vec<Reflection>> {
         let mut stmt = self.conn.prepare(
             "SELECT id, repo, text, created_at, audience, domain, tags, recall_count, last_recalled_at, parent_id \
-             FROM reflections WHERE audience = 'team' AND archived_at IS NULL ORDER BY created_at DESC",
+             FROM reflections WHERE audience = 'team' AND archived_at IS NULL AND deleted_at IS NULL ORDER BY created_at DESC",
         )?;
 
         let rows = stmt.query_map([], map_reflection_row)?;
@@ -926,7 +926,7 @@ impl Database {
         let mut stmt = self.conn.prepare(
             "SELECT id, repo, text, created_at, audience, domain, tags, recall_count, last_recalled_at, parent_id \
              FROM reflections \
-             WHERE audience = 'team' AND archived_at IS NULL \
+             WHERE audience = 'team' AND archived_at IS NULL AND deleted_at IS NULL \
                AND (created_at > ?1 OR (created_at = ?1 AND id > ?2)) \
              ORDER BY created_at ASC, id ASC \
              LIMIT ?3",
@@ -1120,7 +1120,7 @@ impl Database {
              r.recall_count, r.last_recalled_at, r.parent_id \
              FROM reflections r \
              LEFT JOIN watch_handled wh ON wh.signal_id = r.id AND wh.repo_name = ?5 \
-             WHERE r.audience = 'team' \
+             WHERE r.audience = 'team' AND r.deleted_at IS NULL \
                AND wh.signal_id IS NULL \
                AND (r.text LIKE ?1 OR r.text LIKE ?2 OR r.text LIKE ?3 OR r.text LIKE ?4) \
                AND r.repo != ?5{} \
@@ -1287,7 +1287,7 @@ impl Database {
              COALESCE(SUM(recall_count), 0) as boost, \
              SUM(CASE WHEN audience = 'team' THEN 1 ELSE 0 END) as team_cnt, \
              MAX(created_at) as last_act \
-             FROM reflections GROUP BY repo ORDER BY repo",
+             FROM reflections WHERE deleted_at IS NULL GROUP BY repo ORDER BY repo",
         )?;
 
         let rows = stmt.query_map([], |row| {
@@ -1308,7 +1308,7 @@ impl Database {
     pub fn get_all_tasks(&self) -> Result<Vec<crate::task::Task>> {
         let mut stmt = self.conn.prepare(
             "SELECT id, from_repo, to_repo, text, context, priority, status, note, created_at, updated_at \
-             FROM tasks ORDER BY created_at DESC",
+             FROM tasks WHERE deleted_at IS NULL ORDER BY created_at DESC",
         )?;
         let rows = stmt.query_map([], crate::task::map_task_row)?;
         rows.collect::<std::result::Result<Vec<_>, _>>()
@@ -1342,7 +1342,7 @@ impl Database {
     pub fn get_task_by_id(&self, id: &str) -> Result<Option<crate::task::Task>> {
         let mut stmt = self.conn.prepare(
             "SELECT id, from_repo, to_repo, text, context, priority, status, note, created_at, updated_at \
-             FROM tasks WHERE id = ?1",
+             FROM tasks WHERE id = ?1 AND deleted_at IS NULL",
         )?;
         let mut rows = stmt.query_map([id], crate::task::map_task_row)?;
         match rows.next() {
@@ -1360,11 +1360,11 @@ impl Database {
         let sql = match direction {
             crate::task::Direction::Inbound => {
                 "SELECT id, from_repo, to_repo, text, context, priority, status, note, created_at, updated_at \
-                 FROM tasks WHERE to_repo = ?1 ORDER BY created_at DESC"
+                 FROM tasks WHERE to_repo = ?1 AND deleted_at IS NULL ORDER BY created_at DESC"
             }
             crate::task::Direction::Outbound => {
                 "SELECT id, from_repo, to_repo, text, context, priority, status, note, created_at, updated_at \
-                 FROM tasks WHERE from_repo = ?1 ORDER BY created_at DESC"
+                 FROM tasks WHERE from_repo = ?1 AND deleted_at IS NULL ORDER BY created_at DESC"
             }
         };
 
@@ -2054,7 +2054,7 @@ impl Database {
         let cutoff = (Utc::now() - chrono::Duration::hours(hours)).to_rfc3339();
         let mut stmt = self.conn.prepare(
             "SELECT id, repo, text, created_at, audience, domain, tags, recall_count, last_recalled_at, parent_id \
-             FROM reflections WHERE parent_id IS NOT NULL AND created_at > ?1 ORDER BY created_at DESC",
+             FROM reflections WHERE parent_id IS NOT NULL AND deleted_at IS NULL AND created_at > ?1 ORDER BY created_at DESC",
         )?;
         let rows = stmt.query_map([&cutoff], map_reflection_row)?;
         rows.collect::<std::result::Result<Vec<_>, _>>()

--- a/src/db.rs
+++ b/src/db.rs
@@ -597,7 +597,7 @@ impl Database {
     /// Store an embedding BLOB for an existing reflection.
     pub fn store_embedding(&self, id: &str, embedding_bytes: &[u8]) -> Result<bool> {
         let rows = self.conn.execute(
-            "UPDATE reflections SET embedding = ?1 WHERE id = ?2",
+            "UPDATE reflections SET embedding = ?1 WHERE id = ?2 AND deleted_at IS NULL",
             rusqlite::params![embedding_bytes, id],
         )?;
         Ok(rows > 0)
@@ -692,7 +692,7 @@ impl Database {
     pub fn boost_reflection(&self, id: &str) -> Result<bool> {
         let now = Utc::now().to_rfc3339();
         let rows = self.conn.execute(
-            "UPDATE reflections SET recall_count = recall_count + 1, last_recalled_at = ?1 WHERE id = ?2",
+            "UPDATE reflections SET recall_count = recall_count + 1, last_recalled_at = ?1 WHERE id = ?2 AND deleted_at IS NULL",
             (&now, id),
         )?;
         Ok(rows > 0)
@@ -1046,7 +1046,7 @@ impl Database {
 
         let count = self.conn.execute(
             "UPDATE reflections SET archived_at = ?1 \
-             WHERE audience = 'team' AND archived_at IS NULL \
+             WHERE audience = 'team' AND archived_at IS NULL AND deleted_at IS NULL \
              AND created_at < (SELECT MIN(last_read_at) FROM board_reads)",
             rusqlite::params![now],
         )?;
@@ -1380,7 +1380,7 @@ impl Database {
     pub fn update_task_status(&self, id: &str, status: &str, note: Option<&str>) -> Result<()> {
         let now = Utc::now().to_rfc3339();
         let rows = self.conn.execute(
-            "UPDATE tasks SET status = ?1, note = COALESCE(?2, note), updated_at = ?3 WHERE id = ?4",
+            "UPDATE tasks SET status = ?1, note = COALESCE(?2, note), updated_at = ?3 WHERE id = ?4 AND deleted_at IS NULL",
             rusqlite::params![status, &note, &now, id],
         )?;
         if rows == 0 {
@@ -1630,7 +1630,7 @@ impl Database {
         let now = chrono::Utc::now().to_rfc3339();
         let rows_affected = self.conn.execute(
             "UPDATE tasks SET status = 'accepted', started_at = ?1, updated_at = ?2 \
-             WHERE id = ?3 AND status = 'pending'",
+             WHERE id = ?3 AND status = 'pending' AND deleted_at IS NULL",
             rusqlite::params![now, now, card.id],
         )?;
         if rows_affected == 0 {
@@ -1669,22 +1669,22 @@ impl Database {
         let rows = match timestamp {
             CardTimestamp::Assigned => self.conn.execute(
                 "UPDATE tasks SET status = ?1, note = COALESCE(?2, note), \
-                 assigned_at = ?3, updated_at = ?4 WHERE id = ?5",
+                 assigned_at = ?3, updated_at = ?4 WHERE id = ?5 AND deleted_at IS NULL",
                 rusqlite::params![status, note, now, now, id],
             )?,
             CardTimestamp::Started => self.conn.execute(
                 "UPDATE tasks SET status = ?1, note = COALESCE(?2, note), \
-                 started_at = ?3, updated_at = ?4 WHERE id = ?5",
+                 started_at = ?3, updated_at = ?4 WHERE id = ?5 AND deleted_at IS NULL",
                 rusqlite::params![status, note, now, now, id],
             )?,
             CardTimestamp::Completed => self.conn.execute(
                 "UPDATE tasks SET status = ?1, note = COALESCE(?2, note), \
-                 completed_at = ?3, updated_at = ?4 WHERE id = ?5",
+                 completed_at = ?3, updated_at = ?4 WHERE id = ?5 AND deleted_at IS NULL",
                 rusqlite::params![status, note, now, now, id],
             )?,
             CardTimestamp::None => self.conn.execute(
                 "UPDATE tasks SET status = ?1, note = COALESCE(?2, note), \
-                 updated_at = ?3 WHERE id = ?4",
+                 updated_at = ?3 WHERE id = ?4 AND deleted_at IS NULL",
                 rusqlite::params![status, note, now, id],
             )?,
         };
@@ -1706,7 +1706,7 @@ impl Database {
             _ => "",
         };
         let sql = format!(
-            "UPDATE tasks SET status = ?1, sort_order = ?2, updated_at = ?3{ts_sql} WHERE id = ?4"
+            "UPDATE tasks SET status = ?1, sort_order = ?2, updated_at = ?3{ts_sql} WHERE id = ?4 AND deleted_at IS NULL"
         );
         let rows = if ts_sql.is_empty() {
             self.conn
@@ -1729,7 +1729,7 @@ impl Database {
         let now = chrono::Utc::now().to_rfc3339();
         let rows = self.conn.execute(
             "UPDATE tasks SET to_repo = ?1, status = 'pending', \
-             assigned_at = ?2, updated_at = ?3 WHERE id = ?4 AND status = 'backlog'",
+             assigned_at = ?2, updated_at = ?3 WHERE id = ?4 AND status = 'backlog' AND deleted_at IS NULL",
             rusqlite::params![to_repo, now, now, id],
         )?;
         if rows == 0 {
@@ -1860,7 +1860,7 @@ impl Database {
         params.push(Box::new(id.to_string()));
 
         let sql = format!(
-            "UPDATE tasks SET {} WHERE id = ?{}",
+            "UPDATE tasks SET {} WHERE id = ?{} AND deleted_at IS NULL",
             sets.join(", "),
             id_pos
         );
@@ -1952,7 +1952,7 @@ impl Database {
         let next_run_str = next_run.to_rfc3339();
 
         self.conn.execute(
-            "UPDATE schedules SET last_run = ?1, next_run = ?2 WHERE id = ?3",
+            "UPDATE schedules SET last_run = ?1, next_run = ?2 WHERE id = ?3 AND deleted_at IS NULL",
             rusqlite::params![&now_str, &next_run_str, id],
         )?;
 
@@ -1974,7 +1974,7 @@ impl Database {
     pub fn toggle_schedule(&self, id: &str, enabled: bool) -> Result<bool> {
         let enabled_int: i32 = if enabled { 1 } else { 0 };
         let rows = self.conn.execute(
-            "UPDATE schedules SET enabled = ?1 WHERE id = ?2",
+            "UPDATE schedules SET enabled = ?1 WHERE id = ?2 AND deleted_at IS NULL",
             rusqlite::params![enabled_int, id],
         )?;
         Ok(rows > 0)
@@ -2032,7 +2032,7 @@ impl Database {
         }
 
         let query = format!(
-            "UPDATE schedules SET {} WHERE id = ?{}",
+            "UPDATE schedules SET {} WHERE id = ?{} AND deleted_at IS NULL",
             updates.join(", "),
             params.len() + 1
         );

--- a/src/db.rs
+++ b/src/db.rs
@@ -531,6 +531,19 @@ impl Database {
                 ON quality_gates(commit_hash, skill);",
         )?;
 
+        // Migration 13: Soft delete support for multi-node sync (#245).
+        // Adds deleted_at column to syncable tables. Rows with deleted_at set
+        // are excluded from normal queries but included in sync deltas.
+        if !Self::has_column(conn, "reflections", "deleted_at")? {
+            conn.execute_batch("ALTER TABLE reflections ADD COLUMN deleted_at TEXT;")?;
+        }
+        if !Self::has_column(conn, "tasks", "deleted_at")? {
+            conn.execute_batch("ALTER TABLE tasks ADD COLUMN deleted_at TEXT;")?;
+        }
+        if !Self::has_column(conn, "schedules", "deleted_at")? {
+            conn.execute_batch("ALTER TABLE schedules ADD COLUMN deleted_at TEXT;")?;
+        }
+
         Ok(())
     }
 
@@ -594,7 +607,7 @@ impl Database {
     pub fn get_embedding(&self, id: &str) -> Result<Option<Vec<u8>>> {
         let mut stmt = self
             .conn
-            .prepare("SELECT embedding FROM reflections WHERE id = ?1")?;
+            .prepare("SELECT embedding FROM reflections WHERE id = ?1 AND deleted_at IS NULL")?;
         let mut rows = stmt.query_map([id], |row| {
             let blob: Option<Vec<u8>> = row.get(0)?;
             Ok(blob)
@@ -615,7 +628,7 @@ impl Database {
             Ok((row.get(0)?, row.get(1)?))
         };
 
-        let base = "SELECT id, embedding FROM reflections WHERE embedding IS NOT NULL";
+        let base = "SELECT id, embedding FROM reflections WHERE embedding IS NOT NULL AND deleted_at IS NULL";
         let sql = match repo {
             Some(_) => format!("{base} AND repo = ?1"),
             None => base.to_owned(),
@@ -633,7 +646,7 @@ impl Database {
     /// Get all reflection IDs that are missing embeddings.
     pub fn get_ids_without_embeddings(&self) -> Result<Vec<(String, String)>> {
         let mut stmt = self.conn.prepare(
-            "SELECT id, text FROM reflections WHERE embedding IS NULL ORDER BY created_at DESC",
+            "SELECT id, text FROM reflections WHERE embedding IS NULL AND deleted_at IS NULL ORDER BY created_at DESC",
         )?;
         let rows = stmt.query_map([], |row| {
             let id: String = row.get(0)?;
@@ -657,7 +670,7 @@ impl Database {
     ) -> Result<Vec<ReflectionWithEmbedding>> {
         let mut stmt = self.conn.prepare(
             "SELECT id, embedding, text, created_at FROM reflections \
-             WHERE repo = ?1 AND embedding IS NOT NULL \
+             WHERE repo = ?1 AND embedding IS NOT NULL AND deleted_at IS NULL \
              ORDER BY created_at DESC LIMIT ?2",
         )?;
         let rows = stmt.query_map(rusqlite::params![repo, limit], |row| {
@@ -724,9 +737,9 @@ impl Database {
 
     /// Find the child reflection that follows the given parent ID.
     fn find_child(&self, parent_id: &str) -> Result<Option<String>> {
-        let mut stmt = self
-            .conn
-            .prepare("SELECT id FROM reflections WHERE parent_id = ?1 LIMIT 1")?;
+        let mut stmt = self.conn.prepare(
+            "SELECT id FROM reflections WHERE parent_id = ?1 AND deleted_at IS NULL LIMIT 1",
+        )?;
         let mut rows = stmt.query_map([parent_id], |row| row.get::<_, String>(0))?;
         match rows.next() {
             Some(row) => Ok(Some(row?)),
@@ -736,10 +749,10 @@ impl Database {
 
     /// Retrieve a single reflection by its ID.
     ///
-    /// Returns `None` if no reflection exists with the given ID.
+    /// Returns `None` if no reflection exists with the given ID or if soft-deleted.
     pub fn get_reflection_by_id(&self, id: &str) -> Result<Option<Reflection>> {
         let mut stmt = self.conn.prepare(
-            "SELECT id, repo, text, created_at, audience, domain, tags, recall_count, last_recalled_at, parent_id FROM reflections WHERE id = ?1",
+            "SELECT id, repo, text, created_at, audience, domain, tags, recall_count, last_recalled_at, parent_id FROM reflections WHERE id = ?1 AND deleted_at IS NULL",
         )?;
 
         let mut rows = stmt.query_map([id], map_reflection_row)?;
@@ -794,7 +807,7 @@ impl Database {
         let placeholders: Vec<&str> = ids.iter().map(|_| "?").collect();
         let sql = format!(
             "SELECT id, repo, text, created_at, audience, domain, tags, recall_count, \
-             last_recalled_at, parent_id FROM reflections WHERE id IN ({})",
+             last_recalled_at, parent_id FROM reflections WHERE id IN ({}) AND deleted_at IS NULL",
             placeholders.join(", ")
         );
         let mut stmt = self.conn.prepare(&sql)?;
@@ -811,7 +824,7 @@ impl Database {
     #[cfg(test)]
     pub fn get_reflections_by_repo(&self, repo: &str) -> Result<Vec<Reflection>> {
         let mut stmt = self.conn.prepare(
-            "SELECT id, repo, text, created_at, audience, domain, tags, recall_count, last_recalled_at, parent_id FROM reflections WHERE repo = ?1 ORDER BY created_at DESC",
+            "SELECT id, repo, text, created_at, audience, domain, tags, recall_count, last_recalled_at, parent_id FROM reflections WHERE repo = ?1 AND deleted_at IS NULL ORDER BY created_at DESC",
         )?;
 
         let rows = stmt.query_map([repo], map_reflection_row)?;
@@ -825,7 +838,7 @@ impl Database {
     /// number of results are needed, since the database handles the LIMIT.
     pub fn get_latest_self_reflections(&self, repo: &str, limit: usize) -> Result<Vec<Reflection>> {
         let mut stmt = self.conn.prepare(
-            "SELECT id, repo, text, created_at, audience, domain, tags, recall_count, last_recalled_at, parent_id FROM reflections WHERE repo = ?1 AND audience = 'self' ORDER BY created_at DESC LIMIT ?2",
+            "SELECT id, repo, text, created_at, audience, domain, tags, recall_count, last_recalled_at, parent_id FROM reflections WHERE repo = ?1 AND audience = 'self' AND deleted_at IS NULL ORDER BY created_at DESC LIMIT ?2",
         )?;
 
         let rows = stmt.query_map(rusqlite::params![repo, limit], map_reflection_row)?;
@@ -923,7 +936,7 @@ impl Database {
     pub fn get_board_cursor_watermark(&self) -> Result<Option<(String, String)>> {
         let mut stmt = self.conn.prepare(
             "SELECT created_at, id FROM reflections \
-             WHERE audience = 'team' AND archived_at IS NULL \
+             WHERE audience = 'team' AND archived_at IS NULL AND deleted_at IS NULL \
              ORDER BY created_at DESC, id DESC \
              LIMIT 1",
         )?;
@@ -955,7 +968,7 @@ impl Database {
         let mut stmt = txn.prepare(
             "SELECT id, repo, text, created_at, audience, domain, tags, recall_count, last_recalled_at, parent_id \
              FROM reflections \
-             WHERE audience = 'team' AND archived_at IS NULL \
+             WHERE audience = 'team' AND archived_at IS NULL AND deleted_at IS NULL \
              AND created_at > COALESCE( \
                  (SELECT last_read_at FROM board_reads WHERE reader_repo = ?1), \
                  '' \
@@ -999,7 +1012,7 @@ impl Database {
     pub fn get_archived_posts(&self) -> Result<Vec<Reflection>> {
         let mut stmt = self.conn.prepare(
             "SELECT id, repo, text, created_at, audience, domain, tags, recall_count, last_recalled_at, parent_id \
-             FROM reflections WHERE audience = 'team' AND archived_at IS NOT NULL ORDER BY created_at DESC",
+             FROM reflections WHERE audience = 'team' AND archived_at IS NOT NULL AND deleted_at IS NULL ORDER BY created_at DESC",
         )?;
 
         let rows = stmt.query_map([], map_reflection_row)?;
@@ -1033,7 +1046,7 @@ impl Database {
     pub fn get_unread_count(&self, reader_repo: &str) -> Result<u64> {
         let mut stmt = self.conn.prepare(
             "SELECT COUNT(*) FROM reflections WHERE audience = 'team' \
-             AND archived_at IS NULL \
+             AND archived_at IS NULL AND deleted_at IS NULL \
              AND created_at > COALESCE( \
                  (SELECT last_read_at FROM board_reads WHERE reader_repo = ?1), \
                  '' \
@@ -1159,7 +1172,7 @@ impl Database {
     pub fn get_all_for_reindex(&self) -> Result<Vec<Reflection>> {
         let mut stmt = self
             .conn
-            .prepare("SELECT id, repo, text, created_at, audience, domain, tags, recall_count, last_recalled_at, parent_id FROM reflections")?;
+            .prepare("SELECT id, repo, text, created_at, audience, domain, tags, recall_count, last_recalled_at, parent_id FROM reflections WHERE deleted_at IS NULL")?;
         let rows = stmt.query_map([], map_reflection_row)?;
         rows.collect::<std::result::Result<Vec<_>, _>>()
             .map_err(LegionError::Database)
@@ -1177,10 +1190,10 @@ impl Database {
         };
 
         let base = "SELECT repo, COUNT(*) as count, MIN(created_at) as oldest, \
-                     MAX(created_at) as newest FROM reflections";
+                     MAX(created_at) as newest FROM reflections WHERE deleted_at IS NULL";
 
         let sql = match repo {
-            Some(_) => format!("{base} WHERE repo = ?1 GROUP BY repo"),
+            Some(_) => format!("{base} AND repo = ?1 GROUP BY repo"),
             None => format!("{base} GROUP BY repo ORDER BY repo"),
         };
 
@@ -1200,7 +1213,7 @@ impl Database {
         let cutoff = (Utc::now() - chrono::Duration::hours(hours)).to_rfc3339();
         let mut stmt = self.conn.prepare(
             "SELECT id, repo, text, created_at, audience, domain, tags, recall_count, last_recalled_at, parent_id \
-             FROM reflections WHERE audience = 'team' AND archived_at IS NULL AND created_at > ?1 ORDER BY created_at DESC",
+             FROM reflections WHERE audience = 'team' AND archived_at IS NULL AND deleted_at IS NULL AND created_at > ?1 ORDER BY created_at DESC",
         )?;
         let rows = stmt.query_map([&cutoff], map_reflection_row)?;
         rows.collect::<std::result::Result<Vec<_>, _>>()
@@ -1218,7 +1231,7 @@ impl Database {
     ) -> Result<Vec<Reflection>> {
         let mut stmt = self.conn.prepare(
             "SELECT id, repo, text, created_at, audience, domain, tags, recall_count, last_recalled_at, parent_id \
-             FROM reflections WHERE repo != ?1 AND recall_count > 0 ORDER BY recall_count DESC LIMIT ?2",
+             FROM reflections WHERE repo != ?1 AND recall_count > 0 AND deleted_at IS NULL ORDER BY recall_count DESC LIMIT ?2",
         )?;
         let rows = stmt.query_map(rusqlite::params![exclude_repo, limit], map_reflection_row)?;
         rows.collect::<std::result::Result<Vec<_>, _>>()
@@ -1227,9 +1240,9 @@ impl Database {
 
     /// Get all distinct repo names from reflections.
     pub fn get_distinct_repos(&self) -> Result<Vec<String>> {
-        let mut stmt = self
-            .conn
-            .prepare("SELECT DISTINCT repo FROM reflections ORDER BY repo")?;
+        let mut stmt = self.conn.prepare(
+            "SELECT DISTINCT repo FROM reflections WHERE deleted_at IS NULL ORDER BY repo",
+        )?;
         let rows = stmt.query_map([], |row| row.get::<_, String>(0))?;
         rows.collect::<std::result::Result<Vec<_>, _>>()
             .map_err(LegionError::Database)
@@ -1365,7 +1378,7 @@ impl Database {
     pub fn count_pending_tasks_for_repo(&self, repo: &str) -> Result<u64> {
         let mut stmt = self
             .conn
-            .prepare("SELECT COUNT(*) FROM tasks WHERE to_repo = ?1 AND status = 'pending'")?;
+            .prepare("SELECT COUNT(*) FROM tasks WHERE to_repo = ?1 AND status = 'pending' AND deleted_at IS NULL")?;
         let count: u64 = stmt
             .query_row([repo], |row| row.get(0))
             .map_err(LegionError::Database)?;
@@ -1376,7 +1389,7 @@ impl Database {
     pub fn get_pending_tasks_for_repo(&self, repo: &str) -> Result<Vec<crate::task::Task>> {
         let mut stmt = self.conn.prepare(
             "SELECT id, from_repo, to_repo, text, context, priority, status, note, created_at, updated_at \
-             FROM tasks WHERE to_repo = ?1 AND status = 'pending' ORDER BY created_at DESC",
+             FROM tasks WHERE to_repo = ?1 AND status = 'pending' AND deleted_at IS NULL ORDER BY created_at DESC",
         )?;
         let rows = stmt.query_map([repo], crate::task::map_task_row)?;
         rows.collect::<std::result::Result<Vec<_>, _>>()
@@ -1389,7 +1402,7 @@ impl Database {
     pub fn get_active_tasks_for_repo(&self, repo: &str) -> Result<Vec<crate::task::Task>> {
         let mut stmt = self.conn.prepare(
             "SELECT id, from_repo, to_repo, text, context, priority, status, note, created_at, updated_at \
-             FROM tasks WHERE to_repo = ?1 AND status IN ('pending', 'accepted', 'blocked') \
+             FROM tasks WHERE to_repo = ?1 AND status IN ('pending', 'accepted', 'blocked') AND deleted_at IS NULL \
              ORDER BY CASE priority WHEN 'high' THEN 0 WHEN 'med' THEN 1 WHEN 'low' THEN 2 END, created_at DESC",
         )?;
         let rows = stmt.query_map([repo], crate::task::map_task_row)?;
@@ -1401,7 +1414,7 @@ impl Database {
     pub fn get_max_created_at(&self) -> Result<Option<String>> {
         let mut stmt = self
             .conn
-            .prepare("SELECT MAX(created_at) FROM reflections")?;
+            .prepare("SELECT MAX(created_at) FROM reflections WHERE deleted_at IS NULL")?;
         let result: Option<String> = stmt
             .query_row([], |row| row.get(0))
             .map_err(LegionError::Database)?;
@@ -1410,7 +1423,9 @@ impl Database {
 
     /// Get the most recent updated_at timestamp from tasks.
     pub fn get_max_task_updated_at(&self) -> Result<Option<String>> {
-        let mut stmt = self.conn.prepare("SELECT MAX(updated_at) FROM tasks")?;
+        let mut stmt = self
+            .conn
+            .prepare("SELECT MAX(updated_at) FROM tasks WHERE deleted_at IS NULL")?;
         let result: Option<String> = stmt
             .query_row([], |row| row.get(0))
             .map_err(LegionError::Database)?;
@@ -1485,7 +1500,10 @@ impl Database {
 
     /// Retrieve a single card by ID.
     pub fn get_card_by_id(&self, id: &str) -> Result<Option<crate::kanban::Card>> {
-        let sql = format!("SELECT {} FROM tasks WHERE id = ?1", Self::CARD_COLUMNS);
+        let sql = format!(
+            "SELECT {} FROM tasks WHERE id = ?1 AND deleted_at IS NULL",
+            Self::CARD_COLUMNS
+        );
         let mut stmt = self.conn.prepare(&sql)?;
         let mut rows = stmt.query_map([id], crate::kanban::map_card_row)?;
         match rows.next() {
@@ -1503,14 +1521,14 @@ impl Database {
         let sql = match direction {
             crate::kanban::Direction::Inbound => {
                 format!(
-                    "SELECT {} FROM tasks WHERE to_repo = ?1 ORDER BY {}, sort_order ASC, created_at DESC",
+                    "SELECT {} FROM tasks WHERE to_repo = ?1 AND deleted_at IS NULL ORDER BY {}, sort_order ASC, created_at DESC",
                     Self::CARD_COLUMNS,
                     Self::PRIORITY_ORDER
                 )
             }
             crate::kanban::Direction::Outbound => {
                 format!(
-                    "SELECT {} FROM tasks WHERE from_repo = ?1 ORDER BY created_at DESC",
+                    "SELECT {} FROM tasks WHERE from_repo = ?1 AND deleted_at IS NULL ORDER BY created_at DESC",
                     Self::CARD_COLUMNS
                 )
             }
@@ -1524,7 +1542,7 @@ impl Database {
     /// Get all cards for the kanban board view.
     pub fn get_all_cards(&self) -> Result<Vec<crate::kanban::Card>> {
         let sql = format!(
-            "SELECT {} FROM tasks ORDER BY {}, sort_order ASC, created_at DESC",
+            "SELECT {} FROM tasks WHERE deleted_at IS NULL ORDER BY {}, sort_order ASC, created_at DESC",
             Self::CARD_COLUMNS,
             Self::PRIORITY_ORDER
         );
@@ -1538,7 +1556,7 @@ impl Database {
     pub fn count_pending_cards_for_repo(&self, repo: &str) -> Result<u64> {
         let mut stmt = self
             .conn
-            .prepare("SELECT COUNT(*) FROM tasks WHERE to_repo = ?1 AND status = 'pending'")?;
+            .prepare("SELECT COUNT(*) FROM tasks WHERE to_repo = ?1 AND status = 'pending' AND deleted_at IS NULL")?;
         let count: u64 = stmt
             .query_row([repo], |row| row.get(0))
             .map_err(LegionError::Database)?;
@@ -1548,7 +1566,7 @@ impl Database {
     /// Get pending cards assigned to a repo.
     pub fn get_pending_cards_for_repo(&self, repo: &str) -> Result<Vec<crate::kanban::Card>> {
         let sql = format!(
-            "SELECT {} FROM tasks WHERE to_repo = ?1 AND status = 'pending' \
+            "SELECT {} FROM tasks WHERE to_repo = ?1 AND status = 'pending' AND deleted_at IS NULL \
              ORDER BY {}, sort_order ASC, created_at ASC",
             Self::CARD_COLUMNS,
             Self::PRIORITY_ORDER
@@ -1563,7 +1581,7 @@ impl Database {
     #[allow(dead_code)]
     pub fn get_active_cards_for_repo(&self, repo: &str) -> Result<Vec<crate::kanban::Card>> {
         let sql = format!(
-            "SELECT {} FROM tasks WHERE to_repo = ?1 AND status NOT IN ('done', 'cancelled') \
+            "SELECT {} FROM tasks WHERE to_repo = ?1 AND status NOT IN ('done', 'cancelled') AND deleted_at IS NULL \
              ORDER BY {}, sort_order ASC, created_at DESC",
             Self::CARD_COLUMNS,
             Self::PRIORITY_ORDER
@@ -1580,7 +1598,7 @@ impl Database {
     /// Transitions to accepted and sets started_at. Returns None if empty.
     pub fn pick_next_card(&self, repo: &str) -> Result<Option<crate::kanban::Card>> {
         let sql = format!(
-            "SELECT {} FROM tasks WHERE to_repo = ?1 AND status = 'pending' \
+            "SELECT {} FROM tasks WHERE to_repo = ?1 AND status = 'pending' AND deleted_at IS NULL \
              ORDER BY {}, sort_order ASC, created_at ASC LIMIT 1",
             Self::CARD_COLUMNS,
             Self::PRIORITY_ORDER
@@ -1610,7 +1628,7 @@ impl Database {
     /// Peek at the next pending card without accepting it.
     pub fn peek_next_card(&self, repo: &str) -> Result<Option<crate::kanban::Card>> {
         let sql = format!(
-            "SELECT {} FROM tasks WHERE to_repo = ?1 AND status = 'pending' \
+            "SELECT {} FROM tasks WHERE to_repo = ?1 AND status = 'pending' AND deleted_at IS NULL \
              ORDER BY {}, sort_order ASC, created_at ASC LIMIT 1",
             Self::CARD_COLUMNS,
             Self::PRIORITY_ORDER
@@ -1867,7 +1885,7 @@ impl Database {
         let now_str = now.to_rfc3339();
         let mut stmt = self.conn.prepare(
             "SELECT id, name, cron, command, repo, enabled, last_run, next_run, created_at, active_start, active_end \
-             FROM schedules WHERE enabled = 1 AND next_run <= ?1",
+             FROM schedules WHERE enabled = 1 AND next_run <= ?1 AND deleted_at IS NULL",
         )?;
         let rows = stmt.query_map([&now_str], map_schedule_row)?;
         let all: Vec<Schedule> = rows
@@ -1886,9 +1904,11 @@ impl Database {
         // Fetch the cron expression to compute the next run
         let cron: String = self
             .conn
-            .query_row("SELECT cron FROM schedules WHERE id = ?1", [id], |row| {
-                row.get(0)
-            })
+            .query_row(
+                "SELECT cron FROM schedules WHERE id = ?1 AND deleted_at IS NULL",
+                [id],
+                |row| row.get(0),
+            )
             .map_err(|e| match e {
                 rusqlite::Error::QueryReturnedNoRows => {
                     LegionError::ScheduleNotFound(id.to_string())
@@ -1913,7 +1933,7 @@ impl Database {
     pub fn list_schedules(&self) -> Result<Vec<Schedule>> {
         let mut stmt = self.conn.prepare(
             "SELECT id, name, cron, command, repo, enabled, last_run, next_run, created_at, active_start, active_end \
-             FROM schedules ORDER BY created_at",
+             FROM schedules WHERE deleted_at IS NULL ORDER BY created_at",
         )?;
         let rows = stmt.query_map([], map_schedule_row)?;
         rows.collect::<std::result::Result<Vec<_>, _>>()

--- a/src/db.rs
+++ b/src/db.rs
@@ -1071,10 +1071,15 @@ impl Database {
     pub fn get_unhandled_signals_for_repo(
         &self,
         repo_name: &str,
+        recipient: &str,
         since: Option<&str>,
     ) -> Result<Vec<Reflection>> {
-        let pattern_start = format!("@{} %", repo_name);
-        let pattern_mid = format!("%@{} %", repo_name);
+        // `recipient` drives the @mention pattern matching (this is the agent name
+        // when configured, otherwise the repo name). `repo_name` is the stable key
+        // for the watch_handled table and for self-signal exclusion -- signals are
+        // stored by their source repo, not by any agent override.
+        let pattern_start = format!("@{} %", recipient);
+        let pattern_mid = format!("%@{} %", recipient);
         let pattern_all_start = "@all %";
         let pattern_all_mid = "%@all %";
         let since_clause = if since.is_some() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -3639,7 +3639,7 @@ fn run() -> error::Result<()> {
                                 .map(str::to_string)
                                 .ok_or_else(|| {
                                     error::LegionError::WatchConfig(format!(
-                                        "cannot derive repo name from path {}",
+                                        "cannot derive a repo name from path {} -- pass --name <name> explicitly",
                                         path.display()
                                     ))
                                 })?

--- a/src/main.rs
+++ b/src/main.rs
@@ -1191,12 +1191,13 @@ enum QualityGateAction {
 enum WatchAction {
     /// Add a working directory to watch.toml (idempotent by canonicalized path)
     Add {
-        /// Display name for this repo (used for cooldown tracking)
-        #[arg(long)]
-        name: String,
-
         /// Absolute or relative path to the working directory
         path: std::path::PathBuf,
+
+        /// Display name for this repo (used for cooldown tracking).
+        /// Defaults to the basename of the resolved path.
+        #[arg(long)]
+        name: Option<String>,
 
         /// Signal recipient name. Signals addressed to this value (e.g., @my-agent)
         /// will wake this repo. Defaults to --name when absent.
@@ -3620,18 +3621,49 @@ fn run() -> error::Result<()> {
                     );
                     watch::run(&base)?;
                 }
-                Some(WatchAction::Add { name, path, agent }) => {
+                Some(WatchAction::Add { path, name, agent }) => {
                     let config_path = base.join("watch.toml");
-                    let added =
-                        watch::add_repo_to_config(&config_path, &name, &path, agent.as_deref())?;
+                    let effective_name = match name {
+                        Some(n) => n,
+                        None => {
+                            let canonical = path.canonicalize().map_err(|e| {
+                                error::LegionError::WatchConfig(format!(
+                                    "path {} cannot be resolved: {}",
+                                    path.display(),
+                                    e
+                                ))
+                            })?;
+                            canonical
+                                .file_name()
+                                .and_then(std::ffi::OsStr::to_str)
+                                .map(str::to_string)
+                                .ok_or_else(|| {
+                                    error::LegionError::WatchConfig(format!(
+                                        "cannot derive repo name from path {}",
+                                        path.display()
+                                    ))
+                                })?
+                        }
+                    };
+                    let added = watch::add_repo_to_config(
+                        &config_path,
+                        &effective_name,
+                        &path,
+                        agent.as_deref(),
+                    )?;
                     if added {
                         let agent_note = agent
                             .as_deref()
                             .map(|a| format!(" (agent: {})", a))
                             .unwrap_or_default();
-                        println!("added: {} -> {}{}", name, path.display(), agent_note);
+                        println!(
+                            "added: {} -> {}{}",
+                            effective_name,
+                            path.display(),
+                            agent_note
+                        );
                     } else {
-                        println!("already present: {}", name);
+                        println!("already present: {}", effective_name);
                     }
                 }
                 Some(WatchAction::Remove { name }) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -3652,8 +3652,13 @@ fn run() -> error::Result<()> {
                         agent.as_deref(),
                     )?;
                     if added {
+                        // Apply the same trim-empty rule `add_repo_to_config` uses so the
+                        // confirmation output matches what was actually persisted -- a raw
+                        // `--agent "  "` must not display as `(agent:   )` while None is stored.
                         let agent_note = agent
                             .as_deref()
+                            .map(str::trim)
+                            .filter(|s| !s.is_empty())
                             .map(|a| format!(" (agent: {})", a))
                             .unwrap_or_default();
                         println!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -475,8 +475,11 @@ enum Commands {
         json: bool,
     },
 
-    /// Watch for signals and auto-wake sleeping agents
-    Watch,
+    /// Watch for signals and auto-wake sleeping agents (daemon mode when run without a subcommand)
+    Watch {
+        #[command(subcommand)]
+        action: Option<WatchAction>,
+    },
 
     /// MCP stdio server for Claude Code channel integration
     Mcp,
@@ -1182,6 +1185,33 @@ enum QualityGateAction {
         #[arg(long)]
         details_json: Option<String>,
     },
+}
+
+#[derive(Subcommand, Debug)]
+enum WatchAction {
+    /// Add a working directory to watch.toml (idempotent by canonicalized path)
+    Add {
+        /// Display name for this repo (used for cooldown tracking)
+        #[arg(long)]
+        name: String,
+
+        /// Absolute or relative path to the working directory
+        path: std::path::PathBuf,
+
+        /// Signal recipient name. Signals addressed to this value (e.g., @my-agent)
+        /// will wake this repo. Defaults to --name when absent.
+        #[arg(long)]
+        agent: Option<String>,
+    },
+
+    /// Remove a repo entry from watch.toml by name
+    Remove {
+        /// Repo name to remove
+        name: String,
+    },
+
+    /// List all repos currently in watch.toml
+    List,
 }
 
 /// Resolve the legion data directory.
@@ -3581,12 +3611,55 @@ fn run() -> error::Result<()> {
                 }
             }
         }
-        Commands::Watch => {
+        Commands::Watch { action } => {
             let base = data_dir()?;
-            eprintln!(
-                "[legion] `legion watch` is deprecated -- use `legion daemon` to run channel + watch in one process"
-            );
-            watch::run(&base)?;
+            match action {
+                None => {
+                    eprintln!(
+                        "[legion] `legion watch` is deprecated -- use `legion daemon` to run channel + watch in one process"
+                    );
+                    watch::run(&base)?;
+                }
+                Some(WatchAction::Add { name, path, agent }) => {
+                    let config_path = base.join("watch.toml");
+                    let added =
+                        watch::add_repo_to_config(&config_path, &name, &path, agent.as_deref())?;
+                    if added {
+                        let agent_note = agent
+                            .as_deref()
+                            .map(|a| format!(" (agent: {})", a))
+                            .unwrap_or_default();
+                        println!("added: {} -> {}{}", name, path.display(), agent_note);
+                    } else {
+                        println!("already present: {}", name);
+                    }
+                }
+                Some(WatchAction::Remove { name }) => {
+                    let config_path = base.join("watch.toml");
+                    let removed = watch::remove_repo_from_config(&config_path, &name)?;
+                    if removed {
+                        println!("removed: {}", name);
+                    } else {
+                        println!("not found: {}", name);
+                    }
+                }
+                Some(WatchAction::List) => {
+                    let config_path = base.join("watch.toml");
+                    let repos = watch::list_repos_in_config(&config_path)?;
+                    if repos.is_empty() {
+                        println!("no repos in watch.toml");
+                    } else {
+                        for repo in &repos {
+                            let agent_note = repo
+                                .agent
+                                .as_deref()
+                                .map(|a| format!(" (agent: {})", a))
+                                .unwrap_or_default();
+                            println!("{}\t{}{}", repo.name, repo.workdir, agent_note);
+                        }
+                    }
+                }
+            }
         }
         Commands::Mcp => {
             let base = data_dir()?;

--- a/src/watch.rs
+++ b/src/watch.rs
@@ -26,10 +26,16 @@ pub struct WatchRepoConfig {
 }
 
 impl WatchRepoConfig {
-    /// Recipient name used for signal matching. Prefers `agent` when set, falls
-    /// back to `name`. Centralizes the fallback rule so callers never recompute it.
+    /// Recipient name used for signal matching. Prefers `agent` when set to a
+    /// non-empty value, falls back to `name`. Empty or whitespace-only `agent`
+    /// values are treated as absent so a hand-edited `agent = ""` cannot silently
+    /// route to nothing. Centralizes the fallback rule so callers never recompute it.
     pub fn recipient(&self) -> &str {
-        self.agent.as_deref().unwrap_or(&self.name)
+        self.agent
+            .as_deref()
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .unwrap_or(&self.name)
     }
 }
 
@@ -152,8 +158,10 @@ fn read_or_default(path: &Path) -> Result<WatchConfig> {
     if !path.exists() {
         return Ok(WatchConfig::default());
     }
-    let contents = std::fs::read_to_string(path)?;
-    let config: WatchConfig = toml::from_str(&contents)?;
+    let contents = std::fs::read_to_string(path)
+        .map_err(|e| LegionError::WatchConfig(format!("cannot read {}: {}", path.display(), e)))?;
+    let config: WatchConfig = toml::from_str(&contents)
+        .map_err(|e| LegionError::WatchConfig(format!("malformed {}: {}", path.display(), e)))?;
     Ok(config)
 }
 
@@ -162,11 +170,23 @@ fn read_or_default(path: &Path) -> Result<WatchConfig> {
 /// Creates parent directories if they do not exist.
 fn write_config(path: &Path, config: &WatchConfig) -> Result<()> {
     if let Some(parent) = path.parent() {
-        std::fs::create_dir_all(parent)?;
+        std::fs::create_dir_all(parent).map_err(|e| {
+            LegionError::WatchConfig(format!(
+                "cannot create parent dir for {}: {}",
+                path.display(),
+                e
+            ))
+        })?;
     }
-    let toml_str =
-        toml::to_string_pretty(config).map_err(|e| LegionError::WatchConfig(e.to_string()))?;
-    std::fs::write(path, toml_str)?;
+    let toml_str = toml::to_string_pretty(config).map_err(|e| {
+        LegionError::WatchConfig(format!(
+            "cannot serialize watch config for {}: {}",
+            path.display(),
+            e
+        ))
+    })?;
+    std::fs::write(path, toml_str)
+        .map_err(|e| LegionError::WatchConfig(format!("cannot write {}: {}", path.display(), e)))?;
     Ok(())
 }
 
@@ -188,7 +208,20 @@ pub fn add_repo_to_config(
         )));
     }
 
-    let canonical = std::fs::canonicalize(workdir)?;
+    // Trim empty/whitespace-only agent values to None so they never round-trip
+    // to disk or bypass the recipient() fallback.
+    let normalized_agent = agent
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string);
+
+    let canonical = std::fs::canonicalize(workdir).map_err(|e| {
+        LegionError::WatchConfig(format!(
+            "cannot resolve workdir {}: {}",
+            workdir.display(),
+            e
+        ))
+    })?;
     let canonical_str = canonical.to_string_lossy().into_owned();
 
     let mut config = read_or_default(path)?;
@@ -210,7 +243,7 @@ pub fn add_repo_to_config(
     config.repos.push(WatchRepoConfig {
         name: name.to_string(),
         workdir: canonical_str,
-        agent: agent.map(|s| s.to_string()),
+        agent: normalized_agent,
     });
 
     write_config(path, &config)?;
@@ -403,9 +436,10 @@ impl CooldownTracker {
 pub fn find_pending_signals(
     db: &Database,
     repo_name: &str,
+    recipient: &str,
     since: Option<&str>,
 ) -> Result<Vec<(String, String, String)>> {
-    let reflections = db.get_unhandled_signals_for_repo(repo_name, since)?;
+    let reflections = db.get_unhandled_signals_for_repo(repo_name, recipient, since)?;
 
     let mut signals: Vec<(String, String, String)> = Vec::new();
     for r in reflections {
@@ -585,8 +619,14 @@ pub fn poll_cycle(
 
     // Check for auto-unblock opportunities from recent signals
     for repo in &config.repos {
-        if let Ok(signals) = find_pending_signals(db, repo.recipient(), since) {
-            check_auto_unblock(db, &signals);
+        match find_pending_signals(db, &repo.name, repo.recipient(), since) {
+            Ok(signals) => {
+                check_auto_unblock(db, &signals);
+            }
+            Err(e) => eprintln!(
+                "[legion watch] auto-unblock signal lookup failed for {}: {}",
+                repo.name, e
+            ),
         }
     }
 
@@ -596,7 +636,7 @@ pub fn poll_cycle(
         }
 
         let recipient = repo.recipient();
-        let signals = find_pending_signals(db, recipient, since)?;
+        let signals = find_pending_signals(db, &repo.name, recipient, since)?;
         if signals.is_empty() {
             continue;
         }
@@ -618,11 +658,12 @@ pub fn poll_cycle(
                 // Mark ALL signals as handled for THIS repo (per-repo tracking).
                 // This includes @all broadcasts -- each repo marks its own copy,
                 // so other repos still see the signal on their next poll.
+                // Keyed by `repo.name` (stable) so future `agent=` edits do not replay.
                 for (id, _, _) in &signals {
-                    if db.mark_signal_handled_for_repo(id, recipient).is_err() {
+                    if let Err(e) = db.mark_signal_handled_for_repo(id, &repo.name) {
                         eprintln!(
-                            "[legion watch] failed to mark signal {} as handled for {}",
-                            id, repo.name
+                            "[legion watch] failed to mark signal {} as handled for {}: {}",
+                            id, repo.name, e
                         );
                     }
                 }
@@ -823,7 +864,7 @@ workdir = "/tmp"
         db.insert_reflection("rafters", "@all announce: shipped", "team")
             .expect("insert broadcast");
 
-        let signals = find_pending_signals(&db, "legion", None).expect("find signals");
+        let signals = find_pending_signals(&db, "legion", "legion", None).expect("find signals");
         assert_eq!(signals.len(), 2);
 
         // Verify the targeted signal is found
@@ -853,8 +894,9 @@ workdir = "/tmp"
         .expect("insert multi-recipient");
 
         // Both shingle and huttspawn should see it
-        let shingle = find_pending_signals(&db, "shingle", None).expect("shingle");
-        let huttspawn = find_pending_signals(&db, "huttspawn", None).expect("huttspawn");
+        let shingle = find_pending_signals(&db, "shingle", "shingle", None).expect("shingle");
+        let huttspawn =
+            find_pending_signals(&db, "huttspawn", "huttspawn", None).expect("huttspawn");
         assert_eq!(
             shingle.len(),
             1,
@@ -867,11 +909,11 @@ workdir = "/tmp"
         );
 
         // legion (sender) should NOT see it
-        let legion = find_pending_signals(&db, "legion", None).expect("legion");
+        let legion = find_pending_signals(&db, "legion", "legion", None).expect("legion");
         assert!(legion.is_empty(), "sender should not see own signal");
 
         // unrelated repo should NOT see it
-        let kelex = find_pending_signals(&db, "kelex", None).expect("kelex");
+        let kelex = find_pending_signals(&db, "kelex", "kelex", None).expect("kelex");
         assert!(kelex.is_empty(), "unmentioned repo should not see signal");
     }
 
@@ -883,8 +925,37 @@ workdir = "/tmp"
         db.insert_reflection("legion", "@legion review:approved", "team")
             .expect("insert self-signal");
 
-        let signals = find_pending_signals(&db, "legion", None).expect("find signals");
+        let signals = find_pending_signals(&db, "legion", "legion", None).expect("find signals");
         assert!(signals.is_empty(), "self-signals should be excluded");
+    }
+
+    #[test]
+    fn find_pending_signals_with_agent_excludes_self_signals_via_repo_name() {
+        // Regression guard: when agent != name (e.g., platform agent watches ledger repo),
+        // a signal posted FROM the ledger repo targeting @platform must still be excluded
+        // by the repo_name key, not by the recipient. Previously only recipient was passed,
+        // so `r.repo != 'platform'` vs. `r.repo = 'ledger'` produced a self-wake.
+        let (db, _index, _dir) = test_storage();
+
+        db.insert_reflection("ledger", "@platform review:approved", "team")
+            .expect("insert self-signal");
+
+        let signals = find_pending_signals(&db, "ledger", "platform", None).expect("find signals");
+        assert!(
+            signals.is_empty(),
+            "self-signals must be excluded by repo_name, not by recipient"
+        );
+    }
+
+    #[test]
+    fn find_pending_signals_with_agent_accepts_signals_from_other_repos() {
+        let (db, _index, _dir) = test_storage();
+
+        db.insert_reflection("kelex", "@platform review:approved", "team")
+            .expect("insert external signal");
+
+        let signals = find_pending_signals(&db, "ledger", "platform", None).expect("find signals");
+        assert_eq!(signals.len(), 1, "external signal to agent should be found");
     }
 
     #[test]
@@ -894,7 +965,7 @@ workdir = "/tmp"
         db.insert_reflection("kelex", "@legion review:approved", "team")
             .expect("insert signal");
 
-        let signals = find_pending_signals(&db, "legion", None).expect("first poll");
+        let signals = find_pending_signals(&db, "legion", "legion", None).expect("first poll");
         assert_eq!(signals.len(), 1);
 
         // Mark as handled for legion
@@ -903,7 +974,7 @@ workdir = "/tmp"
             .expect("mark handled");
 
         // Should not appear again for legion
-        let signals = find_pending_signals(&db, "legion", None).expect("second poll");
+        let signals = find_pending_signals(&db, "legion", "legion", None).expect("second poll");
         assert!(signals.is_empty());
     }
 
@@ -965,8 +1036,9 @@ workdir = "/tmp"
             .expect("insert broadcast");
 
         // Both legion and rafters should see it
-        let legion_signals = find_pending_signals(&db, "legion", None).expect("legion");
-        let rafters_signals = find_pending_signals(&db, "rafters", None).expect("rafters");
+        let legion_signals = find_pending_signals(&db, "legion", "legion", None).expect("legion");
+        let rafters_signals =
+            find_pending_signals(&db, "rafters", "rafters", None).expect("rafters");
         assert_eq!(legion_signals.len(), 1);
         assert_eq!(rafters_signals.len(), 1);
 
@@ -977,14 +1049,16 @@ workdir = "/tmp"
         }
 
         // legion should NOT see it anymore
-        let legion_after = find_pending_signals(&db, "legion", None).expect("legion after");
+        let legion_after =
+            find_pending_signals(&db, "legion", "legion", None).expect("legion after");
         assert!(
             legion_after.is_empty(),
             "legion should not see broadcast after handling"
         );
 
         // rafters should STILL see the broadcast
-        let rafters_after = find_pending_signals(&db, "rafters", None).expect("rafters after");
+        let rafters_after =
+            find_pending_signals(&db, "rafters", "rafters", None).expect("rafters after");
         assert_eq!(
             rafters_after.len(),
             1,
@@ -998,7 +1072,8 @@ workdir = "/tmp"
         }
 
         // Now rafters should not see it either
-        let rafters_final = find_pending_signals(&db, "rafters", None).expect("rafters final");
+        let rafters_final =
+            find_pending_signals(&db, "rafters", "rafters", None).expect("rafters final");
         assert!(
             rafters_final.is_empty(),
             "rafters should not see broadcast after handling"
@@ -1146,6 +1221,40 @@ workdir = "/nonexistent/path/that/does/not/exist"
             agent: None,
         };
         assert_eq!(repo_without_agent.recipient(), "legion");
+    }
+
+    #[test]
+    fn watch_repo_config_recipient_treats_empty_agent_as_absent() {
+        // Hand-edited watch.toml may set agent = "" or all-whitespace.
+        // recipient() must not return empty -- that would route no signals.
+        let empty = WatchRepoConfig {
+            name: "fallback".to_string(),
+            workdir: "/tmp".to_string(),
+            agent: Some("".to_string()),
+        };
+        assert_eq!(empty.recipient(), "fallback");
+
+        let whitespace = WatchRepoConfig {
+            name: "fallback".to_string(),
+            workdir: "/tmp".to_string(),
+            agent: Some("   ".to_string()),
+        };
+        assert_eq!(whitespace.recipient(), "fallback");
+    }
+
+    #[test]
+    fn add_repo_normalizes_empty_agent_to_none() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let config_path = dir.path().join("watch.toml");
+        let workdir = dir.path().to_path_buf();
+
+        add_repo_to_config(&config_path, "legion", &workdir, Some("")).expect("add");
+        let repos = list_repos_in_config(&config_path).expect("list");
+        assert_eq!(repos.len(), 1);
+        assert!(
+            repos[0].agent.is_none(),
+            "empty --agent should be normalized to None, not stored as Some(\"\")"
+        );
     }
 
     #[test]

--- a/src/watch.rs
+++ b/src/watch.rs
@@ -25,6 +25,14 @@ pub struct WatchRepoConfig {
     pub agent: Option<String>,
 }
 
+impl WatchRepoConfig {
+    /// Recipient name used for signal matching. Prefers `agent` when set, falls
+    /// back to `name`. Centralizes the fallback rule so callers never recompute it.
+    pub fn recipient(&self) -> &str {
+        self.agent.as_deref().unwrap_or(&self.name)
+    }
+}
+
 /// Top-level watch configuration.
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct WatchConfig {
@@ -185,13 +193,18 @@ pub fn add_repo_to_config(
 
     let mut config = read_or_default(path)?;
 
-    // Idempotent check: already present if the canonicalized workdir matches.
-    let already_present = config
-        .repos
-        .iter()
-        .any(|r| r.workdir == canonical_str || r.name == name);
-    if already_present {
+    // Idempotent by canonicalized path. A repeated add for the same path is a no-op.
+    if config.repos.iter().any(|r| r.workdir == canonical_str) {
         return Ok(false);
+    }
+
+    // Name collision with a different path is an error, not a silent no-op,
+    // so the caller sees the conflict instead of a misleading "already present".
+    if let Some(existing) = config.repos.iter().find(|r| r.name == name) {
+        return Err(LegionError::WatchConfig(format!(
+            "name '{}' already in use by {}",
+            name, existing.workdir
+        )));
     }
 
     config.repos.push(WatchRepoConfig {
@@ -227,12 +240,7 @@ pub fn remove_repo_from_config(path: &Path, name: &str) -> Result<bool> {
 ///
 /// Returns an empty vec if the file does not exist.
 pub fn list_repos_in_config(path: &Path) -> Result<Vec<WatchRepoConfig>> {
-    if !path.exists() {
-        return Ok(Vec::new());
-    }
-    let contents = std::fs::read_to_string(path)?;
-    let config: WatchConfig = toml::from_str(&contents)?;
-    Ok(config.repos)
+    Ok(read_or_default(path)?.repos)
 }
 
 /// Load watch config from the given path. Returns a default config if the
@@ -577,9 +585,7 @@ pub fn poll_cycle(
 
     // Check for auto-unblock opportunities from recent signals
     for repo in &config.repos {
-        // Prefer the agent name for signal lookup when configured.
-        let recipient = repo.agent.as_deref().unwrap_or(&repo.name);
-        if let Ok(signals) = find_pending_signals(db, recipient, since) {
+        if let Ok(signals) = find_pending_signals(db, repo.recipient(), since) {
             check_auto_unblock(db, &signals);
         }
     }
@@ -589,8 +595,7 @@ pub fn poll_cycle(
             continue;
         }
 
-        // Prefer the agent name for signal lookup when configured.
-        let recipient = repo.agent.as_deref().unwrap_or(&repo.name);
+        let recipient = repo.recipient();
         let signals = find_pending_signals(db, recipient, since)?;
         if signals.is_empty() {
             continue;
@@ -1093,7 +1098,7 @@ workdir = "/nonexistent/path/that/does/not/exist"
     }
 
     #[test]
-    fn add_repo_is_idempotent_by_name() {
+    fn add_repo_is_idempotent_by_canonical_path() {
         let dir = tempfile::tempdir().expect("tempdir");
         let config_path = dir.path().join("watch.toml");
         let workdir = dir.path().to_path_buf();
@@ -1102,10 +1107,45 @@ workdir = "/nonexistent/path/that/does/not/exist"
         assert!(first);
 
         let second = add_repo_to_config(&config_path, "rafters", &workdir, None).expect("second");
-        assert!(!second, "duplicate by name should return false");
+        assert!(!second, "duplicate by canonical path should return false");
 
         let repos = list_repos_in_config(&config_path).expect("list");
         assert_eq!(repos.len(), 1, "should still have only one entry");
+    }
+
+    #[test]
+    fn add_repo_errors_on_name_collision_with_different_path() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let config_path = dir.path().join("watch.toml");
+        let workdir_a = dir.path().join("a");
+        let workdir_b = dir.path().join("b");
+        std::fs::create_dir_all(&workdir_a).expect("create a");
+        std::fs::create_dir_all(&workdir_b).expect("create b");
+
+        add_repo_to_config(&config_path, "foo", &workdir_a, None).expect("add a");
+        let err = add_repo_to_config(&config_path, "foo", &workdir_b, None).unwrap_err();
+        assert!(
+            err.to_string().contains("already in use"),
+            "expected 'already in use' error, got: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn watch_repo_config_recipient_prefers_agent_over_name() {
+        let repo_with_agent = WatchRepoConfig {
+            name: "ledger".to_string(),
+            workdir: "/tmp".to_string(),
+            agent: Some("platform".to_string()),
+        };
+        assert_eq!(repo_with_agent.recipient(), "platform");
+
+        let repo_without_agent = WatchRepoConfig {
+            name: "legion".to_string(),
+            workdir: "/tmp".to_string(),
+            agent: None,
+        };
+        assert_eq!(repo_without_agent.recipient(), "legion");
     }
 
     #[test]

--- a/src/watch.rs
+++ b/src/watch.rs
@@ -4,7 +4,7 @@ use std::process::Child;
 use std::time::{Duration, Instant};
 
 use chrono::Timelike;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 use crate::db::Database;
 use crate::error::{LegionError, Result};
@@ -14,14 +14,19 @@ use crate::signal;
 // -- Config ------------------------------------------------------------------
 
 /// A watched repository entry from watch.toml.
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct WatchRepoConfig {
     pub name: String,
     pub workdir: String,
+    /// The recipient name used for signal matching. When set, signals addressed
+    /// to this value (e.g., `@my-agent`) wake this repo. Falls back to `name`
+    /// when absent, preserving backward compatibility with existing watch.toml files.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub agent: Option<String>,
 }
 
 /// Top-level watch configuration.
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct WatchConfig {
     #[serde(default = "default_poll_interval")]
     pub poll_interval_secs: u64,
@@ -35,11 +40,11 @@ pub struct WatchConfig {
     pub stagger_secs: u64,
 
     /// Work hours start (0-23, local time). No cooldown during work hours.
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub work_hours_start: Option<u8>,
 
     /// Work hours end (0-23, local time). No cooldown during work hours.
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub work_hours_end: Option<u8>,
 
     /// Pressure threshold (0-100). Spawning is skipped when exceeded.
@@ -131,6 +136,103 @@ pub fn rename_in_config(path: &Path, from: &str, to: &str) -> Result<bool> {
     let updated = contents.replace(&needle, &replacement);
     std::fs::write(path, updated)?;
     Ok(true)
+}
+
+/// Read the current config from disk, or return a fresh default if the file
+/// does not exist. Used by add/remove to do a read-modify-write.
+fn read_or_default(path: &Path) -> Result<WatchConfig> {
+    if !path.exists() {
+        return Ok(WatchConfig::default());
+    }
+    let contents = std::fs::read_to_string(path)?;
+    let config: WatchConfig = toml::from_str(&contents)?;
+    Ok(config)
+}
+
+/// Write a `WatchConfig` to disk as TOML.
+///
+/// Creates parent directories if they do not exist.
+fn write_config(path: &Path, config: &WatchConfig) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let toml_str =
+        toml::to_string_pretty(config).map_err(|e| LegionError::WatchConfig(e.to_string()))?;
+    std::fs::write(path, toml_str)?;
+    Ok(())
+}
+
+/// Add a repo entry to watch.toml. Idempotent by canonicalized path.
+///
+/// Returns `true` if a new entry was written, `false` if the path was already
+/// present (matched by canonicalized workdir). Errors if `workdir` is not an
+/// existing directory.
+pub fn add_repo_to_config(
+    path: &Path,
+    name: &str,
+    workdir: &Path,
+    agent: Option<&str>,
+) -> Result<bool> {
+    if !workdir.is_dir() {
+        return Err(LegionError::WatchConfig(format!(
+            "workdir is not a directory: {}",
+            workdir.display()
+        )));
+    }
+
+    let canonical = std::fs::canonicalize(workdir)?;
+    let canonical_str = canonical.to_string_lossy().into_owned();
+
+    let mut config = read_or_default(path)?;
+
+    // Idempotent check: already present if the canonicalized workdir matches.
+    let already_present = config
+        .repos
+        .iter()
+        .any(|r| r.workdir == canonical_str || r.name == name);
+    if already_present {
+        return Ok(false);
+    }
+
+    config.repos.push(WatchRepoConfig {
+        name: name.to_string(),
+        workdir: canonical_str,
+        agent: agent.map(|s| s.to_string()),
+    });
+
+    write_config(path, &config)?;
+    Ok(true)
+}
+
+/// Remove a repo entry from watch.toml by name.
+///
+/// Returns `true` if an entry was removed, `false` if no entry matched.
+pub fn remove_repo_from_config(path: &Path, name: &str) -> Result<bool> {
+    if !path.exists() {
+        return Ok(false);
+    }
+
+    let mut config = read_or_default(path)?;
+    let before = config.repos.len();
+    config.repos.retain(|r| r.name != name);
+    let removed = config.repos.len() < before;
+
+    if removed {
+        write_config(path, &config)?;
+    }
+    Ok(removed)
+}
+
+/// List all repo entries currently in watch.toml.
+///
+/// Returns an empty vec if the file does not exist.
+pub fn list_repos_in_config(path: &Path) -> Result<Vec<WatchRepoConfig>> {
+    if !path.exists() {
+        return Ok(Vec::new());
+    }
+    let contents = std::fs::read_to_string(path)?;
+    let config: WatchConfig = toml::from_str(&contents)?;
+    Ok(config.repos)
 }
 
 /// Load watch config from the given path. Returns a default config if the
@@ -475,7 +577,9 @@ pub fn poll_cycle(
 
     // Check for auto-unblock opportunities from recent signals
     for repo in &config.repos {
-        if let Ok(signals) = find_pending_signals(db, &repo.name, since) {
+        // Prefer the agent name for signal lookup when configured.
+        let recipient = repo.agent.as_deref().unwrap_or(&repo.name);
+        if let Ok(signals) = find_pending_signals(db, recipient, since) {
             check_auto_unblock(db, &signals);
         }
     }
@@ -485,7 +589,9 @@ pub fn poll_cycle(
             continue;
         }
 
-        let signals = find_pending_signals(db, &repo.name, since)?;
+        // Prefer the agent name for signal lookup when configured.
+        let recipient = repo.agent.as_deref().unwrap_or(&repo.name);
+        let signals = find_pending_signals(db, recipient, since)?;
         if signals.is_empty() {
             continue;
         }
@@ -496,7 +602,7 @@ pub fn poll_cycle(
             repo.name
         );
 
-        let prompt = build_wake_prompt(&repo.name, &signals);
+        let prompt = build_wake_prompt(recipient, &signals);
 
         if spawned > 0 && config.stagger_secs > 0 {
             std::thread::sleep(Duration::from_secs(config.stagger_secs));
@@ -508,7 +614,7 @@ pub fn poll_cycle(
                 // This includes @all broadcasts -- each repo marks its own copy,
                 // so other repos still see the signal on their next poll.
                 for (id, _, _) in &signals {
-                    if db.mark_signal_handled_for_repo(id, &repo.name).is_err() {
+                    if db.mark_signal_handled_for_repo(id, recipient).is_err() {
                         eprintln!(
                             "[legion watch] failed to mark signal {} as handled for {}",
                             id, repo.name
@@ -827,6 +933,7 @@ workdir = "/tmp"
             repos: vec![WatchRepoConfig {
                 name: "legion".to_string(),
                 workdir: "/tmp".to_string(),
+                agent: None,
             }],
             ..WatchConfig::default()
         };
@@ -952,5 +1059,165 @@ workdir = "/nonexistent/path/that/does/not/exist"
 
         // Should succeed because the process is not running
         acquire_pid_lock(&lock_path).expect("acquire lock over stale");
+    }
+
+    // -- Config management tests -----------------------------------------------
+
+    #[test]
+    fn add_repo_creates_file_when_missing() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let config_path = dir.path().join("watch.toml");
+        let workdir = dir.path().to_path_buf();
+
+        let added = add_repo_to_config(&config_path, "rafters", &workdir, None).expect("add");
+        assert!(added, "should report added=true for new entry");
+        assert!(config_path.exists(), "config file should be created");
+
+        let repos = list_repos_in_config(&config_path).expect("list");
+        assert_eq!(repos.len(), 1);
+        assert_eq!(repos[0].name, "rafters");
+        assert!(repos[0].agent.is_none());
+    }
+
+    #[test]
+    fn add_repo_with_agent_stores_agent_field() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let config_path = dir.path().join("watch.toml");
+        let workdir = dir.path().to_path_buf();
+
+        add_repo_to_config(&config_path, "legion", &workdir, Some("my-agent")).expect("add");
+
+        let repos = list_repos_in_config(&config_path).expect("list");
+        assert_eq!(repos.len(), 1);
+        assert_eq!(repos[0].agent.as_deref(), Some("my-agent"));
+    }
+
+    #[test]
+    fn add_repo_is_idempotent_by_name() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let config_path = dir.path().join("watch.toml");
+        let workdir = dir.path().to_path_buf();
+
+        let first = add_repo_to_config(&config_path, "rafters", &workdir, None).expect("first");
+        assert!(first);
+
+        let second = add_repo_to_config(&config_path, "rafters", &workdir, None).expect("second");
+        assert!(!second, "duplicate by name should return false");
+
+        let repos = list_repos_in_config(&config_path).expect("list");
+        assert_eq!(repos.len(), 1, "should still have only one entry");
+    }
+
+    #[test]
+    fn add_repo_rejects_nonexistent_workdir() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let config_path = dir.path().join("watch.toml");
+        let bad_path = std::path::Path::new("/nonexistent/path/that/does/not/exist");
+
+        let err = add_repo_to_config(&config_path, "test", bad_path, None).unwrap_err();
+        assert!(
+            err.to_string().contains("not a directory"),
+            "unexpected error: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn remove_repo_removes_existing_entry() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let config_path = dir.path().join("watch.toml");
+
+        // Use two distinct sub-directories so the idempotency check passes.
+        let workdir_a = dir.path().join("a");
+        let workdir_b = dir.path().join("b");
+        std::fs::create_dir_all(&workdir_a).expect("create a");
+        std::fs::create_dir_all(&workdir_b).expect("create b");
+
+        add_repo_to_config(&config_path, "rafters", &workdir_a, None).expect("add rafters");
+        add_repo_to_config(&config_path, "legion", &workdir_b, None).expect("add legion");
+
+        let removed = remove_repo_from_config(&config_path, "rafters").expect("remove");
+        assert!(removed);
+
+        let repos = list_repos_in_config(&config_path).expect("list");
+        assert_eq!(repos.len(), 1);
+        assert_eq!(repos[0].name, "legion");
+    }
+
+    #[test]
+    fn remove_repo_returns_false_when_not_found() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let config_path = dir.path().join("watch.toml");
+        let workdir = dir.path().to_path_buf();
+
+        add_repo_to_config(&config_path, "rafters", &workdir, None).expect("add");
+
+        let removed = remove_repo_from_config(&config_path, "nonexistent").expect("remove");
+        assert!(!removed, "unknown name should return false");
+    }
+
+    #[test]
+    fn remove_repo_returns_false_when_file_missing() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let config_path = dir.path().join("watch.toml");
+
+        let removed = remove_repo_from_config(&config_path, "anything").expect("remove");
+        assert!(!removed);
+    }
+
+    #[test]
+    fn list_repos_returns_empty_when_file_missing() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let config_path = dir.path().join("watch.toml");
+
+        let repos = list_repos_in_config(&config_path).expect("list");
+        assert!(repos.is_empty());
+    }
+
+    #[test]
+    fn add_repo_stores_canonicalized_path() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let config_path = dir.path().join("watch.toml");
+        let workdir = dir.path().to_path_buf();
+        let canonical = std::fs::canonicalize(&workdir).expect("canonicalize");
+
+        add_repo_to_config(&config_path, "test", &workdir, None).expect("add");
+
+        let repos = list_repos_in_config(&config_path).expect("list");
+        // The stored path must be the canonicalized form.
+        assert_eq!(
+            repos[0].workdir,
+            canonical.to_string_lossy().as_ref(),
+            "workdir should be canonical"
+        );
+    }
+
+    #[test]
+    fn existing_config_without_agent_field_deserializes_cleanly() {
+        // Ensures backward compatibility: old watch.toml files without agent= still parse.
+        let toml_str = r#"
+[[repos]]
+name = "rafters"
+workdir = "/tmp"
+"#;
+        let config: WatchConfig = toml::from_str(toml_str).expect("parse");
+        assert_eq!(config.repos[0].agent, None);
+    }
+
+    #[test]
+    fn config_with_agent_field_round_trips() {
+        let toml_str = r#"
+[[repos]]
+name = "legion"
+workdir = "/tmp"
+agent = "my-agent"
+"#;
+        let config: WatchConfig = toml::from_str(toml_str).expect("parse");
+        assert_eq!(config.repos[0].agent.as_deref(), Some("my-agent"));
+
+        // Serialize and re-parse to confirm round-trip.
+        let serialized = toml::to_string_pretty(&config).expect("serialize");
+        let reparsed: WatchConfig = toml::from_str(&serialized).expect("reparse");
+        assert_eq!(reparsed.repos[0].agent.as_deref(), Some("my-agent"));
     }
 }

--- a/src/watch.rs
+++ b/src/watch.rs
@@ -23,6 +23,12 @@ pub struct WatchRepoConfig {
     /// when absent, preserving backward compatibility with existing watch.toml files.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub agent: Option<String>,
+
+    /// Any additional per-repo fields the struct does not model explicitly
+    /// (e.g., `github`, `worksource`, `review`). These survive a read-modify-write
+    /// cycle so CRUD on one entry never strips integration config on another.
+    #[serde(flatten, default, skip_serializing_if = "toml::Table::is_empty")]
+    pub extra: toml::Table,
 }
 
 impl WatchRepoConfig {
@@ -244,6 +250,7 @@ pub fn add_repo_to_config(
         name: name.to_string(),
         workdir: canonical_str,
         agent: normalized_agent,
+        extra: toml::Table::new(),
     });
 
     write_config(path, &config)?;
@@ -1010,6 +1017,7 @@ workdir = "/tmp"
                 name: "legion".to_string(),
                 workdir: "/tmp".to_string(),
                 agent: None,
+                extra: toml::Table::new(),
             }],
             ..WatchConfig::default()
         };
@@ -1212,6 +1220,7 @@ workdir = "/nonexistent/path/that/does/not/exist"
             name: "ledger".to_string(),
             workdir: "/tmp".to_string(),
             agent: Some("platform".to_string()),
+            extra: toml::Table::new(),
         };
         assert_eq!(repo_with_agent.recipient(), "platform");
 
@@ -1219,6 +1228,7 @@ workdir = "/nonexistent/path/that/does/not/exist"
             name: "legion".to_string(),
             workdir: "/tmp".to_string(),
             agent: None,
+            extra: toml::Table::new(),
         };
         assert_eq!(repo_without_agent.recipient(), "legion");
     }
@@ -1231,6 +1241,7 @@ workdir = "/nonexistent/path/that/does/not/exist"
             name: "fallback".to_string(),
             workdir: "/tmp".to_string(),
             agent: Some("".to_string()),
+            extra: toml::Table::new(),
         };
         assert_eq!(empty.recipient(), "fallback");
 
@@ -1238,6 +1249,7 @@ workdir = "/nonexistent/path/that/does/not/exist"
             name: "fallback".to_string(),
             workdir: "/tmp".to_string(),
             agent: Some("   ".to_string()),
+            extra: toml::Table::new(),
         };
         assert_eq!(whitespace.recipient(), "fallback");
     }
@@ -1254,6 +1266,49 @@ workdir = "/nonexistent/path/that/does/not/exist"
         assert!(
             repos[0].agent.is_none(),
             "empty --agent should be normalized to None, not stored as Some(\"\")"
+        );
+    }
+
+    #[test]
+    fn add_repo_preserves_unknown_fields_on_existing_entries() {
+        // Regression guard: add/remove must NOT strip fields the struct does not
+        // model explicitly (github, worksource, review, etc). A silent round-trip
+        // that drops these breaks `legion pr create` for every repo.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let config_path = dir.path().join("watch.toml");
+
+        let seed = r#"
+[[repos]]
+name = "legion"
+workdir = "/tmp"
+github = "runlegion/legion"
+worksource = "github"
+
+[[repos]]
+name = "rafters"
+workdir = "/tmp"
+github = "rafters-studio/rafters"
+"#;
+        std::fs::write(&config_path, seed).expect("seed config");
+
+        // Add a new repo -- triggers full read-modify-write.
+        let new_workdir = dir.path().join("newrepo");
+        std::fs::create_dir_all(&new_workdir).expect("mkdir");
+        add_repo_to_config(&config_path, "newrepo", &new_workdir, None).expect("add");
+
+        // Both original repos must still carry their github field.
+        let contents = std::fs::read_to_string(&config_path).expect("reread");
+        assert!(
+            contents.contains(r#"github = "runlegion/legion""#),
+            "legion's github field was stripped: {contents}"
+        );
+        assert!(
+            contents.contains(r#"github = "rafters-studio/rafters""#),
+            "rafters's github field was stripped: {contents}"
+        );
+        assert!(
+            contents.contains(r#"worksource = "github""#),
+            "legion's worksource field was stripped: {contents}"
         );
     }
 

--- a/src/watch.rs
+++ b/src/watch.rs
@@ -228,7 +228,18 @@ pub fn add_repo_to_config(
             e
         ))
     })?;
-    let canonical_str = canonical.to_string_lossy().into_owned();
+    // TOML is UTF-8. A lossy conversion would replace non-UTF-8 bytes with U+FFFD,
+    // silently corrupting the stored path and breaking idempotency (two distinct
+    // paths could collide on the same lossy string).
+    let canonical_str = canonical
+        .to_str()
+        .ok_or_else(|| {
+            LegionError::WatchConfig(format!(
+                "workdir path is not valid UTF-8 and cannot be stored in watch.toml: {}",
+                canonical.display()
+            ))
+        })?
+        .to_string();
 
     let mut config = read_or_default(path)?;
 
@@ -643,7 +654,16 @@ pub fn poll_cycle(
         }
 
         let recipient = repo.recipient();
-        let signals = find_pending_signals(db, &repo.name, recipient, since)?;
+        let signals = match find_pending_signals(db, &repo.name, recipient, since) {
+            Ok(s) => s,
+            Err(e) => {
+                eprintln!(
+                    "[legion watch] signal lookup failed for {}: {}",
+                    repo.name, e
+                );
+                continue;
+            }
+        };
         if signals.is_empty() {
             continue;
         }
@@ -1309,6 +1329,83 @@ github = "rafters-studio/rafters"
         assert!(
             contents.contains(r#"worksource = "github""#),
             "legion's worksource field was stripped: {contents}"
+        );
+    }
+
+    #[test]
+    fn add_repo_preserves_nested_table_extras_on_existing_entries() {
+        // Regression guard: `#[serde(flatten)]` + `toml::Table` must round-trip
+        // NESTED tables, not just scalars. If the serializer ever emits a
+        // trailing scalar after `[repos.review]`, TOML would re-parse the scalar
+        // as a child of `repos.review`, silently reshaping the config.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let config_path = dir.path().join("watch.toml");
+
+        let seed = r#"
+[[repos]]
+name = "legion"
+workdir = "/tmp"
+agent = "platform"
+
+[repos.review]
+reviewer = "vault"
+auto = true
+
+[repos.worksource]
+kind = "github"
+repo = "runlegion/legion"
+"#;
+        std::fs::write(&config_path, seed).expect("seed config");
+
+        // Force read-modify-write by adding an unrelated new repo.
+        let new_workdir = dir.path().join("newrepo");
+        std::fs::create_dir_all(&new_workdir).expect("mkdir");
+        add_repo_to_config(&config_path, "newrepo", &new_workdir, None).expect("add");
+
+        let repos = list_repos_in_config(&config_path).expect("list");
+        let legion = repos
+            .iter()
+            .find(|r| r.name == "legion")
+            .expect("legion entry survives");
+
+        // agent MUST still be "platform" (not swallowed into a nested table).
+        assert_eq!(
+            legion.agent.as_deref(),
+            Some("platform"),
+            "agent was reshaped by nested-table round-trip"
+        );
+
+        // Both nested tables must still be present with their original fields.
+        let review = legion
+            .extra
+            .get("review")
+            .and_then(|v| v.as_table())
+            .expect("review table survives");
+        assert_eq!(
+            review.get("reviewer").and_then(|v| v.as_str()),
+            Some("vault"),
+            "review.reviewer was stripped"
+        );
+        assert_eq!(
+            review.get("auto").and_then(|v| v.as_bool()),
+            Some(true),
+            "review.auto was stripped"
+        );
+
+        let worksource = legion
+            .extra
+            .get("worksource")
+            .and_then(|v| v.as_table())
+            .expect("worksource table survives");
+        assert_eq!(
+            worksource.get("kind").and_then(|v| v.as_str()),
+            Some("github"),
+            "worksource.kind was stripped"
+        );
+        assert_eq!(
+            worksource.get("repo").and_then(|v| v.as_str()),
+            Some("runlegion/legion"),
+            "worksource.repo was stripped"
         );
     }
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -3518,6 +3518,39 @@ fn watch_add_creates_entry() {
 }
 
 #[test]
+fn watch_add_derives_name_from_path_basename() {
+    let dir = tempfile::tempdir().unwrap();
+    let workdir_parent = tempfile::tempdir().unwrap();
+    let workdir = workdir_parent.path().join("my-project");
+    std::fs::create_dir(&workdir).unwrap();
+
+    let out = legion_cmd(dir.path())
+        .args(["watch", "add", workdir.to_str().unwrap()])
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "watch add (no --name) failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("my-project"),
+        "expected derived name 'my-project' in output: {stdout}"
+    );
+
+    let listed = legion_cmd(dir.path())
+        .args(["watch", "list"])
+        .output()
+        .unwrap();
+    let listed_stdout = String::from_utf8_lossy(&listed.stdout);
+    assert!(
+        listed_stdout.contains("my-project"),
+        "expected 'my-project' in list output: {listed_stdout}"
+    );
+}
+
+#[test]
 fn watch_add_idempotent() {
     let dir = tempfile::tempdir().unwrap();
     let workdir = tempfile::tempdir().unwrap();

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -3483,3 +3483,220 @@ fn mcp_push_bridge_delivers_cross_process_post() {
         );
     }
 }
+
+// -- legion watch add / remove / list -----------------------------------------
+
+#[test]
+fn watch_add_creates_entry() {
+    let dir = tempfile::tempdir().unwrap();
+    let workdir = tempfile::tempdir().unwrap();
+
+    let out = legion_cmd(dir.path())
+        .args([
+            "watch",
+            "add",
+            "--name",
+            "rafters",
+            workdir.path().to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "watch add failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("added:"),
+        "expected 'added:' in output: {stdout}"
+    );
+    assert!(
+        stdout.contains("rafters"),
+        "expected name in output: {stdout}"
+    );
+}
+
+#[test]
+fn watch_add_idempotent() {
+    let dir = tempfile::tempdir().unwrap();
+    let workdir = tempfile::tempdir().unwrap();
+
+    let first = legion_cmd(dir.path())
+        .args([
+            "watch",
+            "add",
+            "--name",
+            "rafters",
+            workdir.path().to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+    assert!(first.status.success());
+
+    let second = legion_cmd(dir.path())
+        .args([
+            "watch",
+            "add",
+            "--name",
+            "rafters",
+            workdir.path().to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+    assert!(second.status.success());
+    let stdout = String::from_utf8_lossy(&second.stdout);
+    assert!(
+        stdout.contains("already present"),
+        "expected 'already present' for duplicate: {stdout}"
+    );
+}
+
+#[test]
+fn watch_add_with_agent_flag() {
+    let dir = tempfile::tempdir().unwrap();
+    let workdir = tempfile::tempdir().unwrap();
+
+    let out = legion_cmd(dir.path())
+        .args([
+            "watch",
+            "add",
+            "--name",
+            "legion",
+            "--agent",
+            "my-agent",
+            workdir.path().to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "watch add --agent failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("my-agent"),
+        "expected agent name in output: {stdout}"
+    );
+}
+
+#[test]
+fn watch_list_shows_entries() {
+    let dir = tempfile::tempdir().unwrap();
+    let workdir = tempfile::tempdir().unwrap();
+
+    // Empty list first.
+    let empty = legion_cmd(dir.path())
+        .args(["watch", "list"])
+        .output()
+        .unwrap();
+    assert!(empty.status.success());
+    let stdout = String::from_utf8_lossy(&empty.stdout);
+    assert!(
+        stdout.contains("no repos"),
+        "empty list should say 'no repos': {stdout}"
+    );
+
+    // Add one entry.
+    legion_cmd(dir.path())
+        .args([
+            "watch",
+            "add",
+            "--name",
+            "rafters",
+            workdir.path().to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+
+    let list = legion_cmd(dir.path())
+        .args(["watch", "list"])
+        .output()
+        .unwrap();
+    assert!(list.status.success());
+    let stdout = String::from_utf8_lossy(&list.stdout);
+    assert!(
+        stdout.contains("rafters"),
+        "list should show 'rafters': {stdout}"
+    );
+}
+
+#[test]
+fn watch_remove_removes_entry() {
+    let dir = tempfile::tempdir().unwrap();
+    let workdir = tempfile::tempdir().unwrap();
+
+    legion_cmd(dir.path())
+        .args([
+            "watch",
+            "add",
+            "--name",
+            "rafters",
+            workdir.path().to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+
+    let out = legion_cmd(dir.path())
+        .args(["watch", "remove", "rafters"])
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "watch remove failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("removed:"),
+        "expected 'removed:' in output: {stdout}"
+    );
+
+    // Verify it is gone from list.
+    let list = legion_cmd(dir.path())
+        .args(["watch", "list"])
+        .output()
+        .unwrap();
+    let list_out = String::from_utf8_lossy(&list.stdout);
+    assert!(
+        !list_out.contains("rafters"),
+        "entry should be gone after remove: {list_out}"
+    );
+}
+
+#[test]
+fn watch_remove_missing_entry_reports_not_found() {
+    let dir = tempfile::tempdir().unwrap();
+
+    let out = legion_cmd(dir.path())
+        .args(["watch", "remove", "nonexistent"])
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("not found"),
+        "expected 'not found' for unknown name: {stdout}"
+    );
+}
+
+#[test]
+fn watch_add_rejects_nonexistent_workdir() {
+    let dir = tempfile::tempdir().unwrap();
+
+    let out = legion_cmd(dir.path())
+        .args([
+            "watch",
+            "add",
+            "--name",
+            "test",
+            "/nonexistent/path/that/does/not/exist",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        !out.status.success(),
+        "watch add should fail for non-directory path"
+    );
+}


### PR DESCRIPTION
## Summary

Adds `deleted_at TEXT` columns to reflections, tasks, and schedules tables for multi-node sync tombstone propagation. Soft-deleted rows are invisible to normal queries but can be synced to other nodes.

## Changes

- Migration #13: Add `deleted_at` column to reflections, tasks, schedules
- Update all SELECT queries to filter `WHERE deleted_at IS NULL`
- Add `soft_delete_reflection()`, `soft_delete_card()`, `soft_delete_schedule()` functions
- Add tests verifying soft-deleted rows are hidden

## Test Plan

- [x] `cargo test` passes (425 tests)
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt -- --check` clean
- [x] `/legion-simplify` gate passed

Closes #245