### PR TITLE
chore(#268): remove hyperspecific environment assumptions

### DIFF
--- a/.claude/agents/dashboarder.md
+++ b/.claude/agents/dashboarder.md
@@ -12,7 +12,7 @@ You build the operator-facing dashboard that ships with `legion serve`. The dash
 
 Every invocation, in order:
 
-1. Read `/Volumes/store/projects/runlegion/legion/CLAUDE.md` for project rules.
+1. Read `./CLAUDE.md` for project rules.
 2. Read `src/serve.rs` completely -- understand the handler layout, the existing `/api/*` endpoints, and how `rust-embed` serves `static/`.
 3. Read the three current frontend files in full:
    - `static/index.html` (layout + slots)

--- a/.claude/agents/issue-writer.md
+++ b/.claude/agents/issue-writer.md
@@ -14,8 +14,8 @@ You are invoked before work starts, not during. Your output is passed to `legion
 
 Every invocation, in order. Do not skip.
 
-1. Read `/Volumes/store/projects/runlegion/legion/CLAUDE.md` for project rules.
-2. Read `/Volumes/store/projects/runlegion/legion/.github/ISSUE_TEMPLATE/implementation-task.md`. This file is the canonical template and your single source of truth for the body's section structure. If the file does not exist, STOP and return a clarification with `UNCLEAR: canonical issue template is missing from .github/ISSUE_TEMPLATE/implementation-task.md`.
+1. Read `./CLAUDE.md` for project rules.
+2. Read `./.github/ISSUE_TEMPLATE/implementation-task.md`. This file is the canonical template and your single source of truth for the body's section structure. If the file does not exist, STOP and return a clarification with `UNCLEAR: canonical issue template is missing from .github/ISSUE_TEMPLATE/implementation-task.md`.
 3. Call `legion recall --repo legion --context "<key terms from the problem>"` to pull prior context, prior decisions, and any reflection that might change the scope.
 4. If the problem mentions a specific module or file, read that file to understand the current shape before writing the spec. Do not write a spec for code you have not read.
 5. If the problem references another issue or PR, read it via `legion` commands (not `gh`).

--- a/.claude/agents/porter.md
+++ b/.claude/agents/porter.md
@@ -12,7 +12,7 @@ You take a TypeScript module and produce an idiomatic Rust equivalent that match
 
 Every invocation, in order:
 
-1. Read `/Volumes/store/projects/runlegion/legion/CLAUDE.md` for project rules.
+1. Read `./CLAUDE.md` for project rules.
 2. Read every file in the source TS module. Completely. If the scope says "port plugin/channel/sse-client.ts", you read ALL of `plugin/channel/*.ts`, not just the one file -- you need the types, the event shapes, the shared constants, and the import graph.
 3. Read `src/signal.rs`, `src/board.rs`, and any other Rust modules that already implement related legion concepts. The TS module probably duplicates logic that already exists in Rust -- reuse it instead of reimplementing.
 4. Read `src/serve.rs` to see how axum is used in legion (router layout, State pattern, error handling, Json responses, SSE streams if present).

--- a/.claude/agents/reviewer.md
+++ b/.claude/agents/reviewer.md
@@ -24,7 +24,7 @@ You produce a review report. One invocation, one report.
 
 Every invocation, in order:
 
-1. Read `/Volumes/store/projects/runlegion/legion/CLAUDE.md` for the rules you enforce.
+1. Read `./CLAUDE.md` for the rules you enforce.
 2. Read the scope summary in full. This is the contract. The code must match it.
 3. Read the rust agent's work summary. This is what the implementer claims shipped. Cross-check against the actual diff -- do not trust the summary blindly.
 4. Get the diff: `git fetch origin <branch>; git diff main..origin/<branch>`. Read ALL of it, not just the files you expect.

--- a/.claude/agents/rust.md
+++ b/.claude/agents/rust.md
@@ -12,7 +12,7 @@ You implement one kanban card at a time on a feature branch. The orchestrator ha
 
 Every invocation, in order:
 
-1. Read `/Volumes/store/projects/runlegion/legion/CLAUDE.md` for project rules.
+1. Read `./CLAUDE.md` for project rules.
 2. `legion recall --repo legion --context "<main topic from the scope summary>"` -- pull prior reflections that touch the same area. These are the highest-leverage reads you have. If a reflection disagrees with your planned approach, stop and signal the orchestrator with the conflict before writing code.
 3. Read every file the scope summary names under "FILES IN PLAY". Read them completely, not just the section you think you need. You are responsible for not breaking the surrounding code.
 4. Read `src/error.rs` once per session so you use existing `LegionError` variants instead of inventing new ones.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -204,8 +204,8 @@ cooldown_secs = 300
 stagger_secs = 15       # seconds between spawns; 0 disables
 
 [[repos]]
-name = "rafters"
-workdir = "/Volumes/store/projects/rafters-studio/rafters"
+name = "myrepo"
+workdir = "/path/to/your/repo"
 ```
 
 Opt-IN per repo. Only repos listed in `watch.toml` get auto-woken. PID lock prevents multiple watchers.

--- a/docs/site/getting-started.md
+++ b/docs/site/getting-started.md
@@ -401,12 +401,12 @@ retention_days = 7             # days to keep health samples (default: 7)
 serve = false                  # enable web dashboard on this node (default: false)
 
 [[repos]]
-name = "rafters"
-workdir = "/Volumes/store/projects/rafters-studio/rafters"
+name = "frontend"
+workdir = "/path/to/your/frontend"
 
 [[repos]]
-name = "legion"
-workdir = "/Volumes/store/projects/runlegion/legion"
+name = "backend"
+workdir = "/path/to/your/backend"
 ```
 
 Repos are opt-in. Only repos listed in `watch.toml` get auto-woken. The `/watch-sync` slash command can populate this from your Claude Code project settings.

--- a/src/main.rs
+++ b/src/main.rs
@@ -76,7 +76,7 @@ enum DedupeMode {
 enum Commands {
     /// Store a reflection from a completed session
     Reflect {
-        /// Repository name(s), comma-separated (e.g., "kelex" or "platform,legion")
+        /// Repository name(s), comma-separated (e.g., "myrepo" or "frontend,backend")
         #[arg(long, value_delimiter = ',', required = true)]
         repo: Vec<String>,
 
@@ -88,7 +88,7 @@ enum Commands {
         #[arg(long, conflicts_with = "text")]
         transcript: Option<PathBuf>,
 
-        /// Domain tag for classification (e.g., "color-tokens", "auth")
+        /// Domain tag for classification (e.g., "auth", "schema", "ui")
         #[arg(long)]
         domain: Option<String>,
 
@@ -97,7 +97,7 @@ enum Commands {
         #[arg(long, conflicts_with = "domain")]
         whoami: bool,
 
-        /// Comma-separated tags (e.g., "semantic-tokens,consumer,debugging")
+        /// Comma-separated tags (e.g., "debugging,performance,review")
         #[arg(long)]
         tags: Option<String>,
 
@@ -220,7 +220,7 @@ enum Commands {
 
     /// Post a message to the shared bullpen for other agents
     Post {
-        /// Repository name(s), comma-separated (e.g., "kelex" or "platform,legion")
+        /// Repository name(s), comma-separated (e.g., "myrepo" or "frontend,backend")
         #[arg(long, value_delimiter = ',', required = true)]
         repo: Vec<String>,
 


### PR DESCRIPTION
## Summary

Closes #268. Survey found Sean-team vocabulary and hardcoded absolute paths leaking into user-visible surfaces. Anyone installing legion fresh saw \"kelex\", \"rafters\", \"color-tokens\", and /Volumes/store paths with no context.

## Changes

**User-visible clap help text** (\`src/main.rs\`):
- \`--repo\` example: \"kelex\" or \"platform,legion\" → \"myrepo\" or \"frontend,backend\"
- \`--domain\` example: \"color-tokens\", \"auth\" → \"auth\", \"schema\", \"ui\"
- \`--tags\` example: \"semantic-tokens,consumer,debugging\" → \"debugging,performance,review\"

**Repo-relative paths** (\`.claude/agents/*.md\`):
- All 5 agent defs read \`./CLAUDE.md\` instead of \`/Volumes/store/projects/runlegion/legion/CLAUDE.md\`. Previously broken for anyone cloning this repo elsewhere.

**Docs cleanup**:
- \`docs/site/getting-started.md\` example TOML uses \"/path/to/your/frontend\" instead of Sean's actual paths.
- \`CLAUDE.md\` example matches the doc convention.

## Not changed (intentional)

- Test fixtures use \"kelex\", \"rafters\" as arbitrary repo name strings. Semantic noise to rename and not user-visible. Tracked as out-of-scope in #268.
- \`musing\`, \`signal\`, \`bullpen\`, \`identity\`, \`snooze\` are legion primitives, not team vocabulary. Stay.

## Test plan

- [x] \`cargo test\` -- 83 pass
- [x] \`cargo clippy --all-targets -- -D warnings\` -- clean
- [x] \`cargo fmt --all -- --check\` -- clean
- [x] \`grep -r '/Volumes/store|ssilvius|vault-2026'\` returns zero results
- [x] \`/legion-simplify\` clean gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)