### PR TITLE
chore: release v0.9.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
     {
       "name": "legion",
       "description": "Agent memory layer with recall, reflect, consult, bullpen, and cross-agent coordination. Includes health monitoring and auto-wake. Hooks wire legion into every session automatically.",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "author": {
         "name": "Sean Silvius",
         "email": "sean@silvius.me"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1444,7 +1444,7 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "legion"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "async-stream",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "legion"
-version = "0.9.0"
+version = "0.9.1"
 edition = "2024"
 description = "Agent specialization through deliberate practice"
 

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "legion",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Institutional memory for Claude Code agents with real-time team channel.",
   "author": {
     "name": "Sean Silvius",

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Legion Changelog
 
+## 0.9.1
+
+Ergonomic + cleanup release. No schema changes, no breaking changes.
+
+### New
+
+- **`legion reflect --whoami`** (#266, #269): Shortcut flag for `--domain identity`. Mutually exclusive with `--domain`. Stores the reflection under the reserved `identity` domain that SessionStart injects on every boot. Writing agent identity no longer requires remembering the domain string.
+
+### Cleanup
+
+- **Remove hyperspecific environment assumptions** (#268, #270): Clap help text examples, `.claude/agents/*.md` file references, and docs example TOML all carried Sean-team-specific repo names and `/Volumes/store` absolute paths. Replaced with generic placeholders (`myrepo`, `frontend,backend`, `./CLAUDE.md`, `/path/to/your/repo`). Test-fixture strings (`kelex`, `rafters` as arbitrary repo names in `#[cfg(test)]` blocks) intentionally left alone -- they are semantic noise to rename and not user-visible.
+
+### Deferred
+
+- Empty-identity SessionStart nudge: an earlier PR (#267) bundled this with `--whoami` but hardcoded team-specific vocabulary and vault paths into legion's hook code. Closed. The nudge returns in v0.10.0 driven by a user-supplied prompt template at `<data-dir>/prompts/empty-identity.md` -- legion triggers, user owns the content.
+
 ## 0.9.0
 
 ### Multi-Node Sync Infrastructure (#245-#256)


### PR DESCRIPTION
## Summary

Ergonomic + cleanup release. No schema changes, no breaking changes.

## Included

- **#269** -- \`legion reflect --whoami\` flag (shortcut for \`--domain identity\`)
- **#270** -- Remove hyperspecific environment assumptions (generic clap help examples, repo-relative agent def paths, generic docs TOML)

## Version sync

- \`Cargo.toml\`: 0.9.0 -> 0.9.1
- \`plugin/.claude-plugin/plugin.json\`: 0.9.0 -> 0.9.1 (auto-synced)
- \`.claude-plugin/marketplace.json\`: 0.9.0 -> 0.9.1 (auto-synced)
- \`plugin/CHANGELOG.md\`: new 0.9.1 section above 0.9.0

## Deferred to v0.10.0

Empty-identity SessionStart nudge -- legion triggers, user owns the content via \`<data-dir>/prompts/empty-identity.md\` template file. Documented in the CHANGELOG's "Deferred" block.

## Test plan

- [x] \`cargo test\` -- 87 pass
- [x] \`cargo clippy --all-targets -- -D warnings\` -- clean
- [x] \`cargo fmt --all -- --check\` -- clean
- [x] \`scripts/sync-version.sh\` confirms all versions match 0.9.1
- [x] CHANGELOG top header matches Cargo.toml version

🤖 Generated with [Claude Code](https://claude.com/claude-code)