### PR TITLE
chore: release v0.9.2

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
     {
       "name": "legion",
       "description": "Agent memory layer with recall, reflect, consult, bullpen, and cross-agent coordination. Includes health monitoring and auto-wake. Hooks wire legion into every session automatically.",
-      "version": "0.9.1",
+      "version": "0.9.2",
       "author": {
         "name": "Sean Silvius",
         "email": "sean@silvius.me"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1444,7 +1444,7 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "legion"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "async-stream",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "legion"
-version = "0.9.1"
+version = "0.9.2"
 edition = "2024"
 description = "Agent specialization through deliberate practice"
 

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "legion",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "Institutional memory for Claude Code agents with real-time team channel.",
   "author": {
     "name": "Sean Silvius",

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Legion Changelog
 
+## 0.9.2
+
+Patch release. New CLI surface closes a self-inflicted gap; safety hardening on the new gate.
+
+### New
+
+- **`legion pr checks --repo <r> --number <n> [--json]`** (#290, #291): Lists CI check status for a PR via the existing worksource plugin protocol. Exits non-zero when any check is in a terminal-failure state. Closes the gap where `gh` was blocked by `no-gh.sh` but no replacement existed -- agents previously had to ask the user to `! gh pr checks N` in their prompt to see what broke a build.
+
+### Safety
+
+- **`is_failing` is fail-closed**: The failed-state predicate now lists known passing/in-flight states (`SUCCESS`, `PENDING`, `IN_PROGRESS`, `NEUTRAL`, `SKIPPED`) and treats everything else as failing. A new gh state -- e.g. an unknown failure-class variant -- surfaces as a loud non-zero exit instead of silent green. Adding a new passing state requires an explicit allow-list edit, the correct review burden for a merge gate.
+- **`pr_checks` returns `Err` on plugin-not-found** instead of `Ok(Vec::new())`, matching the established pattern from `view_issue` / `review_pr` / `merge_pr` and the PR #227 fix to `close_issue`. A misconfigured `watch.toml` now fails loudly rather than yielding "nothing failing" and letting a bad merge through.
+
 ## 0.9.1
 
 Ergonomic + cleanup release. No schema changes, no breaking changes.


### PR DESCRIPTION
Patch release.

## Changes since 0.9.1

**New surface:** `legion pr checks --repo <r> --number <n> [--json]` (#290, #291). Closes the gap where `gh` was blocked by `no-gh.sh` but no replacement existed -- agents previously had to ask the user to run `! gh pr checks N` in their prompt to see what broke a build.

**Safety hardening on the new gate** (smugglr pre-merge review):

1. `ExternalPRCheck::is_failing` flipped to fail-closed. Lists known passing/in-flight states; everything else is failing. A new gh state surfaces as a non-zero exit instead of silent green.
2. `worksource::pr_checks` returns `Err` on plugin-not-found instead of `Ok(Vec::new())`. Misconfigured `watch.toml` fails loudly instead of yielding "nothing failing" and letting a bad merge through.

## Versions synced

- `Cargo.toml` 0.9.1 -> 0.9.2
- `plugin/.claude-plugin/plugin.json` 0.9.1 -> 0.9.2
- `.claude-plugin/marketplace.json` 0.9.1 -> 0.9.2
- `plugin/CHANGELOG.md` new `## 0.9.2` section

## Gates

- `cargo fmt --check`: clean
- `cargo clippy --all-targets -- -D warnings`: clean
- `cargo test`: 89 passed
- legion-simplify gate recorded clean