### PR TITLE
feat(#287): legion statusline subcommand -- rate-limit + usage ingest, chip render

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -581,6 +581,56 @@ impl Database {
                  ON schedules(repo) WHERE deleted_at IS NULL;",
         )?;
 
+        // Migration 16: Rate limit and usage samples for pillar-2 scheduler (#287).
+        // Populated by `legion statusline` on every Claude Code render. Both
+        // tables carry deleted_at + updated_at for smugglr content-hash sync.
+        conn.execute_batch(
+            "CREATE TABLE IF NOT EXISTS rate_limit_samples (
+                id TEXT PRIMARY KEY,
+                hostname TEXT NOT NULL,
+                session_id TEXT NOT NULL,
+                sampled_at TEXT NOT NULL,
+                five_hour_pct REAL,
+                five_hour_resets_at INTEGER,
+                seven_day_pct REAL,
+                seven_day_resets_at INTEGER,
+                model TEXT,
+                deleted_at TEXT,
+                updated_at TEXT
+            );
+            CREATE INDEX IF NOT EXISTS idx_rate_limit_samples_sampled \
+                ON rate_limit_samples(sampled_at);
+            CREATE INDEX IF NOT EXISTS idx_rate_limit_samples_host \
+                ON rate_limit_samples(hostname);
+            CREATE INDEX IF NOT EXISTS idx_rate_limit_samples_live \
+                ON rate_limit_samples(hostname, sampled_at) WHERE deleted_at IS NULL;
+
+            CREATE TABLE IF NOT EXISTS usage_samples (
+                id TEXT PRIMARY KEY,
+                hostname TEXT NOT NULL,
+                session_id TEXT NOT NULL,
+                turn_index INTEGER,
+                model TEXT,
+                input_tokens INTEGER NOT NULL DEFAULT 0,
+                output_tokens INTEGER NOT NULL DEFAULT 0,
+                cache_write_tokens INTEGER NOT NULL DEFAULT 0,
+                cache_read_tokens INTEGER NOT NULL DEFAULT 0,
+                effective_tokens INTEGER NOT NULL,
+                error_bytes INTEGER NOT NULL DEFAULT 0,
+                sampled_at TEXT NOT NULL,
+                deleted_at TEXT,
+                updated_at TEXT
+            );
+            CREATE INDEX IF NOT EXISTS idx_usage_samples_sampled \
+                ON usage_samples(sampled_at);
+            CREATE INDEX IF NOT EXISTS idx_usage_samples_host \
+                ON usage_samples(hostname);
+            CREATE INDEX IF NOT EXISTS idx_usage_samples_session \
+                ON usage_samples(session_id);
+            CREATE INDEX IF NOT EXISTS idx_usage_samples_live \
+                ON usage_samples(hostname, sampled_at) WHERE deleted_at IS NULL;",
+        )?;
+
         Ok(())
     }
 
@@ -2350,6 +2400,86 @@ impl Database {
             [older_than],
         )?;
         Ok(rows as u64)
+    }
+
+    // -- Statusline Samples ------------------------------------------------------
+
+    /// Insert a rate-limit sample captured from a Claude Code statusline render.
+    pub fn insert_rate_limit_sample(
+        &self,
+        sample: &crate::statusline::RateLimitSample,
+    ) -> Result<String> {
+        self.conn.execute(
+            "INSERT INTO rate_limit_samples (id, hostname, session_id, sampled_at, \
+             five_hour_pct, five_hour_resets_at, seven_day_pct, seven_day_resets_at, \
+             model, updated_at) \
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?4)",
+            rusqlite::params![
+                sample.id,
+                sample.hostname,
+                sample.session_id,
+                sample.sampled_at,
+                sample.five_hour_pct,
+                sample.five_hour_resets_at,
+                sample.seven_day_pct,
+                sample.seven_day_resets_at,
+                sample.model,
+            ],
+        )?;
+        Ok(sample.id.clone())
+    }
+
+    /// Insert a usage sample captured from a Claude Code statusline render.
+    pub fn insert_usage_sample(&self, sample: &crate::statusline::UsageSample) -> Result<String> {
+        self.conn.execute(
+            "INSERT INTO usage_samples (id, hostname, session_id, turn_index, model, \
+             input_tokens, output_tokens, cache_write_tokens, cache_read_tokens, \
+             effective_tokens, error_bytes, sampled_at, updated_at) \
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?12)",
+            rusqlite::params![
+                sample.id,
+                sample.hostname,
+                sample.session_id,
+                sample.turn_index,
+                sample.model,
+                sample.input_tokens,
+                sample.output_tokens,
+                sample.cache_write_tokens,
+                sample.cache_read_tokens,
+                sample.effective_tokens,
+                sample.error_bytes,
+                sample.sampled_at,
+            ],
+        )?;
+        Ok(sample.id.clone())
+    }
+
+    /// Most recent rate-limit sample across all hosts in the cluster.
+    /// Returns `None` when no sample has been written yet. Used by the
+    /// budget gate to read cluster-wide headroom.
+    #[allow(dead_code)] // Consumed by the upcoming `legion budget` subcommand.
+    pub fn latest_rate_limit_sample(&self) -> Result<Option<crate::statusline::RateLimitSample>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT id, hostname, session_id, sampled_at, five_hour_pct, \
+             five_hour_resets_at, seven_day_pct, seven_day_resets_at, model \
+             FROM rate_limit_samples WHERE deleted_at IS NULL \
+             ORDER BY sampled_at DESC LIMIT 1",
+        )?;
+        let mut rows = stmt.query([])?;
+        match rows.next().map_err(LegionError::Database)? {
+            Some(row) => Ok(Some(crate::statusline::RateLimitSample {
+                id: row.get(0)?,
+                hostname: row.get(1)?,
+                session_id: row.get(2)?,
+                sampled_at: row.get(3)?,
+                five_hour_pct: row.get(4)?,
+                five_hour_resets_at: row.get(5)?,
+                seven_day_pct: row.get(6)?,
+                seven_day_resets_at: row.get(7)?,
+                model: row.get(8)?,
+            })),
+            None => Ok(None),
+        }
     }
 
     /// Rename a repo across all tables. Returns total rows updated.

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,6 +18,7 @@ mod serve;
 mod signal;
 mod stats;
 mod status;
+mod statusline;
 mod surface;
 mod sync;
 mod sync_actor;
@@ -536,6 +537,18 @@ enum Commands {
         all_hosts: bool,
 
         /// Output as JSON
+        #[arg(long)]
+        json: bool,
+    },
+
+    /// Claude Code statusLine subcommand: ingest rate-limit + usage, render chip
+    ///
+    /// Reads the Claude Code statusLine JSON on stdin, persists a
+    /// `rate_limit_samples` row (and a `usage_samples` row when the
+    /// transcript is readable), then prints a single-line chip on stdout.
+    /// Wire via `statusLine.command` in settings.json.
+    Statusline {
+        /// Print the parsed sample state as JSON instead of the chip
         #[arg(long)]
         json: bool,
     },
@@ -3835,6 +3848,12 @@ fn run() -> error::Result<()> {
                 println!("{}", row.id);
             }
         },
+        Commands::Statusline { json } => {
+            // Never surface an error to the Claude Code UI: statusline::run
+            // already swallows internal failures and logs them.
+            statusline::run(json)?;
+        }
+
         Commands::Usage {
             session,
             since,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1305,7 +1305,7 @@ enum WatchAction {
 /// leaves the legacy path in place as a safety net. This is the reverse
 /// of the previous migration direction, which moved data INTO the plugin
 /// data dir and caused the split-brain in the first place.
-fn data_dir() -> error::Result<PathBuf> {
+pub(crate) fn data_dir() -> error::Result<PathBuf> {
     use std::sync::OnceLock;
     static CACHED: OnceLock<PathBuf> = OnceLock::new();
 

--- a/src/statusline.rs
+++ b/src/statusline.rs
@@ -150,7 +150,13 @@ pub fn run(json: bool) -> Result<()> {
                 "max_error_bytes": tail.max_error_bytes,
             },
         });
-        println!("{}", serde_json::to_string_pretty(&payload)?);
+        // Serialisation failures on a well-typed JSON value are effectively
+        // impossible, but swallow them anyway to preserve the "never break
+        // the Claude Code UI" invariant.
+        match serde_json::to_string_pretty(&payload) {
+            Ok(s) => println!("{s}"),
+            Err(e) => log_error(format!("serialise json output: {e}")),
+        }
         return Ok(());
     }
 
@@ -418,9 +424,13 @@ fn cap_segment(pct: Option<f64>, resets_at: Option<i64>, cfg: &CapConfig) -> Opt
         .filter(|s| !s.is_empty())
         .map(|s| format!("\u{2192}{s}"))
         .unwrap_or_default();
+    // Round rather than truncate so the displayed integer matches what
+    // the user expects from the float we are showing (e.g. 89.9 displays
+    // as "90%", not "89%"). The marker is still driven by the raw float
+    // so band semantics do not change.
     Some(format!(
         "{marker} {pct}%\u{00B7}{label}{suffix}",
-        pct = pct as i64,
+        pct = pct.round() as i64,
         label = cfg.label,
     ))
 }
@@ -455,6 +465,10 @@ fn format_reset_day_time(epoch_secs: i64) -> String {
 
 fn cache_path_for(session_id: &str) -> PathBuf {
     // session_id is untrusted; keep only safe chars to avoid path escapes.
+    // Claude Code session IDs in practice are UUIDv7 strings (hyphens and
+    // hex digits only) so the sanitiser is a no-op on real input. It still
+    // defends against malformed input that could collide through character
+    // stripping if Anthropic ever changes the ID shape.
     let safe: String = session_id
         .chars()
         .filter(|c| c.is_ascii_alphanumeric() || *c == '-' || *c == '_')

--- a/src/statusline.rs
+++ b/src/statusline.rs
@@ -362,54 +362,66 @@ fn error_suffix(bytes: u64) -> String {
 /// Concatenated cap segments (5h, weekly) in order.
 fn cap_segments(parsed: &ParsedInput) -> String {
     let mut out = String::new();
-    if let Some(s) = five_hour_segment(parsed.five_hour_pct, parsed.five_hour_resets_at) {
+    if let Some(s) = cap_segment(
+        parsed.five_hour_pct,
+        parsed.five_hour_resets_at,
+        &FIVE_HOUR_CONFIG,
+    ) {
         out.push_str(&format!(" \u{00B7} {s}"));
     }
-    if let Some(s) = seven_day_segment(parsed.seven_day_pct, parsed.seven_day_resets_at) {
+    if let Some(s) = cap_segment(
+        parsed.seven_day_pct,
+        parsed.seven_day_resets_at,
+        &SEVEN_DAY_CONFIG,
+    ) {
         out.push_str(&format!(" \u{00B7} {s}"));
     }
     out
 }
 
-fn five_hour_segment(pct: Option<f64>, resets_at: Option<i64>) -> Option<String> {
-    let pct = pct?;
-    let marker = if pct >= FIVE_HOUR_ALERT_PCT {
-        ALERT
-    } else if pct >= FIVE_HOUR_WARN_PCT {
-        WARN
-    } else {
-        return None;
-    };
-    let suffix = resets_at
-        .filter(|&t| t > 0)
-        .map(format_reset_same_day)
-        .filter(|s| !s.is_empty())
-        .map(|s| format!("\u{2192}{s}"))
-        .unwrap_or_default();
-    Some(format!(
-        "{marker} {pct}%\u{00B7}5h{suffix}",
-        pct = pct as i64
-    ))
+/// Per-window calibration used by [`cap_segment`].
+struct CapConfig {
+    warn_pct: f64,
+    alert_pct: f64,
+    label: &'static str,
+    format_reset: fn(i64) -> String,
 }
 
-fn seven_day_segment(pct: Option<f64>, resets_at: Option<i64>) -> Option<String> {
+const FIVE_HOUR_CONFIG: CapConfig = CapConfig {
+    warn_pct: FIVE_HOUR_WARN_PCT,
+    alert_pct: FIVE_HOUR_ALERT_PCT,
+    label: "5h",
+    format_reset: format_reset_same_day,
+};
+
+const SEVEN_DAY_CONFIG: CapConfig = CapConfig {
+    warn_pct: SEVEN_DAY_WARN_PCT,
+    alert_pct: SEVEN_DAY_ALERT_PCT,
+    label: "wk",
+    format_reset: format_reset_day_time,
+};
+
+/// Produce one cap segment (e.g. "WARN 78%·5h→14:32") or `None` when the
+/// percentage sits below the warn threshold for this window.
+fn cap_segment(pct: Option<f64>, resets_at: Option<i64>, cfg: &CapConfig) -> Option<String> {
     let pct = pct?;
-    let marker = if pct >= SEVEN_DAY_ALERT_PCT {
+    let marker = if pct >= cfg.alert_pct {
         ALERT
-    } else if pct >= SEVEN_DAY_WARN_PCT {
+    } else if pct >= cfg.warn_pct {
         WARN
     } else {
         return None;
     };
     let suffix = resets_at
         .filter(|&t| t > 0)
-        .map(format_reset_day_time)
+        .map(cfg.format_reset)
         .filter(|s| !s.is_empty())
         .map(|s| format!("\u{2192}{s}"))
         .unwrap_or_default();
     Some(format!(
-        "{marker} {pct}%\u{00B7}wk{suffix}",
-        pct = pct as i64
+        "{marker} {pct}%\u{00B7}{label}{suffix}",
+        pct = pct as i64,
+        label = cfg.label,
     ))
 }
 
@@ -549,12 +561,12 @@ mod tests {
 
     #[test]
     fn five_hour_segment_hidden_below_warn() {
-        assert!(five_hour_segment(Some(60.0), Some(1_800_000_000)).is_none());
+        assert!(cap_segment(Some(60.0), Some(1_800_000_000), &FIVE_HOUR_CONFIG).is_none());
     }
 
     #[test]
     fn five_hour_segment_warn_at_75() {
-        let s = five_hour_segment(Some(78.0), None).expect("warn segment present");
+        let s = cap_segment(Some(78.0), None, &FIVE_HOUR_CONFIG).expect("warn segment present");
         assert!(s.contains(WARN));
         assert!(s.contains("78%"));
         assert!(s.contains("5h"));
@@ -562,14 +574,14 @@ mod tests {
 
     #[test]
     fn five_hour_segment_alert_at_90() {
-        let s = five_hour_segment(Some(92.0), None).expect("alert segment present");
+        let s = cap_segment(Some(92.0), None, &FIVE_HOUR_CONFIG).expect("alert segment present");
         assert!(s.contains(ALERT));
         assert!(s.contains("92%"));
     }
 
     #[test]
     fn seven_day_segment_warn_at_60() {
-        let s = seven_day_segment(Some(62.0), None).expect("warn segment present");
+        let s = cap_segment(Some(62.0), None, &SEVEN_DAY_CONFIG).expect("warn segment present");
         assert!(s.contains(WARN));
         assert!(s.contains("62%"));
         assert!(s.contains("wk"));
@@ -577,7 +589,7 @@ mod tests {
 
     #[test]
     fn seven_day_segment_alert_at_85() {
-        let s = seven_day_segment(Some(88.0), None).expect("alert segment present");
+        let s = cap_segment(Some(88.0), None, &SEVEN_DAY_CONFIG).expect("alert segment present");
         assert!(s.contains(ALERT));
         assert!(s.contains("88%"));
     }

--- a/src/statusline.rs
+++ b/src/statusline.rs
@@ -1,0 +1,720 @@
+//! Claude Code statusline subcommand.
+//!
+//! Consumes the Claude Code statusLine JSON on stdin, persists rate-limit
+//! and usage samples to legion's local store, and renders a single-line
+//! status chip on stdout.
+//!
+//! See docs at code.claude.com/docs/en/statusline for the input JSON contract.
+//! The mtberlin2023 reference implementation (MIT) informed the threshold
+//! calibration and rendering conventions; legion's implementation is native.
+
+use std::io::{Read, Write};
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use chrono::{Local, TimeZone, Utc};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use uuid::Uuid;
+
+use crate::db::Database;
+use crate::error::{LegionError, Result};
+use crate::usage::{RawTokens, TranscriptTail, format_tokens, parse_transcript_tail};
+
+// ---------------------------------------------------------------------------
+// Persisted sample types
+// ---------------------------------------------------------------------------
+
+/// A rate-limit sample drawn from a single Claude Code statusline render.
+/// Mirrors the `rate_limits.{five_hour,seven_day}` blocks in the input.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RateLimitSample {
+    pub id: String,
+    pub hostname: String,
+    pub session_id: String,
+    pub sampled_at: String,
+    pub five_hour_pct: Option<f64>,
+    pub five_hour_resets_at: Option<i64>,
+    pub seven_day_pct: Option<f64>,
+    pub seven_day_resets_at: Option<i64>,
+    pub model: Option<String>,
+}
+
+/// A per-turn usage sample drawn from the most recent assistant message
+/// in the session transcript. `effective_tokens` is the weighted total
+/// used by the cost estimator.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UsageSample {
+    pub id: String,
+    pub hostname: String,
+    pub session_id: String,
+    pub turn_index: Option<i64>,
+    pub model: Option<String>,
+    pub input_tokens: i64,
+    pub output_tokens: i64,
+    pub cache_write_tokens: i64,
+    pub cache_read_tokens: i64,
+    pub effective_tokens: i64,
+    pub error_bytes: i64,
+    pub sampled_at: String,
+}
+
+// ---------------------------------------------------------------------------
+// Thresholds (starting calibration; refine from cluster data over time)
+// ---------------------------------------------------------------------------
+
+/// Next-turn replay bands driving chip color and action hint.
+const REPLAY_YELLOW: u64 = 200_000;
+const REPLAY_RED: u64 = 500_000;
+const REPLAY_HARD_CAP: u64 = 1_000_000;
+
+/// Rate-limit warn/alert thresholds; below warn the cap segment is hidden.
+const FIVE_HOUR_WARN_PCT: f64 = 75.0;
+const FIVE_HOUR_ALERT_PCT: f64 = 90.0;
+const SEVEN_DAY_WARN_PCT: f64 = 60.0;
+const SEVEN_DAY_ALERT_PCT: f64 = 85.0;
+
+/// Cache window: how long a rendered chip stays fresh before re-render.
+const CACHE_TTL_SECS: u64 = 10;
+const CACHE_PREFIX: &str = "/tmp/legion-statusline-";
+const ERROR_LOG: &str = "/tmp/legion-hook-errors.log";
+
+/// Default action slash command surfaced at yellow+ replay thresholds.
+/// Overridable via the `LEGION_STATUSLINE_ACTION` environment variable.
+const DEFAULT_ACTION: &str = "/log";
+
+// Chip glyphs are part of the output contract -- agents and dashboards
+// parse them. Escape sequences keep the source bytes ASCII-only while
+// rendering emoji at runtime.
+const GREEN: &str = "\u{1F7E2}";
+const YELLOW: &str = "\u{1F7E1}";
+const RED: &str = "\u{1F534}";
+const WARN: &str = "\u{26A0}";
+const ALERT: &str = "\u{1F6A8}";
+
+// ---------------------------------------------------------------------------
+// Public entry point
+// ---------------------------------------------------------------------------
+
+/// Run the statusline subcommand. Reads JSON on stdin, writes samples
+/// to the database, and prints either the rendered chip (default) or
+/// a JSON summary (when `json` is true).
+///
+/// Always returns `Ok(())` in production: a broken statusline must not
+/// surface as an error to the Claude Code UI. Internal failures are
+/// logged to `/tmp/legion-hook-errors.log`.
+pub fn run(json: bool) -> Result<()> {
+    let mut raw = String::new();
+    if std::io::stdin().read_to_string(&mut raw).is_err() {
+        return Ok(());
+    }
+    let parsed = match parse_input(&raw) {
+        Some(p) => p,
+        None => return Ok(()),
+    };
+
+    let session_id = match parsed.session_id.as_deref() {
+        Some(sid) if !sid.is_empty() => sid.to_string(),
+        _ => return Ok(()),
+    };
+
+    let cache_path = cache_path_for(&session_id);
+
+    // Fast path: cache hit, re-emit and exit without DB writes.
+    if !json && let Some(cached) = read_cache_if_fresh(&cache_path, CACHE_TTL_SECS) {
+        print!("{cached}");
+        return Ok(());
+    }
+
+    let hostname = resolve_hostname();
+    let sampled_at = Utc::now().to_rfc3339();
+
+    let tail: TranscriptTail = parsed
+        .transcript_path
+        .as_deref()
+        .map(parse_transcript_tail)
+        .unwrap_or_default();
+
+    let rate_sample = build_rate_sample(&hostname, &session_id, &sampled_at, &parsed);
+    let usage_sample = build_usage_sample(&hostname, &session_id, &sampled_at, &parsed, &tail);
+
+    persist_samples(&rate_sample, usage_sample.as_ref());
+
+    if json {
+        let payload = serde_json::json!({
+            "rate_limit": rate_sample,
+            "usage": usage_sample,
+            "tail": {
+                "last_assistant": &tail.last_assistant,
+                "real_turns": tail.real_turns,
+                "max_error_bytes": tail.max_error_bytes,
+            },
+        });
+        println!("{}", serde_json::to_string_pretty(&payload)?);
+        return Ok(());
+    }
+
+    let chip = render_chip(&tail, &parsed);
+    write_cache(&cache_path, &chip);
+    println!("{chip}");
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Input parsing
+// ---------------------------------------------------------------------------
+
+/// Parsed view of the Claude Code statusline JSON input.
+/// Fields are all optional since the render layer is robust to partial
+/// payloads and the subcommand must never crash the UI.
+#[derive(Debug, Default, Clone)]
+struct ParsedInput {
+    session_id: Option<String>,
+    transcript_path: Option<PathBuf>,
+    model: Option<String>,
+    five_hour_pct: Option<f64>,
+    five_hour_resets_at: Option<i64>,
+    seven_day_pct: Option<f64>,
+    seven_day_resets_at: Option<i64>,
+}
+
+fn parse_input(raw: &str) -> Option<ParsedInput> {
+    let v: Value = serde_json::from_str(raw).ok()?;
+    let session_id = v
+        .get("session_id")
+        .and_then(|x| x.as_str())
+        .map(str::to_owned);
+    let transcript_path = v
+        .get("transcript_path")
+        .and_then(|x| x.as_str())
+        .map(PathBuf::from);
+    let model = v
+        .get("model")
+        .and_then(|m| m.get("id"))
+        .and_then(|x| x.as_str())
+        .map(str::to_owned);
+
+    let rl = v.get("rate_limits");
+    let fh = rl.and_then(|r| r.get("five_hour"));
+    let sd = rl.and_then(|r| r.get("seven_day"));
+
+    Some(ParsedInput {
+        session_id,
+        transcript_path,
+        model,
+        five_hour_pct: fh.and_then(|x| x.get("used_percentage")).and_then(as_f64),
+        five_hour_resets_at: fh.and_then(|x| x.get("resets_at")).and_then(as_i64),
+        seven_day_pct: sd.and_then(|x| x.get("used_percentage")).and_then(as_f64),
+        seven_day_resets_at: sd.and_then(|x| x.get("resets_at")).and_then(as_i64),
+    })
+}
+
+fn as_f64(v: &Value) -> Option<f64> {
+    v.as_f64().or_else(|| v.as_i64().map(|n| n as f64))
+}
+
+fn as_i64(v: &Value) -> Option<i64> {
+    v.as_i64().or_else(|| v.as_f64().map(|n| n as i64))
+}
+
+// ---------------------------------------------------------------------------
+// Sample construction + persistence
+// ---------------------------------------------------------------------------
+
+fn build_rate_sample(
+    hostname: &str,
+    session_id: &str,
+    sampled_at: &str,
+    parsed: &ParsedInput,
+) -> RateLimitSample {
+    RateLimitSample {
+        id: Uuid::now_v7().to_string(),
+        hostname: hostname.to_owned(),
+        session_id: session_id.to_owned(),
+        sampled_at: sampled_at.to_owned(),
+        five_hour_pct: parsed.five_hour_pct,
+        five_hour_resets_at: parsed.five_hour_resets_at,
+        seven_day_pct: parsed.seven_day_pct,
+        seven_day_resets_at: parsed.seven_day_resets_at,
+        model: parsed.model.clone(),
+    }
+}
+
+fn build_usage_sample(
+    hostname: &str,
+    session_id: &str,
+    sampled_at: &str,
+    parsed: &ParsedInput,
+    tail: &TranscriptTail,
+) -> Option<UsageSample> {
+    // Only emit a usage sample when the transcript produced a tail. An empty
+    // or unreadable transcript leaves all tokens zero, which would create
+    // misleading cluster-wide aggregates.
+    parsed.transcript_path.as_ref()?;
+    let raw = &tail.last_assistant;
+    if raw.input == 0 && raw.output == 0 && raw.cache_write == 0 && raw.cache_read == 0 {
+        return None;
+    }
+    Some(UsageSample {
+        id: Uuid::now_v7().to_string(),
+        hostname: hostname.to_owned(),
+        session_id: session_id.to_owned(),
+        turn_index: if tail.real_turns > 0 {
+            Some(tail.real_turns as i64)
+        } else {
+            None
+        },
+        model: parsed.model.clone(),
+        input_tokens: raw.input as i64,
+        output_tokens: raw.output as i64,
+        cache_write_tokens: raw.cache_write as i64,
+        cache_read_tokens: raw.cache_read as i64,
+        effective_tokens: raw.effective() as i64,
+        error_bytes: tail.max_error_bytes as i64,
+        sampled_at: sampled_at.to_owned(),
+    })
+}
+
+fn persist_samples(rate: &RateLimitSample, usage: Option<&UsageSample>) {
+    let db_path = match database_path() {
+        Some(p) => p,
+        None => return,
+    };
+    let db = match Database::open(&db_path) {
+        Ok(d) => d,
+        Err(e) => {
+            log_error(format!("open database: {e}"));
+            return;
+        }
+    };
+    if let Err(e) = db.insert_rate_limit_sample(rate) {
+        log_error(format!("insert rate_limit_samples: {e}"));
+    }
+    if let Some(u) = usage
+        && let Err(e) = db.insert_usage_sample(u)
+    {
+        log_error(format!("insert usage_samples: {e}"));
+    }
+}
+
+fn database_path() -> Option<PathBuf> {
+    let dirs = directories::ProjectDirs::from("dev", "runlegion", "legion")?;
+    Some(dirs.data_dir().join("legion.db"))
+}
+
+// ---------------------------------------------------------------------------
+// Chip rendering
+// ---------------------------------------------------------------------------
+
+/// Render the statusline chip for the given tail + parsed input.
+fn render_chip(tail: &TranscriptTail, parsed: &ParsedInput) -> String {
+    let replay = next_turn_replay(&tail.last_assistant);
+    let (emoji, action_suffix) = replay_band(replay, &action_command());
+    let err_suffix = error_suffix(tail.max_error_bytes);
+    let cap_suffix = cap_segments(parsed);
+
+    format!(
+        "{emoji} [{turns}] {replay} next turn{action}{err}{cap}",
+        emoji = emoji,
+        turns = tail.real_turns,
+        replay = format_tokens(replay),
+        action = action_suffix,
+        err = err_suffix,
+        cap = cap_suffix,
+    )
+}
+
+/// Next-turn replay cost: the tokens Claude Code will re-read on the
+/// next API call. Sum of cache read, cache creation, and raw input.
+/// Output is deliberately excluded: it is output by the last turn,
+/// not input for the next.
+fn next_turn_replay(raw: &RawTokens) -> u64 {
+    raw.cache_read + raw.cache_write + raw.input
+}
+
+/// Return the action-command slash phrase, overridable via env.
+fn action_command() -> String {
+    std::env::var("LEGION_STATUSLINE_ACTION").unwrap_or_else(|_| DEFAULT_ACTION.to_owned())
+}
+
+/// Map replay tokens to (emoji, action-suffix).
+fn replay_band(replay: u64, action: &str) -> (&'static str, String) {
+    if replay < REPLAY_YELLOW {
+        (GREEN, String::new())
+    } else if replay < REPLAY_RED {
+        (YELLOW, format!(" \u{00B7} {action} after task"))
+    } else if replay < REPLAY_HARD_CAP {
+        (RED, format!(" \u{00B7} {action} now"))
+    } else {
+        (RED, format!(" \u{00B7} {action} before next msg"))
+    }
+}
+
+/// " · ⚠ NKB err" suffix when a large cached error was observed.
+fn error_suffix(bytes: u64) -> String {
+    if bytes == 0 {
+        return String::new();
+    }
+    let kb = bytes / 1024;
+    format!(" \u{00B7} {WARN} {kb}KB err")
+}
+
+/// Concatenated cap segments (5h, weekly) in order.
+fn cap_segments(parsed: &ParsedInput) -> String {
+    let mut out = String::new();
+    if let Some(s) = five_hour_segment(parsed.five_hour_pct, parsed.five_hour_resets_at) {
+        out.push_str(&format!(" \u{00B7} {s}"));
+    }
+    if let Some(s) = seven_day_segment(parsed.seven_day_pct, parsed.seven_day_resets_at) {
+        out.push_str(&format!(" \u{00B7} {s}"));
+    }
+    out
+}
+
+fn five_hour_segment(pct: Option<f64>, resets_at: Option<i64>) -> Option<String> {
+    let pct = pct?;
+    let marker = if pct >= FIVE_HOUR_ALERT_PCT {
+        ALERT
+    } else if pct >= FIVE_HOUR_WARN_PCT {
+        WARN
+    } else {
+        return None;
+    };
+    let suffix = resets_at
+        .filter(|&t| t > 0)
+        .map(format_reset_same_day)
+        .filter(|s| !s.is_empty())
+        .map(|s| format!("\u{2192}{s}"))
+        .unwrap_or_default();
+    Some(format!(
+        "{marker} {pct}%\u{00B7}5h{suffix}",
+        pct = pct as i64
+    ))
+}
+
+fn seven_day_segment(pct: Option<f64>, resets_at: Option<i64>) -> Option<String> {
+    let pct = pct?;
+    let marker = if pct >= SEVEN_DAY_ALERT_PCT {
+        ALERT
+    } else if pct >= SEVEN_DAY_WARN_PCT {
+        WARN
+    } else {
+        return None;
+    };
+    let suffix = resets_at
+        .filter(|&t| t > 0)
+        .map(format_reset_day_time)
+        .filter(|s| !s.is_empty())
+        .map(|s| format!("\u{2192}{s}"))
+        .unwrap_or_default();
+    Some(format!(
+        "{marker} {pct}%\u{00B7}wk{suffix}",
+        pct = pct as i64
+    ))
+}
+
+/// Format a 5-hour reset timestamp. Same-day resets use HH:MM local time;
+/// resets that cross a day boundary use "Day HH:MM".
+fn format_reset_same_day(epoch_secs: i64) -> String {
+    let dt = match Local.timestamp_opt(epoch_secs, 0).single() {
+        Some(d) => d,
+        None => return String::new(),
+    };
+    let today = Local::now();
+    if dt.format("%Y-%m-%d").to_string() == today.format("%Y-%m-%d").to_string() {
+        dt.format("%H:%M").to_string()
+    } else {
+        dt.format("%a %H:%M").to_string()
+    }
+}
+
+/// Format a weekly reset timestamp as "Day HH:MM".
+fn format_reset_day_time(epoch_secs: i64) -> String {
+    let dt = match Local.timestamp_opt(epoch_secs, 0).single() {
+        Some(d) => d,
+        None => return String::new(),
+    };
+    dt.format("%a %H:%M").to_string()
+}
+
+// ---------------------------------------------------------------------------
+// Cache helpers
+// ---------------------------------------------------------------------------
+
+fn cache_path_for(session_id: &str) -> PathBuf {
+    // session_id is untrusted; keep only safe chars to avoid path escapes.
+    let safe: String = session_id
+        .chars()
+        .filter(|c| c.is_ascii_alphanumeric() || *c == '-' || *c == '_')
+        .collect();
+    PathBuf::from(format!("{CACHE_PREFIX}{safe}"))
+}
+
+fn read_cache_if_fresh(path: &Path, ttl_secs: u64) -> Option<String> {
+    let meta = std::fs::metadata(path).ok()?;
+    let modified = meta.modified().ok()?;
+    let now = SystemTime::now();
+    let age = now.duration_since(modified).ok()?;
+    if age.as_secs() >= ttl_secs {
+        return None;
+    }
+    std::fs::read_to_string(path).ok()
+}
+
+fn write_cache(path: &Path, content: &str) {
+    // Best-effort: a failed cache write is not fatal; next render just
+    // recomputes. Writing via create+write avoids truncation races.
+    if let Ok(mut f) = std::fs::File::create(path) {
+        let _ = f.write_all(content.as_bytes());
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Misc helpers
+// ---------------------------------------------------------------------------
+
+fn resolve_hostname() -> String {
+    sysinfo::System::host_name().unwrap_or_else(|| "unknown".to_owned())
+}
+
+fn log_error(msg: String) {
+    let line = format!(
+        "{ts} [statusline] {msg}\n",
+        ts = Utc::now().to_rfc3339(),
+        msg = msg,
+    );
+    if let Ok(mut f) = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(ERROR_LOG)
+    {
+        let _ = f.write_all(line.as_bytes());
+    }
+}
+
+// Keep the LegionError import live so the error wiring compiles even if
+// callers decide to propagate in the future.
+#[allow(dead_code)]
+fn _typecheck_error(e: LegionError) -> LegionError {
+    e
+}
+
+// Keep SystemTime + UNIX_EPOCH imports live for potential timestamp math
+// in follow-up work on forecast/runway chips. The current implementation
+// uses chrono for time formatting so these live in scope only.
+#[allow(dead_code)]
+fn _system_epoch() -> Option<u64> {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .ok()
+        .map(|d| d.as_secs())
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn raw(input: u64, output: u64, cache_write: u64, cache_read: u64) -> RawTokens {
+        RawTokens {
+            input,
+            output,
+            cache_write,
+            cache_read,
+        }
+    }
+
+    fn tail(raw_tokens: RawTokens, real_turns: u64, max_error_bytes: u64) -> TranscriptTail {
+        TranscriptTail {
+            last_assistant: raw_tokens,
+            real_turns,
+            max_error_bytes,
+        }
+    }
+
+    #[test]
+    fn replay_band_green_below_yellow() {
+        let (emoji, suffix) = replay_band(150_000, "/log");
+        assert_eq!(emoji, GREEN);
+        assert!(suffix.is_empty());
+    }
+
+    #[test]
+    fn replay_band_yellow_suggests_after_task() {
+        let (emoji, suffix) = replay_band(300_000, "/log");
+        assert_eq!(emoji, YELLOW);
+        assert!(suffix.contains("/log"));
+        assert!(suffix.contains("after task"));
+    }
+
+    #[test]
+    fn replay_band_red_says_now() {
+        let (emoji, suffix) = replay_band(700_000, "/log");
+        assert_eq!(emoji, RED);
+        assert!(suffix.contains("now"));
+    }
+
+    #[test]
+    fn replay_band_hard_cap_says_before_next() {
+        let (emoji, suffix) = replay_band(1_500_000, "/compact");
+        assert_eq!(emoji, RED);
+        assert!(suffix.contains("/compact"));
+        assert!(suffix.contains("before next msg"));
+    }
+
+    #[test]
+    fn five_hour_segment_hidden_below_warn() {
+        assert!(five_hour_segment(Some(60.0), Some(1_800_000_000)).is_none());
+    }
+
+    #[test]
+    fn five_hour_segment_warn_at_75() {
+        let s = five_hour_segment(Some(78.0), None).expect("warn segment present");
+        assert!(s.contains(WARN));
+        assert!(s.contains("78%"));
+        assert!(s.contains("5h"));
+    }
+
+    #[test]
+    fn five_hour_segment_alert_at_90() {
+        let s = five_hour_segment(Some(92.0), None).expect("alert segment present");
+        assert!(s.contains(ALERT));
+        assert!(s.contains("92%"));
+    }
+
+    #[test]
+    fn seven_day_segment_warn_at_60() {
+        let s = seven_day_segment(Some(62.0), None).expect("warn segment present");
+        assert!(s.contains(WARN));
+        assert!(s.contains("62%"));
+        assert!(s.contains("wk"));
+    }
+
+    #[test]
+    fn seven_day_segment_alert_at_85() {
+        let s = seven_day_segment(Some(88.0), None).expect("alert segment present");
+        assert!(s.contains(ALERT));
+        assert!(s.contains("88%"));
+    }
+
+    #[test]
+    fn error_suffix_hidden_below_threshold() {
+        // Tail detection already filters <2KB; this fn treats 0 as absent.
+        assert!(error_suffix(0).is_empty());
+    }
+
+    #[test]
+    fn error_suffix_shows_kb_above_threshold() {
+        let s = error_suffix(5120);
+        assert!(s.contains("5KB err"));
+        assert!(s.contains(WARN));
+    }
+
+    #[test]
+    fn render_chip_healthy() {
+        let t = tail(raw(100, 200, 0, 10_000), 3, 0);
+        let parsed = ParsedInput::default();
+        let chip = render_chip(&t, &parsed);
+        assert!(chip.starts_with(GREEN), "expected green chip, got {chip}");
+        assert!(chip.contains("[3]"));
+        assert!(chip.contains("next turn"));
+        // No cap segments shown when nothing is set.
+        assert!(!chip.contains("5h"));
+        assert!(!chip.contains("wk"));
+    }
+
+    #[test]
+    fn render_chip_with_all_warnings() {
+        let t = tail(raw(0, 0, 250_000, 300_000), 12, 4096);
+        let parsed = ParsedInput {
+            five_hour_pct: Some(92.0),
+            seven_day_pct: Some(87.0),
+            ..Default::default()
+        };
+        let chip = render_chip(&t, &parsed);
+        assert!(chip.starts_with(RED), "expected red chip");
+        assert!(chip.contains("now"));
+        assert!(chip.contains("4KB err"));
+        assert!(chip.contains("92%"));
+        assert!(chip.contains("87%"));
+    }
+
+    #[test]
+    fn parse_input_accepts_full_payload() {
+        let raw = r#"{
+            "session_id": "abc-123",
+            "transcript_path": "/tmp/x.jsonl",
+            "model": {"id": "claude-opus-4-7"},
+            "rate_limits": {
+                "five_hour": {"used_percentage": 45.5, "resets_at": 1714000000},
+                "seven_day": {"used_percentage": 72.1, "resets_at": 1714400000}
+            }
+        }"#;
+        let p = parse_input(raw).expect("parse succeeds");
+        assert_eq!(p.session_id.as_deref(), Some("abc-123"));
+        assert_eq!(p.model.as_deref(), Some("claude-opus-4-7"));
+        assert!((p.five_hour_pct.unwrap() - 45.5).abs() < f64::EPSILON);
+        assert_eq!(p.five_hour_resets_at, Some(1714000000));
+        assert_eq!(p.seven_day_resets_at, Some(1714400000));
+    }
+
+    #[test]
+    fn parse_input_tolerates_missing_rate_limits() {
+        let raw = r#"{
+            "session_id": "abc-123",
+            "transcript_path": "/tmp/x.jsonl"
+        }"#;
+        let p = parse_input(raw).expect("parse succeeds");
+        assert_eq!(p.session_id.as_deref(), Some("abc-123"));
+        assert!(p.five_hour_pct.is_none());
+        assert!(p.seven_day_pct.is_none());
+    }
+
+    #[test]
+    fn parse_input_returns_none_for_garbage() {
+        assert!(parse_input("not json at all").is_none());
+    }
+
+    #[test]
+    fn cache_path_sanitises_session_id() {
+        let p = cache_path_for("../../../etc/passwd");
+        let s = p.to_string_lossy();
+        assert!(s.ends_with("etcpasswd"), "path should be sanitised: {s}");
+        assert!(s.starts_with(CACHE_PREFIX));
+    }
+
+    #[test]
+    fn cache_read_returns_none_for_missing_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("absent");
+        assert!(read_cache_if_fresh(&path, CACHE_TTL_SECS).is_none());
+    }
+
+    #[test]
+    fn cache_read_returns_none_when_ttl_is_zero() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("cache");
+        std::fs::write(&path, "hello").unwrap();
+        // A TTL of zero means any non-zero age is stale.
+        std::thread::sleep(std::time::Duration::from_millis(5));
+        assert!(read_cache_if_fresh(&path, 0).is_none());
+    }
+
+    #[test]
+    fn cache_read_returns_content_when_fresh() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("cache");
+        std::fs::write(&path, "hello").unwrap();
+        let got = read_cache_if_fresh(&path, CACHE_TTL_SECS);
+        assert_eq!(got.as_deref(), Some("hello"));
+    }
+
+    #[test]
+    fn next_turn_replay_excludes_output() {
+        let r = raw(100, 999_999, 200, 300);
+        assert_eq!(next_turn_replay(&r), 600);
+    }
+}

--- a/src/statusline.rs
+++ b/src/statusline.rs
@@ -105,22 +105,31 @@ const ALERT: &str = "\u{1F6A8}";
 /// logged to `/tmp/legion-hook-errors.log`.
 pub fn run(json: bool) -> Result<()> {
     let mut raw = String::new();
-    if std::io::stdin().read_to_string(&mut raw).is_err() {
+    if let Err(e) = std::io::stdin().read_to_string(&mut raw) {
+        log_error(format!("read stdin: {e}"));
         return Ok(());
     }
     let parsed = match parse_input(&raw) {
         Some(p) => p,
-        None => return Ok(()),
+        None => {
+            log_error("parse stdin JSON failed or payload empty".to_string());
+            return Ok(());
+        }
     };
 
     let session_id = match parsed.session_id.as_deref() {
         Some(sid) if !sid.is_empty() => sid.to_string(),
-        _ => return Ok(()),
+        _ => {
+            log_error("stdin JSON missing session_id".to_string());
+            return Ok(());
+        }
     };
 
     let cache_path = cache_path_for(&session_id);
 
-    // Fast path: cache hit, re-emit and exit without DB writes.
+    // Fast path: cache hit, re-emit and exit without DB writes. The cached
+    // content already carries its trailing newline from write_cache, so emit
+    // it verbatim with print! rather than println!.
     if !json && let Some(cached) = read_cache_if_fresh(&cache_path, CACHE_TTL_SECS) {
         print!("{cached}");
         return Ok(());
@@ -161,8 +170,11 @@ pub fn run(json: bool) -> Result<()> {
     }
 
     let chip = render_chip(&tail, &parsed);
-    write_cache(&cache_path, &chip);
-    println!("{chip}");
+    // Include the trailing newline in both the stdout emission and the
+    // cached bytes so a subsequent cache-hit emits byte-identical output.
+    let chip_line = format!("{chip}\n");
+    write_cache(&cache_path, &chip_line);
+    print!("{chip_line}");
     Ok(())
 }
 
@@ -724,5 +736,126 @@ mod tests {
     fn next_turn_replay_excludes_output() {
         let r = raw(100, 999_999, 200, 300);
         assert_eq!(next_turn_replay(&r), 600);
+    }
+
+    // --- build_usage_sample contract ---------------------------------
+
+    #[test]
+    fn build_usage_sample_returns_none_when_transcript_absent() {
+        let parsed = ParsedInput::default();
+        let tail = tail(raw(100, 200, 0, 0), 1, 0);
+        assert!(build_usage_sample("host", "sid", "now", &parsed, &tail).is_none());
+    }
+
+    #[test]
+    fn build_usage_sample_returns_none_when_all_tokens_zero() {
+        let parsed = ParsedInput {
+            transcript_path: Some(PathBuf::from("/nonexistent")),
+            ..Default::default()
+        };
+        let tail = tail(raw(0, 0, 0, 0), 0, 0);
+        assert!(build_usage_sample("host", "sid", "now", &parsed, &tail).is_none());
+    }
+
+    #[test]
+    fn build_usage_sample_populated_when_tokens_and_transcript_present() {
+        let parsed = ParsedInput {
+            transcript_path: Some(PathBuf::from("/nonexistent")),
+            model: Some("claude-opus-4-7".into()),
+            ..Default::default()
+        };
+        let tail = tail(raw(10, 20, 30, 40), 3, 5120);
+        let sample = build_usage_sample("host", "sid", "2026-04-21T00:00:00Z", &parsed, &tail)
+            .expect("populated sample");
+        assert_eq!(sample.input_tokens, 10);
+        assert_eq!(sample.output_tokens, 20);
+        assert_eq!(sample.cache_write_tokens, 30);
+        assert_eq!(sample.cache_read_tokens, 40);
+        // 10 + 20*1.0 + 30*1.25 + 40*0.1 = 10 + 20 + 37.5 + 4 = 71.5 -> 72
+        assert_eq!(sample.effective_tokens, 72);
+        assert_eq!(sample.error_bytes, 5120);
+        assert_eq!(sample.turn_index, Some(3));
+        assert_eq!(sample.model.as_deref(), Some("claude-opus-4-7"));
+    }
+
+    // --- DB round-trip ------------------------------------------------
+
+    #[test]
+    fn db_rate_limit_sample_round_trip() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = Database::open(&dir.path().join("legion.db")).unwrap();
+        let sample = RateLimitSample {
+            id: Uuid::now_v7().to_string(),
+            hostname: "puck".into(),
+            session_id: "sess-1".into(),
+            sampled_at: "2026-04-21T00:00:00Z".into(),
+            five_hour_pct: Some(42.5),
+            five_hour_resets_at: Some(1714500000),
+            seven_day_pct: Some(68.0),
+            seven_day_resets_at: Some(1714900000),
+            model: Some("claude-opus-4-7".into()),
+        };
+        db.insert_rate_limit_sample(&sample).unwrap();
+
+        let got = db
+            .latest_rate_limit_sample()
+            .unwrap()
+            .expect("sample present");
+        assert_eq!(got.id, sample.id);
+        assert_eq!(got.hostname, "puck");
+        assert_eq!(got.five_hour_pct, Some(42.5));
+        assert_eq!(got.seven_day_resets_at, Some(1714900000));
+        assert_eq!(got.model.as_deref(), Some("claude-opus-4-7"));
+    }
+
+    #[test]
+    fn db_usage_sample_insert_succeeds() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = Database::open(&dir.path().join("legion.db")).unwrap();
+        let sample = UsageSample {
+            id: Uuid::now_v7().to_string(),
+            hostname: "puck".into(),
+            session_id: "sess-1".into(),
+            turn_index: Some(5),
+            model: Some("claude-sonnet-4-6".into()),
+            input_tokens: 100,
+            output_tokens: 200,
+            cache_write_tokens: 300,
+            cache_read_tokens: 400,
+            effective_tokens: 715,
+            error_bytes: 0,
+            sampled_at: "2026-04-21T00:00:00Z".into(),
+        };
+        // Schema drift would panic here; presence of an id in the return
+        // proves the insert hit every NOT NULL column correctly.
+        let id = db.insert_usage_sample(&sample).unwrap();
+        assert_eq!(id, sample.id);
+    }
+
+    #[test]
+    fn db_latest_returns_most_recent_rate_limit_sample() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = Database::open(&dir.path().join("legion.db")).unwrap();
+        let mk = |id: &str, sampled: &str, pct: f64| RateLimitSample {
+            id: id.to_string(),
+            hostname: "puck".into(),
+            session_id: "sess".into(),
+            sampled_at: sampled.to_string(),
+            five_hour_pct: Some(pct),
+            five_hour_resets_at: None,
+            seven_day_pct: None,
+            seven_day_resets_at: None,
+            model: None,
+        };
+        db.insert_rate_limit_sample(&mk("a", "2026-04-21T00:00:00Z", 30.0))
+            .unwrap();
+        db.insert_rate_limit_sample(&mk("b", "2026-04-21T01:00:00Z", 80.0))
+            .unwrap();
+        db.insert_rate_limit_sample(&mk("c", "2026-04-21T00:30:00Z", 55.0))
+            .unwrap();
+
+        let got = db.latest_rate_limit_sample().unwrap().expect("has sample");
+        assert_eq!(got.id, "b", "most recent by sampled_at should win");
+        assert_eq!(got.five_hour_pct, Some(80.0));
     }
 }

--- a/src/statusline.rs
+++ b/src/statusline.rs
@@ -10,7 +10,7 @@
 
 use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::time::SystemTime;
 
 use chrono::{Local, TimeZone, Utc};
 use serde::{Deserialize, Serialize};
@@ -18,7 +18,7 @@ use serde_json::Value;
 use uuid::Uuid;
 
 use crate::db::Database;
-use crate::error::{LegionError, Result};
+use crate::error::Result;
 use crate::usage::{RawTokens, TranscriptTail, format_tokens, parse_transcript_tail};
 
 // ---------------------------------------------------------------------------
@@ -490,24 +490,6 @@ fn log_error(msg: String) {
     {
         let _ = f.write_all(line.as_bytes());
     }
-}
-
-// Keep the LegionError import live so the error wiring compiles even if
-// callers decide to propagate in the future.
-#[allow(dead_code)]
-fn _typecheck_error(e: LegionError) -> LegionError {
-    e
-}
-
-// Keep SystemTime + UNIX_EPOCH imports live for potential timestamp math
-// in follow-up work on forecast/runway chips. The current implementation
-// uses chrono for time formatting so these live in scope only.
-#[allow(dead_code)]
-fn _system_epoch() -> Option<u64> {
-    SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .ok()
-        .map(|d| d.as_secs())
 }
 
 // ---------------------------------------------------------------------------

--- a/src/statusline.rs
+++ b/src/statusline.rs
@@ -76,8 +76,17 @@ const SEVEN_DAY_ALERT_PCT: f64 = 85.0;
 
 /// Cache window: how long a rendered chip stays fresh before re-render.
 const CACHE_TTL_SECS: u64 = 10;
-const CACHE_PREFIX: &str = "/tmp/legion-statusline-";
-const ERROR_LOG: &str = "/tmp/legion-hook-errors.log";
+
+/// Subdirectory (under legion's data dir) that holds per-session chip caches.
+/// User-scoped by construction: the parent `data_dir()` lives under the
+/// current user's XDG data / macOS Application Support tree, so a different
+/// user on the same host cannot poison or collide with these files.
+const CACHE_SUBDIR: &str = "cache/statusline";
+
+/// Error log path relative to legion's data dir. Same user-scoping rationale
+/// as the cache dir -- a `/tmp` log is symlink-attackable on shared hosts
+/// because `OpenOptions::append` follows symlinks.
+const ERROR_LOG_SUBPATH: &str = "logs/hook-errors.log";
 
 /// Default action slash command surfaced at yellow+ replay thresholds.
 /// Overridable via the `LEGION_STATUSLINE_ACTION` environment variable.
@@ -102,7 +111,7 @@ const ALERT: &str = "\u{1F6A8}";
 ///
 /// Always returns `Ok(())` in production: a broken statusline must not
 /// surface as an error to the Claude Code UI. Internal failures are
-/// logged to `/tmp/legion-hook-errors.log`.
+/// logged to `<legion-data-dir>/logs/hook-errors.log`.
 pub fn run(json: bool) -> Result<()> {
     let mut raw = String::new();
     if let Err(e) = std::io::stdin().read_to_string(&mut raw) {
@@ -129,8 +138,12 @@ pub fn run(json: bool) -> Result<()> {
 
     // Fast path: cache hit, re-emit and exit without DB writes. The cached
     // content already carries its trailing newline from write_cache, so emit
-    // it verbatim with print! rather than println!.
-    if !json && let Some(cached) = read_cache_if_fresh(&cache_path, CACHE_TTL_SECS) {
+    // it verbatim with print! rather than println!. A missing or unresolvable
+    // cache path just skips the fast path; the render below still runs.
+    if !json
+        && let Some(ref p) = cache_path
+        && let Some(cached) = read_cache_if_fresh(p, CACHE_TTL_SECS)
+    {
         print!("{cached}");
         return Ok(());
     }
@@ -173,7 +186,9 @@ pub fn run(json: bool) -> Result<()> {
     // Include the trailing newline in both the stdout emission and the
     // cached bytes so a subsequent cache-hit emits byte-identical output.
     let chip_line = format!("{chip}\n");
-    write_cache(&cache_path, &chip_line);
+    if let Some(ref p) = cache_path {
+        write_cache(p, &chip_line);
+    }
     print!("{chip_line}");
     Ok(())
 }
@@ -316,8 +331,14 @@ fn persist_samples(rate: &RateLimitSample, usage: Option<&UsageSample>) {
 }
 
 fn database_path() -> Option<PathBuf> {
-    let dirs = directories::ProjectDirs::from("dev", "runlegion", "legion")?;
-    Some(dirs.data_dir().join("legion.db"))
+    // Resolve through the same `data_dir()` the rest of the binary uses so
+    // statusline samples land in the one canonical legion.db. A previous
+    // revision constructed its own ProjectDirs tuple here, which pointed at
+    // a different path on macOS and silently split the sample stream off
+    // from the rest of legion's state -- the exact split-brain the
+    // `data_dir()` doc warns against. Swallow errors: the statusline must
+    // never crash the Claude Code UI just because the home dir is weird.
+    crate::data_dir().ok().map(|d| d.join("legion.db"))
 }
 
 // ---------------------------------------------------------------------------
@@ -475,7 +496,16 @@ fn format_reset_day_time(epoch_secs: i64) -> String {
 // Cache helpers
 // ---------------------------------------------------------------------------
 
-fn cache_path_for(session_id: &str) -> PathBuf {
+fn cache_path_for(session_id: &str) -> Option<PathBuf> {
+    cache_path_in(&crate::data_dir().ok()?, session_id)
+}
+
+/// Compute the statusline cache path for `session_id` under an explicit
+/// data dir. Split out from [`cache_path_for`] so unit tests can exercise
+/// the sanitiser and path layout without relying on the process-wide
+/// `data_dir()` cache, which resolves once per process and can leak state
+/// between tests run in the same binary.
+fn cache_path_in(data_dir: &Path, session_id: &str) -> Option<PathBuf> {
     // session_id is untrusted; keep only safe chars to avoid path escapes.
     // Claude Code session IDs in practice are UUIDv7 strings (hyphens and
     // hex digits only) so the sanitiser is a no-op on real input. It still
@@ -485,7 +515,13 @@ fn cache_path_for(session_id: &str) -> PathBuf {
         .chars()
         .filter(|c| c.is_ascii_alphanumeric() || *c == '-' || *c == '_')
         .collect();
-    PathBuf::from(format!("{CACHE_PREFIX}{safe}"))
+    if safe.is_empty() {
+        return None;
+    }
+    let dir = data_dir.join(CACHE_SUBDIR);
+    // Best-effort: if mkdir fails the write path will fail-soft too.
+    let _ = std::fs::create_dir_all(&dir);
+    Some(dir.join(safe))
 }
 
 fn read_cache_if_fresh(path: &Path, ttl_secs: u64) -> Option<String> {
@@ -500,10 +536,33 @@ fn read_cache_if_fresh(path: &Path, ttl_secs: u64) -> Option<String> {
 }
 
 fn write_cache(path: &Path, content: &str) {
-    // Best-effort: a failed cache write is not fatal; next render just
-    // recomputes. Writing via create+write avoids truncation races.
-    if let Ok(mut f) = std::fs::File::create(path) {
-        let _ = f.write_all(content.as_bytes());
+    // Atomic write via tmp file + rename: a concurrent reader either sees
+    // the previous complete file or the new complete file, never a partial
+    // write. The previous revision used `File::create(path)` which truncates
+    // in place -- a reader racing the writer could observe zero bytes or a
+    // half-written chip. All steps are best-effort: a failure just means
+    // the next render recomputes instead of hitting the cache.
+    let Some(parent) = path.parent() else {
+        return;
+    };
+    let file_name = match path.file_name().and_then(|s| s.to_str()) {
+        Some(s) => s,
+        None => return,
+    };
+    let tmp = parent.join(format!(".{file_name}.tmp.{pid}", pid = std::process::id()));
+    let Ok(mut f) = std::fs::File::create(&tmp) else {
+        return;
+    };
+    if f.write_all(content.as_bytes()).is_err() {
+        let _ = std::fs::remove_file(&tmp);
+        return;
+    }
+    // Flush before rename so a crash between rename and fsync still leaves
+    // a file whose bytes are on disk (rename is atomic on the same fs).
+    let _ = f.sync_data();
+    drop(f);
+    if std::fs::rename(&tmp, path).is_err() {
+        let _ = std::fs::remove_file(&tmp);
     }
 }
 
@@ -521,13 +580,28 @@ fn log_error(msg: String) {
         ts = Utc::now().to_rfc3339(),
         msg = msg,
     );
+    // Resolve the error log path through legion's data dir so shared hosts
+    // cannot poison the file or race symlink attacks through `/tmp`.
+    // If the data dir can't be resolved (unusual -- no HOME, filesystem
+    // unwritable) swallow the error: the statusline must never surface a
+    // failure to the Claude Code UI.
+    let Some(path) = error_log_path() else {
+        return;
+    };
+    if let Some(parent) = path.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
     if let Ok(mut f) = std::fs::OpenOptions::new()
         .create(true)
         .append(true)
-        .open(ERROR_LOG)
+        .open(&path)
     {
         let _ = f.write_all(line.as_bytes());
     }
+}
+
+fn error_log_path() -> Option<PathBuf> {
+    crate::data_dir().ok().map(|d| d.join(ERROR_LOG_SUBPATH))
 }
 
 // ---------------------------------------------------------------------------
@@ -700,10 +774,53 @@ mod tests {
 
     #[test]
     fn cache_path_sanitises_session_id() {
-        let p = cache_path_for("../../../etc/passwd");
+        // Run the sanitiser through `cache_path_in` with an explicit tmp data
+        // dir so the test stays hermetic: `cache_path_for` resolves through
+        // the process-wide `data_dir()` cache which is not safely swappable
+        // from within a unit test.
+        let dir = tempfile::tempdir().unwrap();
+        let p = cache_path_in(dir.path(), "../../../etc/passwd").expect("path resolves");
         let s = p.to_string_lossy();
         assert!(s.ends_with("etcpasswd"), "path should be sanitised: {s}");
-        assert!(s.starts_with(CACHE_PREFIX));
+        assert!(
+            s.contains(CACHE_SUBDIR),
+            "path should live under cache subdir: {s}"
+        );
+        // And it must stay under the data dir we passed in -- no `/tmp` leakage.
+        assert!(
+            p.starts_with(dir.path()),
+            "path must live under the passed-in data dir: {s}"
+        );
+    }
+
+    #[test]
+    fn cache_path_returns_none_for_empty_sanitised_id() {
+        // After sanitising, "/////" collapses to the empty string. The path
+        // must resolve to None rather than a dir-only path that would point
+        // the cache write at the cache directory itself.
+        let dir = tempfile::tempdir().unwrap();
+        assert!(cache_path_in(dir.path(), "/////").is_none());
+    }
+
+    #[test]
+    fn write_cache_is_atomic_against_concurrent_readers() {
+        // The previous revision used `File::create(path)` which truncates
+        // in place -- a reader racing the writer could observe zero bytes.
+        // The atomic rename flow guarantees the target file either has the
+        // old content or the new content, never a partial write.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("chip");
+        std::fs::write(&path, "OLD\n").unwrap();
+        write_cache(&path, "NEW-CONTENT\n");
+        let got = std::fs::read_to_string(&path).unwrap();
+        assert_eq!(got, "NEW-CONTENT\n");
+        // No stray tmp file left behind on the success path.
+        let stray: Vec<_> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .filter(|e| e.file_name().to_string_lossy().starts_with(".chip.tmp."))
+            .collect();
+        assert!(stray.is_empty(), "tmp files left behind: {stray:?}");
     }
 
     #[test]

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -91,6 +91,94 @@ pub struct CardDelta {
     pub acceptance: Option<String>,
 }
 
+/// A rate-limit sample serialized for sync transmission.
+///
+/// Written by `legion statusline` on every Claude Code render. Synced
+/// cluster-wide so any node can read the latest account-level headroom
+/// when the budget gate decides whether to pick up a card.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RateLimitDelta {
+    pub id: String,
+    pub hostname: String,
+    pub session_id: String,
+    pub sampled_at: String,
+    pub five_hour_pct: Option<f64>,
+    pub five_hour_resets_at: Option<i64>,
+    pub seven_day_pct: Option<f64>,
+    pub seven_day_resets_at: Option<i64>,
+    pub model: Option<String>,
+    pub updated_at: Option<String>,
+    pub deleted_at: Option<String>,
+}
+
+impl RateLimitDelta {
+    /// Convert a RateLimitSample into its sync delta. Callers that need
+    /// a tombstone pass the deletion timestamp through `deleted_at`.
+    #[allow(dead_code)] // Consumed by the sync actor once #276 wires transport.
+    pub fn from_sample(s: &crate::statusline::RateLimitSample, deleted_at: Option<String>) -> Self {
+        Self {
+            id: s.id.clone(),
+            hostname: s.hostname.clone(),
+            session_id: s.session_id.clone(),
+            sampled_at: s.sampled_at.clone(),
+            five_hour_pct: s.five_hour_pct,
+            five_hour_resets_at: s.five_hour_resets_at,
+            seven_day_pct: s.seven_day_pct,
+            seven_day_resets_at: s.seven_day_resets_at,
+            model: s.model.clone(),
+            updated_at: Some(s.sampled_at.clone()),
+            deleted_at,
+        }
+    }
+}
+
+/// A per-turn usage sample serialized for sync transmission.
+///
+/// Feeds the empirical cost estimator: historical `usage_samples` rows
+/// grouped by card shape give the p50/p90/p99 distribution used at
+/// gate time to predict cost against remaining rate-limit headroom.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UsageDelta {
+    pub id: String,
+    pub hostname: String,
+    pub session_id: String,
+    pub turn_index: Option<i64>,
+    pub model: Option<String>,
+    pub input_tokens: i64,
+    pub output_tokens: i64,
+    pub cache_write_tokens: i64,
+    pub cache_read_tokens: i64,
+    pub effective_tokens: i64,
+    pub error_bytes: i64,
+    pub sampled_at: String,
+    pub updated_at: Option<String>,
+    pub deleted_at: Option<String>,
+}
+
+impl UsageDelta {
+    /// Convert a UsageSample into its sync delta. Tombstones flow via
+    /// `deleted_at`; live rows carry `updated_at = sampled_at`.
+    #[allow(dead_code)] // Consumed by the sync actor once #276 wires transport.
+    pub fn from_sample(s: &crate::statusline::UsageSample, deleted_at: Option<String>) -> Self {
+        Self {
+            id: s.id.clone(),
+            hostname: s.hostname.clone(),
+            session_id: s.session_id.clone(),
+            turn_index: s.turn_index,
+            model: s.model.clone(),
+            input_tokens: s.input_tokens,
+            output_tokens: s.output_tokens,
+            cache_write_tokens: s.cache_write_tokens,
+            cache_read_tokens: s.cache_read_tokens,
+            effective_tokens: s.effective_tokens,
+            error_bytes: s.error_bytes,
+            sampled_at: s.sampled_at.clone(),
+            updated_at: Some(s.sampled_at.clone()),
+            deleted_at,
+        }
+    }
+}
+
 /// A schedule row serialized for sync transmission.
 ///
 /// Schedules define cron-like commands that fire periodically.
@@ -161,5 +249,66 @@ mod tests {
 
         assert!(delta.deleted_at.is_some());
         assert_eq!(delta.deleted_at.unwrap(), "2026-04-15T01:00:00Z");
+    }
+
+    #[test]
+    fn rate_limit_delta_from_sample_roundtrips_fields() {
+        let sample = crate::statusline::RateLimitSample {
+            id: "rl-1".into(),
+            hostname: "puck".into(),
+            session_id: "sess-a".into(),
+            sampled_at: "2026-04-20T01:00:00Z".into(),
+            five_hour_pct: Some(42.5),
+            five_hour_resets_at: Some(1714500000),
+            seven_day_pct: Some(68.0),
+            seven_day_resets_at: Some(1714900000),
+            model: Some("claude-opus-4-7".into()),
+        };
+        let delta = RateLimitDelta::from_sample(&sample, None);
+        assert_eq!(delta.id, "rl-1");
+        assert_eq!(delta.five_hour_pct, Some(42.5));
+        assert_eq!(delta.updated_at.as_deref(), Some("2026-04-20T01:00:00Z"));
+        assert!(delta.deleted_at.is_none());
+    }
+
+    #[test]
+    fn rate_limit_delta_tombstone_carries_deleted_at() {
+        let sample = crate::statusline::RateLimitSample {
+            id: "rl-2".into(),
+            hostname: "puck".into(),
+            session_id: "sess-b".into(),
+            sampled_at: "2026-04-20T02:00:00Z".into(),
+            five_hour_pct: None,
+            five_hour_resets_at: None,
+            seven_day_pct: None,
+            seven_day_resets_at: None,
+            model: None,
+        };
+        let delta = RateLimitDelta::from_sample(&sample, Some("2026-04-20T03:00:00Z".into()));
+        assert_eq!(delta.deleted_at.as_deref(), Some("2026-04-20T03:00:00Z"));
+    }
+
+    #[test]
+    fn usage_delta_from_sample_preserves_token_fields() {
+        let sample = crate::statusline::UsageSample {
+            id: "us-1".into(),
+            hostname: "puck".into(),
+            session_id: "sess-a".into(),
+            turn_index: Some(12),
+            model: Some("claude-sonnet-4-6".into()),
+            input_tokens: 100,
+            output_tokens: 200,
+            cache_write_tokens: 300,
+            cache_read_tokens: 400,
+            effective_tokens: 640,
+            error_bytes: 0,
+            sampled_at: "2026-04-20T04:00:00Z".into(),
+        };
+        let delta = UsageDelta::from_sample(&sample, None);
+        assert_eq!(delta.input_tokens, 100);
+        assert_eq!(delta.cache_read_tokens, 400);
+        assert_eq!(delta.effective_tokens, 640);
+        assert_eq!(delta.turn_index, Some(12));
+        assert!(delta.deleted_at.is_none());
     }
 }

--- a/src/usage.rs
+++ b/src/usage.rs
@@ -634,10 +634,8 @@ pub fn parse_transcript_tail(path: &Path) -> TranscriptTail {
                     tail.last_assistant = extract_tokens(usage);
                 }
             }
-            Some("user") => {
-                if is_real_user_turn(&obj, &mut tail.max_error_bytes) {
-                    tail.real_turns += 1;
-                }
+            Some("user") if is_real_user_turn(&obj, &mut tail.max_error_bytes) => {
+                tail.real_turns += 1;
             }
             _ => {}
         }

--- a/src/usage.rs
+++ b/src/usage.rs
@@ -966,4 +966,134 @@ mod tests {
         assert_eq!(result.len(), 5);
         assert!(result.ends_with('~'));
     }
+
+    // -----------------------------------------------------------------
+    // parse_transcript_tail coverage
+    // -----------------------------------------------------------------
+
+    fn user_text_event(ts: &str, text: &str) -> String {
+        let escaped = text.replace('\\', "\\\\").replace('"', "\\\"");
+        format!(
+            r#"{{"type":"user","timestamp":"{ts}","message":{{"role":"user","content":"{escaped}"}}}}"#
+        )
+    }
+
+    fn tool_result_event(ts: &str, body: &str, is_error: bool) -> String {
+        let escaped = body.replace('\\', "\\\\").replace('"', "\\\"");
+        let flag = if is_error { "true" } else { "false" };
+        format!(
+            r#"{{"type":"user","timestamp":"{ts}","message":{{"role":"user","content":[{{"type":"tool_result","is_error":{flag},"content":"{escaped}"}}]}}}}"#
+        )
+    }
+
+    #[test]
+    fn tail_defaults_for_missing_file() {
+        let tail = parse_transcript_tail(&PathBuf::from("/nonexistent/path.jsonl"));
+        assert_eq!(tail.real_turns, 0);
+        assert_eq!(tail.last_assistant.input, 0);
+        assert_eq!(tail.max_error_bytes, 0);
+    }
+
+    #[test]
+    fn tail_captures_last_assistant_tokens() {
+        let ts = "2026-04-21T00:00:00Z";
+        let (_dir, path) = write_fixture(&[
+            assistant_event(1, 2, 3, 4, ts),
+            assistant_event(10, 20, 30, 40, ts),
+            assistant_event(100, 200, 300, 400, ts),
+        ]);
+        let tail = parse_transcript_tail(&path);
+        // Last assistant wins, not sum.
+        assert_eq!(tail.last_assistant.input, 100);
+        assert_eq!(tail.last_assistant.output, 200);
+        assert_eq!(tail.last_assistant.cache_write, 300);
+        assert_eq!(tail.last_assistant.cache_read, 400);
+    }
+
+    #[test]
+    fn tail_counts_real_user_turns() {
+        let ts = "2026-04-21T00:00:00Z";
+        let (_dir, path) = write_fixture(&[
+            user_text_event(ts, "first question"),
+            assistant_event(1, 2, 0, 0, ts),
+            user_text_event(ts, "second question"),
+            assistant_event(3, 4, 0, 0, ts),
+        ]);
+        let tail = parse_transcript_tail(&path);
+        assert_eq!(tail.real_turns, 2);
+    }
+
+    #[test]
+    fn tail_filters_every_synthetic_prefix() {
+        let ts = "2026-04-21T00:00:00Z";
+        let mut lines: Vec<String> = SYNTHETIC_PREFIXES
+            .iter()
+            .map(|p| user_text_event(ts, &format!("{p} payload")))
+            .collect();
+        lines.push(user_text_event(ts, "this one is real"));
+        let (_dir, path) = write_fixture(&lines);
+        let tail = parse_transcript_tail(&path);
+        assert_eq!(
+            tail.real_turns, 1,
+            "only the non-synthetic user turn should count"
+        );
+    }
+
+    #[test]
+    fn tail_reports_large_error_tool_result_size() {
+        let ts = "2026-04-21T00:00:00Z";
+        let big = "x".repeat(3000);
+        let (_dir, path) = write_fixture(&[tool_result_event(ts, &big, true)]);
+        let tail = parse_transcript_tail(&path);
+        assert_eq!(tail.max_error_bytes, 3000);
+    }
+
+    #[test]
+    fn tail_suppresses_error_below_2kb_threshold() {
+        let ts = "2026-04-21T00:00:00Z";
+        // Exactly 2048 is NOT surfaced (strict > 2048). 2049 would be.
+        let at_threshold = "x".repeat(2048);
+        let (_dir, path) = write_fixture(&[tool_result_event(ts, &at_threshold, true)]);
+        let tail = parse_transcript_tail(&path);
+        assert_eq!(tail.max_error_bytes, 0);
+    }
+
+    #[test]
+    fn tail_ignores_non_error_tool_result_even_when_large() {
+        let ts = "2026-04-21T00:00:00Z";
+        let big = "x".repeat(5000);
+        // is_error: false -> must not surface.
+        let (_dir, path) = write_fixture(&[tool_result_event(ts, &big, false)]);
+        let tail = parse_transcript_tail(&path);
+        assert_eq!(tail.max_error_bytes, 0);
+    }
+
+    #[test]
+    fn tail_survives_malformed_lines_mixed_with_good_ones() {
+        let ts = "2026-04-21T00:00:00Z";
+        let lines = vec![
+            assistant_event(1, 2, 3, 4, ts),
+            "not json at all".to_string(),
+            "{\"broken\": ".to_string(),
+            assistant_event(100, 200, 300, 400, ts),
+        ];
+        let (_dir, path) = write_fixture(&lines);
+        let tail = parse_transcript_tail(&path);
+        // Malformed lines are skipped; the valid final assistant wins.
+        assert_eq!(tail.last_assistant.input, 100);
+        assert_eq!(tail.last_assistant.cache_read, 400);
+    }
+
+    #[test]
+    fn tail_parses_array_form_tool_result_content() {
+        let ts = "2026-04-21T00:00:00Z";
+        let big_text = "y".repeat(2500);
+        let escaped = big_text.replace('\\', "\\\\").replace('"', "\\\"");
+        let event = format!(
+            r#"{{"type":"user","timestamp":"{ts}","message":{{"role":"user","content":[{{"type":"tool_result","is_error":true,"content":[{{"type":"text","text":"{escaped}"}}]}}]}}}}"#
+        );
+        let (_dir, path) = write_fixture(&[event]);
+        let tail = parse_transcript_tail(&path);
+        assert_eq!(tail.max_error_bytes, 2500);
+    }
 }

--- a/src/usage.rs
+++ b/src/usage.rs
@@ -552,6 +552,189 @@ fn truncate_str(s: &str, max_len: usize) -> String {
 }
 
 // ---------------------------------------------------------------------------
+// Tail parsing for the statusline subcommand
+// ---------------------------------------------------------------------------
+
+/// Per-turn summary of the most recent state of a transcript.
+///
+/// Unlike [`SessionUsage::from_file`], which aggregates every assistant turn,
+/// this function returns only the information the statusline needs:
+/// the last assistant message's raw token counts (the "next-turn replay"
+/// cost driver), the count of real user turns (filtering synthetic content
+/// that Claude Code injects on every render), and the maximum size of any
+/// cached `tool_result` error in the tail of the transcript.
+///
+/// The parser walks the whole file; sessions with hundreds of turns still
+/// complete in well under the statusline's 300ms budget because each line
+/// is JSON-decoded once and the work per line is negligible.
+#[derive(Debug, Default, Clone)]
+pub struct TranscriptTail {
+    /// Raw tokens on the most recent assistant message that carried a
+    /// `usage` object. Zero if the transcript has no such message.
+    pub last_assistant: RawTokens,
+    /// Number of genuine user turns seen in the transcript.
+    /// Excludes synthetic content (system reminders, command echoes,
+    /// tool-result relays) that Claude Code injects per render.
+    pub real_turns: u64,
+    /// Maximum byte size of any cached `tool_result` content flagged
+    /// as an error in the tail of the transcript. Zero when none
+    /// exceed the 2KB threshold.
+    pub max_error_bytes: u64,
+}
+
+/// Prefixes indicating a `user` event whose content is not a genuine
+/// user turn but some synthetic injection from Claude Code or its hooks.
+/// Matches the set used by the mtberlin2023 reference statusline (MIT).
+const SYNTHETIC_PREFIXES: &[&str] = &[
+    "<command-message>",
+    "<command-name>",
+    "<command-args>",
+    "<task-notification>",
+    "<local-command-caveat>",
+    "<system-reminder>",
+    "<user-prompt-submit-hook>",
+    "Unknown command:",
+    "Caveat:",
+];
+
+/// Size above which an error `tool_result` is considered large enough
+/// to surface as a statusline warning. Matches the mtberlin2023 reference.
+const ERROR_SURFACE_THRESHOLD_BYTES: u64 = 2048;
+
+/// Parse the transcript file at `path` and return a [`TranscriptTail`].
+///
+/// Malformed lines are skipped silently. A missing file returns the
+/// default tail (all zeros); the caller decides how to surface that.
+pub fn parse_transcript_tail(path: &Path) -> TranscriptTail {
+    let mut tail = TranscriptTail::default();
+
+    let file = match std::fs::File::open(path) {
+        Ok(f) => f,
+        Err(_) => return tail,
+    };
+    let reader = io::BufReader::new(file);
+
+    for line in reader.lines() {
+        let line = match line {
+            Ok(l) => l,
+            Err(_) => continue,
+        };
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let obj: Value = match serde_json::from_str(trimmed) {
+            Ok(v) => v,
+            Err(_) => continue,
+        };
+
+        match obj.get("type").and_then(|v| v.as_str()) {
+            Some("assistant") => {
+                if let Some(usage) = obj.get("message").and_then(|m| m.get("usage")) {
+                    tail.last_assistant = extract_tokens(usage);
+                }
+            }
+            Some("user") => {
+                if is_real_user_turn(&obj, &mut tail.max_error_bytes) {
+                    tail.real_turns += 1;
+                }
+            }
+            _ => {}
+        }
+    }
+
+    tail
+}
+
+/// Determine whether a `user`-type event represents a genuine user turn
+/// and update `max_error_bytes` if any error-flagged tool_result content
+/// exceeds the surfacing threshold.
+fn is_real_user_turn(obj: &Value, max_error_bytes: &mut u64) -> bool {
+    let msg = match obj.get("message") {
+        Some(m) => m,
+        None => return false,
+    };
+    let content = match msg.get("content") {
+        Some(c) => c,
+        None => return false,
+    };
+
+    if let Some(text) = content.as_str() {
+        return !is_synthetic_text(text);
+    }
+
+    let Some(items) = content.as_array() else {
+        return false;
+    };
+
+    let mut real = false;
+    for item in items {
+        let Some(obj_item) = item.as_object() else {
+            continue;
+        };
+        let itype = obj_item.get("type").and_then(|v| v.as_str());
+        match itype {
+            Some("tool_result") => {
+                let body_len = tool_result_body_len(obj_item);
+                let is_error = obj_item
+                    .get("is_error")
+                    .and_then(|v| v.as_bool())
+                    .unwrap_or(false);
+                if is_error
+                    && body_len > ERROR_SURFACE_THRESHOLD_BYTES
+                    && body_len > *max_error_bytes
+                {
+                    *max_error_bytes = body_len;
+                }
+            }
+            Some("text") => {
+                let text = obj_item.get("text").and_then(|v| v.as_str()).unwrap_or("");
+                if !is_synthetic_text(text) {
+                    real = true;
+                }
+            }
+            _ => {
+                real = true;
+            }
+        }
+    }
+    real
+}
+
+/// Check whether a piece of user text is synthetic content that should
+/// not be counted as a real user turn.
+fn is_synthetic_text(text: &str) -> bool {
+    let trimmed = text.trim_start();
+    if trimmed.is_empty() {
+        return true;
+    }
+    SYNTHETIC_PREFIXES
+        .iter()
+        .any(|prefix| trimmed.starts_with(prefix))
+}
+
+/// Compute the byte length of a `tool_result.content` field, handling
+/// both the string form and the list-of-content-parts form.
+fn tool_result_body_len(item: &serde_json::Map<String, Value>) -> u64 {
+    let Some(body) = item.get("content") else {
+        return 0;
+    };
+    if let Some(text) = body.as_str() {
+        return text.len() as u64;
+    }
+    let Some(parts) = body.as_array() else {
+        return 0;
+    };
+    let mut total: u64 = 0;
+    for part in parts {
+        if let Some(text) = part.get("text").and_then(|v| v.as_str()) {
+            total += text.len() as u64;
+        }
+    }
+    total
+}
+
+// ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Closes #287. Adds the `legion statusline` subcommand: Claude Code pipes its
statusLine JSON to stdin, legion persists the rate-limit and usage samples
to its local store, renders a single-line chip on stdout.

This is the pillar-2 foundation: every assistant turn writes authoritative
5-hour and 7-day rate-limit state into a cluster-syncable table, giving
every node in the cluster a live view of account-wide headroom. The
budget gate wires onto this surface in a follow-up.

## What's in the diff

- **Schema (migration 16)**: `rate_limit_samples` and `usage_samples`
  tables. Both carry `deleted_at` + `updated_at` for smugglr content-hash
  sync. Partial indexes on live rows.
- **`legion statusline`**: parses the Claude Code JSON via `serde_json::Value`
  (robust to partial payloads), reuses `src/usage.rs` token accounting via
  a new `parse_transcript_tail`, writes samples, renders the chip, caches
  output at `/tmp/legion-statusline-<session>` for 10s.
- **Chip format**: matches the proven mtberlin2023 MIT reference. Emoji by
  next-turn-replay band (green/yellow/red/hard-cap), action hint at yellow+,
  cached `tool_result` error warning >2KB, 5h/weekly cap segments with local
  reset times. Chip glyphs are unicode escapes so the source stays ASCII.
- **Thresholds** (starting calibration; refine from data):
  - replay: green <200K, yellow 200-499K, red 500-999K, hard-cap >=1M
  - 5h: warn 75%, alert 90%
  - weekly: warn 60%, alert 85%
- **Smugglr deltas**: `RateLimitDelta`, `UsageDelta` with `from_sample`
  constructors. Wired into sync actor once #276 lands transport.
- **Transcript tail**: `parse_transcript_tail` in `usage.rs` filters nine
  synthetic content prefixes so real user turns are counted correctly.

## Test plan

- [x] 21 new unit tests in `src/statusline.rs` cover band thresholds,
      cap segments, error suffix, cache freshness, input parsing (full,
      partial, garbage), path sanitisation, render end-to-end for healthy
      and critical states.
- [x] 3 new `sync.rs` tests cover delta round-trip for rate-limit and
      usage samples including tombstone paths.
- [x] `cargo test` -- 87 passing, 0 failures, 0 regressions.
- [x] `cargo clippy -- -D warnings` clean.
- [x] `cargo fmt --check` clean.
- [x] Smoke-tested end-to-end with a real Claude Code transcript; chip
      renders as expected: `🟡 [34] 409K next turn · /log after task
      · 🚨 91%·5h→Tue 11:00 · 🚨 88%·wk→Sun 02:06`.
- [x] `/legion-simplify` gate: clean, recorded via `legion quality-gate record`.
- [x] Pre-push review agent: all findings addressed (pct.round(), JSON
      error swallow, cache-path comment).

## Out of scope

These are follow-up issues, not blockers:

- `setup-binary.sh` integration that writes `statusLine.command` into
  `~/.claude/settings.json` idempotently on SessionStart.
- `legion budget show` / `legion budget check` query surface for the gate.
- Weekly runway chip (depends on cluster-wide `usage_samples` accumulating
  enough data; needs #276 + #277 transport first).
- Per-model weight calibration (sonnet-1x / opus-multiplier derived from
  paired observations).

## Reference

Mark Turrell's MIT statusline at github.com/mtberlin2023/claude-code-skills
informed the threshold calibration and chip render conventions. Not a
fork or dependency; legion's implementation is native Rust.