### PR TITLE
feat(#266): add --whoami flag to legion reflect

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -92,6 +92,11 @@ enum Commands {
         #[arg(long)]
         domain: Option<String>,
 
+        /// Shortcut for --domain identity. Stores as an identity reflection,
+        /// which the SessionStart hook injects on every boot.
+        #[arg(long, conflicts_with = "domain")]
+        whoami: bool,
+
         /// Comma-separated tags (e.g., "semantic-tokens,consumer,debugging")
         #[arg(long)]
         tags: Option<String>,
@@ -1851,11 +1856,17 @@ fn run() -> error::Result<()> {
             text,
             transcript,
             domain,
+            whoami,
             tags,
             follows,
             force,
             dedupe_mode,
         } => {
+            let domain = if whoami {
+                Some("identity".to_owned())
+            } else {
+                domain
+            };
             let base = data_dir()?;
             let database = db::Database::open(&base.join("legion.db"))?;
             let index = search::SearchIndex::open(&base.join("index"))?;

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -155,6 +155,142 @@ fn recall_by_domain_filters_correctly() {
     );
 }
 
+#[test]
+fn whoami_flag_stores_as_identity_domain() {
+    let dir = tempfile::tempdir().unwrap();
+
+    let out = legion_cmd(dir.path())
+        .args([
+            "reflect",
+            "--repo",
+            "test",
+            "--whoami",
+            "--text",
+            "I am the test agent",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "whoami reflect failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let out = legion_cmd(dir.path())
+        .args([
+            "recall", "--repo", "test", "--domain", "identity", "--limit", "5",
+        ])
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+    let stdout = String::from_utf8(out.stdout).unwrap();
+    assert!(
+        stdout.contains("I am the test agent"),
+        "expected whoami reflection under domain=identity, got: {stdout}"
+    );
+}
+
+#[test]
+fn whoami_conflicts_with_domain_flag() {
+    let dir = tempfile::tempdir().unwrap();
+
+    let out = legion_cmd(dir.path())
+        .args([
+            "reflect",
+            "--repo",
+            "test",
+            "--whoami",
+            "--domain",
+            "something-else",
+            "--text",
+            "should not store",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        !out.status.success(),
+        "expected --whoami + --domain to fail, but it succeeded"
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("cannot be used with"),
+        "expected clap conflict error, got: {stderr}"
+    );
+}
+
+#[test]
+fn whoami_flag_works_with_transcript_input() {
+    let dir = tempfile::tempdir().unwrap();
+    let transcript = dir.path().join("transcript.jsonl");
+    std::fs::write(
+        &transcript,
+        r#"{"role":"assistant","content":"I am the test agent from transcript"}
+"#,
+    )
+    .unwrap();
+
+    let out = legion_cmd(dir.path())
+        .args(["reflect", "--repo", "test", "--whoami", "--transcript"])
+        .arg(&transcript)
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "whoami + transcript reflect failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let out = legion_cmd(dir.path())
+        .args([
+            "recall", "--repo", "test", "--domain", "identity", "--limit", "5",
+        ])
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+    let stdout = String::from_utf8(out.stdout).unwrap();
+    assert!(
+        stdout.contains("I am the test agent from transcript"),
+        "expected whoami reflection from transcript under domain=identity, got: {stdout}"
+    );
+}
+
+#[test]
+fn whoami_works_with_compound_repo() {
+    let dir = tempfile::tempdir().unwrap();
+
+    let out = legion_cmd(dir.path())
+        .args([
+            "reflect",
+            "--repo",
+            "alpha,beta",
+            "--whoami",
+            "--text",
+            "shared identity text",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "compound whoami reflect failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    for repo in ["alpha", "beta"] {
+        let out = legion_cmd(dir.path())
+            .args([
+                "recall", "--repo", repo, "--domain", "identity", "--limit", "5",
+            ])
+            .output()
+            .unwrap();
+        assert!(out.status.success());
+        let stdout = String::from_utf8(out.stdout).unwrap();
+        assert!(
+            stdout.contains("shared identity text"),
+            "expected identity reflection in {repo}, got: {stdout}"
+        );
+    }
+}
+
 /// Validate that a string looks like a UUIDv7 (36 chars, 4 hyphens).
 fn assert_uuid_format(s: &str) {
     let trimmed = s.trim();


### PR DESCRIPTION
## Summary

Closes #266. Adds \`--whoami\` boolean flag to \`legion reflect\` as a shortcut for \`--domain identity\`. Mutually exclusive with \`--domain\`.

\`\`\`bash
legion reflect --repo <repo> --whoami --text 'I am ...'
\`\`\`

Stores under the reserved \`identity\` domain that SessionStart already injects on every boot. Pure ergonomic sugar over existing behavior. No prompt injection, no hook changes, no opinions about what identity reflections should say -- that belongs in userland (see #268 for the broader audit of hyperspecific environment assumptions).

A prior version (PR #267) bundled this flag with a SessionStart nudge. It was closed for baking team-specific vocabulary into hook code. This PR is the flag alone.

## Test plan

- [x] \`cargo test\` -- 87 pass
- [x] \`cargo clippy --all-targets -- -D warnings\` -- clean
- [x] \`cargo fmt --all -- --check\` -- clean
- [x] Integration tests: stores as identity, conflicts with --domain, works with --transcript, works with compound repos
- [x] \`/legion-simplify\` clean gate recorded

🤖 Generated with [Claude Code](https://claude.com/claude-code)