### PR TITLE
docs: sync architecture/getting-started/CLAUDE for v0.9.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,6 +59,14 @@ legion audit --action create-pr              # filter by action type
 legion audit --json                          # output as JSON
 legion quality-gate record --skill legion-simplify --result clean|issues [--findings-count N] [--details-json '<json>']
 legion watch                                 # auto-wake sleeping agents on signal arrival
+legion watch add <path> [--name <n>] [--agent <a>]  # add repo to watch.toml (idempotent by path)
+legion watch remove <name>                   # remove repo entry from watch.toml
+legion watch list                            # list watch.toml entries
+legion cluster init [--key <hex>] [--port <n>]  # initialize LAN cluster sync (generates key if omitted)
+legion cluster key                           # print current cluster key (share with other nodes)
+legion cluster enable                        # start broadcasting deltas
+legion cluster disable                       # stop broadcasting (key preserved)
+legion cluster status                        # peers, sync state, last sync time
 legion -v <command>                          # show informational messages (quiet by default)
 ```
 
@@ -124,12 +132,17 @@ CREATE TABLE reflections (
     recall_count INTEGER NOT NULL DEFAULT 0,  -- boost counter
     last_recalled_at TEXT,         -- for decay calculation
     parent_id TEXT,                -- learning chain link
-    embedding BLOB                 -- nullable, Phase 2.5
+    embedding BLOB,                -- nullable, Phase 2.5
+    archived_at TEXT,              -- bullpen archive timestamp (nullable)
+    deleted_at TEXT,               -- tombstone for multi-node sync (nullable)
+    updated_at TEXT                -- ISO 8601, LWW conflict resolution
 );
 
 CREATE INDEX idx_reflections_repo ON reflections(repo);
 CREATE INDEX idx_reflections_created ON reflections(created_at);
 ```
+
+`tasks` and `schedules` also carry `deleted_at` + `updated_at` for sync. Partial indexes skip soft-deleted rows. See `docs/site/architecture.md` for the full schema and migration list.
 
 ### Tasks (Agent Delegation)
 
@@ -199,6 +212,23 @@ Opt-IN per repo. Only repos listed in `watch.toml` get auto-woken. PID lock prev
 Cooldown prevents wake storms (default 5 minutes between wakes per repo).
 Stagger prevents I/O storms by sleeping between spawns (default 15s; set to 0 to disable).
 
+`legion watch add|remove|list` manage `watch.toml` entries without hand-editing.
+
+### Multi-Node Cluster Sync
+
+Legion nodes on the same LAN can sync reflections, cards, and schedules via UDP broadcast with XChaCha20-Poly1305 encryption. Opt-in via `cluster.toml` (0o600, contains a pre-shared 256-bit secret).
+
+```bash
+legion cluster init                # generate key, write cluster.toml
+legion cluster init --key <hex>    # second node: use key from first node
+legion cluster enable              # start broadcasting
+legion cluster key                 # print key (to share with another node)
+legion cluster status              # peers, sync state, last sync time
+legion cluster disable             # stop broadcasting (key preserved)
+```
+
+Soft delete + LWW: syncable tables carry `deleted_at` and `updated_at`. Conflicts resolve via higher `updated_at`. Tombstones replicate to peers and are hard-deleted after 7 days by the weekly housekeeper. The delta types (`ReflectionDelta`, `CardDelta`, `ScheduleDelta`) ship; broadcast transport is still landing.
+
 ## Phase Plan
 
 1. **Phase 1** (complete): SQLite + Tantivy BM25. Store reflections, recall by text similarity.
@@ -207,8 +237,9 @@ Stagger prevents I/O storms by sleeping between spawns (default 15s; set to 0 to
 4. **Phase 2.0** (complete): Synapse metadata. Domain/tags, learning chains, boost/decay ranking, `legion surface`.
 5. **Phase 2.1** (complete): Signals. Structured coordination via `@recipient verb:status {details}`. Bullpen filtering (`--signals`, `--musings`).
 6. **Phase 2.2** (complete): Watch. Auto-wake sleeping agents when signals arrive. `legion watch` with opt-in config.
-7. **Phase 2.5** (next): Add model2vec-rs embeddings, hybrid BM25 + cosine scoring, transfer detection.
+7. **Phase 2.5** (complete): model2vec-rs embeddings, hybrid BM25 + cosine scoring.
 8. **Phase 3.0** (planned): LLM classification via Synapse agent for quality gating.
+9. **Phase 4.0** (in progress, v0.9.0): Multi-node cluster sync. Soft delete, LWW, delta types, sync actor, tombstone housekeeper shipped. Broadcast transport landing.
 
 ## Hook Integration
 

--- a/docs/site/architecture.md
+++ b/docs/site/architecture.md
@@ -1,6 +1,6 @@
 # Architecture
 
-Legion is a local Rust binary backed by SQLite and Tantivy. This document covers the storage layout, database schema, search index, scoring algorithms, state machines, the watch daemon, the health system, and the web server.
+Legion is a local Rust binary backed by SQLite and Tantivy. This document covers the storage layout, database schema, search index, scoring algorithms, state machines, the watch daemon, multi-node cluster sync, the health system, and the web server.
 
 ## Storage layout
 
@@ -11,6 +11,7 @@ legion.db          SQLite database (WAL mode)
 index/             Tantivy full-text search index
 watch.toml         Watch daemon configuration
 watch.pid          PID lock for watch daemon (created at runtime)
+cluster.toml       Multi-node cluster sync config (0o600, contains secret)
 ```
 
 ## Database schema
@@ -34,7 +35,10 @@ CREATE TABLE reflections (
     recall_count INTEGER NOT NULL DEFAULT 0,           -- boost counter
     last_recalled_at TEXT,                              -- for decay calculation
     parent_id TEXT,                                     -- learning chain link
-    handled_at TEXT                                     -- legacy watch handling (superseded by watch_handled)
+    handled_at TEXT,                                    -- legacy watch handling (superseded by watch_handled)
+    archived_at TEXT,                                   -- bullpen archive timestamp (nullable)
+    deleted_at TEXT,                                    -- tombstone for multi-node sync (nullable)
+    updated_at TEXT                                     -- ISO 8601, LWW conflict resolution
 );
 
 CREATE INDEX idx_reflections_repo ON reflections(repo);
@@ -75,7 +79,8 @@ CREATE TABLE tasks (
     sort_order INTEGER NOT NULL DEFAULT 0,             -- manual ordering
     assigned_at TEXT,                                   -- when card was assigned to an agent
     started_at TEXT,                                    -- when agent accepted the card
-    completed_at TEXT                                   -- when card reached done/cancelled
+    completed_at TEXT,                                  -- when card reached done/cancelled
+    deleted_at TEXT                                     -- tombstone for multi-node sync (nullable)
 );
 
 CREATE INDEX idx_tasks_to ON tasks(to_repo, status);
@@ -83,6 +88,8 @@ CREATE INDEX idx_tasks_from ON tasks(from_repo, status);
 CREATE INDEX idx_tasks_parent ON tasks(parent_card_id);
 CREATE INDEX idx_tasks_status_sort ON tasks(status, sort_order, created_at);
 ```
+
+`tasks.updated_at` already existed pre-sync and is reused for LWW.
 
 ### schedules
 
@@ -100,7 +107,9 @@ CREATE TABLE schedules (
     next_run TEXT NOT NULL,                             -- ISO 8601 of next fire
     created_at TEXT NOT NULL,                           -- ISO 8601
     active_start TEXT,                                  -- HH:MM UTC window start
-    active_end TEXT                                     -- HH:MM UTC window end
+    active_end TEXT,                                    -- HH:MM UTC window end
+    deleted_at TEXT,                                    -- tombstone for multi-node sync (nullable)
+    updated_at TEXT                                     -- ISO 8601, LWW conflict resolution
 );
 ```
 
@@ -153,7 +162,7 @@ CREATE INDEX idx_health_sampled ON health_samples(sampled_at);
 
 ## Migrations
 
-The `init_schema` function applies 10 migrations incrementally using `has_column` checks:
+The `init_schema` function applies migrations incrementally using `has_column` checks:
 
 | # | Description |
 |---|-------------|
@@ -167,6 +176,12 @@ The `init_schema` function applies 10 migrations incrementally using `has_column
 | 7 | Create watch_handled table (per-repo signal tracking) |
 | 8 | Create health_samples table |
 | 9 | Kanban upgrade: add labels, parent_card_id, source_url, source_type, sort_order, assigned_at, started_at, completed_at to tasks. Backfill timestamps from existing status. |
+| 10 | Bullpen archive: add nullable archived_at on reflections (#168) |
+| 11 | Audit log table for work source actions (#142) |
+| 12 | Quality gates table for PR creation guard (#200) |
+| 13 | Soft delete support for multi-node sync: add deleted_at on reflections, tasks, schedules (#245) |
+| 14 | LWW conflict resolution: add updated_at on reflections and schedules (#255) |
+| 15 | Partial indexes that skip soft-deleted rows (#256) |
 
 On a fully-migrated database, `init_schema` does minimal work: `CREATE IF NOT EXISTS` checks and a few `PRAGMA table_info` queries.
 
@@ -431,6 +446,62 @@ When the poll cycle finds signals, it calls `check_auto_unblock`. This scans for
 ### Cooldown
 
 Per-repo cooldown prevents wake storms. After waking a repo, no further wakes happen for `cooldown_secs` (default 300 seconds / 5 minutes). During work hours (if configured), cooldown is disabled entirely.
+
+### Watch config subcommands
+
+`watch.toml` can be edited in place, but `legion watch add|remove|list` manage entries without hand-editing TOML. `add` canonicalizes the path and is idempotent (repeated calls with the same resolved path are a no-op). `remove` deletes by display name. `list` prints the current entries.
+
+```bash
+legion watch add /Volumes/store/projects/acme --name acme --agent acme-bot
+legion watch remove acme
+legion watch list
+```
+
+The unknown-field preservation pattern (`#[serde(flatten)] toml::Table extras`) means these commands round-trip user-added fields that legion does not yet understand.
+
+## Multi-node cluster sync
+
+Legion nodes on the same LAN can synchronize reflections, cards, and schedules over UDP broadcast. All packets are encrypted with XChaCha20-Poly1305 using a pre-shared 256-bit key. Sync is opt-in and disabled by default.
+
+### cluster.toml
+
+Stored in the data directory with `0o600` permissions on Unix (contains the pre-shared secret):
+
+```toml
+enabled = true
+secret = "64-hex-chars"          # 256-bit key, generated by `legion cluster init`
+port = 31337                     # UDP broadcast port (default: 31337)
+instance_id = "hostname"         # optional; defaults to system hostname
+last_sync = "2026-04-15T00:00:00Z"
+```
+
+Unknown fields round-trip via `#[serde(flatten)] toml::Table extras`.
+
+### Sync actor
+
+When `cluster.enabled = true`, `legion watch` spawns a sync actor alongside the health/spawn loops. The actor discovers peers by listening on the configured UDP port, and periodically queries the local database for deltas produced since the last broadcast. Delta transmission over the wire is scaffolded -- the serialization format is shipped (ReflectionDelta, CardDelta, ScheduleDelta) but the broadcast/apply pipeline is still landing behind it.
+
+### Soft delete + LWW
+
+Every syncable table (reflections, tasks, schedules) carries `deleted_at` and `updated_at`:
+
+- **Soft delete**: deletes set `deleted_at` rather than removing the row. Reads are filtered through partial indexes (migration #15) that skip tombstoned rows. This lets delete operations replicate to peers that may not have received the row yet.
+- **LWW conflict resolution**: when two nodes update the same row, the higher `updated_at` wins. Clock skew is not handled -- operators are expected to run NTP.
+
+### Delta types
+
+`ReflectionDelta`, `CardDelta`, and `ScheduleDelta` are the wire-format shapes. Each carries the row's primary key, its `updated_at`, and the full field set. Apply is idempotent: re-applying an older delta is a no-op because the local `updated_at` already exceeds the incoming one.
+
+### Tombstone housekeeper
+
+`legion watch` also runs a weekly housekeeper that hard-deletes rows whose `deleted_at` exceeds the tombstone retention window (default 7 days). Housekeeping is bounded so late-joining peers still see recent deletes but the database does not grow unbounded.
+
+### Keys and enrollment
+
+- `legion cluster init` generates a new 256-bit key and writes `cluster.toml`. Pass `--key <hex>` to use an existing key (for the second node in a cluster).
+- `legion cluster key` prints the current key so it can be shared with another node.
+- `legion cluster enable|disable` toggles the `enabled` flag.
+- `legion cluster status` reports the instance ID, peer list, and last successful sync.
 
 ## Health and pressure
 

--- a/docs/site/getting-started.md
+++ b/docs/site/getting-started.md
@@ -78,6 +78,7 @@ Contents:
 | `index/` | Tantivy full-text search index |
 | `watch.toml` | Watch daemon configuration |
 | `watch.pid` | PID lock for the watch daemon |
+| `cluster.toml` | Multi-node cluster sync config (0o600, contains secret) |
 
 ## What the hooks do
 
@@ -410,6 +411,18 @@ workdir = "/Volumes/store/projects/runlegion/legion"
 
 Repos are opt-in. Only repos listed in `watch.toml` get auto-woken. The `/watch-sync` slash command can populate this from your Claude Code project settings.
 
+### Manage watch.toml from the CLI
+
+```bash
+legion watch add /Volumes/store/projects/acme                    # add a repo (name = basename)
+legion watch add /Volumes/store/projects/acme --name acme \
+  --agent acme-bot                                               # custom display name and signal recipient
+legion watch remove acme                                          # remove by name
+legion watch list                                                 # show current entries
+```
+
+`add` canonicalizes the path and is idempotent -- repeated calls with the same resolved path are a no-op. Unknown TOML fields are preserved across edits.
+
 ### How it works
 
 The daemon runs a dual-interval loop:
@@ -431,6 +444,56 @@ When a `@all announce` signal contains "completed:", the watch daemon checks for
 ### Work hours
 
 Set `work_hours_start` and `work_hours_end` to disable cooldown during active hours. During work hours, agents can be woken as often as needed. Supports overnight ranges (e.g., 22-06).
+
+## Multi-node cluster sync
+
+Legion nodes on the same LAN can share reflections, cards, and schedules over UDP broadcast. Traffic is encrypted with XChaCha20-Poly1305 using a pre-shared 256-bit key. Sync is opt-in and disabled by default.
+
+### First node
+
+Initialize the cluster. Legion generates a fresh key and writes `cluster.toml`:
+
+```bash
+legion cluster init
+legion cluster enable
+```
+
+The key is printed once on `init`. Save it -- it is the only way to enroll another node.
+
+### Second node (enrolling)
+
+Use the key from the first node:
+
+```bash
+legion cluster init --key <64-hex-chars>
+legion cluster enable
+```
+
+Or print the key from the first node and copy it over:
+
+```bash
+legion cluster key              # on node A
+legion cluster init --key ...   # on node B
+legion cluster enable           # on node B
+```
+
+### Status and control
+
+```bash
+legion cluster status           # peers, sync state, last sync time
+legion cluster disable          # stop broadcasting without deleting the key
+legion cluster enable           # resume
+```
+
+### What syncs
+
+`legion watch` spawns the sync actor when `cluster.enabled = true`. Reflections, kanban cards, and schedules flow between nodes. Conflicts are resolved last-write-wins on `updated_at`, so operators should run NTP. Deletes are tombstones that replicate to peers and are hard-deleted after 7 days by the weekly housekeeper.
+
+The delta format is shipped (ReflectionDelta, CardDelta, ScheduleDelta). Broadcast transport is scaffolded and still landing behind it.
+
+### Security notes
+
+`cluster.toml` contains the pre-shared secret and is written with `0o600` on Unix. Do not commit it. A leaked key lets an attacker on the same subnet read and write to your database.
 
 ## Boost and learning chains
 


### PR DESCRIPTION
## Summary

Catches the site docs and project CLAUDE.md up to what v0.9.0 actually ships. The site docs had stopped tracking the DB schema at migration 9 and had zero coverage of multi-node cluster sync -- meaning a user following the docs would not know the cluster feature exists, let alone how to use it.

Sean's framing from the session: "if [the docs] were complete we could ship without a UI." This PR is that completion.

## Changes

**`docs/site/architecture.md`**
- Storage layout: add `cluster.toml`
- reflections/tasks/schedules schemas: add `deleted_at`, `updated_at`, `archived_at` columns
- Migrations table: extend with rows 10-15 (bullpen archive, audit log, quality gates, soft delete, LWW, partial indexes)
- New section: **Multi-node cluster sync** covering `cluster.toml` shape, sync actor behavior, soft delete + LWW semantics, delta types (\`ReflectionDelta\`/\`CardDelta\`/\`ScheduleDelta\`), tombstone housekeeper, keys + enrollment
- Watch daemon: document \`legion watch add|remove|list\`

**`docs/site/getting-started.md`**
- Storage location: add \`cluster.toml\`
- Watch section: document \`legion watch add|remove|list\`
- New section: **Multi-node cluster sync** walking through first-node init, second-node enrollment, status/control, and security notes

**`CLAUDE.md`**
- Commands block: add cluster subcommands and watch add/remove/list
- Data model: reflections schema now includes sync columns, note about partial indexes
- New subsection under Watch: **Multi-Node Cluster Sync**
- Phase plan: mark Phase 2.5 complete, add Phase 4.0 (multi-node sync) as in-progress for v0.9.0

## What's honest about in-progress state

The delta types ship but the broadcast transport is still landing -- both docs explicitly say so rather than implying full end-to-end sync. This matches reality.

## Test plan

- [x] Claims cross-referenced against \`src/cluster.rs\`, \`src/sync_actor.rs\`, \`src/watch.rs\`, \`src/db.rs\` migrations
- [x] Migration numbers verified against comments in \`src/db.rs\` (#10-#15)
- [x] Command surfaces verified against \`ClusterAction\` and \`WatchAction\` enums in \`src/main.rs\`
- [x] \`cluster.toml\` shape verified against \`ClusterConfig\` struct
- [x] No code changes; pre-commit simplify + pre-push review both passed