### PR TITLE
chore: release v0.9.3

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
     {
       "name": "legion",
       "description": "Agent memory layer with recall, reflect, consult, bullpen, and cross-agent coordination. Includes health monitoring and auto-wake. Hooks wire legion into every session automatically.",
-      "version": "0.9.2",
+      "version": "0.9.3",
       "author": {
         "name": "Sean Silvius",
         "email": "sean@silvius.me"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1444,7 +1444,7 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "legion"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "async-stream",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "legion"
-version = "0.9.2"
+version = "0.9.3"
 edition = "2024"
 description = "Agent specialization through deliberate practice"
 

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "legion",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "description": "Institutional memory for Claude Code agents with real-time team channel.",
   "author": {
     "name": "Sean Silvius",

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Legion Changelog
 
+## 0.9.3
+
+Daily-loop release. New read-side `legion pr` surface closes the write-only monologue so agents can actually read reviews, comments, and failing-check logs through legion instead of the blocked `gh` CLI. Plugin timeout and statusline polish ride along.
+
+### New
+
+- **`legion pr view` / `pr comments` / `pr reviews` / `pr checks --log-failed`** (#295, #297): Full read-side surface for GitHub PRs via the existing worksource plugin. `pr view` shows metadata + body; `pr comments` renders issue + inline review comments chronologically; `pr reviews` groups inline comments under their parent review; `pr checks --log-failed` streams the raw CI log for every failing job, each preceded by a `===== <name> (<job-id>) =====` header. Every command also accepts `--json`. Closes the "step 7 of the workflow -- fix every issue the review found -- was impossible through legion" gap. Dogfooded on PR #288 the same session it was built.
+- **`legion statusline`** (#287, #288): Claude Code statusLine consumer. Ingests rate-limit + usage samples on every assistant turn, persists to legion's store (cluster-sync-aware via smugglr deltas), renders a single-line chip. Replay-band thresholds + 5h/weekly cap segments + cached-turn error surfacing. Foundation for the upcoming `legion budget` gate.
+
+### Safety
+
+- **`call_plugin` wall-clock timeout** (#292, #298): Every worksource plugin invocation now runs under a bounded budget (default 30s, `LEGION_WS_TIMEOUT_SECS` to override, `0` to disable). On expiry the entire process subtree is SIGKILLed via `killpg` so an orphaned `gh` grandchild cannot keep pipe fds open and defeat the timeout. `legion watch`, CI runners, and the merge gate no longer wedge on a hung auth prompt / DNS stall / stuck TLS handshake.
+- **`is_failing` state partition** (#292, #298): Extracted `PR_CHECK_PASSING_STATES` and `PR_CHECK_FAILING_STATES` as module-level constants. New partition test asserts the two sets are disjoint so a future PR can't list a state in both (or neither) and silently break the merge gate. Unknown states still fail-closed.
+- **Read-side surface is fail-closed**: `view_pr` / `list_pr_comments` / `list_pr_reviews` / `fetch_check_log` return `Err(WorkSource)` on plugin-not-found, matching the established pattern. Empty results would be indistinguishable from "PR has no body" / "thread has no comments" and would mask a misconfigured `watch.toml`.
+
+### Polish
+
+- **`i64::try_from` casts on token counts** (#289, #299): `statusline::build_usage_sample` swaps `u64 as i64` for `i64::try_from(n).unwrap_or(i64::MAX)` on all token/turn/byte counts. Unreachable in practice, but `as` silently wraps past the boundary -- try_from clamps explicitly.
+- **`statusline::run` signature no longer lies** (#289, #299): The function's docstring said "always returns `Ok(())`" but the type was `Result<()>`. Dropped the `Result` so the signature reflects the contract.
+- **Load-bearing comments added** (#289, #299) for the INSERT bind-index reuse in `insert_rate_limit_sample` / `insert_usage_sample`, the doc drift between `parse_transcript_tail` and `SessionUsage::from_file`, and the deliberate over-count bias in `is_real_user_turn`'s unknown-content arm.
+
 ## 0.9.2
 
 Patch release. New CLI surface closes a self-inflicted gap; safety hardening on the new gate.


### PR DESCRIPTION
Daily-loop release. Bundles the PR read-surface, plugin timeout, statusline hardening, and statusline polish.

## What's in

- **New: legion pr read-side surface** (#295, #297) -- `pr view`, `pr comments`, `pr reviews`, `pr checks --log-failed`. Closes the write-only monologue that broke step 7 of the workflow. Dogfooded on PR #288 the same session it was built.
- **New: legion statusline** (#287, #288) -- Claude Code statusLine consumer with cluster-sync-aware rate-limit + usage samples. Foundation for the upcoming `legion budget` gate.
- **Safety: `call_plugin` wall-clock timeout** (#292, #298) -- 30s default, `killpg` kills orphan grandchildren so a hung `gh` can't wedge `legion watch` / CI runners / merge gate.
- **Safety: `is_failing` state partition** (#292, #298) -- `PR_CHECK_PASSING_STATES` + `PR_CHECK_FAILING_STATES` constants with a partition test so a future PR can't list a state in both (or neither).
- **Polish: `i64::try_from` casts** (#289, #299) -- statusline token/turn/byte counts clamp explicitly instead of silently wrapping past i64::MAX.
- **Polish: honest `statusline::run` signature** (#289, #299) -- dropped the `Result<()>` that the function never returned; docstring was already explicit.

## What's deferred (v0.9.4)

- #289 remainder -- `sysinfo` to `gethostname` crate swap, stdin byte cap, cache roundtrip test. Nice-to-haves only.
- #296 -- gh fixture contract test (offline test harness for jq projections; catches gh field-rename regressions). Highest-leverage safety net for the read surface; needs plugin refactor to be testable.
- #300 -- `legion pr create` idempotent per-issue (enforce what CLAUDE.md currently documents as policy).
- #301 -- runtime branch-writer lease (enforce "one agent per branch" via DB-backed leases, cluster-sync aware).

## Bumps

- Cargo.toml + Cargo.lock
- .claude-plugin/marketplace.json
- plugin/.claude-plugin/plugin.json
- plugin/CHANGELOG.md

## Test plan

- [x] `cargo test` -- 98 passing, 0 failures, 0 regressions on main
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] Dogfooded: `legion pr view / comments / reviews / checks --log-failed` against PRs #288 and #297
- [x] Dogfooded: `legion pr checks --log-failed` caught the real Clippy failure on #288 and the Windows TOML-table-scope bug on #298

Do not merge without explicit user approval.