### PR TITLE
perf(#256): add partial indexes for soft-deleted rows

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -565,6 +565,22 @@ impl Database {
             )?;
         }
 
+        // Migration 15: Partial indexes for soft-deleted rows (#256).
+        // Most queries filter by deleted_at IS NULL. Partial indexes exclude
+        // tombstones, reducing index size and improving query performance.
+        conn.execute_batch(
+            "CREATE INDEX IF NOT EXISTS idx_reflections_repo_live \
+                 ON reflections(repo) WHERE deleted_at IS NULL;
+             CREATE INDEX IF NOT EXISTS idx_reflections_audience_live \
+                 ON reflections(audience, created_at) WHERE deleted_at IS NULL;
+             CREATE INDEX IF NOT EXISTS idx_tasks_to_live \
+                 ON tasks(to_repo, status) WHERE deleted_at IS NULL;
+             CREATE INDEX IF NOT EXISTS idx_tasks_from_live \
+                 ON tasks(from_repo) WHERE deleted_at IS NULL;
+             CREATE INDEX IF NOT EXISTS idx_schedules_repo_live \
+                 ON schedules(repo) WHERE deleted_at IS NULL;",
+        )?;
+
         Ok(())
     }
 
@@ -4065,5 +4081,43 @@ mod tests {
             .unwrap();
         assert_eq!(deltas.len(), 1);
         assert!(deltas[0].deleted_at.is_some());
+    }
+
+    #[test]
+    fn partial_indexes_created_for_soft_delete() {
+        let db = test_db();
+
+        // Query sqlite_master for our partial indexes.
+        let mut stmt = db
+            .conn
+            .prepare("SELECT name FROM sqlite_master WHERE type = 'index' AND name LIKE '%_live'")
+            .unwrap();
+        let indexes: Vec<String> = stmt
+            .query_map([], |row| row.get(0))
+            .unwrap()
+            .collect::<std::result::Result<Vec<_>, _>>()
+            .unwrap();
+
+        // Verify all expected partial indexes exist.
+        assert!(
+            indexes.contains(&"idx_reflections_repo_live".to_string()),
+            "idx_reflections_repo_live should exist"
+        );
+        assert!(
+            indexes.contains(&"idx_reflections_audience_live".to_string()),
+            "idx_reflections_audience_live should exist"
+        );
+        assert!(
+            indexes.contains(&"idx_tasks_to_live".to_string()),
+            "idx_tasks_to_live should exist"
+        );
+        assert!(
+            indexes.contains(&"idx_tasks_from_live".to_string()),
+            "idx_tasks_from_live should exist"
+        );
+        assert!(
+            indexes.contains(&"idx_schedules_repo_live".to_string()),
+            "idx_schedules_repo_live should exist"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Add partial indexes that exclude tombstones (rows with `deleted_at IS NULL`). Most queries filter by `deleted_at IS NULL`, so these indexes:

- Reduce index size by excluding soft-deleted rows
- Improve query performance for live-row queries
- Are automatically used by SQLite's query planner for matching WHERE clauses

## Indexes Added

| Index | Table | Columns | Purpose |
|-------|-------|---------|---------|
| idx_reflections_repo_live | reflections | repo | Repo-scoped reflection queries |
| idx_reflections_audience_live | reflections | audience, created_at | Board posts and team queries |
| idx_tasks_to_live | tasks | to_repo, status | Inbound card queries |
| idx_tasks_from_live | tasks | from_repo | Outbound card queries |
| idx_schedules_repo_live | schedules | repo | Schedule listing |

## Test Plan

- [x] `partial_indexes_created_for_soft_delete` - verifies all 5 indexes exist in sqlite_master

Closes #256

🤖 Generated with [Claude Code](https://claude.com/claude-code)