### PR TITLE
feat(#308): cluster-wide persona wake leases

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -323,6 +323,8 @@ async fn run_watch_task(data_dir: &Path) {
     );
     let mut tracker = watch::AgentTracker::new();
     let session_locks = watch::SessionLockTracker::new(data_dir, config.session_lock_ttl_secs);
+    let host = watch::resolve_host_id();
+    let lease_ttl = std::time::Duration::from_secs(config.persona_lease_ttl_secs);
     let mut sampler = crate::health::HealthSampler::new(config.health_window_size);
 
     let poll_interval = std::time::Duration::from_secs(config.poll_interval_secs);
@@ -343,7 +345,10 @@ async fn run_watch_task(data_dir: &Path) {
 
         if health_timer.elapsed() >= health_interval {
             sampler.sample();
-            tracker.reap_finished();
+            tracker.reap_finished(Some(&db));
+            if let Err(e) = db.heartbeat_persona_leases(&host, lease_ttl) {
+                eprintln!("[legion daemon] lease heartbeat error: {e}");
+            }
 
             match sampler.to_health_sample(tracker.active_count()) {
                 Ok(sample) => {
@@ -361,12 +366,18 @@ async fn run_watch_task(data_dir: &Path) {
 
         if poll_timer.elapsed() >= poll_interval {
             if sampler.can_spawn(config.health_threshold_pct) {
+                let lease_gate = watch::PersonaLeaseGate {
+                    db: &db,
+                    host: &host,
+                    ttl: lease_ttl,
+                };
                 match watch::poll_cycle(
                     &db,
                     &config,
                     &mut cooldown,
                     &mut tracker,
                     Some(&session_locks),
+                    Some(&lease_gate),
                     Some(&lookback),
                 ) {
                     Ok(n) if n > 0 => {

--- a/src/db.rs
+++ b/src/db.rs
@@ -2732,12 +2732,15 @@ fn map_persona_lease_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<PersonaWak
 impl Database {
     /// Try to acquire a persona wake lease. Returns `Ok(true)` on success,
     /// `Ok(false)` when a live lease for `(persona_id, signal_id)` is already
-    /// held by someone else. Expired or soft-deleted leases are treated as
-    /// free -- the new acquire overwrites them.
+    /// held. Expired or soft-deleted leases are treated as free and may be
+    /// claimed by the caller.
     ///
-    /// Atomicity: the check-then-insert runs inside a transaction, and SQLite
-    /// serializes writers per connection. Cross-host races are resolved by
-    /// `apply_persona_wake_lease_delta` using earlier `acquired_at` wins.
+    /// Atomicity: a single `UPDATE ... WHERE expires_at <= now OR deleted_at IS NOT NULL`
+    /// followed by `INSERT OR IGNORE` runs inside a transaction. Both
+    /// statements take SQLite's write lock so cross-process races are
+    /// serialized by the DB file lock; the caller sees the outcome via
+    /// `rows_changed()`. This matches the issue spec: "INSERT OR FAIL with
+    /// primary-key collision; first-writer-wins."
     pub fn try_acquire_persona_lease(
         &self,
         persona_id: &str,
@@ -2754,31 +2757,42 @@ impl Database {
 
         let tx = self.conn.unchecked_transaction()?;
 
-        let existing: Option<String> = tx
-            .query_row(
-                "SELECT acquired_by_host FROM persona_wake_leases \
-                 WHERE persona_id = ?1 AND signal_id = ?2 \
-                   AND deleted_at IS NULL AND expires_at > ?3",
-                rusqlite::params![persona_id, signal_id, &now_str],
-                |r| r.get(0),
-            )
-            .optional()?;
-
-        if existing.is_some() {
-            tx.commit()?;
-            return Ok(false);
-        }
-
+        // Reclaim stale rows so INSERT OR IGNORE below can succeed against
+        // them. Scoped by PK so this only touches the row we are trying to
+        // acquire -- no broad sweep here.
         tx.execute(
-            "INSERT OR REPLACE INTO persona_wake_leases \
+            "UPDATE persona_wake_leases \
+             SET acquired_by_host = ?1, acquired_at = ?2, heartbeat_at = ?2, \
+                 expires_at = ?3, updated_at = ?2, deleted_at = NULL \
+             WHERE persona_id = ?4 AND signal_id = ?5 \
+               AND (deleted_at IS NOT NULL OR expires_at <= ?2)",
+            rusqlite::params![host, &now_str, &expires, persona_id, signal_id],
+        )?;
+
+        let inserted = tx.execute(
+            "INSERT OR IGNORE INTO persona_wake_leases \
              (persona_id, signal_id, acquired_by_host, acquired_at, heartbeat_at, \
               expires_at, updated_at, deleted_at) \
              VALUES (?1, ?2, ?3, ?4, ?4, ?5, ?4, NULL)",
             rusqlite::params![persona_id, signal_id, host, &now_str, &expires],
         )?;
 
+        // If INSERT OR IGNORE inserted (1) or the reclaim UPDATE touched a
+        // stale row we now own, the lease is ours. Confirm we hold it by
+        // reading back -- covers the edge case where the stale-reclaim
+        // UPDATE succeeded but the INSERT was a no-op.
+        let holder: Option<String> = tx
+            .query_row(
+                "SELECT acquired_by_host FROM persona_wake_leases \
+                 WHERE persona_id = ?1 AND signal_id = ?2 AND deleted_at IS NULL",
+                rusqlite::params![persona_id, signal_id],
+                |r| r.get(0),
+            )
+            .optional()?;
+
         tx.commit()?;
-        Ok(true)
+        let _ = inserted;
+        Ok(holder.as_deref() == Some(host))
     }
 
     /// Refresh every live lease held by `host`, extending `expires_at` to
@@ -2801,6 +2815,11 @@ impl Database {
 
     /// Soft-delete one lease by (persona_id, signal_id). Returns true if a
     /// matching live lease existed. Idempotent on an already-released lease.
+    ///
+    /// Unscoped by host -- used by the operator CLI to forcibly drop any
+    /// stuck lease. The watch reaper uses `release_persona_lease_if_owner`
+    /// instead so a late-loser whose lease was overwritten by sync cannot
+    /// accidentally release the winner's row.
     pub fn release_persona_lease(&self, persona_id: &str, signal_id: &str) -> Result<bool> {
         let now = Utc::now().to_rfc3339();
         let updated = self.conn.execute(
@@ -2808,6 +2827,27 @@ impl Database {
              SET deleted_at = ?1, updated_at = ?1 \
              WHERE persona_id = ?2 AND signal_id = ?3 AND deleted_at IS NULL",
             rusqlite::params![&now, persona_id, signal_id],
+        )?;
+        Ok(updated > 0)
+    }
+
+    /// Like `release_persona_lease`, but only if the lease is still held by
+    /// `host`. Used by the watch reaper so a late-loser whose lease was
+    /// overwritten by a sync-resolved peer cannot release the peer's row.
+    /// Returns true only when this host's row was released.
+    pub fn release_persona_lease_if_owner(
+        &self,
+        persona_id: &str,
+        signal_id: &str,
+        host: &str,
+    ) -> Result<bool> {
+        let now = Utc::now().to_rfc3339();
+        let updated = self.conn.execute(
+            "UPDATE persona_wake_leases \
+             SET deleted_at = ?1, updated_at = ?1 \
+             WHERE persona_id = ?2 AND signal_id = ?3 \
+               AND acquired_by_host = ?4 AND deleted_at IS NULL",
+            rusqlite::params![&now, persona_id, signal_id, host],
         )?;
         Ok(updated > 0)
     }
@@ -5127,33 +5167,190 @@ mod tests {
 
     #[test]
     fn persona_lease_apply_delta_earlier_acquired_at_wins() {
-        let db = test_db();
-        // Local lease acquired now (later than the incoming delta).
-        db.try_acquire_persona_lease("legion", "sig-1", "local", Duration::from_secs(60))
-            .unwrap();
+        // Two real acquires against separate databases, 50ms apart, then
+        // sync-apply the earlier one onto the later's database and assert
+        // the earlier wins. Uses realistic clock deltas rather than hardcoded
+        // ancient timestamps so the test exercises actual RFC3339 ordering
+        // at sub-second precision.
+        let peer_db = test_db();
+        assert!(
+            peer_db
+                .try_acquire_persona_lease("legion", "sig-1", "peer", Duration::from_secs(3600))
+                .unwrap()
+        );
+        let peer_row = peer_db.list_persona_leases(None).unwrap().remove(0);
 
+        std::thread::sleep(Duration::from_millis(50));
+
+        let local_db = test_db();
+        assert!(
+            local_db
+                .try_acquire_persona_lease("legion", "sig-1", "local", Duration::from_secs(3600))
+                .unwrap()
+        );
+
+        // Peer's lease is older; when its delta reaches local, local is the
+        // late loser.
         let delta = crate::sync::PersonaWakeLeaseDelta {
-            persona_id: "legion".into(),
-            signal_id: "sig-1".into(),
-            acquired_by_host: "peer".into(),
-            acquired_at: "2000-01-01T00:00:00Z".into(), // ancient -- earlier wins
-            heartbeat_at: "2000-01-01T00:00:00Z".into(),
-            expires_at: "2099-01-01T00:00:00Z".into(),
-            updated_at: "2000-01-01T00:00:00Z".into(),
-            deleted_at: None,
+            persona_id: peer_row.persona_id,
+            signal_id: peer_row.signal_id,
+            acquired_by_host: peer_row.acquired_by_host,
+            acquired_at: peer_row.acquired_at.clone(),
+            heartbeat_at: peer_row.heartbeat_at,
+            expires_at: peer_row.expires_at,
+            updated_at: peer_row.updated_at,
+            deleted_at: peer_row.deleted_at,
         };
-        let late = db.apply_persona_wake_lease_delta(&delta).unwrap();
+        let late = local_db.apply_persona_wake_lease_delta(&delta).unwrap();
         assert_eq!(
             late.as_deref(),
             Some("local"),
             "local node is the late loser; its host identity must surface"
         );
 
-        let listed = db.list_persona_leases(None).unwrap();
+        let listed = local_db.list_persona_leases(None).unwrap();
         assert_eq!(listed.len(), 1);
         assert_eq!(
             listed[0].acquired_by_host, "peer",
             "peer's earlier lease must win"
+        );
+        assert_eq!(
+            listed[0].acquired_at, delta.acquired_at,
+            "winning acquired_at must be peer's, not local's"
+        );
+    }
+
+    #[test]
+    fn persona_lease_acquire_succeeds_after_ttl_expires_without_release() {
+        // Crash-recovery path: the holder acquires with a short TTL, never
+        // calls release (simulating a crash), and after the TTL elapses the
+        // next acquirer succeeds. This is the behavior the issue calls out:
+        // "session crashes without releasing -> lease expires via heartbeat
+        // TTL. Another wake on the same signal succeeds after expiration."
+        let db = test_db();
+        assert!(
+            db.try_acquire_persona_lease(
+                "legion",
+                "sig-1",
+                "crashy-host",
+                Duration::from_millis(100)
+            )
+            .unwrap()
+        );
+
+        // While the lease is still live, a second acquire must fail.
+        assert!(
+            !db.try_acquire_persona_lease(
+                "legion",
+                "sig-1",
+                "recovery-host",
+                Duration::from_secs(3600)
+            )
+            .unwrap(),
+            "live lease (even near expiry) must block a concurrent acquire"
+        );
+
+        // Wait past the TTL without calling release.
+        std::thread::sleep(Duration::from_millis(200));
+
+        assert!(
+            db.try_acquire_persona_lease(
+                "legion",
+                "sig-1",
+                "recovery-host",
+                Duration::from_secs(3600)
+            )
+            .unwrap(),
+            "after TTL elapses, a new acquirer must succeed"
+        );
+
+        let listed = db.list_persona_leases(None).unwrap();
+        assert_eq!(listed.len(), 1);
+        assert_eq!(
+            listed[0].acquired_by_host, "recovery-host",
+            "recovery host must own the post-crash lease"
+        );
+    }
+
+    #[test]
+    fn persona_lease_acquire_is_cross_connection_race_safe() {
+        // Issue #308 atomicity contract: two independent Database handles
+        // against the same file race to acquire the same (persona, signal).
+        // Each thread opens its own handle (Database is !Send because it
+        // wraps rusqlite::Connection; ownership stays thread-local). Exactly
+        // one must win; neither can surface SQLITE_BUSY as Err.
+        use std::thread;
+
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("race.sqlite");
+
+        // Prime the schema once so neither racing thread takes the migration
+        // path (what's being tested is acquire atomicity, not open atomicity).
+        let _ = Database::open(&db_path).unwrap();
+
+        let path_a = db_path.clone();
+        let path_b = db_path.clone();
+
+        let t_a = thread::spawn(move || -> Result<bool> {
+            let db = Database::open(&path_a)?;
+            db.try_acquire_persona_lease("legion", "sig-race", "host-A", Duration::from_secs(60))
+        });
+        let t_b = thread::spawn(move || -> Result<bool> {
+            let db = Database::open(&path_b)?;
+            db.try_acquire_persona_lease("legion", "sig-race", "host-B", Duration::from_secs(60))
+        });
+
+        let r_a = t_a.join().unwrap();
+        let r_b = t_b.join().unwrap();
+
+        let mut wins = 0usize;
+        for r in [&r_a, &r_b] {
+            match r {
+                Ok(true) => wins += 1,
+                Ok(false) => {}
+                Err(e) => panic!("acquire surfaced SQLITE_BUSY as Err: {e}"),
+            }
+        }
+        assert_eq!(
+            wins, 1,
+            "exactly one concurrent acquire must win (got {} winners)",
+            wins
+        );
+
+        let observer = Database::open(&db_path).unwrap();
+        let listed = observer.list_persona_leases(None).unwrap();
+        assert_eq!(listed.len(), 1);
+        assert!(
+            listed[0].acquired_by_host == "host-A" || listed[0].acquired_by_host == "host-B",
+            "unexpected host recorded: {}",
+            listed[0].acquired_by_host
+        );
+    }
+
+    #[test]
+    fn persona_lease_release_if_owner_refuses_foreign_host() {
+        // Guards the late-loser reaper scenario: after sync conflict
+        // resolution overwrites local's row with peer's, local's AgentTracker
+        // will try to reap and release the lease it thought it held. The
+        // host-scoped release must refuse because the row now belongs to
+        // peer, preventing the late-loser from dropping the winner's lease.
+        let db = test_db();
+        db.try_acquire_persona_lease("legion", "sig-1", "peer", Duration::from_secs(60))
+            .unwrap();
+
+        let released = db
+            .release_persona_lease_if_owner("legion", "sig-1", "late-loser")
+            .unwrap();
+        assert!(
+            !released,
+            "host-scoped release must refuse to touch a row owned by another host"
+        );
+
+        let listed = db.list_persona_leases(None).unwrap();
+        assert_eq!(listed.len(), 1);
+        assert_eq!(
+            listed[0].acquired_by_host, "peer",
+            "peer's lease must survive the late-loser's release attempt"
         );
     }
 

--- a/src/db.rs
+++ b/src/db.rs
@@ -631,6 +631,34 @@ impl Database {
                 ON usage_samples(hostname, sampled_at) WHERE deleted_at IS NULL;",
         )?;
 
+        // Migration 17: Persona wake leases for cluster-wide wake coordination (#308).
+        //
+        // When a signal arrives addressed to a persona (either `--to P` or `--to all`),
+        // watch acquires a lease keyed by (persona_id, signal_id) before spawning. Other
+        // nodes (or later poll cycles on the same node) see the lease is held and skip
+        // the wake. Heartbeats keep the lease fresh; crashes release via TTL.
+        //
+        // `deleted_at` + `updated_at` carry the usual LWW semantics for smugglr sync.
+        // `expires_at` is a denormalized scalar for cheap "is this lease still live"
+        // filters without constructing a duration against `heartbeat_at` at query time.
+        conn.execute_batch(
+            "CREATE TABLE IF NOT EXISTS persona_wake_leases (
+                persona_id TEXT NOT NULL,
+                signal_id TEXT NOT NULL,
+                acquired_by_host TEXT NOT NULL,
+                acquired_at TEXT NOT NULL,
+                heartbeat_at TEXT NOT NULL,
+                expires_at TEXT NOT NULL,
+                deleted_at TEXT,
+                updated_at TEXT NOT NULL,
+                PRIMARY KEY (persona_id, signal_id)
+            );
+            CREATE INDEX IF NOT EXISTS idx_persona_wake_leases_persona \
+                ON persona_wake_leases(persona_id) WHERE deleted_at IS NULL;
+            CREATE INDEX IF NOT EXISTS idx_persona_wake_leases_expires \
+                ON persona_wake_leases(expires_at) WHERE deleted_at IS NULL;",
+        )?;
+
         Ok(())
     }
 
@@ -2670,6 +2698,302 @@ impl RenameCounts {
     }
 }
 
+/// A persona wake lease -- "host H is handling signal S for persona P until T".
+///
+/// Acquired by watch before spawning an agent in response to a wake signal.
+/// Other watchers (on this node or peers) see the live lease and skip their
+/// own spawn. Heartbeats keep `expires_at` rolling forward; a crashed session
+/// whose heartbeats stop lets the lease age out via TTL.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq)]
+pub struct PersonaWakeLease {
+    pub persona_id: String,
+    pub signal_id: String,
+    pub acquired_by_host: String,
+    pub acquired_at: String,
+    pub heartbeat_at: String,
+    pub expires_at: String,
+    pub updated_at: String,
+    pub deleted_at: Option<String>,
+}
+
+fn map_persona_lease_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<PersonaWakeLease> {
+    Ok(PersonaWakeLease {
+        persona_id: row.get(0)?,
+        signal_id: row.get(1)?,
+        acquired_by_host: row.get(2)?,
+        acquired_at: row.get(3)?,
+        heartbeat_at: row.get(4)?,
+        expires_at: row.get(5)?,
+        deleted_at: row.get(6)?,
+        updated_at: row.get(7)?,
+    })
+}
+
+impl Database {
+    /// Try to acquire a persona wake lease. Returns `Ok(true)` on success,
+    /// `Ok(false)` when a live lease for `(persona_id, signal_id)` is already
+    /// held by someone else. Expired or soft-deleted leases are treated as
+    /// free -- the new acquire overwrites them.
+    ///
+    /// Atomicity: the check-then-insert runs inside a transaction, and SQLite
+    /// serializes writers per connection. Cross-host races are resolved by
+    /// `apply_persona_wake_lease_delta` using earlier `acquired_at` wins.
+    pub fn try_acquire_persona_lease(
+        &self,
+        persona_id: &str,
+        signal_id: &str,
+        host: &str,
+        lease_ttl: std::time::Duration,
+    ) -> Result<bool> {
+        let now = Utc::now();
+        let now_str = now.to_rfc3339();
+        let expires = (now
+            + chrono::Duration::from_std(lease_ttl)
+                .unwrap_or_else(|_| chrono::Duration::minutes(10)))
+        .to_rfc3339();
+
+        let tx = self.conn.unchecked_transaction()?;
+
+        let existing: Option<String> = tx
+            .query_row(
+                "SELECT acquired_by_host FROM persona_wake_leases \
+                 WHERE persona_id = ?1 AND signal_id = ?2 \
+                   AND deleted_at IS NULL AND expires_at > ?3",
+                rusqlite::params![persona_id, signal_id, &now_str],
+                |r| r.get(0),
+            )
+            .optional()?;
+
+        if existing.is_some() {
+            tx.commit()?;
+            return Ok(false);
+        }
+
+        tx.execute(
+            "INSERT OR REPLACE INTO persona_wake_leases \
+             (persona_id, signal_id, acquired_by_host, acquired_at, heartbeat_at, \
+              expires_at, updated_at, deleted_at) \
+             VALUES (?1, ?2, ?3, ?4, ?4, ?5, ?4, NULL)",
+            rusqlite::params![persona_id, signal_id, host, &now_str, &expires],
+        )?;
+
+        tx.commit()?;
+        Ok(true)
+    }
+
+    /// Refresh every live lease held by `host`, extending `expires_at` to
+    /// `now + ttl`. Returns the number of leases touched.
+    pub fn heartbeat_persona_leases(&self, host: &str, ttl: std::time::Duration) -> Result<u64> {
+        let now = Utc::now();
+        let now_str = now.to_rfc3339();
+        let expires = (now
+            + chrono::Duration::from_std(ttl).unwrap_or_else(|_| chrono::Duration::minutes(10)))
+        .to_rfc3339();
+
+        let updated = self.conn.execute(
+            "UPDATE persona_wake_leases \
+             SET heartbeat_at = ?1, expires_at = ?2, updated_at = ?1 \
+             WHERE acquired_by_host = ?3 AND deleted_at IS NULL",
+            rusqlite::params![&now_str, &expires, host],
+        )?;
+        Ok(updated as u64)
+    }
+
+    /// Soft-delete one lease by (persona_id, signal_id). Returns true if a
+    /// matching live lease existed. Idempotent on an already-released lease.
+    pub fn release_persona_lease(&self, persona_id: &str, signal_id: &str) -> Result<bool> {
+        let now = Utc::now().to_rfc3339();
+        let updated = self.conn.execute(
+            "UPDATE persona_wake_leases \
+             SET deleted_at = ?1, updated_at = ?1 \
+             WHERE persona_id = ?2 AND signal_id = ?3 AND deleted_at IS NULL",
+            rusqlite::params![&now, persona_id, signal_id],
+        )?;
+        Ok(updated > 0)
+    }
+
+    /// Soft-delete every live lease held by `host`. Called on daemon shutdown
+    /// so a graceful exit does not leave ghost leases that must age out via TTL.
+    #[allow(dead_code)] // wired by a future SIGTERM handler; kept in the API surface now
+    pub fn release_persona_leases_by_host(&self, host: &str) -> Result<u64> {
+        let now = Utc::now().to_rfc3339();
+        let updated = self.conn.execute(
+            "UPDATE persona_wake_leases \
+             SET deleted_at = ?1, updated_at = ?1 \
+             WHERE acquired_by_host = ?2 AND deleted_at IS NULL",
+            rusqlite::params![&now, host],
+        )?;
+        Ok(updated as u64)
+    }
+
+    /// Return every live (non-expired, non-deleted) lease, optionally filtered
+    /// to a single persona. Ordered oldest-first by `acquired_at` so the CLI
+    /// lists leases in the order they were taken.
+    pub fn list_persona_leases(&self, persona: Option<&str>) -> Result<Vec<PersonaWakeLease>> {
+        let now = Utc::now().to_rfc3339();
+        match persona {
+            Some(p) => {
+                let mut stmt = self.conn.prepare(
+                    "SELECT persona_id, signal_id, acquired_by_host, acquired_at, \
+                            heartbeat_at, expires_at, deleted_at, updated_at \
+                     FROM persona_wake_leases \
+                     WHERE deleted_at IS NULL AND expires_at > ?1 AND persona_id = ?2 \
+                     ORDER BY acquired_at ASC",
+                )?;
+                Ok(stmt
+                    .query_map(rusqlite::params![&now, p], map_persona_lease_row)?
+                    .collect::<rusqlite::Result<Vec<_>>>()?)
+            }
+            None => {
+                let mut stmt = self.conn.prepare(
+                    "SELECT persona_id, signal_id, acquired_by_host, acquired_at, \
+                            heartbeat_at, expires_at, deleted_at, updated_at \
+                     FROM persona_wake_leases \
+                     WHERE deleted_at IS NULL AND expires_at > ?1 \
+                     ORDER BY acquired_at ASC",
+                )?;
+                Ok(stmt
+                    .query_map(rusqlite::params![&now], map_persona_lease_row)?
+                    .collect::<rusqlite::Result<Vec<_>>>()?)
+            }
+        }
+    }
+
+    /// Delta query for cluster sync. Returns every lease row (including
+    /// tombstones) whose `updated_at > since`. Wire transport is not yet live;
+    /// `sync_actor` reads this today so the count shows up in broadcast logs,
+    /// and late-loser resolution is ready to engage when transport lands.
+    #[allow(dead_code)] // wired when broadcast transport ships
+    pub fn get_persona_wake_lease_deltas_since(
+        &self,
+        since: &str,
+    ) -> Result<Vec<crate::sync::PersonaWakeLeaseDelta>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT persona_id, signal_id, acquired_by_host, acquired_at, \
+                    heartbeat_at, expires_at, deleted_at, updated_at \
+             FROM persona_wake_leases \
+             WHERE updated_at > ?1 \
+             ORDER BY updated_at ASC",
+        )?;
+        let deltas = stmt
+            .query_map(rusqlite::params![since], |row| {
+                Ok(crate::sync::PersonaWakeLeaseDelta {
+                    persona_id: row.get(0)?,
+                    signal_id: row.get(1)?,
+                    acquired_by_host: row.get(2)?,
+                    acquired_at: row.get(3)?,
+                    heartbeat_at: row.get(4)?,
+                    expires_at: row.get(5)?,
+                    deleted_at: row.get(6)?,
+                    updated_at: row.get(7)?,
+                })
+            })?
+            .collect::<rusqlite::Result<Vec<_>>>()?;
+        Ok(deltas)
+    }
+
+    /// Apply an incoming lease delta from a peer. Resolution rules:
+    ///
+    /// - Tombstone (`deleted_at` set): LWW on `updated_at`. Newer wins.
+    /// - Live lease vs. live lease for the same (persona, signal):
+    ///   earlier `acquired_at` wins. The late-loser releases its local lease
+    ///   so the spawned child is the only handler.
+    /// - Live lease vs. no local row: insert the peer's lease as-is.
+    ///
+    /// Returns `Some(released)` with the locally-held `acquired_by_host` when
+    /// this node was the late loser and its lease was downgraded to a
+    /// tombstone. Callers can use this to stop the losing spawn.
+    #[allow(dead_code)] // wired when broadcast transport ships
+    pub fn apply_persona_wake_lease_delta(
+        &self,
+        delta: &crate::sync::PersonaWakeLeaseDelta,
+    ) -> Result<Option<String>> {
+        let tx = self.conn.unchecked_transaction()?;
+
+        let local: Option<(String, String, Option<String>, String)> = tx
+            .query_row(
+                "SELECT acquired_by_host, acquired_at, deleted_at, updated_at \
+                 FROM persona_wake_leases \
+                 WHERE persona_id = ?1 AND signal_id = ?2",
+                rusqlite::params![&delta.persona_id, &delta.signal_id],
+                |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?, r.get(3)?)),
+            )
+            .optional()?;
+
+        let mut late_loser: Option<String> = None;
+
+        match local {
+            None => {
+                tx.execute(
+                    "INSERT INTO persona_wake_leases \
+                     (persona_id, signal_id, acquired_by_host, acquired_at, heartbeat_at, \
+                      expires_at, updated_at, deleted_at) \
+                     VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+                    rusqlite::params![
+                        &delta.persona_id,
+                        &delta.signal_id,
+                        &delta.acquired_by_host,
+                        &delta.acquired_at,
+                        &delta.heartbeat_at,
+                        &delta.expires_at,
+                        &delta.updated_at,
+                        &delta.deleted_at,
+                    ],
+                )?;
+            }
+            Some((local_host, local_acquired, local_deleted, local_updated)) => {
+                let delta_deleted = delta.deleted_at.is_some();
+                let local_is_deleted = local_deleted.is_some();
+
+                if delta_deleted || local_is_deleted {
+                    // Tombstone involved: plain LWW on updated_at.
+                    if delta.updated_at > local_updated {
+                        tx.execute(
+                            "UPDATE persona_wake_leases \
+                             SET acquired_by_host = ?1, acquired_at = ?2, heartbeat_at = ?3, \
+                                 expires_at = ?4, updated_at = ?5, deleted_at = ?6 \
+                             WHERE persona_id = ?7 AND signal_id = ?8",
+                            rusqlite::params![
+                                &delta.acquired_by_host,
+                                &delta.acquired_at,
+                                &delta.heartbeat_at,
+                                &delta.expires_at,
+                                &delta.updated_at,
+                                &delta.deleted_at,
+                                &delta.persona_id,
+                                &delta.signal_id,
+                            ],
+                        )?;
+                    }
+                } else if delta.acquired_at < local_acquired {
+                    // Two live leases -- earlier acquired_at wins, regardless
+                    // of updated_at ordering. Local is the late loser.
+                    let now = Utc::now().to_rfc3339();
+                    tx.execute(
+                        "UPDATE persona_wake_leases \
+                         SET acquired_by_host = ?1, acquired_at = ?2, heartbeat_at = ?3, \
+                             expires_at = ?4, updated_at = ?5, deleted_at = NULL \
+                         WHERE persona_id = ?6 AND signal_id = ?7",
+                        rusqlite::params![
+                            &delta.acquired_by_host,
+                            &delta.acquired_at,
+                            &delta.heartbeat_at,
+                            &delta.expires_at,
+                            &now,
+                            &delta.persona_id,
+                            &delta.signal_id,
+                        ],
+                    )?;
+                    late_loser = Some(local_host);
+                }
+            }
+        }
+
+        tx.commit()?;
+        Ok(late_loser)
+    }
+}
+
 /// Map a database row to a HealthSample struct.
 fn map_health_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<crate::health::HealthSample> {
     Ok(crate::health::HealthSample {
@@ -4597,6 +4921,266 @@ mod tests {
         let db = test_db();
         let got = db.latest_rate_limit_samples_per_host().unwrap();
         assert!(got.is_empty());
+    }
+
+    // -- Persona wake lease tests -------------------------------------------
+
+    use std::time::Duration;
+
+    #[test]
+    fn persona_lease_acquire_succeeds_when_free() {
+        let db = test_db();
+        let got = db
+            .try_acquire_persona_lease("legion", "sig-1", "hostA", Duration::from_secs(60))
+            .unwrap();
+        assert!(
+            got,
+            "first acquire on a free (persona, signal) must succeed"
+        );
+    }
+
+    #[test]
+    fn persona_lease_acquire_fails_when_held_by_another_host() {
+        let db = test_db();
+        assert!(
+            db.try_acquire_persona_lease("legion", "sig-1", "hostA", Duration::from_secs(60))
+                .unwrap()
+        );
+        let got = db
+            .try_acquire_persona_lease("legion", "sig-1", "hostB", Duration::from_secs(60))
+            .unwrap();
+        assert!(
+            !got,
+            "second acquire on a live lease must report 'held' (false)"
+        );
+
+        let listed = db.list_persona_leases(Some("legion")).unwrap();
+        assert_eq!(listed.len(), 1);
+        assert_eq!(
+            listed[0].acquired_by_host, "hostA",
+            "hostA's lease must remain untouched by hostB's failed acquire"
+        );
+    }
+
+    #[test]
+    fn persona_lease_acquire_succeeds_after_release() {
+        let db = test_db();
+        db.try_acquire_persona_lease("legion", "sig-1", "hostA", Duration::from_secs(60))
+            .unwrap();
+        let released = db.release_persona_lease("legion", "sig-1").unwrap();
+        assert!(released, "release of a live lease must report true");
+
+        let got = db
+            .try_acquire_persona_lease("legion", "sig-1", "hostB", Duration::from_secs(60))
+            .unwrap();
+        assert!(got, "acquire after release must succeed");
+    }
+
+    #[test]
+    fn persona_lease_release_is_idempotent() {
+        let db = test_db();
+        db.try_acquire_persona_lease("legion", "sig-1", "hostA", Duration::from_secs(60))
+            .unwrap();
+        assert!(db.release_persona_lease("legion", "sig-1").unwrap());
+        assert!(
+            !db.release_persona_lease("legion", "sig-1").unwrap(),
+            "second release of the same lease must report false (already released)"
+        );
+    }
+
+    #[test]
+    fn persona_lease_acquire_succeeds_after_expiry() {
+        let db = test_db();
+        // TTL of 0 seconds -> lease expires immediately.
+        assert!(
+            db.try_acquire_persona_lease("legion", "sig-1", "hostA", Duration::from_secs(0))
+                .unwrap()
+        );
+        // Sleep long enough that the clock advances past `expires_at`.
+        std::thread::sleep(Duration::from_millis(10));
+        let got = db
+            .try_acquire_persona_lease("legion", "sig-1", "hostB", Duration::from_secs(60))
+            .unwrap();
+        assert!(
+            got,
+            "acquire against an expired lease must succeed (hostB takes over)"
+        );
+
+        let listed = db.list_persona_leases(Some("legion")).unwrap();
+        assert_eq!(listed.len(), 1);
+        assert_eq!(
+            listed[0].acquired_by_host, "hostB",
+            "the fresh lease must be owned by the reacquirer"
+        );
+    }
+
+    #[test]
+    fn persona_lease_heartbeat_extends_expiry() {
+        let db = test_db();
+        db.try_acquire_persona_lease("legion", "sig-1", "hostA", Duration::from_secs(60))
+            .unwrap();
+        let before = db.list_persona_leases(Some("legion")).unwrap().remove(0);
+
+        std::thread::sleep(Duration::from_millis(20));
+        let n = db
+            .heartbeat_persona_leases("hostA", Duration::from_secs(3600))
+            .unwrap();
+        assert_eq!(n, 1, "heartbeat should touch exactly hostA's live lease");
+
+        let after = db.list_persona_leases(Some("legion")).unwrap().remove(0);
+        assert!(
+            after.expires_at > before.expires_at,
+            "heartbeat must push expires_at forward (before: {}, after: {})",
+            before.expires_at,
+            after.expires_at
+        );
+        assert!(
+            after.heartbeat_at > before.heartbeat_at,
+            "heartbeat must advance heartbeat_at"
+        );
+    }
+
+    #[test]
+    fn persona_lease_heartbeat_skips_foreign_hosts() {
+        let db = test_db();
+        db.try_acquire_persona_lease("legion", "sig-1", "hostA", Duration::from_secs(60))
+            .unwrap();
+        let n = db
+            .heartbeat_persona_leases("hostB", Duration::from_secs(3600))
+            .unwrap();
+        assert_eq!(n, 0, "heartbeat must only touch the caller's leases");
+    }
+
+    #[test]
+    fn persona_lease_list_filters_by_persona() {
+        let db = test_db();
+        db.try_acquire_persona_lease("legion", "sig-1", "hostA", Duration::from_secs(60))
+            .unwrap();
+        db.try_acquire_persona_lease("huttspawn", "sig-2", "hostA", Duration::from_secs(60))
+            .unwrap();
+
+        let all = db.list_persona_leases(None).unwrap();
+        assert_eq!(all.len(), 2);
+
+        let legion_only = db.list_persona_leases(Some("legion")).unwrap();
+        assert_eq!(legion_only.len(), 1);
+        assert_eq!(legion_only[0].persona_id, "legion");
+    }
+
+    #[test]
+    fn persona_lease_list_omits_expired() {
+        let db = test_db();
+        db.try_acquire_persona_lease("legion", "sig-1", "hostA", Duration::from_secs(0))
+            .unwrap();
+        std::thread::sleep(Duration::from_millis(10));
+        let listed = db.list_persona_leases(None).unwrap();
+        assert!(listed.is_empty(), "expired leases must not appear in list");
+    }
+
+    #[test]
+    fn persona_lease_list_omits_tombstones() {
+        let db = test_db();
+        db.try_acquire_persona_lease("legion", "sig-1", "hostA", Duration::from_secs(60))
+            .unwrap();
+        db.release_persona_lease("legion", "sig-1").unwrap();
+        let listed = db.list_persona_leases(None).unwrap();
+        assert!(listed.is_empty(), "released leases must not appear in list");
+    }
+
+    #[test]
+    fn persona_lease_release_by_host_clears_all_host_leases() {
+        let db = test_db();
+        db.try_acquire_persona_lease("legion", "sig-1", "hostA", Duration::from_secs(60))
+            .unwrap();
+        db.try_acquire_persona_lease("huttspawn", "sig-2", "hostA", Duration::from_secs(60))
+            .unwrap();
+        db.try_acquire_persona_lease("kessel", "sig-3", "hostB", Duration::from_secs(60))
+            .unwrap();
+
+        let cleared = db.release_persona_leases_by_host("hostA").unwrap();
+        assert_eq!(cleared, 2, "must release exactly hostA's two leases");
+
+        let remaining = db.list_persona_leases(None).unwrap();
+        assert_eq!(remaining.len(), 1);
+        assert_eq!(remaining[0].acquired_by_host, "hostB");
+    }
+
+    #[test]
+    fn persona_lease_apply_delta_inserts_new() {
+        let db = test_db();
+        let delta = crate::sync::PersonaWakeLeaseDelta {
+            persona_id: "legion".into(),
+            signal_id: "sig-1".into(),
+            acquired_by_host: "peer".into(),
+            acquired_at: "2026-04-24T00:00:00Z".into(),
+            heartbeat_at: "2026-04-24T00:00:00Z".into(),
+            expires_at: "2099-01-01T00:00:00Z".into(),
+            updated_at: "2026-04-24T00:00:00Z".into(),
+            deleted_at: None,
+        };
+        let late = db.apply_persona_wake_lease_delta(&delta).unwrap();
+        assert!(late.is_none(), "no local row means no late loser");
+        let listed = db.list_persona_leases(None).unwrap();
+        assert_eq!(listed.len(), 1);
+        assert_eq!(listed[0].acquired_by_host, "peer");
+    }
+
+    #[test]
+    fn persona_lease_apply_delta_earlier_acquired_at_wins() {
+        let db = test_db();
+        // Local lease acquired now (later than the incoming delta).
+        db.try_acquire_persona_lease("legion", "sig-1", "local", Duration::from_secs(60))
+            .unwrap();
+
+        let delta = crate::sync::PersonaWakeLeaseDelta {
+            persona_id: "legion".into(),
+            signal_id: "sig-1".into(),
+            acquired_by_host: "peer".into(),
+            acquired_at: "2000-01-01T00:00:00Z".into(), // ancient -- earlier wins
+            heartbeat_at: "2000-01-01T00:00:00Z".into(),
+            expires_at: "2099-01-01T00:00:00Z".into(),
+            updated_at: "2000-01-01T00:00:00Z".into(),
+            deleted_at: None,
+        };
+        let late = db.apply_persona_wake_lease_delta(&delta).unwrap();
+        assert_eq!(
+            late.as_deref(),
+            Some("local"),
+            "local node is the late loser; its host identity must surface"
+        );
+
+        let listed = db.list_persona_leases(None).unwrap();
+        assert_eq!(listed.len(), 1);
+        assert_eq!(
+            listed[0].acquired_by_host, "peer",
+            "peer's earlier lease must win"
+        );
+    }
+
+    #[test]
+    fn persona_lease_apply_delta_tombstone_wins_by_lww() {
+        let db = test_db();
+        db.try_acquire_persona_lease("legion", "sig-1", "local", Duration::from_secs(60))
+            .unwrap();
+
+        // Incoming tombstone with a later updated_at.
+        let delta = crate::sync::PersonaWakeLeaseDelta {
+            persona_id: "legion".into(),
+            signal_id: "sig-1".into(),
+            acquired_by_host: "local".into(),
+            acquired_at: "2026-04-24T00:00:00Z".into(),
+            heartbeat_at: "2026-04-24T00:00:00Z".into(),
+            expires_at: "2099-01-01T00:00:00Z".into(),
+            updated_at: "2099-01-01T00:00:00Z".into(),
+            deleted_at: Some("2099-01-01T00:00:00Z".into()),
+        };
+        db.apply_persona_wake_lease_delta(&delta).unwrap();
+
+        let listed = db.list_persona_leases(None).unwrap();
+        assert!(
+            listed.is_empty(),
+            "incoming tombstone with newer updated_at must eclipse local live lease"
+        );
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1380,6 +1380,33 @@ enum WatchAction {
 
     /// List all repos currently in watch.toml
     List,
+
+    /// Inspect or manage persona wake leases (cluster-wide wake coordination)
+    Leases {
+        #[command(subcommand)]
+        action: LeaseAction,
+    },
+}
+
+#[derive(Subcommand, Debug)]
+enum LeaseAction {
+    /// List currently held persona wake leases
+    List {
+        /// Show only leases for this persona (e.g. `legion`, `huttspawn`)
+        #[arg(long)]
+        persona: Option<String>,
+    },
+
+    /// Release a single lease by (persona, signal_id). Idempotent.
+    Release {
+        /// Persona whose lease should be released
+        #[arg(long)]
+        persona: String,
+
+        /// Signal id whose lease should be released
+        #[arg(long)]
+        signal: String,
+    },
 }
 
 /// Resolve the legion data directory.
@@ -4079,6 +4106,42 @@ fn run() -> error::Result<()> {
                                 .map(|a| format!(" (agent: {})", a))
                                 .unwrap_or_default();
                             println!("{}\t{}{}", repo.name, repo.workdir, agent_note);
+                        }
+                    }
+                }
+                Some(WatchAction::Leases { action }) => {
+                    let base = data_dir()?;
+                    let db_path = base.join("legion.db");
+                    let db = db::Database::open(&db_path)?;
+                    match action {
+                        LeaseAction::List { persona } => {
+                            let leases = db.list_persona_leases(persona.as_deref())?;
+                            if leases.is_empty() {
+                                println!("no active persona wake leases");
+                            } else {
+                                println!("PERSONA\tSIGNAL\tHOST\tACQUIRED\tEXPIRES");
+                                for l in &leases {
+                                    println!(
+                                        "{}\t{}\t{}\t{}\t{}",
+                                        l.persona_id,
+                                        l.signal_id,
+                                        l.acquired_by_host,
+                                        l.acquired_at,
+                                        l.expires_at,
+                                    );
+                                }
+                            }
+                        }
+                        LeaseAction::Release { persona, signal } => {
+                            let released = db.release_persona_lease(&persona, &signal)?;
+                            if released {
+                                println!("released lease {}/{}", persona, signal);
+                            } else {
+                                println!(
+                                    "no live lease found for {}/{} (may already be released)",
+                                    persona, signal
+                                );
+                            }
                         }
                     }
                 }

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -199,6 +199,23 @@ pub struct ScheduleDelta {
     pub active_end: Option<String>,
 }
 
+/// A persona wake lease row serialized for sync transmission.
+///
+/// Leases prevent two nodes from waking the same persona for the same signal.
+/// See `db::PersonaWakeLease` for acquire / release / heartbeat semantics and
+/// `db::apply_persona_wake_lease_delta` for the late-loser conflict rule.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PersonaWakeLeaseDelta {
+    pub persona_id: String,
+    pub signal_id: String,
+    pub acquired_by_host: String,
+    pub acquired_at: String,
+    pub heartbeat_at: String,
+    pub expires_at: String,
+    pub updated_at: String,
+    pub deleted_at: Option<String>,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/sync_actor.rs
+++ b/src/sync_actor.rs
@@ -141,15 +141,25 @@ async fn run_sync_loop(
                             eprintln!("[legion sync] schedule delta query failed: {}", e);
                             Vec::new()
                         });
+                let lease_deltas = db
+                    .get_persona_wake_lease_deltas_since(&last_sync)
+                    .unwrap_or_else(|e| {
+                        eprintln!("[legion sync] lease delta query failed: {}", e);
+                        Vec::new()
+                    });
 
-                let total = reflection_deltas.len() + card_deltas.len() + schedule_deltas.len();
+                let total = reflection_deltas.len()
+                    + card_deltas.len()
+                    + schedule_deltas.len()
+                    + lease_deltas.len();
                 if total > 0 {
                     eprintln!(
-                        "[legion sync] broadcasting {} delta(s) ({} reflections, {} cards, {} schedules)",
+                        "[legion sync] broadcasting {} delta(s) ({} reflections, {} cards, {} schedules, {} leases)",
                         total,
                         reflection_deltas.len(),
                         card_deltas.len(),
-                        schedule_deltas.len()
+                        schedule_deltas.len(),
+                        lease_deltas.len()
                     );
 
                     // TODO: Actually broadcast the deltas to peers

--- a/src/watch.rs
+++ b/src/watch.rs
@@ -749,7 +749,12 @@ pub fn spawn_agent(workdir: &str, prompt: &str) -> Result<Child> {
 pub struct TrackedChild {
     pub repo: String,
     pub child: Child,
+    /// `(persona_id, signal_id)` pairs this child acquired at spawn.
     pub held_leases: Vec<(String, String)>,
+    /// Host identity the leases were acquired under. Required for the
+    /// host-scoped release so a sync-resolved late-loser cannot drop the
+    /// peer winner's row.
+    pub host: String,
 }
 
 pub struct AgentTracker {
@@ -763,18 +768,28 @@ impl AgentTracker {
         }
     }
 
-    /// Record a spawned child process together with the leases it holds.
-    pub fn track(&mut self, repo: String, child: Child, held_leases: Vec<(String, String)>) {
+    /// Record a spawned child process together with the leases it holds and
+    /// the host identity under which they were acquired.
+    pub fn track(
+        &mut self,
+        repo: String,
+        child: Child,
+        held_leases: Vec<(String, String)>,
+        host: String,
+    ) {
         self.children.push(TrackedChild {
             repo,
             child,
             held_leases,
+            host,
         });
     }
 
     /// Reap finished child processes, removing them from tracking and
-    /// releasing their held persona wake leases. Lease release errors are
-    /// logged but not propagated -- a missed release will age out via TTL.
+    /// releasing their held persona wake leases. Uses host-scoped release so
+    /// a late-loser whose lease was overwritten by sync conflict resolution
+    /// cannot accidentally drop the peer winner's row. Release errors are
+    /// logged but not propagated -- a missed release ages out via TTL.
     pub fn reap_finished(&mut self, db: Option<&Database>) {
         self.children
             .retain_mut(|tracked| match tracked.child.try_wait() {
@@ -786,7 +801,9 @@ impl AgentTracker {
                     );
                     if let Some(db) = db {
                         for (persona, signal_id) in &tracked.held_leases {
-                            if let Err(e) = db.release_persona_lease(persona, signal_id) {
+                            if let Err(e) =
+                                db.release_persona_lease_if_owner(persona, signal_id, &tracked.host)
+                            {
                                 eprintln!(
                                     "[legion watch] failed to release lease {}/{}: {}",
                                     persona, signal_id, e
@@ -965,16 +982,12 @@ pub fn poll_cycle(
                         recipient,
                         skipped.len()
                     );
-                    // Mark locally so we don't retry on the next poll; whoever
-                    // holds the lease is the authoritative handler.
-                    for id in &skipped {
-                        if let Err(e) = db.mark_signal_handled_for_repo(id, &repo.name) {
-                            eprintln!(
-                                "[legion watch] failed to mark signal {} as handled for {}: {}",
-                                id, repo.name, e
-                            );
-                        }
-                    }
+                    // Do NOT mark signals handled here. The lease TTL is the
+                    // authoritative signal for "is the holder still alive."
+                    // If the holder crashes before spawning, its lease ages
+                    // out and the next poll on this host can try again. Local
+                    // handled-marking would turn a crashed peer into a
+                    // permanently-lost signal from our perspective.
                     continue;
                 }
                 acquired
@@ -1017,7 +1030,8 @@ pub fn poll_cycle(
                         repo.name, e
                     );
                 }
-                tracker.track(repo.name.clone(), child, held_leases);
+                let track_host = lease_gate.map(|g| g.host.to_string()).unwrap_or_default();
+                tracker.track(repo.name.clone(), child, held_leases, track_host);
                 cooldown.record_wake(&repo.name);
                 spawned += 1;
                 eprintln!("[legion watch] spawned agent for {}", repo.name);

--- a/src/watch.rs
+++ b/src/watch.rs
@@ -193,6 +193,13 @@ pub struct WatchConfig {
     #[serde(default = "default_session_lock_ttl_secs")]
     pub session_lock_ttl_secs: u64,
 
+    /// TTL for persona wake leases, in seconds. A lease expires this many
+    /// seconds after its last heartbeat. Default 10 minutes. The daemon
+    /// heartbeats every poll cycle, so healthy sessions keep their lease
+    /// rolling forward; a crashed session's lease ages out within one TTL.
+    #[serde(default = "default_persona_lease_ttl_secs")]
+    pub persona_lease_ttl_secs: u64,
+
     /// Whether this node serves the web dashboard.
     /// Only one node per network should have this set to true.
     #[serde(default)]
@@ -239,6 +246,10 @@ fn default_session_lock_ttl_secs() -> u64 {
     3600
 }
 
+fn default_persona_lease_ttl_secs() -> u64 {
+    600
+}
+
 impl Default for WatchConfig {
     fn default() -> Self {
         Self {
@@ -252,6 +263,7 @@ impl Default for WatchConfig {
             health_window_size: default_health_window_size(),
             retention_days: default_retention_days(),
             session_lock_ttl_secs: default_session_lock_ttl_secs(),
+            persona_lease_ttl_secs: default_persona_lease_ttl_secs(),
             serve: false,
             cluster: None,
             repos: Vec::new(),
@@ -730,9 +742,18 @@ pub fn spawn_agent(workdir: &str, prompt: &str) -> Result<Child> {
 
 // -- Agent Tracker -----------------------------------------------------------
 
-/// Tracks spawned child processes for active agent counting.
+/// Tracks spawned child processes for active agent counting and persona
+/// wake lease cleanup. Each tracked entry carries the (persona, signal_id)
+/// pairs it acquired leases for so that `reap_finished` can release them
+/// when the child exits.
+pub struct TrackedChild {
+    pub repo: String,
+    pub child: Child,
+    pub held_leases: Vec<(String, String)>,
+}
+
 pub struct AgentTracker {
-    children: Vec<(String, Child)>,
+    children: Vec<TrackedChild>,
 }
 
 impl AgentTracker {
@@ -742,30 +763,48 @@ impl AgentTracker {
         }
     }
 
-    /// Record a spawned child process.
-    pub fn track(&mut self, repo: String, child: Child) {
-        self.children.push((repo, child));
+    /// Record a spawned child process together with the leases it holds.
+    pub fn track(&mut self, repo: String, child: Child, held_leases: Vec<(String, String)>) {
+        self.children.push(TrackedChild {
+            repo,
+            child,
+            held_leases,
+        });
     }
 
-    /// Reap finished child processes, removing them from tracking.
-    pub fn reap_finished(&mut self) {
-        self.children.retain_mut(|(repo, child)| {
-            match child.try_wait() {
+    /// Reap finished child processes, removing them from tracking and
+    /// releasing their held persona wake leases. Lease release errors are
+    /// logged but not propagated -- a missed release will age out via TTL.
+    pub fn reap_finished(&mut self, db: Option<&Database>) {
+        self.children
+            .retain_mut(|tracked| match tracked.child.try_wait() {
                 Ok(Some(status)) => {
                     eprintln!(
                         "[legion watch] agent for {} exited ({})",
-                        repo,
+                        tracked.repo,
                         if status.success() { "ok" } else { "error" }
                     );
+                    if let Some(db) = db {
+                        for (persona, signal_id) in &tracked.held_leases {
+                            if let Err(e) = db.release_persona_lease(persona, signal_id) {
+                                eprintln!(
+                                    "[legion watch] failed to release lease {}/{}: {}",
+                                    persona, signal_id, e
+                                );
+                            }
+                        }
+                    }
                     false // remove from list
                 }
                 Ok(None) => true, // still running
                 Err(e) => {
-                    eprintln!("[legion watch] error checking agent for {}: {}", repo, e);
+                    eprintln!(
+                        "[legion watch] error checking agent for {}: {}",
+                        tracked.repo, e
+                    );
                     true // keep tracking -- process may still be running
                 }
-            }
-        });
+            });
     }
 
     /// Number of currently active agents.
@@ -837,12 +876,28 @@ pub fn check_auto_unblock(db: &Database, signals: &[(String, String, String)]) -
     unblocked
 }
 
+/// Cluster-wide persona wake lease gate. When present, watch will try to
+/// acquire a lease for each signal before spawning; if every lease is already
+/// held, the spawn is skipped (another node or session is handling it).
+pub struct PersonaLeaseGate<'a> {
+    pub db: &'a Database,
+    pub host: &'a str,
+    pub ttl: Duration,
+}
+
+/// Resolve this host's identity for persona wake lease ownership. Falls back
+/// to `"unknown"` when the system hostname is not available.
+pub fn resolve_host_id() -> String {
+    sysinfo::System::host_name().unwrap_or_else(|| "unknown".to_owned())
+}
+
 pub fn poll_cycle(
     db: &Database,
     config: &WatchConfig,
     cooldown: &mut CooldownTracker,
     tracker: &mut AgentTracker,
     session_locks: Option<&SessionLockTracker>,
+    lease_gate: Option<&PersonaLeaseGate<'_>>,
     since: Option<&str>,
 ) -> Result<u32> {
     let mut spawned: u32 = 0;
@@ -881,6 +936,52 @@ pub fn poll_cycle(
             continue;
         }
 
+        // Try to acquire a persona wake lease for each signal. Policy:
+        // - All acquires fail  -> another node/session is already handling
+        //   every one of these signals; skip this spawn entirely.
+        // - Any acquire succeeds -> proceed with the spawn. The held leases
+        //   travel with the child and are released on reap.
+        let held_leases = match lease_gate {
+            Some(gate) => {
+                let mut acquired: Vec<(String, String)> = Vec::new();
+                let mut skipped: Vec<String> = Vec::new();
+                for (id, _, _) in &signals {
+                    match gate
+                        .db
+                        .try_acquire_persona_lease(recipient, id, gate.host, gate.ttl)
+                    {
+                        Ok(true) => acquired.push((recipient.to_string(), id.clone())),
+                        Ok(false) => skipped.push(id.clone()),
+                        Err(e) => eprintln!(
+                            "[legion watch] lease acquire error for {}/{}: {}",
+                            recipient, id, e
+                        ),
+                    }
+                }
+                if acquired.is_empty() {
+                    eprintln!(
+                        "[legion watch] skipping {}: persona {} lease held elsewhere ({} signal(s))",
+                        repo.name,
+                        recipient,
+                        skipped.len()
+                    );
+                    // Mark locally so we don't retry on the next poll; whoever
+                    // holds the lease is the authoritative handler.
+                    for id in &skipped {
+                        if let Err(e) = db.mark_signal_handled_for_repo(id, &repo.name) {
+                            eprintln!(
+                                "[legion watch] failed to mark signal {} as handled for {}: {}",
+                                id, repo.name, e
+                            );
+                        }
+                    }
+                    continue;
+                }
+                acquired
+            }
+            None => Vec::new(),
+        };
+
         eprintln!(
             "[legion watch] {} signal(s) for {} -- waking agent",
             signals.len(),
@@ -916,12 +1017,25 @@ pub fn poll_cycle(
                         repo.name, e
                     );
                 }
-                tracker.track(repo.name.clone(), child);
+                tracker.track(repo.name.clone(), child, held_leases);
                 cooldown.record_wake(&repo.name);
                 spawned += 1;
                 eprintln!("[legion watch] spawned agent for {}", repo.name);
             }
             Err(e) => {
+                // Spawn failed -- release any leases we acquired so another
+                // node/poll cycle can retry. Missing release would block
+                // re-wakes for a full TTL.
+                if let Some(gate) = lease_gate {
+                    for (persona, sig_id) in &held_leases {
+                        if let Err(re) = gate.db.release_persona_lease(persona, sig_id) {
+                            eprintln!(
+                                "[legion watch] failed to release lease {}/{} after spawn failure: {}",
+                                persona, sig_id, re
+                            );
+                        }
+                    }
+                }
                 eprintln!("[legion watch] spawn failed for {}: {}", repo.name, e);
             }
         }
@@ -972,6 +1086,13 @@ pub fn run(data_dir: &Path) -> Result<()> {
     let poll_interval = Duration::from_secs(config.poll_interval_secs);
     let health_interval = Duration::from_secs(config.health_poll_secs);
     let retention_cutoff = chrono::Duration::days(config.retention_days as i64);
+    let host = resolve_host_id();
+    let lease_ttl = Duration::from_secs(config.persona_lease_ttl_secs);
+    let lease_gate = PersonaLeaseGate {
+        db: &db,
+        host: &host,
+        ttl: lease_ttl,
+    };
     // On startup, only look back 24 hours for unhandled signals.
     // Prevents historical flood when watch restarts after downtime.
     // The watch_handled table prevents re-processing, but without a
@@ -1015,7 +1136,10 @@ pub fn run(data_dir: &Path) -> Result<()> {
         // Health sample on its own interval
         if health_timer.elapsed() >= health_interval {
             sampler.sample();
-            tracker.reap_finished();
+            tracker.reap_finished(Some(&db));
+            if let Err(e) = db.heartbeat_persona_leases(&host, lease_ttl) {
+                eprintln!("[legion watch] lease heartbeat error: {}", e);
+            }
 
             // Persist health sample (failure is non-fatal)
             match sampler.to_health_sample(tracker.active_count()) {
@@ -1041,6 +1165,7 @@ pub fn run(data_dir: &Path) -> Result<()> {
                     &mut cooldown,
                     &mut tracker,
                     Some(&session_locks),
+                    Some(&lease_gate),
                     Some(&lookback),
                 ) {
                     Ok(n) if n > 0 => {
@@ -1483,12 +1608,69 @@ workdir = "/tmp"
             &mut tracker,
             Some(&locks),
             None,
+            None,
         )
         .expect("poll");
         assert_eq!(
             spawned, 0,
             "active session lock must block a second wake for the same repo"
         );
+    }
+
+    #[test]
+    fn poll_cycle_skips_when_persona_lease_is_held() {
+        // Cluster-gate test: a peer node has already acquired the lease for
+        // the inbound signal. This host's poll_cycle must skip the wake
+        // entirely and mark the signal handled so it does not retry.
+        let (db, _index, _dir) = test_storage();
+
+        let config = WatchConfig {
+            repos: vec![WatchRepoConfig {
+                name: "legion".to_string(),
+                workdir: "/tmp".to_string(),
+                agent: None,
+                extra: toml::Table::new(),
+            }],
+            ..WatchConfig::default()
+        };
+
+        let signal = db
+            .insert_reflection("kelex", "@legion question:help", "team")
+            .expect("insert signal");
+
+        // Simulate a peer holding the lease for this (persona, signal).
+        let held = db
+            .try_acquire_persona_lease("legion", &signal.id, "peer-host", Duration::from_secs(3600))
+            .expect("peer acquire");
+        assert!(held, "peer must be able to acquire a free lease");
+
+        let gate = PersonaLeaseGate {
+            db: &db,
+            host: "this-host",
+            ttl: Duration::from_secs(3600),
+        };
+        let mut cooldown = CooldownTracker::new(0, None, None);
+        let mut tracker = AgentTracker::new();
+        let spawned = poll_cycle(
+            &db,
+            &config,
+            &mut cooldown,
+            &mut tracker,
+            None,
+            Some(&gate),
+            None,
+        )
+        .expect("poll");
+        assert_eq!(
+            spawned, 0,
+            "persona lease held by peer must block this host from spawning"
+        );
+
+        // The lease holder (peer) must still own the lease after the skip --
+        // the failed local acquire must not have disturbed peer's row.
+        let listed = db.list_persona_leases(Some("legion")).expect("list");
+        assert_eq!(listed.len(), 1);
+        assert_eq!(listed[0].acquired_by_host, "peer-host");
     }
 
     #[test]
@@ -1515,7 +1697,7 @@ workdir = "/tmp"
 
         let mut tracker = AgentTracker::new();
         let spawned =
-            poll_cycle(&db, &config, &mut cooldown, &mut tracker, None, None).expect("poll");
+            poll_cycle(&db, &config, &mut cooldown, &mut tracker, None, None, None).expect("poll");
         assert_eq!(spawned, 0, "cooling repo should be skipped");
     }
 


### PR DESCRIPTION
## Summary

Adds a cluster-wide wake-coordination gate so two legion nodes (or two poll cycles on the same host) cannot both wake the same persona for the same signal.

Closes #308.

## Why

#274's session lockfile stops the local-host twin (huttspawn's freak-out case). It does not stop the mesh-twin: two hosts running watch, both subscribed to the same \`@all\` signal, both spawning. The RFC #307 thread hit exactly that shape on 2026-04-22 -- two legion sessions on Puck aggregated the same RFC and posted conflicting consolidations.

Platform's framing applies again: exclusion lives at the gate, not inside the critical section.

## Data model

Migration 17, \`persona_wake_leases\`:

- Primary key \`(persona_id, signal_id)\` makes INSERT OR REPLACE atomic against same-node racers.
- \`acquired_by_host\`, \`acquired_at\`, \`heartbeat_at\`, \`expires_at\` carry lease state.
- \`deleted_at\` + \`updated_at\` carry smugglr sync semantics (tombstone + LWW).
- Partial indexes skip tombstones and expired rows so the live-lease filter hits an index directly.

## Acquire path

\`poll_cycle\` takes an optional \`PersonaLeaseGate\`. Before spawning, it calls \`try_acquire_persona_lease(persona, signal_id, host, ttl)\` for each inbound signal:

- **all acquires fail** -> skip spawn entirely, mark signals handled locally so we don't retry.
- **any acquire succeeds** -> spawn and hand the held \`(persona, signal_id)\` tuples to \`AgentTracker\`.

On spawn failure, any leases acquired in that attempt are released so the next poll can retry cleanly.

## Heartbeat + release

- Daemon heartbeats on the health interval via \`heartbeat_persona_leases(host, ttl)\`. One UPDATE touches every live lease held by this host; crashed sessions age out within one TTL.
- \`AgentTracker::reap_finished\` takes \`Option<&Database>\` and releases each held lease when its child exits.
- \`release_persona_leases_by_host\` is available (marked dead_code) for a future graceful-shutdown hook.

## Cluster sync

- \`sync::PersonaWakeLeaseDelta\` mirrors the existing delta pattern.
- \`sync_actor\` includes lease deltas in its broadcast log count.
- \`apply_persona_wake_lease_delta\` implements the late-loser rule:
  - tombstone or local-tombstone: plain LWW on \`updated_at\`.
  - two live leases: earlier \`acquired_at\` wins; the losing local host identity is returned so the caller can stop its losing spawn.
- Wire transport is still the pre-existing \`TODO\` in \`sync_actor.rs\`. The delta types ship ready, same as reflection / card / schedule deltas.

## CLI

\`\`\`
legion watch leases list [--persona P]
legion watch leases release --persona P --signal S
\`\`\`

List shows only live leases. Release is idempotent.

## Config

\`WatchConfig.persona_lease_ttl_secs\` (default 600s / 10min). Tunable via watch.toml.

## Test plan

- [x] \`cargo test --bin legion\` -- 559 pass (14 persona-lease DB tests + 1 poll_cycle integration test \`poll_cycle_skips_when_persona_lease_is_held\`)
- [x] \`cargo test --test '*'\` -- 105 pass
- [x] \`cargo clippy --bin legion --tests -- -D warnings\` -- clean
- [x] \`cargo fmt -- --check\` -- clean
- [x] \`legion quality-gate record\` -- clean
- [ ] Dogfood: next RFC-shape \`@all\` thread must not produce two legion consolidations on the same signal (the #307 regression trigger)
- [ ] Operator smoke: \`legion watch leases list\` returns empty when idle, shows a row during an active wake