### PR TITLE
fix(#289): statusline polish -- try_from casts, honest signature, doc drift

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -2405,6 +2405,12 @@ impl Database {
     // -- Statusline Samples ------------------------------------------------------
 
     /// Insert a rate-limit sample captured from a Claude Code statusline render.
+    ///
+    /// Note the VALUES clause reuses bind index `?4` for both `sampled_at`
+    /// and `updated_at`. This is intentional on INSERT -- a fresh row's
+    /// updated_at equals its sampled_at -- but a future UPDATE path must
+    /// re-bind updated_at to a fresh timestamp. Don't copy the pattern
+    /// blindly into an UPDATE statement.
     pub fn insert_rate_limit_sample(
         &self,
         sample: &crate::statusline::RateLimitSample,
@@ -2430,6 +2436,11 @@ impl Database {
     }
 
     /// Insert a usage sample captured from a Claude Code statusline render.
+    ///
+    /// VALUES reuses bind index `?12` for both `sampled_at` and
+    /// `updated_at`. Intentional on INSERT; a future UPDATE path must
+    /// re-bind updated_at separately. See `insert_rate_limit_sample`
+    /// for the same pattern.
     pub fn insert_usage_sample(&self, sample: &crate::statusline::UsageSample) -> Result<String> {
         self.conn.execute(
             "INSERT INTO usage_samples (id, hostname, session_id, turn_index, model, \

--- a/src/main.rs
+++ b/src/main.rs
@@ -4075,8 +4075,9 @@ fn run() -> error::Result<()> {
         },
         Commands::Statusline { json } => {
             // Never surface an error to the Claude Code UI: statusline::run
-            // already swallows internal failures and logs them.
-            statusline::run(json)?;
+            // already swallows internal failures and logs them, and its
+            // signature reflects that contract (cannot return an error).
+            statusline::run(json);
         }
 
         Commands::Usage {

--- a/src/statusline.rs
+++ b/src/statusline.rs
@@ -18,7 +18,6 @@ use serde_json::Value;
 use uuid::Uuid;
 
 use crate::db::Database;
-use crate::error::Result;
 use crate::usage::{RawTokens, TranscriptTail, format_tokens, parse_transcript_tail};
 
 // ---------------------------------------------------------------------------
@@ -109,20 +108,23 @@ const ALERT: &str = "\u{1F6A8}";
 /// to the database, and prints either the rendered chip (default) or
 /// a JSON summary (when `json` is true).
 ///
-/// Always returns `Ok(())` in production: a broken statusline must not
-/// surface as an error to the Claude Code UI. Internal failures are
-/// logged to `<legion-data-dir>/logs/hook-errors.log`.
-pub fn run(json: bool) -> Result<()> {
+/// Cannot fail: a broken statusline must not surface as an error to the
+/// Claude Code UI (which would display a distracting red banner on every
+/// assistant turn). Every internal failure path is swallowed, logged to
+/// `<legion-data-dir>/logs/hook-errors.log`, and returns cleanly. The
+/// signature reflects that contract -- no `Result<()>` lying about
+/// failure modes that never surface.
+pub fn run(json: bool) {
     let mut raw = String::new();
     if let Err(e) = std::io::stdin().read_to_string(&mut raw) {
         log_error(format!("read stdin: {e}"));
-        return Ok(());
+        return;
     }
     let parsed = match parse_input(&raw) {
         Some(p) => p,
         None => {
             log_error("parse stdin JSON failed or payload empty".to_string());
-            return Ok(());
+            return;
         }
     };
 
@@ -130,7 +132,7 @@ pub fn run(json: bool) -> Result<()> {
         Some(sid) if !sid.is_empty() => sid.to_string(),
         _ => {
             log_error("stdin JSON missing session_id".to_string());
-            return Ok(());
+            return;
         }
     };
 
@@ -145,7 +147,7 @@ pub fn run(json: bool) -> Result<()> {
         && let Some(cached) = read_cache_if_fresh(p, CACHE_TTL_SECS)
     {
         print!("{cached}");
-        return Ok(());
+        return;
     }
 
     let hostname = resolve_hostname();
@@ -179,7 +181,7 @@ pub fn run(json: bool) -> Result<()> {
             Ok(s) => println!("{s}"),
             Err(e) => log_error(format!("serialise json output: {e}")),
         }
-        return Ok(());
+        return;
     }
 
     let chip = render_chip(&tail, &parsed);
@@ -190,7 +192,6 @@ pub fn run(json: bool) -> Result<()> {
         write_cache(p, &chip_line);
     }
     print!("{chip_line}");
-    Ok(())
 }
 
 // ---------------------------------------------------------------------------
@@ -288,22 +289,28 @@ fn build_usage_sample(
     if raw.input == 0 && raw.output == 0 && raw.cache_write == 0 && raw.cache_read == 0 {
         return None;
     }
+    // Token counts and real_turns are u64 from the parser; SQLite stores i64.
+    // `as i64` would silently truncate above 2^63 (impossible in practice for
+    // tokens, but the idiom is wrong and removes the upper-bound guarantee);
+    // `try_from().unwrap_or(i64::MAX)` makes the clamp explicit so an
+    // unexpectedly huge value pins at i64::MAX rather than wrapping to a
+    // negative-looking gigantic number in the DB.
     Some(UsageSample {
         id: Uuid::now_v7().to_string(),
         hostname: hostname.to_owned(),
         session_id: session_id.to_owned(),
         turn_index: if tail.real_turns > 0 {
-            Some(tail.real_turns as i64)
+            Some(i64::try_from(tail.real_turns).unwrap_or(i64::MAX))
         } else {
             None
         },
         model: parsed.model.clone(),
-        input_tokens: raw.input as i64,
-        output_tokens: raw.output as i64,
-        cache_write_tokens: raw.cache_write as i64,
-        cache_read_tokens: raw.cache_read as i64,
-        effective_tokens: raw.effective() as i64,
-        error_bytes: tail.max_error_bytes as i64,
+        input_tokens: i64::try_from(raw.input).unwrap_or(i64::MAX),
+        output_tokens: i64::try_from(raw.output).unwrap_or(i64::MAX),
+        cache_write_tokens: i64::try_from(raw.cache_write).unwrap_or(i64::MAX),
+        cache_read_tokens: i64::try_from(raw.cache_read).unwrap_or(i64::MAX),
+        effective_tokens: i64::try_from(raw.effective()).unwrap_or(i64::MAX),
+        error_bytes: i64::try_from(tail.max_error_bytes).unwrap_or(i64::MAX),
         sampled_at: sampled_at.to_owned(),
     })
 }

--- a/src/usage.rs
+++ b/src/usage.rs
@@ -4,8 +4,13 @@
 /// Each slug encodes the filesystem path of the project (hyphens substitute
 /// for slashes). Only `type == "assistant"` events with a populated
 /// `message.usage` object contribute token counts. Lines that do not parse
-/// as JSON or that lack usage data are skipped silently (one stderr warning
-/// per session, not per line).
+/// as JSON or that lack usage data are skipped silently.
+///
+/// `SessionUsage::from_file` additionally emits a single stderr warning per
+/// session (not per malformed line) summarising skip counts. The lighter
+/// [`parse_transcript_tail`] entry point -- used by the statusline where
+/// any stderr output would taint the chip -- skips silently with no
+/// aggregation.
 use std::io::{self, BufRead};
 use std::path::{Path, PathBuf};
 
@@ -692,6 +697,11 @@ fn is_real_user_turn(obj: &Value, max_error_bytes: &mut u64) -> bool {
                 }
             }
             _ => {
+                // Unknown content-item type counts as a real turn. Deliberate
+                // bias toward over-counting: a missed real turn (under-count)
+                // corrupts turn-based cluster aggregates silently, while an
+                // extra counted turn is visible in metrics and self-heals
+                // once the unknown type gets its own explicit arm.
                 real = true;
             }
         }


### PR DESCRIPTION
Closes the load-bearing subset of #289. Nice-to-haves (sysinfo crate swap, stdin byte cap, cache roundtrip test) intentionally left for a separate v0.9.4 PR.

## Changes

**i64 cast safety.** `statusline::build_usage_sample` swaps every u64->i64 `as` cast on token/turn/byte counts for `i64::try_from(n).unwrap_or(i64::MAX)`. Unreachable in practice (no real transcript approaches 2^63 tokens), but `as` silently wraps past the boundary, while `try_from` clamps to i64::MAX -- at least visible in metrics.

**Honest signature.** `statusline::run` returned `Result<()>` but its docstring said "Always returns Ok(()) in production" and every internal error path was swallowed + logged. Changed to `fn run(json: bool)`; callsite in main.rs updated. Claude Code UI invariant is preserved -- failures log to `<legion-data-dir>/logs/hook-errors.log` as before.

**Load-bearing comments.**
- `src/usage.rs` module doc: clarify that the "one stderr warning per session" aggregation lives in `SessionUsage::from_file`, not `parse_transcript_tail` (which the statusline uses). Prevents a future maintainer from adding stderr logging to the statusline path.
- `is_real_user_turn` unknown-content arm: document the deliberate over-count bias. A missed real turn corrupts cluster aggregates silently; an extra counted turn is visible and self-heals once the unknown type gets its own arm.
- `db::insert_rate_limit_sample` / `insert_usage_sample`: document the `?4,?4` / `?12,?12` bind-index reuse. Intentional on INSERT; a future UPDATE path must rebind `updated_at` separately.

## Tests

No new tests; no happy-path behavior change. 98 tests passing, clippy + fmt clean.

## Release posture

Scope-bundled with #295/#297 and #298 for v0.9.3. Do not merge to main without explicit user approval.