### PR TITLE
feat(#290): legion pr checks subcommand

### DIFF
--- a/plugin/worksources/github
+++ b/plugin/worksources/github
@@ -298,8 +298,23 @@ case "${1:-}" in
     echo '{"ok":true}'
     ;;
 
+  pr-checks)
+    PR_NUMBER="${LEGION_WS_PR_NUMBER:-}"
+    if [ -z "$REPO" ] || [ -z "$PR_NUMBER" ]; then
+      echo '{"error":"LEGION_WS_REPO and LEGION_WS_PR_NUMBER required"}' >&2
+      exit 1
+    fi
+    if ! command -v gh &>/dev/null; then
+      echo "[]"
+      exit 0
+    fi
+    gh pr checks "$PR_NUMBER" --repo "$REPO" \
+      --json name,state,workflow,link,description \
+      2>/dev/null || echo "[]"
+    ;;
+
   *)
-    echo "Usage: github <list|close|detect|create-issue|create-pr|comment|pr-list|review|merge|pr-close>" >&2
+    echo "Usage: github <list|close|detect|create-issue|create-pr|comment|pr-list|review|merge|pr-close|pr-checks>" >&2
     exit 1
     ;;
 esac

--- a/plugin/worksources/github
+++ b/plugin/worksources/github
@@ -305,12 +305,19 @@ case "${1:-}" in
       exit 1
     fi
     if ! command -v gh &>/dev/null; then
-      echo "[]"
-      exit 0
+      echo "gh CLI not found" >&2
+      exit 1
     fi
-    gh pr checks "$PR_NUMBER" --repo "$REPO" \
-      --json name,state,workflow,link,description \
-      2>/dev/null || echo "[]"
+    # gh pr checks exits non-zero when any check is failing -- that is data,
+    # not an error from our perspective. Capture stdout, only fail if gh
+    # produced no JSON at all (network error, auth failure, missing PR).
+    OUTPUT=$(gh pr checks "$PR_NUMBER" --repo "$REPO" \
+      --json name,state,workflow,link,description 2>&1)
+    if [ -z "$OUTPUT" ] || ! printf '%s' "$OUTPUT" | jq -e . >/dev/null 2>&1; then
+      echo "gh pr checks failed: $OUTPUT" >&2
+      exit 1
+    fi
+    printf '%s\n' "$OUTPUT"
     ;;
 
   *)

--- a/plugin/worksources/github
+++ b/plugin/worksources/github
@@ -309,14 +309,19 @@ case "${1:-}" in
       exit 1
     fi
     # gh pr checks exits non-zero when any check is failing -- that is data,
-    # not an error from our perspective. Capture stdout, only fail if gh
-    # produced no JSON at all (network error, auth failure, missing PR).
+    # not an error from our perspective. Capture stdout and stderr separately
+    # so a gh warning printed to stderr cannot slip into the JSON blob jq
+    # then accepts. Only fail if stdout is empty or not valid JSON
+    # (network error, auth failure, missing PR).
+    STDERR_FILE=$(mktemp)
     OUTPUT=$(gh pr checks "$PR_NUMBER" --repo "$REPO" \
-      --json name,state,workflow,link,description 2>&1)
+      --json name,state,workflow,link,description 2>"$STDERR_FILE")
     if [ -z "$OUTPUT" ] || ! printf '%s' "$OUTPUT" | jq -e . >/dev/null 2>&1; then
-      echo "gh pr checks failed: $OUTPUT" >&2
+      echo "gh pr checks failed: $(cat "$STDERR_FILE")" >&2
+      rm -f "$STDERR_FILE"
       exit 1
     fi
+    rm -f "$STDERR_FILE"
     printf '%s\n' "$OUTPUT"
     ;;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1139,8 +1139,10 @@ enum PrAction {
     },
 
     /// Show CI check status for a pull request.
-    /// Exits non-zero if any check is in a terminal-failure state
-    /// (see `ExternalPRCheck::is_failing` for the exact set).
+    /// Exits non-zero if any check is not in a known passing or in-flight
+    /// state (see `ExternalPRCheck::is_failing` -- fail-closed on unknown
+    /// states so a future gh release with a new failure variant cannot
+    /// silently render as green to the merge gate).
     Checks {
         /// Repository name (resolves work source config from watch.toml)
         #[arg(long)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1139,7 +1139,8 @@ enum PrAction {
     },
 
     /// Show CI check status for a pull request.
-    /// Exits non-zero if any check is failed, cancelled, or timed out.
+    /// Exits non-zero if any check is in a terminal-failure state
+    /// (see `ExternalPRCheck::is_failing` for the exact set).
     Checks {
         /// Repository name (resolves work source config from watch.toml)
         #[arg(long)]
@@ -3517,12 +3518,7 @@ fn run() -> error::Result<()> {
 
                 let failed: Vec<&str> = checks
                     .iter()
-                    .filter(|c| {
-                        matches!(
-                            c.state.as_str(),
-                            "FAILURE" | "CANCELLED" | "TIMED_OUT" | "ACTION_REQUIRED" | "STALE"
-                        )
-                    })
+                    .filter(|c| c.is_failing())
                     .map(|c| c.name.as_str())
                     .collect();
                 if !failed.is_empty() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1138,6 +1138,22 @@ enum PrAction {
         repo: String,
     },
 
+    /// Show CI check status for a pull request.
+    /// Exits non-zero if any check is failed, cancelled, or timed out.
+    Checks {
+        /// Repository name (resolves work source config from watch.toml)
+        #[arg(long)]
+        repo: String,
+
+        /// PR number
+        #[arg(long)]
+        number: u64,
+
+        /// Emit raw JSON instead of human-formatted output
+        #[arg(long)]
+        json: bool,
+    },
+
     /// Post a review on a pull request
     Review {
         /// Repository name (resolves work source config from watch.toml)
@@ -3456,6 +3472,61 @@ fn run() -> error::Result<()> {
                             pr.number, pr.title, pr.head_ref_name, review, draft
                         );
                     }
+                }
+            }
+            PrAction::Checks { repo, number, json } => {
+                let (plugin_name, source_repo, _workdir) = worksource::resolve_config(&repo)
+                    .ok_or_else(|| {
+                        error::LegionError::WorkSource(format!(
+                            "no work source configured for repo '{}' in watch.toml",
+                            repo
+                        ))
+                    })?;
+
+                let checks = worksource::pr_checks(&plugin_name, &source_repo, number)?;
+
+                if json {
+                    println!(
+                        "{}",
+                        serde_json::to_string_pretty(&checks).unwrap_or_else(|_| "[]".into())
+                    );
+                } else if checks.is_empty() {
+                    eprintln!(
+                        "[legion] no checks reported for PR #{} on {}",
+                        number, source_repo
+                    );
+                } else {
+                    let mut name_w = 0usize;
+                    let mut wf_w = 0usize;
+                    for c in &checks {
+                        name_w = name_w.max(c.name.len());
+                        wf_w = wf_w.max(c.workflow.len());
+                    }
+                    for c in &checks {
+                        println!(
+                            "{:<8} {:<name_w$}  {:<wf_w$}  {}",
+                            c.state,
+                            c.name,
+                            c.workflow,
+                            c.link,
+                            name_w = name_w,
+                            wf_w = wf_w,
+                        );
+                    }
+                }
+
+                let failed: Vec<&str> = checks
+                    .iter()
+                    .filter(|c| matches!(c.state.as_str(), "FAILURE" | "CANCELLED" | "TIMED_OUT"))
+                    .map(|c| c.name.as_str())
+                    .collect();
+                if !failed.is_empty() {
+                    return Err(error::LegionError::WorkSource(format!(
+                        "{} check(s) failed on PR #{}: {}",
+                        failed.len(),
+                        number,
+                        failed.join(", ")
+                    )));
                 }
             }
             PrAction::Review {

--- a/src/main.rs
+++ b/src/main.rs
@@ -3517,7 +3517,12 @@ fn run() -> error::Result<()> {
 
                 let failed: Vec<&str> = checks
                     .iter()
-                    .filter(|c| matches!(c.state.as_str(), "FAILURE" | "CANCELLED" | "TIMED_OUT"))
+                    .filter(|c| {
+                        matches!(
+                            c.state.as_str(),
+                            "FAILURE" | "CANCELLED" | "TIMED_OUT" | "ACTION_REQUIRED" | "STALE"
+                        )
+                    })
                     .map(|c| c.name.as_str())
                     .collect();
                 if !failed.is_empty() {

--- a/src/worksource.rs
+++ b/src/worksource.rs
@@ -457,6 +457,45 @@ pub fn list_prs(plugin_name: &str, github_repo: &str) -> Result<Vec<ExternalPR>>
     Ok(prs)
 }
 
+/// A single CI check on a PR. State values mirror gh's: SUCCESS, FAILURE,
+/// PENDING, IN_PROGRESS, NEUTRAL, SKIPPED, CANCELLED, TIMED_OUT.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct ExternalPRCheck {
+    pub name: String,
+    pub state: String,
+    pub workflow: String,
+    pub link: String,
+    #[serde(default)]
+    pub description: String,
+}
+
+/// Fetch CI check status for a PR via a work source plugin.
+pub fn pr_checks(
+    plugin_name: &str,
+    github_repo: &str,
+    pr_number: u64,
+) -> Result<Vec<ExternalPRCheck>> {
+    let plugin_path = match find_plugin(plugin_name) {
+        Some(p) => p,
+        None => return Ok(Vec::new()),
+    };
+
+    let pr_num_str = pr_number.to_string();
+    let output = call_plugin(
+        &plugin_path,
+        &["pr-checks"],
+        &[
+            ("LEGION_WS_REPO", github_repo),
+            ("LEGION_WS_PR_NUMBER", &pr_num_str),
+        ],
+    )?;
+
+    let checks: Vec<ExternalPRCheck> =
+        serde_json::from_str(&output).map_err(|e| LegionError::WorkSource(e.to_string()))?;
+
+    Ok(checks)
+}
+
 /// Post a review on a PR via a work source plugin.
 pub fn review_pr(
     plugin_name: &str,

--- a/src/worksource.rs
+++ b/src/worksource.rs
@@ -457,8 +457,9 @@ pub fn list_prs(plugin_name: &str, github_repo: &str) -> Result<Vec<ExternalPR>>
     Ok(prs)
 }
 
-/// A single CI check on a PR. State values mirror gh's: SUCCESS, FAILURE,
-/// PENDING, IN_PROGRESS, NEUTRAL, SKIPPED, CANCELLED, TIMED_OUT.
+/// A single CI check on a PR. `state` mirrors gh's check-state vocabulary;
+/// see `gh pr checks --json state`. Stringly-typed so unknown states from a
+/// future gh release deserialize cleanly instead of failing the whole call.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct ExternalPRCheck {
     pub name: String,
@@ -467,6 +468,18 @@ pub struct ExternalPRCheck {
     pub link: String,
     #[serde(default)]
     pub description: String,
+}
+
+impl ExternalPRCheck {
+    /// True if `state` is a terminal failure that should make `legion pr checks`
+    /// exit non-zero. Excludes in-flight (`PENDING`, `IN_PROGRESS`) and
+    /// non-required-passing (`NEUTRAL`, `SKIPPED`, `SUCCESS`) states.
+    pub fn is_failing(&self) -> bool {
+        matches!(
+            self.state.as_str(),
+            "FAILURE" | "CANCELLED" | "TIMED_OUT" | "ACTION_REQUIRED" | "STALE"
+        )
+    }
 }
 
 /// Fetch CI check status for a PR via a work source plugin.
@@ -735,6 +748,49 @@ pub fn resolve_review_config() -> Option<ReviewConfig> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn check_with_state(state: &str) -> ExternalPRCheck {
+        ExternalPRCheck {
+            name: "Test".into(),
+            state: state.into(),
+            workflow: "CI".into(),
+            link: String::new(),
+            description: String::new(),
+        }
+    }
+
+    #[test]
+    fn is_failing_terminal_failure_states() {
+        for state in [
+            "FAILURE",
+            "CANCELLED",
+            "TIMED_OUT",
+            "ACTION_REQUIRED",
+            "STALE",
+        ] {
+            assert!(
+                check_with_state(state).is_failing(),
+                "expected {state} to be failing"
+            );
+        }
+    }
+
+    #[test]
+    fn is_failing_passing_and_in_flight_states() {
+        for state in ["SUCCESS", "PENDING", "IN_PROGRESS", "NEUTRAL", "SKIPPED"] {
+            assert!(
+                !check_with_state(state).is_failing(),
+                "expected {state} to NOT be failing"
+            );
+        }
+    }
+
+    #[test]
+    fn is_failing_unknown_state_treated_as_passing() {
+        // Forward-compat: a future gh state we have not heard of must not poison
+        // the exit code. Worse to break the build than miss a new failure.
+        assert!(!check_with_state("FUTURE_GH_STATE").is_failing());
+    }
 
     #[test]
     fn extract_issue_number_from_url() {

--- a/src/worksource.rs
+++ b/src/worksource.rs
@@ -471,27 +471,40 @@ pub struct ExternalPRCheck {
 }
 
 impl ExternalPRCheck {
-    /// True if `state` is a terminal failure that should make `legion pr checks`
-    /// exit non-zero. Excludes in-flight (`PENDING`, `IN_PROGRESS`) and
-    /// non-required-passing (`NEUTRAL`, `SKIPPED`, `SUCCESS`) states.
+    /// True unless `state` is a known passing or in-flight value.
+    ///
+    /// `legion pr checks` is a merge gate. Fail-closed on unknown states: a
+    /// future gh release that adds a new failure variant must surface as a
+    /// loud non-zero exit, not a silent green that lets a bad merge through.
+    /// Adding a new passing state will trip this and require an explicit
+    /// allow-list edit, which is the correct review burden for the gate.
     pub fn is_failing(&self) -> bool {
-        matches!(
+        !matches!(
             self.state.as_str(),
-            "FAILURE" | "CANCELLED" | "TIMED_OUT" | "ACTION_REQUIRED" | "STALE"
+            "SUCCESS"
+                | "NEUTRAL"
+                | "SKIPPED"
+                | "PENDING"
+                | "IN_PROGRESS"
+                | "QUEUED"
+                | "WAITING"
+                | "REQUESTED"
         )
     }
 }
 
 /// Fetch CI check status for a PR via a work source plugin.
+///
+/// Returns `Err` when the named plugin is not installed. Callers gate merges
+/// on this; an empty `Ok(Vec)` would render as a clean green and let a
+/// misconfigured `watch.toml` auto-approve a PR with no checks ever run.
 pub fn pr_checks(
     plugin_name: &str,
     github_repo: &str,
     pr_number: u64,
 ) -> Result<Vec<ExternalPRCheck>> {
-    let plugin_path = match find_plugin(plugin_name) {
-        Some(p) => p,
-        None => return Ok(Vec::new()),
-    };
+    let plugin_path = find_plugin(plugin_name)
+        .ok_or_else(|| LegionError::WorkSource(format!("plugin not found: {plugin_name}")))?;
 
     let pr_num_str = pr_number.to_string();
     let output = call_plugin(
@@ -777,7 +790,16 @@ mod tests {
 
     #[test]
     fn is_failing_passing_and_in_flight_states() {
-        for state in ["SUCCESS", "PENDING", "IN_PROGRESS", "NEUTRAL", "SKIPPED"] {
+        for state in [
+            "SUCCESS",
+            "NEUTRAL",
+            "SKIPPED",
+            "PENDING",
+            "IN_PROGRESS",
+            "QUEUED",
+            "WAITING",
+            "REQUESTED",
+        ] {
             assert!(
                 !check_with_state(state).is_failing(),
                 "expected {state} to NOT be failing"
@@ -786,10 +808,29 @@ mod tests {
     }
 
     #[test]
-    fn is_failing_unknown_state_treated_as_passing() {
-        // Forward-compat: a future gh state we have not heard of must not poison
-        // the exit code. Worse to break the build than miss a new failure.
-        assert!(!check_with_state("FUTURE_GH_STATE").is_failing());
+    fn is_failing_unknown_state_treated_as_failing() {
+        // Fail-closed: a future gh state we have not heard of must surface as
+        // a loud non-zero exit, not a silent green. Adding a new passing
+        // state requires an explicit allow-list edit -- the correct review
+        // burden for a merge gate.
+        assert!(check_with_state("FUTURE_GH_STATE").is_failing());
+    }
+
+    /// Regression guard for the silent-Ok hazard smugglr flagged on PR #291.
+    ///
+    /// `pr_checks` previously returned `Ok(Vec::new())` when the plugin
+    /// binary could not be resolved. `legion pr checks` reads that empty
+    /// vector, finds nothing failing, and exits 0 -- a false-green merge
+    /// gate. Mirrors the close_issue / reopen_issue regression guards
+    /// inherited from PR #227.
+    #[test]
+    fn pr_checks_returns_worksource_error_when_plugin_missing() {
+        let result = pr_checks("nonexistent-plugin-xyz", "owner/repo", 1);
+        assert!(
+            matches!(result, Err(LegionError::WorkSource(_))),
+            "expected WorkSource error, got {:?}",
+            result
+        );
     }
 
     #[test]

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -2494,6 +2494,55 @@ fn pr_close_delete_branch_flag_accepted() {
     );
 }
 
+#[test]
+fn pr_checks_errors_without_worksource_config() {
+    let dir = tempfile::tempdir().unwrap();
+
+    let out = legion_cmd(dir.path())
+        .args(["pr", "checks", "--repo", "no-such-repo", "--number", "42"])
+        .output()
+        .unwrap();
+
+    assert!(
+        !out.status.success(),
+        "expected failure when no work source configured"
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("no work source configured"),
+        "expected 'no work source configured' in stderr, got: {stderr}"
+    );
+}
+
+#[test]
+fn pr_checks_json_flag_accepted() {
+    let dir = tempfile::tempdir().unwrap();
+
+    let out = legion_cmd(dir.path())
+        .args([
+            "pr",
+            "checks",
+            "--repo",
+            "no-such-repo",
+            "--number",
+            "42",
+            "--json",
+        ])
+        .output()
+        .unwrap();
+
+    // Fails at worksource resolution, not arg parsing -- confirms --json parses
+    assert!(
+        !out.status.success(),
+        "expected failure when no work source configured"
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("no work source configured"),
+        "expected worksource error, got: {stderr}"
+    );
+}
+
 // ---------------------------------------------------------------------------
 // Usage command integration tests
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #290.

Adds `legion pr checks --repo <r> --number <n> [--json]` exposing CI check status via the existing worksource plugin protocol. Closes the self-inflicted gap where agents had to ask the user to run `! gh pr checks N` in their prompt because `gh` is blocked by our own `no-gh.sh` hook and `legion pr list` only carried review decision, not check state.

## Surface

- **Human output** (default): one line per check with state (8-col), name, workflow, link
- **JSON output**: `--json` dumps the raw `Vec<ExternalPRCheck>` as pretty-printed JSON for programmatic callers
- **Exit code**: non-zero if any check state is `FAILURE`, `CANCELLED`, `TIMED_OUT`, `ACTION_REQUIRED`, or `STALE`. Zero otherwise.

## Files

- `plugin/worksources/github` — new `pr-checks` subcommand wrapping `gh pr checks --json`. Does NOT mask gh failures as empty data: if gh produces no JSON at all (network/auth/missing PR), surfaces stderr and exits non-zero. Exit-code-with-output from gh means "checks failed" (data), which is passed through as-is.
- `src/worksource.rs` — `ExternalPRCheck` struct + `pr_checks()` fn mirroring `list_prs` shape.
- `src/main.rs` — `PrAction::Checks { repo, number, json }` variant + handler.
- `tests/integration.rs` — arg parsing + worksource-missing path.

## Dogfood

Verified against PR #288 (which is currently red):

```
$ legion pr checks --repo legion --number 288
SUCCESS  Check                  CI  ...
SUCCESS  Format                 CI  ...
FAILURE  Clippy                 CI  ...
SUCCESS  ShellCheck             CI  ...
SUCCESS  Test (ubuntu-latest)   CI  ...
SUCCESS  Test (macos-latest)    CI  ...
SUCCESS  Test (windows-latest)  CI  ...
Error: 1 check(s) failed on PR #288: Clippy
```

## Simplify gate

Recorded clean (id `019db1eb-a4b3-7ca1-a9ca-b12e47dd4ead`). Pre-commit hook caught and fixed two hazards before the first push: silent gh-failure masked as empty data, and incomplete failed-state filter.

## Out of scope

- Polling / watching for completion (separate issue if we want it)
- Aggregate status glyph in `legion pr list` output (separate issue)