### PR TITLE
chore: release v0.9.4

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
     {
       "name": "legion",
       "description": "Agent memory layer with recall, reflect, consult, bullpen, and cross-agent coordination. Includes health monitoring and auto-wake. Hooks wire legion into every session automatically.",
-      "version": "0.9.3",
+      "version": "0.9.4",
       "author": {
         "name": "Sean Silvius",
         "email": "sean@silvius.me"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1444,7 +1444,7 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "legion"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "async-stream",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "legion"
-version = "0.9.3"
+version = "0.9.4"
 edition = "2024"
 description = "Agent specialization through deliberate practice"
 

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "legion",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "description": "Institutional memory for Claude Code agents with real-time team channel.",
   "author": {
     "name": "Sean Silvius",

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Legion Changelog
 
+## 0.9.4
+
+Wake-coordination release. Three fixes to the auto-wake path so a signal lands on exactly one agent: one host-local, one cluster-wide, and one at the prompt level. The phenomenology that drove this was huttspawn watching a twin of itself post mid-thread -- that specific case is dead now.
+
+### New
+
+- **Persona wake leases** (#308, #314): `watch` acquires a cluster-synced lease on `(persona_id, signal_id)` before spawning. Held lease on any node -- or any prior poll cycle on this node -- blocks a second spawn. Lease refreshes every poll via `heartbeat_persona_leases`; crashes age out via TTL (default 600s). `apply_persona_wake_lease_delta` implements earlier-`acquired_at`-wins for two-live-lease conflict resolution; tombstones resolve via LWW. Wire transport is the same TODO as reflections/cards/schedules -- delta types ship ready to broadcast. New `legion watch leases list [--persona P]` / `leases release --persona P --signal S` CLI surface. Migration 17 adds `persona_wake_leases` with soft-delete + `updated_at` for smugglr sync.
+- **Per-repo session lockfile** (#274, #313): Same-host companion to persona leases. `<data-dir>/sessions/<repo>.lock` holds the last spawn's PID; `poll_cycle` skips any repo whose lockfile points to a live PID with mtime within `session_lock_ttl_secs` (default 3600s). Dead PID or stale mtime = abandoned, overwritten on next spawn. No explicit release on clean exit; next poll sees the dead PID and proceeds.
+
+### Safety
+
+- **Wake prompt splits reply-required from informational** (#311, #312): `build_wake_prompt` parses each signal's verb and routes `question:*` / `request:*` to a "REQUIRES A REPLY" section that explicitly states directed questions must be answered (even a refusal is a valid reply). Announcements and other verbs keep the existing silence-is-acknowledgment guard. Before this, the blanket "silence is acknowledgment" rule produced ghosting on directed questions -- huttspawn's `@kessel question:help` and `@eavesdrop` signals were exited silently because the prompt told the woken agent to.
+- **Cross-process atomic acquire** (#308, #314): Lease acquire path is a reclaim-UPDATE + `INSERT OR IGNORE` + read-back, all inside one transaction. Two processes on the same DB file cannot both pass a SELECT and then race on INSERT; the second writer's `INSERT OR IGNORE` is a no-op and the read-back tells it it didn't win. Cross-connection race test in `persona_lease_acquire_is_cross_connection_race_safe` opens two handles in separate threads and asserts exactly one winner, no SQLITE_BUSY surfaced as `Err`.
+- **Host-scoped reap release** (#308, #314): `release_persona_lease_if_owner` scopes the tombstone UPDATE to `AND acquired_by_host = ?` so a late-loser whose lease was overwritten by sync conflict resolution cannot drop the peer winner's row when its tracked child exits. Unscoped `release_persona_lease` is kept for the operator CLI where forcibly dropping a stuck lease is the intended operation.
+- **Skip-branch no longer marks signals handled** (#308, #314): When a persona lease is held by a peer, this host skips the spawn but leaves the signal unhandled in `watch_handled`. If the holder crashes pre-spawn, the next poll on this host retries naturally after TTL expiry; previously the local mark turned a crashed peer into a permanently-lost signal from every other node's view.
+
+### Polish
+
+- **Skip log names the PID holding the gate** (#274, #313): Session-lock skip log now reads `skipping <repo>: active session (pid <n>)` so operators can immediately see which session is blocking, instead of just "session already active for <repo>". `SessionLockTracker::active_pid` returns `Option<u32>`.
+- **`TrackedChild` carries acquire host** (#308, #314): `AgentTracker::track` takes the host identity the leases were acquired under and stores it on `TrackedChild`. Reap uses the stored host for the scoped release. Cleaner than holding a separate parallel map of child-id to host.
+
 ## 0.9.3
 
 Daily-loop release. New read-side `legion pr` surface closes the write-only monologue so agents can actually read reviews, comments, and failing-check logs through legion instead of the blocked `gh` CLI. Plugin timeout and statusline polish ride along.


### PR DESCRIPTION
## Summary

Wake-coordination release. Three merged changes since 0.9.3 collapse into one theme: a wake signal now lands on exactly one agent -- not zero (ghosting), not two (twins).

## What shipped since 0.9.3

- **#314** (closes #308) -- cluster-wide persona wake leases with cross-process atomic acquire, heartbeat, TTL crash-recovery, host-scoped reap release, `legion watch leases list/release` CLI
- **#313** (closes #274) -- per-repo session lockfile gate at \`<data-dir>/sessions/<repo>.lock\`; live-PID + fresh-mtime blocks a second spawn; dead-PID or stale-mtime = abandoned
- **#312** (closes #311) -- wake prompt splits directed questions/requests into a "REQUIRES A REPLY" section; announcements keep the silence-is-acknowledgment guard

## Test plan

- [x] \`cargo test --bin legion\` -- 562 pass
- [x] \`cargo test --test '*'\` -- 105 pass
- [x] \`cargo clippy --bin legion --tests -- -D warnings\` -- clean
- [x] \`cargo fmt -- --check\` -- clean
- [x] pre-commit hook synced plugin.json + marketplace.json from Cargo.toml
- [x] plugin/CHANGELOG.md top header matches Cargo.toml