### PR TITLE
feat(#303): mesh-aware task placement -- headroom + pick

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -2493,6 +2493,91 @@ impl Database {
         }
     }
 
+    /// Most recent rate-limit sample per hostname.
+    ///
+    /// Returns one row per host, picking the newest `sampled_at` for each.
+    /// Soft-deleted rows are skipped. Cluster-sync pushes samples from
+    /// peers into the same table, so a single node running this query
+    /// sees the whole mesh once sync has settled.
+    ///
+    /// Used by `legion mesh headroom / pick` to rank hosts by available
+    /// capacity. Paired with [`latest_usage_samples_per_host`].
+    pub fn latest_rate_limit_samples_per_host(
+        &self,
+    ) -> Result<Vec<crate::statusline::RateLimitSample>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT id, hostname, session_id, sampled_at, five_hour_pct, \
+             five_hour_resets_at, seven_day_pct, seven_day_resets_at, model \
+             FROM rate_limit_samples \
+             WHERE deleted_at IS NULL \
+             AND (hostname, sampled_at) IN ( \
+                 SELECT hostname, MAX(sampled_at) \
+                 FROM rate_limit_samples \
+                 WHERE deleted_at IS NULL \
+                 GROUP BY hostname \
+             ) \
+             ORDER BY hostname",
+        )?;
+        let rows = stmt.query_map([], |row| {
+            Ok(crate::statusline::RateLimitSample {
+                id: row.get(0)?,
+                hostname: row.get(1)?,
+                session_id: row.get(2)?,
+                sampled_at: row.get(3)?,
+                five_hour_pct: row.get(4)?,
+                five_hour_resets_at: row.get(5)?,
+                seven_day_pct: row.get(6)?,
+                seven_day_resets_at: row.get(7)?,
+                model: row.get(8)?,
+            })
+        })?;
+        let mut out = Vec::new();
+        for row in rows {
+            out.push(row?);
+        }
+        Ok(out)
+    }
+
+    /// Most recent usage sample per hostname. Pair of
+    /// [`latest_rate_limit_samples_per_host`].
+    pub fn latest_usage_samples_per_host(&self) -> Result<Vec<crate::statusline::UsageSample>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT id, hostname, session_id, turn_index, model, \
+             input_tokens, output_tokens, cache_write_tokens, cache_read_tokens, \
+             effective_tokens, error_bytes, sampled_at \
+             FROM usage_samples \
+             WHERE deleted_at IS NULL \
+             AND (hostname, sampled_at) IN ( \
+                 SELECT hostname, MAX(sampled_at) \
+                 FROM usage_samples \
+                 WHERE deleted_at IS NULL \
+                 GROUP BY hostname \
+             ) \
+             ORDER BY hostname",
+        )?;
+        let rows = stmt.query_map([], |row| {
+            Ok(crate::statusline::UsageSample {
+                id: row.get(0)?,
+                hostname: row.get(1)?,
+                session_id: row.get(2)?,
+                turn_index: row.get(3)?,
+                model: row.get(4)?,
+                input_tokens: row.get(5)?,
+                output_tokens: row.get(6)?,
+                cache_write_tokens: row.get(7)?,
+                cache_read_tokens: row.get(8)?,
+                effective_tokens: row.get(9)?,
+                error_bytes: row.get(10)?,
+                sampled_at: row.get(11)?,
+            })
+        })?;
+        let mut out = Vec::new();
+        for row in rows {
+            out.push(row?);
+        }
+        Ok(out)
+    }
+
     /// Rename a repo across all tables. Returns total rows updated.
     pub fn rename_repo(&self, from: &str, to: &str) -> Result<RenameCounts> {
         // unchecked_transaction because Database uses &self (shared ref),
@@ -4372,5 +4457,150 @@ mod tests {
             result.is_empty(),
             "fresh tombstone should not be cleaned up"
         );
+    }
+
+    fn rate_sample(
+        id: &str,
+        host: &str,
+        sampled_at: &str,
+        five_hour_pct: Option<f64>,
+        seven_day_pct: Option<f64>,
+    ) -> crate::statusline::RateLimitSample {
+        crate::statusline::RateLimitSample {
+            id: id.to_string(),
+            hostname: host.to_string(),
+            session_id: "sess".to_string(),
+            sampled_at: sampled_at.to_string(),
+            five_hour_pct,
+            five_hour_resets_at: None,
+            seven_day_pct,
+            seven_day_resets_at: None,
+            model: None,
+        }
+    }
+
+    fn usage_sample(
+        id: &str,
+        host: &str,
+        sampled_at: &str,
+        effective: i64,
+    ) -> crate::statusline::UsageSample {
+        crate::statusline::UsageSample {
+            id: id.to_string(),
+            hostname: host.to_string(),
+            session_id: "sess".to_string(),
+            turn_index: None,
+            model: None,
+            input_tokens: 0,
+            output_tokens: 0,
+            cache_write_tokens: 0,
+            cache_read_tokens: 0,
+            effective_tokens: effective,
+            error_bytes: 0,
+            sampled_at: sampled_at.to_string(),
+        }
+    }
+
+    #[test]
+    fn latest_rate_limit_samples_per_host_returns_newest_per_host() {
+        let db = test_db();
+        // Two hosts, two samples each; expect the newest per host.
+        db.insert_rate_limit_sample(&rate_sample(
+            "1",
+            "Puck",
+            "2026-04-22T10:00:00Z",
+            Some(30.0),
+            Some(50.0),
+        ))
+        .unwrap();
+        db.insert_rate_limit_sample(&rate_sample(
+            "2",
+            "Puck",
+            "2026-04-22T11:00:00Z",
+            Some(40.0),
+            Some(55.0),
+        ))
+        .unwrap();
+        db.insert_rate_limit_sample(&rate_sample(
+            "3",
+            "laptop",
+            "2026-04-22T09:00:00Z",
+            Some(60.0),
+            Some(70.0),
+        ))
+        .unwrap();
+        db.insert_rate_limit_sample(&rate_sample(
+            "4",
+            "laptop",
+            "2026-04-22T12:00:00Z",
+            Some(70.0),
+            Some(75.0),
+        ))
+        .unwrap();
+
+        let got = db.latest_rate_limit_samples_per_host().unwrap();
+        assert_eq!(got.len(), 2);
+        let by_host: std::collections::HashMap<_, _> =
+            got.into_iter().map(|s| (s.hostname.clone(), s)).collect();
+        assert_eq!(by_host["Puck"].id, "2");
+        assert_eq!(by_host["laptop"].id, "4");
+    }
+
+    #[test]
+    fn latest_rate_limit_samples_per_host_skips_soft_deleted() {
+        let db = test_db();
+        db.insert_rate_limit_sample(&rate_sample(
+            "1",
+            "Puck",
+            "2026-04-22T10:00:00Z",
+            Some(30.0),
+            Some(50.0),
+        ))
+        .unwrap();
+        db.insert_rate_limit_sample(&rate_sample(
+            "2",
+            "Puck",
+            "2026-04-22T11:00:00Z",
+            Some(40.0),
+            Some(55.0),
+        ))
+        .unwrap();
+        // Tombstone the newer row. The query should fall back to the older
+        // row, NOT return Puck with sampled_at=null or skip the host entirely.
+        db.conn
+            .execute(
+                "UPDATE rate_limit_samples SET deleted_at = ?1 WHERE id = '2'",
+                rusqlite::params!["2026-04-22T12:00:00Z"],
+            )
+            .unwrap();
+
+        let got = db.latest_rate_limit_samples_per_host().unwrap();
+        assert_eq!(got.len(), 1);
+        assert_eq!(got[0].id, "1");
+    }
+
+    #[test]
+    fn latest_rate_limit_samples_per_host_empty_table() {
+        let db = test_db();
+        let got = db.latest_rate_limit_samples_per_host().unwrap();
+        assert!(got.is_empty());
+    }
+
+    #[test]
+    fn latest_usage_samples_per_host_returns_newest_per_host() {
+        let db = test_db();
+        db.insert_usage_sample(&usage_sample("1", "Puck", "2026-04-22T10:00:00Z", 100))
+            .unwrap();
+        db.insert_usage_sample(&usage_sample("2", "Puck", "2026-04-22T11:00:00Z", 200))
+            .unwrap();
+        db.insert_usage_sample(&usage_sample("3", "laptop", "2026-04-22T11:30:00Z", 300))
+            .unwrap();
+
+        let got = db.latest_usage_samples_per_host().unwrap();
+        assert_eq!(got.len(), 2);
+        let by_host: std::collections::HashMap<_, _> =
+            got.into_iter().map(|s| (s.hostname.clone(), s)).collect();
+        assert_eq!(by_host["Puck"].effective_tokens, 200);
+        assert_eq!(by_host["laptop"].effective_tokens, 300);
     }
 }

--- a/src/db.rs
+++ b/src/db.rs
@@ -2505,17 +2505,26 @@ impl Database {
     pub fn latest_rate_limit_samples_per_host(
         &self,
     ) -> Result<Vec<crate::statusline::RateLimitSample>> {
+        // ROW_NUMBER partitioned by hostname gives a deterministic tie-break
+        // when two rows share the same MAX(sampled_at). Without it, the
+        // IN-subquery variant returned both rows and the caller's BTreeMap
+        // collapsed them in insertion order, so a pair of statusline writes
+        // within one RFC3339-second could produce non-deterministic scores.
+        // Tie-break: newer sampled_at, then higher id (UUIDv7 embeds time).
         let mut stmt = self.conn.prepare(
             "SELECT id, hostname, session_id, sampled_at, five_hour_pct, \
              five_hour_resets_at, seven_day_pct, seven_day_resets_at, model \
-             FROM rate_limit_samples \
-             WHERE deleted_at IS NULL \
-             AND (hostname, sampled_at) IN ( \
-                 SELECT hostname, MAX(sampled_at) \
+             FROM ( \
+                 SELECT id, hostname, session_id, sampled_at, five_hour_pct, \
+                     five_hour_resets_at, seven_day_pct, seven_day_resets_at, model, \
+                     ROW_NUMBER() OVER ( \
+                         PARTITION BY hostname \
+                         ORDER BY sampled_at DESC, id DESC \
+                     ) AS rn \
                  FROM rate_limit_samples \
                  WHERE deleted_at IS NULL \
-                 GROUP BY hostname \
              ) \
+             WHERE rn = 1 \
              ORDER BY hostname",
         )?;
         let rows = stmt.query_map([], |row| {
@@ -2545,14 +2554,18 @@ impl Database {
             "SELECT id, hostname, session_id, turn_index, model, \
              input_tokens, output_tokens, cache_write_tokens, cache_read_tokens, \
              effective_tokens, error_bytes, sampled_at \
-             FROM usage_samples \
-             WHERE deleted_at IS NULL \
-             AND (hostname, sampled_at) IN ( \
-                 SELECT hostname, MAX(sampled_at) \
+             FROM ( \
+                 SELECT id, hostname, session_id, turn_index, model, \
+                     input_tokens, output_tokens, cache_write_tokens, cache_read_tokens, \
+                     effective_tokens, error_bytes, sampled_at, \
+                     ROW_NUMBER() OVER ( \
+                         PARTITION BY hostname \
+                         ORDER BY sampled_at DESC, id DESC \
+                     ) AS rn \
                  FROM usage_samples \
                  WHERE deleted_at IS NULL \
-                 GROUP BY hostname \
              ) \
+             WHERE rn = 1 \
              ORDER BY hostname",
         )?;
         let rows = stmt.query_map([], |row| {

--- a/src/error.rs
+++ b/src/error.rs
@@ -94,6 +94,9 @@ pub enum LegionError {
 
     #[error("cluster config error: {0}")]
     Config(String),
+
+    #[error("mesh error: {0}")]
+    Mesh(String),
 }
 
 pub type Result<T> = std::result::Result<T, LegionError>;

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,7 @@ mod init;
 #[allow(dead_code)] // Items used by tests + pending surface/status/serve migration
 mod kanban;
 mod mcp;
+mod mesh;
 mod pr_view;
 mod recall;
 mod reflect;
@@ -554,6 +555,12 @@ enum Commands {
         json: bool,
     },
 
+    /// Mesh-aware task placement -- rank hosts by statusline-sample headroom
+    Mesh {
+        #[command(subcommand)]
+        action: MeshAction,
+    },
+
     /// Show Claude Code session token usage and cost analysis
     Usage {
         /// Show only this specific session UUID
@@ -679,6 +686,32 @@ enum ClusterAction {
 
     /// Show cluster status: peers, sync state, last sync time
     Status,
+}
+
+#[derive(Subcommand)]
+enum MeshAction {
+    /// Print per-host ranked table with headroom, burn, and staleness
+    Headroom {
+        /// Emit raw JSON instead of the human-formatted table
+        #[arg(long)]
+        json: bool,
+    },
+
+    /// Print the best hostname to run a task on. Exit 1 if no host is fresh.
+    Pick {
+        /// Comma-separated hostnames to omit from the ranking
+        #[arg(long)]
+        exclude: Option<String>,
+
+        /// Emit raw JSON instead of the plain hostname
+        #[arg(long)]
+        json: bool,
+
+        /// Kanban card ID this pick is for (reserved for future
+        /// task-specific weighting; today a plain tag in the JSON output).
+        #[arg(long)]
+        for_task: Option<String>,
+    },
 }
 
 #[derive(Subcommand)]
@@ -1916,6 +1949,51 @@ fn raise_fd_limit() {
     match rlimit::increase_nofile_limit(u64::MAX) {
         Ok(_) => {}
         Err(e) => eprintln!("[legion] warning: could not raise fd limit: {e}"),
+    }
+}
+
+/// Mesh stale-threshold. Statusline writes on every assistant turn, so
+/// minutes of silence usually means "no session live on that host". Let
+/// operators override via env -- useful when running a flaky network
+/// where 5min is too tight, or when diagnosing a specific host.
+fn resolve_stale_cutoff() -> std::time::Duration {
+    let secs = std::env::var("LEGION_MESH_STALE_SECS")
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok())
+        .unwrap_or(mesh::DEFAULT_STALE_SECS);
+    std::time::Duration::from_secs(secs)
+}
+
+fn round_f64(v: f64, digits: u32) -> f64 {
+    let factor = 10f64.powi(digits as i32);
+    (v * factor).round() / factor
+}
+
+fn fmt_pct(v: Option<f64>) -> String {
+    match v {
+        Some(p) => format!("{:.0}", p),
+        None => "-".into(),
+    }
+}
+
+fn fmt_i64(v: Option<i64>) -> String {
+    match v {
+        Some(n) if n >= 1000 => format!("{:.0}K", n as f64 / 1000.0),
+        Some(n) => n.to_string(),
+        None => "-".into(),
+    }
+}
+
+fn format_age(d: std::time::Duration) -> String {
+    let secs = d.as_secs();
+    if secs < 60 {
+        format!("{}s", secs)
+    } else if secs < 3600 {
+        format!("{}m", secs / 60)
+    } else if secs < 86400 {
+        format!("{}h", secs / 3600)
+    } else {
+        format!("{}d", secs / 86400)
     }
 }
 
@@ -4078,6 +4156,98 @@ fn run() -> error::Result<()> {
             // already swallows internal failures and logs them, and its
             // signature reflects that contract (cannot return an error).
             statusline::run(json);
+        }
+
+        Commands::Mesh { action } => {
+            let db_path = data_dir()?.join("legion.db");
+            let database = db::Database::open(&db_path)?;
+            let stale_cutoff = resolve_stale_cutoff();
+            let now = chrono::Utc::now();
+            let ranked = mesh::ranked_hosts_from_db(&database, now, stale_cutoff)?;
+
+            match action {
+                MeshAction::Headroom { json } => {
+                    if json {
+                        let rows: Vec<_> = ranked
+                            .iter()
+                            .map(|h| {
+                                serde_json::json!({
+                                    "hostname": h.hostname,
+                                    "score": round_f64(h.score, 1),
+                                    "fiveHourPct": h.five_hour_pct,
+                                    "sevenDayPct": h.seven_day_pct,
+                                    "lastEffectiveTokens": h.last_effective_tokens,
+                                    "sampledAt": h.sampled_at,
+                                    "ageSecs": h.age.map(|a| a.as_secs()),
+                                    "stale": h.stale,
+                                })
+                            })
+                            .collect();
+                        println!(
+                            "{}",
+                            serde_json::to_string_pretty(&rows)
+                                .expect("ranked rows serialize infallibly")
+                        );
+                    } else if ranked.is_empty() {
+                        eprintln!(
+                            "[legion] no samples yet -- run `legion statusline` on at least one node first"
+                        );
+                    } else {
+                        println!(
+                            "host                 score    5h%    7d%   last_turn       age  status"
+                        );
+                        for h in &ranked {
+                            let age = h.age.map(format_age).unwrap_or_else(|| "-".into());
+                            let status = if h.stale { "stale" } else { "fresh" };
+                            println!(
+                                "{:<20} {:>6.1}  {:>5}  {:>5}  {:>10}  {:>8}  {}",
+                                h.hostname,
+                                h.score,
+                                fmt_pct(h.five_hour_pct),
+                                fmt_pct(h.seven_day_pct),
+                                fmt_i64(h.last_effective_tokens),
+                                age,
+                                status,
+                            );
+                        }
+                    }
+                }
+                MeshAction::Pick {
+                    exclude,
+                    json,
+                    for_task,
+                } => {
+                    let excluded: std::collections::HashSet<String> = exclude
+                        .as_deref()
+                        .map(|s| s.split(',').map(|v| v.trim().to_string()).collect())
+                        .unwrap_or_default();
+                    let winner = ranked
+                        .iter()
+                        .find(|h| !h.stale && !excluded.contains(&h.hostname));
+                    match winner {
+                        Some(h) => {
+                            if json {
+                                println!(
+                                    "{}",
+                                    serde_json::to_string_pretty(&serde_json::json!({
+                                        "hostname": h.hostname,
+                                        "score": round_f64(h.score, 1),
+                                        "forTask": for_task,
+                                    }))
+                                    .expect("pick payload serializes infallibly")
+                                );
+                            } else {
+                                println!("{}", h.hostname);
+                            }
+                        }
+                        None => {
+                            return Err(error::LegionError::WorkSource(
+                                "no fresh host available to pick".to_string(),
+                            ));
+                        }
+                    }
+                }
+            }
         }
 
         Commands::Usage {

--- a/src/main.rs
+++ b/src/main.rs
@@ -4241,7 +4241,7 @@ fn run() -> error::Result<()> {
                             }
                         }
                         None => {
-                            return Err(error::LegionError::WorkSource(
+                            return Err(error::LegionError::Mesh(
                                 "no fresh host available to pick".to_string(),
                             ));
                         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1964,8 +1964,8 @@ fn resolve_stale_cutoff() -> std::time::Duration {
     std::time::Duration::from_secs(secs)
 }
 
-fn round_f64(v: f64, digits: u32) -> f64 {
-    let factor = 10f64.powi(digits as i32);
+fn round_f64(v: f64, digits: i32) -> f64 {
+    let factor = 10f64.powi(digits);
     (v * factor).round() / factor
 }
 

--- a/src/mesh.rs
+++ b/src/mesh.rs
@@ -74,21 +74,39 @@ pub fn score_host(
         - seven_day_pct
             .unwrap_or(UNKNOWN_PCT_NEUTRAL)
             .clamp(0.0, 100.0);
-    WEIGHT_FIVE_HOUR * h5 + WEIGHT_SEVEN_DAY * h7 + WEIGHT_BURN * burn_component
+    // Clamp burn defensively. compute_burn_components emits 0..100 today,
+    // but a future tweak to its formula that returns out-of-range values
+    // would silently push `score` outside [0, 100] and break the
+    // partial_cmp-based sort assumption.
+    let burn = burn_component.clamp(0.0, 100.0);
+    WEIGHT_FIVE_HOUR * h5 + WEIGHT_SEVEN_DAY * h7 + WEIGHT_BURN * burn
 }
 
 /// Map hostname -> burn_component in 0..100, where higher means less
 /// burning. Derived from the median effective-token count across the
-/// cluster: any host <= median gets 100; any host >= 2x median gets 0;
-/// linear interpolation in between. Hosts with no usage sample default
-/// to 100 (we don't know they're burning, so don't penalise them).
+/// cluster (average of the two middle values on even-sized inputs):
+/// any host <= median gets 100; any host >= 2x median gets 0; linear
+/// interpolation in between. Hosts with no usage sample default to 100
+/// (we don't know they're burning, so don't penalise them).
 fn compute_burn_components(usage_by_host: &BTreeMap<String, UsageSample>) -> BTreeMap<String, f64> {
     let mut burns: Vec<i64> = usage_by_host.values().map(|s| s.effective_tokens).collect();
     if burns.is_empty() {
         return BTreeMap::new();
     }
     burns.sort_unstable();
-    let median = burns[burns.len() / 2].max(1) as f64;
+    // True median: for even n, average the two middle values. burns[n/2]
+    // alone (upper-middle) collapsed the differentiator on 2-host clusters
+    // -- both hosts satisfy ratio <= 1 and both score 100 on burn. Common
+    // LAN setups (Puck + laptop) are exactly 2 hosts, so this mattered.
+    let median = {
+        let n = burns.len();
+        let raw = if n.is_multiple_of(2) {
+            (burns[n / 2 - 1] as f64 + burns[n / 2] as f64) / 2.0
+        } else {
+            burns[n / 2] as f64
+        };
+        raw.max(1.0)
+    };
 
     let mut out = BTreeMap::new();
     for (host, sample) in usage_by_host {
@@ -200,21 +218,50 @@ fn newest_sampled_at(
     }
 }
 
+/// Maximum permitted clock skew before a peer's sample is treated as
+/// unusable. A statusline sample stamped more than this far in the
+/// future means the peer's clock is too far off to score against the
+/// cluster; treat it as stale rather than preferring it forever.
+const MAX_FUTURE_SKEW_SECS: i64 = 60;
+
 fn newest_age(
     rate: Option<&RateLimitSample>,
     usage: Option<&UsageSample>,
     now: DateTime<Utc>,
 ) -> Option<Duration> {
     let ts = newest_sampled_at(rate, usage)?;
-    let parsed = DateTime::parse_from_rfc3339(&ts).ok()?;
+    let parsed = match DateTime::parse_from_rfc3339(&ts) {
+        Ok(p) => p,
+        Err(e) => {
+            // Do not silently swallow: a corrupted sampled_at field (from
+            // schema drift or a broken peer) would otherwise return None
+            // here and silently mark the host stale with zero diagnostic.
+            eprintln!(
+                "[legion] warning: unparseable sampled_at '{}': {} -- host will be marked stale",
+                ts, e
+            );
+            return None;
+        }
+    };
     let parsed_utc = parsed.with_timezone(&Utc);
     let delta = now.signed_duration_since(parsed_utc);
-    // Negative deltas (sample timestamped in the future) clamp to zero so
-    // a clock-skew on a peer cannot silently push that host into stale.
-    if delta.num_seconds() < 0 {
+    let secs = delta.num_seconds();
+    if secs < -MAX_FUTURE_SKEW_SECS {
+        // Peer clock off by more than the grace window -- their samples
+        // cannot be ranked honestly against the cluster. Return None so
+        // the host is flagged stale rather than silently winning forever.
+        eprintln!(
+            "[legion] warning: sample timestamped {}s in the future -- peer clock skew beyond grace, marking stale",
+            -secs
+        );
+        None
+    } else if secs < 0 {
+        // Small forward skew (peer a few seconds ahead of us) is normal
+        // and harmless -- clamp age to zero so the host still counts
+        // as fresh.
         Some(Duration::from_secs(0))
     } else {
-        Some(Duration::from_secs(delta.num_seconds() as u64))
+        Some(Duration::from_secs(secs as u64))
     }
 }
 
@@ -276,6 +323,38 @@ mod tests {
         let puck = score_host(Some(30.0), Some(50.0), 100.0);
         let laptop = score_host(Some(70.0), Some(60.0), 100.0);
         assert!(puck > laptop, "lower used-% must score higher");
+    }
+
+    #[test]
+    fn score_host_neutral_default_is_exactly_50_pct_used() {
+        // Pin the magnitude, not just the ordering -- a "helpful" PR that
+        // moves UNKNOWN_PCT_NEUTRAL from 50 to 10 would still pass the
+        // ordering test (full > missing > exhausted). This one fails.
+        // score(None, None, 0) = 0.5*50 + 0.4*50 + 0.1*0 = 45.0
+        let s = score_host(None, None, 0.0);
+        assert!(
+            (s - 45.0).abs() < 1e-9,
+            "neutral default must score 45.0 given burn=0, got {s}"
+        );
+    }
+
+    #[test]
+    fn score_host_clamps_burn_out_of_range() {
+        // If compute_burn_components ever emits a value outside [0,100]
+        // (regression), score_host must clamp so the resulting score
+        // stays in [0,100] and partial_cmp ordering remains meaningful.
+        let low = score_host(Some(0.0), Some(0.0), -50.0);
+        let zero_burn = score_host(Some(0.0), Some(0.0), 0.0);
+        let high = score_host(Some(0.0), Some(0.0), 200.0);
+        let cap_burn = score_host(Some(0.0), Some(0.0), 100.0);
+        assert!(
+            (low - zero_burn).abs() < 1e-9,
+            "burn below 0 must clamp to 0"
+        );
+        assert!(
+            (high - cap_burn).abs() < 1e-9,
+            "burn above 100 must clamp to 100"
+        );
     }
 
     #[test]
@@ -353,6 +432,34 @@ mod tests {
     }
 
     #[test]
+    fn rank_hosts_huge_future_skew_marks_host_stale() {
+        // Sample stamped 2 hours in the future -- peer clock is broken
+        // beyond the grace window. Without the upper bound the host
+        // would show age=0 and win every pick forever; with it, treat
+        // as stale so an operator can see the problem.
+        let rates = vec![rate("broken-clock", "2026-04-22T14:00:00Z", 5.0, 5.0)];
+        let ranked = rank_hosts(&rates, &[], now(), Duration::from_secs(600));
+        assert_eq!(ranked.len(), 1);
+        assert!(
+            ranked[0].stale,
+            "2h-future sample must be flagged stale, not rank-winning"
+        );
+        assert!(ranked[0].age.is_none());
+    }
+
+    #[test]
+    fn rank_hosts_malformed_sampled_at_marks_host_stale() {
+        // Corrupted sampled_at field (schema drift, tampering). Stale
+        // path triggers with a warning on stderr; host does not
+        // mysteriously win pick or vanish from the table.
+        let rates = vec![rate("garbled", "not-a-timestamp", 5.0, 5.0)];
+        let ranked = rank_hosts(&rates, &[], now(), Duration::from_secs(600));
+        assert_eq!(ranked.len(), 1);
+        assert!(ranked[0].stale);
+        assert!(ranked[0].age.is_none());
+    }
+
+    #[test]
     fn ranked_hosts_from_db_roundtrips_multi_host_samples() {
         let dir = tempfile::tempdir().unwrap();
         let db = Database::open(&dir.path().join("mesh.db")).unwrap();
@@ -397,6 +504,47 @@ mod tests {
         assert_eq!(ranked.len(), 1);
         assert!(ranked[0].stale);
         assert!(ranked[0].age.is_some());
+    }
+
+    #[test]
+    fn burn_component_n1_has_sole_host_at_midpoint() {
+        // Single-host cluster: the only sample IS the midpoint, ratio=1.0,
+        // burn=100. Locks in the benign behaviour and guards against a
+        // future "divide-by-len" regression that would underflow.
+        let rates = vec![rate("solo", "2026-04-22T11:59:00Z", 30.0, 30.0)];
+        let usages = vec![usage("solo", "2026-04-22T11:59:00Z", 12345)];
+        let ranked = rank_hosts(&rates, &usages, now(), Duration::from_secs(600));
+        assert_eq!(ranked.len(), 1);
+        // score = 0.5*70 + 0.4*70 + 0.1*100 = 73
+        assert!((ranked[0].score - 73.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn burn_component_n2_lower_burner_beats_higher_on_burn() {
+        // Two-host cluster. With true-median (avg of two middles =
+        // (100+500)/2 = 300), cheap has ratio 0.33 (burn=100), spendy
+        // ratio 1.67 (burn=33). Headroom terms are equal, so burn
+        // differentiates -- the common LAN case (Puck + laptop) now
+        // gets a real picker signal.
+        let rates = vec![
+            rate("cheap", "2026-04-22T11:59:00Z", 30.0, 30.0),
+            rate("spendy", "2026-04-22T11:59:00Z", 30.0, 30.0),
+        ];
+        let usages = vec![
+            usage("cheap", "2026-04-22T11:59:00Z", 100),
+            usage("spendy", "2026-04-22T11:59:00Z", 500),
+        ];
+        let ranked = rank_hosts(&rates, &usages, now(), Duration::from_secs(600));
+        let by_host: std::collections::HashMap<_, _> = ranked
+            .into_iter()
+            .map(|h| (h.hostname.clone(), h))
+            .collect();
+        assert!(
+            by_host["cheap"].score > by_host["spendy"].score,
+            "true-median burn must differentiate the 2-host case: cheap={} spendy={}",
+            by_host["cheap"].score,
+            by_host["spendy"].score
+        );
     }
 
     #[test]

--- a/src/mesh.rs
+++ b/src/mesh.rs
@@ -206,7 +206,23 @@ fn newest_sampled_at(
 ) -> Option<String> {
     match (rate, usage) {
         (Some(r), Some(u)) => {
-            if r.sampled_at >= u.sampled_at {
+            // Parse + compare chronologically. Lex-comparing RFC3339 strings
+            // works today because every writer goes through
+            // `Utc::now().to_rfc3339()` (see src/statusline.rs), but cluster
+            // sync is the path where peer-written rows with a different
+            // serialization (`Z` vs `+00:00`, fractional seconds, whitespace)
+            // could land here. Lex ordering would silently diverge from
+            // chronological ordering at that point. Fall back to string
+            // compare only if parsing fails for both sides.
+            let rp = DateTime::parse_from_rfc3339(&r.sampled_at).ok();
+            let up = DateTime::parse_from_rfc3339(&u.sampled_at).ok();
+            let pick_rate = match (rp, up) {
+                (Some(a), Some(b)) => a >= b,
+                (Some(_), None) => true,
+                (None, Some(_)) => false,
+                (None, None) => r.sampled_at >= u.sampled_at,
+            };
+            if pick_rate {
                 Some(r.sampled_at.clone())
             } else {
                 Some(u.sampled_at.clone())
@@ -445,6 +461,30 @@ mod tests {
             "2h-future sample must be flagged stale, not rank-winning"
         );
         assert!(ranked[0].age.is_none());
+    }
+
+    #[test]
+    fn newest_sampled_at_compares_chronologically_across_rfc3339_dialects() {
+        // Cluster-sync path: peer writes `Z` suffix, local writes `+00:00`.
+        // Lex-comparing the strings would pick `+00:00` as newer because
+        // `+` (0x2B) < `Z` (0x5A), so the older local sample would win
+        // even when the peer sample is actually newer. Parse + compare
+        // chronologically to prevent the silent divergence.
+        let older_plus = rate("host", "2026-04-22T11:58:00+00:00", 30.0, 50.0);
+        let newer_z = usage("host", "2026-04-22T11:59:00Z", 100);
+        assert_eq!(
+            newest_sampled_at(Some(&older_plus), Some(&newer_z)),
+            Some("2026-04-22T11:59:00Z".to_string()),
+            "newer `Z`-suffixed sample must win even against lex-greater `+00:00` string"
+        );
+
+        // And the symmetric case: local newer (+00:00), peer older (Z).
+        let newer_plus = rate("host", "2026-04-22T12:00:00+00:00", 30.0, 50.0);
+        let older_z = usage("host", "2026-04-22T11:59:00Z", 100);
+        assert_eq!(
+            newest_sampled_at(Some(&newer_plus), Some(&older_z)),
+            Some("2026-04-22T12:00:00+00:00".to_string()),
+        );
     }
 
     #[test]

--- a/src/mesh.rs
+++ b/src/mesh.rs
@@ -1,0 +1,424 @@
+//! Mesh-aware task placement. Ranks hosts by headroom using the statusline
+//! samples that every node writes on every Claude Code turn (see
+//! `src/statusline.rs`). Cluster sync makes those samples visible to peers,
+//! so any node can ask the store "who has the most runway right now?".
+//!
+//! Consumer surface: `legion mesh headroom` prints the full ranked table,
+//! `legion mesh pick` emits the top hostname. The ranker itself is
+//! separated from the CLI so a future `legion mesh pick --for-task <id>`
+//! can apply task-specific weighting without duplicating the scoring math.
+
+use chrono::{DateTime, Utc};
+use std::collections::BTreeMap;
+use std::time::Duration;
+
+use crate::db::Database;
+use crate::error::Result;
+use crate::statusline::{RateLimitSample, UsageSample};
+
+/// Upper bound on the age of a statusline sample before a host counts as
+/// "stale" (effectively idle/offline). Statusline writes on every
+/// assistant turn, so minutes of silence usually means "no session is
+/// live there right now". Configurable via `LEGION_MESH_STALE_SECS` in
+/// the CLI layer; this constant is the compile-time default.
+pub const DEFAULT_STALE_SECS: u64 = 600;
+
+/// One host's slot in the ranked table. Carries both raw inputs (so the
+/// CLI can render them) and the derived score, plus a `stale` flag so a
+/// caller can decide to include vs exclude without re-checking the age.
+#[derive(Debug, Clone)]
+pub struct HostRanking {
+    pub hostname: String,
+    pub score: f64,
+    pub five_hour_pct: Option<f64>,
+    pub seven_day_pct: Option<f64>,
+    pub last_effective_tokens: Option<i64>,
+    pub sampled_at: Option<String>,
+    pub age: Option<Duration>,
+    pub stale: bool,
+}
+
+/// Score formula weights. Five-hour headroom dominates (it's the binding
+/// constraint in practice); seven-day is secondary; recent token burn is
+/// a small tiebreaker. Exposed so tests can reason about the shape.
+pub const WEIGHT_FIVE_HOUR: f64 = 0.5;
+pub const WEIGHT_SEVEN_DAY: f64 = 0.4;
+pub const WEIGHT_BURN: f64 = 0.1;
+
+/// Neutral default for an absent rate-limit % (50% used). A new node that
+/// has not yet written a rate-limit sample must not win the picker for
+/// free: we have no evidence it has headroom, and defaulting to 0% (full
+/// headroom) would trivially outrank every host with actual data. Neutral
+/// means "treat unknown as cluster-median, not best-case".
+const UNKNOWN_PCT_NEUTRAL: f64 = 50.0;
+
+/// Combine a host's rate-limit + usage samples into a single 0..100 score.
+///
+/// Semantics of the inputs:
+/// - `five_hour_pct` / `seven_day_pct` are USED-%; `None` means "we don't
+///   have a rate-limit sample yet" and is treated as cluster-neutral
+///   (50% used) rather than best-case.
+/// - `burn_component` is a 0..100 value representing "how few tokens this
+///   host is burning relative to the cluster median" (higher == less
+///   burning). Derived by `compute_burn_components`.
+pub fn score_host(
+    five_hour_pct: Option<f64>,
+    seven_day_pct: Option<f64>,
+    burn_component: f64,
+) -> f64 {
+    let h5 = 100.0
+        - five_hour_pct
+            .unwrap_or(UNKNOWN_PCT_NEUTRAL)
+            .clamp(0.0, 100.0);
+    let h7 = 100.0
+        - seven_day_pct
+            .unwrap_or(UNKNOWN_PCT_NEUTRAL)
+            .clamp(0.0, 100.0);
+    WEIGHT_FIVE_HOUR * h5 + WEIGHT_SEVEN_DAY * h7 + WEIGHT_BURN * burn_component
+}
+
+/// Map hostname -> burn_component in 0..100, where higher means less
+/// burning. Derived from the median effective-token count across the
+/// cluster: any host <= median gets 100; any host >= 2x median gets 0;
+/// linear interpolation in between. Hosts with no usage sample default
+/// to 100 (we don't know they're burning, so don't penalise them).
+fn compute_burn_components(usage_by_host: &BTreeMap<String, UsageSample>) -> BTreeMap<String, f64> {
+    let mut burns: Vec<i64> = usage_by_host.values().map(|s| s.effective_tokens).collect();
+    if burns.is_empty() {
+        return BTreeMap::new();
+    }
+    burns.sort_unstable();
+    let median = burns[burns.len() / 2].max(1) as f64;
+
+    let mut out = BTreeMap::new();
+    for (host, sample) in usage_by_host {
+        let ratio = sample.effective_tokens as f64 / median;
+        let score = if ratio <= 1.0 {
+            100.0
+        } else if ratio >= 2.0 {
+            0.0
+        } else {
+            // Linear: ratio=1 -> 100, ratio=2 -> 0.
+            100.0 * (2.0 - ratio)
+        };
+        out.insert(host.clone(), score);
+    }
+    out
+}
+
+/// Rank every host that has appeared in either the rate-limit or usage
+/// tables by the combined score. Stale hosts are included in the output
+/// (sorted last) but flagged so callers can filter them.
+///
+/// `now` and `stale_cutoff` are parameters rather than computed inside so
+/// tests can pin the clock.
+pub fn rank_hosts(
+    rate_samples: &[RateLimitSample],
+    usage_samples: &[UsageSample],
+    now: DateTime<Utc>,
+    stale_cutoff: Duration,
+) -> Vec<HostRanking> {
+    let mut rate_by_host: BTreeMap<String, RateLimitSample> = BTreeMap::new();
+    for s in rate_samples {
+        rate_by_host.insert(s.hostname.clone(), s.clone());
+    }
+    let mut usage_by_host: BTreeMap<String, UsageSample> = BTreeMap::new();
+    for s in usage_samples {
+        usage_by_host.insert(s.hostname.clone(), s.clone());
+    }
+
+    let burn_by_host = compute_burn_components(&usage_by_host);
+
+    let mut hosts: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
+    for k in rate_by_host.keys() {
+        hosts.insert(k.clone());
+    }
+    for k in usage_by_host.keys() {
+        hosts.insert(k.clone());
+    }
+
+    let mut out: Vec<HostRanking> = hosts
+        .into_iter()
+        .map(|host| {
+            let rate = rate_by_host.get(&host);
+            let usage = usage_by_host.get(&host);
+
+            // Age is taken from the newest of the two samples so a host
+            // with only a rate-limit sample (or only a usage sample) is
+            // not penalised as stale just because one table is empty.
+            let age = newest_age(rate, usage, now);
+            let stale = age.is_none_or(|a| a > stale_cutoff);
+
+            let burn = burn_by_host.get(&host).copied().unwrap_or(100.0);
+            let score = score_host(
+                rate.and_then(|s| s.five_hour_pct),
+                rate.and_then(|s| s.seven_day_pct),
+                burn,
+            );
+
+            HostRanking {
+                hostname: host,
+                score,
+                five_hour_pct: rate.and_then(|s| s.five_hour_pct),
+                seven_day_pct: rate.and_then(|s| s.seven_day_pct),
+                last_effective_tokens: usage.map(|u| u.effective_tokens),
+                sampled_at: newest_sampled_at(rate, usage),
+                age,
+                stale,
+            }
+        })
+        .collect();
+
+    // Fresh hosts first (highest score wins), stale hosts last
+    // (preserve their score-order for operator legibility).
+    out.sort_by(|a, b| match (a.stale, b.stale) {
+        (false, true) => std::cmp::Ordering::Less,
+        (true, false) => std::cmp::Ordering::Greater,
+        _ => b
+            .score
+            .partial_cmp(&a.score)
+            .unwrap_or(std::cmp::Ordering::Equal),
+    });
+    out
+}
+
+fn newest_sampled_at(
+    rate: Option<&RateLimitSample>,
+    usage: Option<&UsageSample>,
+) -> Option<String> {
+    match (rate, usage) {
+        (Some(r), Some(u)) => {
+            if r.sampled_at >= u.sampled_at {
+                Some(r.sampled_at.clone())
+            } else {
+                Some(u.sampled_at.clone())
+            }
+        }
+        (Some(r), None) => Some(r.sampled_at.clone()),
+        (None, Some(u)) => Some(u.sampled_at.clone()),
+        (None, None) => None,
+    }
+}
+
+fn newest_age(
+    rate: Option<&RateLimitSample>,
+    usage: Option<&UsageSample>,
+    now: DateTime<Utc>,
+) -> Option<Duration> {
+    let ts = newest_sampled_at(rate, usage)?;
+    let parsed = DateTime::parse_from_rfc3339(&ts).ok()?;
+    let parsed_utc = parsed.with_timezone(&Utc);
+    let delta = now.signed_duration_since(parsed_utc);
+    // Negative deltas (sample timestamped in the future) clamp to zero so
+    // a clock-skew on a peer cannot silently push that host into stale.
+    if delta.num_seconds() < 0 {
+        Some(Duration::from_secs(0))
+    } else {
+        Some(Duration::from_secs(delta.num_seconds() as u64))
+    }
+}
+
+/// Convenience entry point for the CLI: load samples from the store and
+/// return the ranked table in one call.
+pub fn ranked_hosts_from_db(
+    db: &Database,
+    now: DateTime<Utc>,
+    stale_cutoff: Duration,
+) -> Result<Vec<HostRanking>> {
+    let rates = db.latest_rate_limit_samples_per_host()?;
+    let usages = db.latest_usage_samples_per_host()?;
+    Ok(rank_hosts(&rates, &usages, now, stale_cutoff))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn rate(host: &str, sampled_at: &str, five: f64, seven: f64) -> RateLimitSample {
+        RateLimitSample {
+            id: format!("r-{host}-{sampled_at}"),
+            hostname: host.into(),
+            session_id: "sess".into(),
+            sampled_at: sampled_at.into(),
+            five_hour_pct: Some(five),
+            five_hour_resets_at: None,
+            seven_day_pct: Some(seven),
+            seven_day_resets_at: None,
+            model: None,
+        }
+    }
+
+    fn usage(host: &str, sampled_at: &str, effective: i64) -> UsageSample {
+        UsageSample {
+            id: format!("u-{host}-{sampled_at}"),
+            hostname: host.into(),
+            session_id: "sess".into(),
+            turn_index: None,
+            model: None,
+            input_tokens: 0,
+            output_tokens: 0,
+            cache_write_tokens: 0,
+            cache_read_tokens: 0,
+            effective_tokens: effective,
+            error_bytes: 0,
+            sampled_at: sampled_at.into(),
+        }
+    }
+
+    fn now() -> DateTime<Utc> {
+        DateTime::parse_from_rfc3339("2026-04-22T12:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc)
+    }
+
+    #[test]
+    fn score_host_prefers_more_headroom() {
+        let puck = score_host(Some(30.0), Some(50.0), 100.0);
+        let laptop = score_host(Some(70.0), Some(60.0), 100.0);
+        assert!(puck > laptop, "lower used-% must score higher");
+    }
+
+    #[test]
+    fn score_host_handles_none_as_neutral_not_best_case() {
+        // Unknown % must not beat a host with actual low-usage data.
+        // Otherwise a brand-new node that has not yet written a rate-limit
+        // sample wins the picker for free.
+        let full = score_host(Some(0.0), Some(0.0), 100.0);
+        let missing = score_host(None, None, 100.0);
+        let exhausted = score_host(Some(100.0), Some(100.0), 100.0);
+        assert!(full > missing, "known-zero-used must outrank unknown");
+        assert!(missing > exhausted, "unknown must outrank known-exhausted");
+    }
+
+    #[test]
+    fn rank_hosts_orders_by_score_descending() {
+        let rates = vec![
+            rate("laptop", "2026-04-22T11:59:00Z", 70.0, 60.0),
+            rate("puck", "2026-04-22T11:59:00Z", 30.0, 50.0),
+        ];
+        let usages = vec![
+            usage("laptop", "2026-04-22T11:59:00Z", 100),
+            usage("puck", "2026-04-22T11:59:00Z", 100),
+        ];
+        let ranked = rank_hosts(&rates, &usages, now(), Duration::from_secs(600));
+        assert_eq!(ranked.len(), 2);
+        assert_eq!(ranked[0].hostname, "puck");
+        assert_eq!(ranked[1].hostname, "laptop");
+    }
+
+    #[test]
+    fn rank_hosts_pushes_stale_to_bottom_regardless_of_score() {
+        // stale host has "better" raw headroom, but its age blows the cutoff.
+        let rates = vec![
+            rate("stale-host", "2026-04-22T00:00:00Z", 5.0, 10.0),
+            rate("fresh-host", "2026-04-22T11:59:00Z", 50.0, 50.0),
+        ];
+        let usages = vec![];
+        let ranked = rank_hosts(&rates, &usages, now(), Duration::from_secs(600));
+        assert_eq!(ranked.len(), 2);
+        assert_eq!(ranked[0].hostname, "fresh-host");
+        assert!(!ranked[0].stale);
+        assert_eq!(ranked[1].hostname, "stale-host");
+        assert!(ranked[1].stale);
+    }
+
+    #[test]
+    fn rank_hosts_empty_returns_empty() {
+        let ranked = rank_hosts(&[], &[], now(), Duration::from_secs(600));
+        assert!(ranked.is_empty());
+    }
+
+    #[test]
+    fn rank_hosts_host_with_only_usage_sample_ranks() {
+        // usage-only host has no rate %'s -- scores as full headroom,
+        // but we still want it to appear in the table.
+        let rates = vec![];
+        let usages = vec![usage("lone", "2026-04-22T11:59:30Z", 100)];
+        let ranked = rank_hosts(&rates, &usages, now(), Duration::from_secs(600));
+        assert_eq!(ranked.len(), 1);
+        assert_eq!(ranked[0].hostname, "lone");
+        assert_eq!(ranked[0].five_hour_pct, None);
+        assert!(!ranked[0].stale);
+    }
+
+    #[test]
+    fn rank_hosts_clock_skew_does_not_stale_a_future_sample() {
+        // Sample timestamped 30 seconds in the future (peer with slight
+        // clock skew). Must NOT be flagged stale.
+        let rates = vec![rate("skewed", "2026-04-22T12:00:30Z", 30.0, 50.0)];
+        let ranked = rank_hosts(&rates, &[], now(), Duration::from_secs(600));
+        assert_eq!(ranked.len(), 1);
+        assert!(!ranked[0].stale);
+        assert_eq!(ranked[0].age, Some(Duration::from_secs(0)));
+    }
+
+    #[test]
+    fn ranked_hosts_from_db_roundtrips_multi_host_samples() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = Database::open(&dir.path().join("mesh.db")).unwrap();
+
+        // Puck: newer rate sample (should win); laptop: older rate sample;
+        // kestrel: only a usage sample, no rate %s.
+        db.insert_rate_limit_sample(&rate("puck", "2026-04-22T11:59:00Z", 30.0, 50.0))
+            .unwrap();
+        db.insert_rate_limit_sample(&rate("puck", "2026-04-22T11:58:00Z", 80.0, 80.0))
+            .unwrap();
+        db.insert_rate_limit_sample(&rate("laptop", "2026-04-22T11:55:00Z", 70.0, 60.0))
+            .unwrap();
+        db.insert_usage_sample(&usage("puck", "2026-04-22T11:59:00Z", 100))
+            .unwrap();
+        db.insert_usage_sample(&usage("laptop", "2026-04-22T11:55:00Z", 120))
+            .unwrap();
+        db.insert_usage_sample(&usage("kestrel", "2026-04-22T11:59:30Z", 80))
+            .unwrap();
+
+        let ranked = ranked_hosts_from_db(&db, now(), Duration::from_secs(600)).unwrap();
+        assert_eq!(ranked.len(), 3);
+        // Puck wins: low used-% + recent sample. Kestrel has no rate %s so
+        // scores as full headroom but with the burn floor. Laptop trails on
+        // higher used-%.
+        assert_eq!(ranked[0].hostname, "puck");
+        assert!(
+            !ranked.iter().any(|h| h.stale),
+            "all three samples are within the 600s cutoff"
+        );
+    }
+
+    #[test]
+    fn ranked_hosts_from_db_stale_samples_render_as_stale() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = Database::open(&dir.path().join("mesh.db")).unwrap();
+
+        // Sample from a day ago: definitely stale under the default cutoff.
+        db.insert_rate_limit_sample(&rate("forgotten", "2026-04-21T12:00:00Z", 10.0, 10.0))
+            .unwrap();
+
+        let ranked = ranked_hosts_from_db(&db, now(), Duration::from_secs(600)).unwrap();
+        assert_eq!(ranked.len(), 1);
+        assert!(ranked[0].stale);
+        assert!(ranked[0].age.is_some());
+    }
+
+    #[test]
+    fn burn_component_penalises_heavy_burner() {
+        // Three hosts, median effective = 200. heavy host is 2x, should
+        // receive burn=0; light host is <= median, burn=100.
+        let rates = vec![
+            rate("light", "2026-04-22T11:59:00Z", 30.0, 30.0),
+            rate("medium", "2026-04-22T11:59:00Z", 30.0, 30.0),
+            rate("heavy", "2026-04-22T11:59:00Z", 30.0, 30.0),
+        ];
+        let usages = vec![
+            usage("light", "2026-04-22T11:59:00Z", 100),
+            usage("medium", "2026-04-22T11:59:00Z", 200),
+            usage("heavy", "2026-04-22T11:59:00Z", 400),
+        ];
+        let ranked = rank_hosts(&rates, &usages, now(), Duration::from_secs(600));
+        let by_host: std::collections::HashMap<_, _> = ranked
+            .into_iter()
+            .map(|h| (h.hostname.clone(), h))
+            .collect();
+        // All three share identical headroom; burn is the sole differentiator.
+        assert!(by_host["light"].score > by_host["heavy"].score);
+    }
+}

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -4404,4 +4404,163 @@ fn mesh_pick_on_empty_store_exits_nonzero() {
         stderr.contains("no fresh host"),
         "error message must name the condition, got: {stderr}"
     );
+    assert!(
+        !stderr.contains("WorkSource"),
+        "error must not surface as a WorkSource variant -- operators grep that token for real plugin failures, got: {stderr}"
+    );
+}
+
+/// Seed a single rate-limit sample by invoking `legion statusline` with a
+/// minimal synthetic Claude Code JSON payload. Returns the path to a
+/// transcript file we do NOT create -- statusline tolerates a missing
+/// transcript (skips usage sample) and still writes the rate-limit row.
+fn seed_rate_limit_sample(data_dir: &std::path::Path, five_hour_pct: f64, seven_day_pct: f64) {
+    let session_id = format!("seed-{}", uuid::Uuid::now_v7());
+    let payload = serde_json::json!({
+        "session_id": session_id,
+        "rate_limits": {
+            "five_hour": { "used_percentage": five_hour_pct, "resets_at": 0 },
+            "seven_day": { "used_percentage": seven_day_pct, "resets_at": 0 },
+        },
+    });
+    let mut child = legion_cmd(data_dir)
+        .args(["statusline"])
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .spawn()
+        .unwrap();
+    use std::io::Write;
+    child
+        .stdin
+        .as_mut()
+        .unwrap()
+        .write_all(payload.to_string().as_bytes())
+        .unwrap();
+    let out = child.wait_with_output().unwrap();
+    assert!(out.status.success(), "statusline seed failed");
+}
+
+#[test]
+fn mesh_headroom_json_shape_pins_field_names() {
+    let dir = tempfile::tempdir().unwrap();
+    seed_rate_limit_sample(dir.path(), 40.0, 55.0);
+
+    let out = legion_cmd(dir.path())
+        .args(["mesh", "headroom", "--json"])
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "headroom failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let parsed: serde_json::Value = serde_json::from_str(&stdout).expect("valid JSON");
+    let rows = parsed.as_array().expect("expected array");
+    assert!(
+        !rows.is_empty(),
+        "seed should produce at least one host row"
+    );
+    let row = &rows[0];
+    // Contract: downstream schedulers / hooks will key on these names.
+    // A typo or camelCase flip is a silent breakage otherwise.
+    for field in [
+        "hostname",
+        "score",
+        "fiveHourPct",
+        "sevenDayPct",
+        "lastEffectiveTokens",
+        "sampledAt",
+        "ageSecs",
+        "stale",
+    ] {
+        assert!(
+            row.get(field).is_some(),
+            "missing field '{field}' in headroom JSON: {row}"
+        );
+    }
+}
+
+#[test]
+fn mesh_pick_json_shape_pins_field_names() {
+    let dir = tempfile::tempdir().unwrap();
+    seed_rate_limit_sample(dir.path(), 40.0, 55.0);
+
+    let out = legion_cmd(dir.path())
+        .args(["mesh", "pick", "--json", "--for-task", "card-xyz"])
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "pick --json failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let parsed: serde_json::Value = serde_json::from_str(&stdout).expect("valid JSON");
+    for field in ["hostname", "score", "forTask"] {
+        assert!(
+            parsed.get(field).is_some(),
+            "missing field '{field}' in pick JSON: {parsed}"
+        );
+    }
+    assert_eq!(
+        parsed["forTask"].as_str(),
+        Some("card-xyz"),
+        "--for-task must round-trip into the JSON payload"
+    );
+}
+
+#[test]
+fn mesh_pick_exclude_removes_named_host() {
+    let dir = tempfile::tempdir().unwrap();
+    seed_rate_limit_sample(dir.path(), 10.0, 10.0);
+    // Figure out the host's name from headroom output.
+    let head = legion_cmd(dir.path())
+        .args(["mesh", "headroom", "--json"])
+        .output()
+        .unwrap();
+    let parsed: serde_json::Value =
+        serde_json::from_str(&String::from_utf8_lossy(&head.stdout)).unwrap();
+    let host = parsed[0]["hostname"].as_str().unwrap().to_string();
+
+    // Excluding the only fresh host must exit 1 with "no fresh host".
+    let out = legion_cmd(dir.path())
+        .args(["mesh", "pick", "--exclude", &host])
+        .output()
+        .unwrap();
+    assert!(
+        !out.status.success(),
+        "pick must fail when every fresh host is excluded"
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("no fresh host"),
+        "error must name condition, got: {stderr}"
+    );
+}
+
+#[test]
+fn mesh_stale_cutoff_env_override_is_respected() {
+    // Default cutoff is 600s. Seed a sample, sleep so the sample is
+    // definitely older than 3 seconds, then run pick with a 3-second
+    // cutoff. Sample must register as stale; pick must fail.
+    let dir = tempfile::tempdir().unwrap();
+    seed_rate_limit_sample(dir.path(), 40.0, 55.0);
+    std::thread::sleep(std::time::Duration::from_secs(4));
+
+    let out = legion_cmd(dir.path())
+        .env("LEGION_MESH_STALE_SECS", "3")
+        .args(["mesh", "pick"])
+        .output()
+        .unwrap();
+    assert!(
+        !out.status.success(),
+        "with cutoff=3s the >=4s-old sample is stale; pick must fail. stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("no fresh host"),
+        "stale env-override path must surface the same no-fresh-host error, got: {stderr}"
+    );
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -4358,3 +4358,50 @@ fn watch_add_rejects_nonexistent_workdir() {
         "watch add should fail for non-directory path"
     );
 }
+
+#[test]
+fn mesh_headroom_on_empty_store_notices_no_samples() {
+    let dir = tempfile::tempdir().unwrap();
+    let out = legion_cmd(dir.path())
+        .args(["mesh", "headroom"])
+        .output()
+        .unwrap();
+    assert!(out.status.success(), "headroom on empty store exits 0");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("no samples yet"),
+        "empty-store notice expected, got stderr: {stderr}"
+    );
+}
+
+#[test]
+fn mesh_headroom_json_on_empty_store_returns_array() {
+    let dir = tempfile::tempdir().unwrap();
+    let out = legion_cmd(dir.path())
+        .args(["mesh", "headroom", "--json"])
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let parsed: serde_json::Value = serde_json::from_str(&stdout).expect("valid JSON");
+    assert!(parsed.is_array(), "expected JSON array, got {parsed}");
+    assert_eq!(parsed.as_array().unwrap().len(), 0);
+}
+
+#[test]
+fn mesh_pick_on_empty_store_exits_nonzero() {
+    let dir = tempfile::tempdir().unwrap();
+    let out = legion_cmd(dir.path())
+        .args(["mesh", "pick"])
+        .output()
+        .unwrap();
+    assert!(
+        !out.status.success(),
+        "pick must fail when no fresh host exists"
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("no fresh host"),
+        "error message must name the condition, got: {stderr}"
+    );
+}


### PR DESCRIPTION
Closes #303.

## Summary

Load-bearing piece of v0.9.4: makes the cluster-synced statusline data from v0.9.3 actually consumable. A node can now ask the store "who has the most runway?" and get a ranked answer.

## New CLI

```
legion mesh headroom [--json]         # per-host ranked table
legion mesh pick [--json]             # best host, exit 1 if none fresh
legion mesh pick --exclude host1,host2
legion mesh pick --for-task <card>    # reserved for future weighting
```

`pick` is designed for shell pipelines: `HOST=\$(legion mesh pick) && ssh \$HOST -- legion work`. Exit code is load-bearing.

## Design

Ranker is a score in 0..100:
- 0.5 * (100 - five_hour_pct)
- 0.4 * (100 - seven_day_pct)
- 0.1 * burn_component

Five-hour headroom dominates because it's the binding constraint in practice. Seven-day is secondary. Burn is a small tiebreaker derived from the cluster median of recent effective-token counts.

**Unknown rate-limit % defaults to neutral (50% used), not best-case.** A brand-new node that has not yet written a rate-limit sample must not win the picker for free. Codified in test `score_host_neutral_default_is_exactly_50_pct_used` (pins the magnitude, not just the ordering).

**Stale hosts are included in the ranked table but pushed to the bottom.** Operators see them for diagnostic purposes; `pick` filters them out.

**Clock-skew handling is explicit.** Small forward skew (\<=60s) clamps age to zero and the host counts fresh. Beyond 60s future, the peer's clock is too broken to rank honestly -- mark stale with a stderr warning. No silent "preferred forever" bug.

**Deterministic tie-break in the DB query.** Switched from \`(hostname, sampled_at) IN (SELECT MAX GROUP BY hostname)\` to a ROW_NUMBER OVER (PARTITION BY hostname ORDER BY sampled_at DESC, id DESC) window. The old form returned both rows when two writes collided on the same RFC3339-second tick; BTreeMap then collapsed them in non-deterministic iteration order. Now the tie-break is: newer sampled_at, then higher id (UUIDv7 embeds time as a secondary proof).

**True median for burn component.** Old formula used \`burns[n/2]\` which is the upper-middle on even-sized inputs; for n=2 that IS the max, so both hosts got ratio \<= 1 and burn=100 -- zero differentiation on a two-host LAN (the common Puck + laptop case). Now: average of the two middle values on even n.

## Tests

**22 mesh + DB tests, 5 CLI integration tests.**

Unit tests (src/mesh.rs):
- score_host ordering + magnitude + burn clamp + neutral-default contract
- rank_hosts ordering, stale bottom-pushing, clock-skew clamp, huge-skew stale, malformed-timestamp stale
- burn median n=1, n=2 (now differentiating), heavy-burner penalty
- ranked_hosts_from_db multi-host roundtrip + stale surfacing

DB unit tests (src/db.rs):
- latest_rate_limit_samples_per_host newest-per-host + soft-delete + empty
- latest_usage_samples_per_host newest-per-host

CLI integration tests (tests/integration.rs) use a new seed_rate_limit_sample helper that pipes synthetic statusline JSON:
- headroom empty-store notice
- headroom --json empty-array
- pick empty-store exits 1
- headroom --json field-name pin (hostname/score/fiveHourPct/sevenDayPct/lastEffectiveTokens/sampledAt/ageSecs/stale)
- pick --json field-name pin (hostname/score/forTask) + --for-task round-trip
- pick --exclude removes named host, exits 1 when all fresh hosts excluded
- LEGION_MESH_STALE_SECS env override

**105 total tests passing**, 0 regressions. \`cargo clippy --all-targets -- -D warnings\` clean, \`cargo fmt --check\` clean. Simplify gate recorded clean.

## New error variant

\`LegionError::Mesh(String)\`. Returned by \`mesh pick\` when no fresh host is available. Previously this used \`LegionError::WorkSource\` which operators grep for real plugin failures; the mesh condition would have poisoned that filter.

## Review posture

Dogfooded locally: \`legion mesh headroom\` on empty store emits the notice; \`mesh pick\` exits 1 with "no fresh host available to pick". Full cluster dogfood is gated on the laptop coming up with v0.9.3.

Do not merge without explicit user approval. v0.9.4 release PR will follow once this merges.