### PR TITLE
feat: block writes to Claude auto-memory, redirect to legion reflect

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
     {
       "name": "legion",
       "description": "Agent memory layer with recall, reflect, consult, bullpen, and cross-agent coordination. Includes health monitoring and auto-wake. Hooks wire legion into every session automatically.",
-      "version": "0.9.4",
+      "version": "0.9.5",
       "author": {
         "name": "Sean Silvius",
         "email": "sean@silvius.me"

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
     {
       "name": "legion",
       "description": "Agent memory layer with recall, reflect, consult, bullpen, and cross-agent coordination. Includes health monitoring and auto-wake. Hooks wire legion into every session automatically.",
-      "version": "0.9.3",
+      "version": "0.9.4",
       "author": {
         "name": "Sean Silvius",
         "email": "sean@silvius.me"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1444,7 +1444,7 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "legion"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "async-stream",
  "axum",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1444,7 +1444,7 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "legion"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "async-stream",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "legion"
-version = "0.9.4"
+version = "0.9.5"
 edition = "2024"
 description = "Agent specialization through deliberate practice"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "legion"
-version = "0.9.3"
+version = "0.9.4"
 edition = "2024"
 description = "Agent specialization through deliberate practice"
 

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "legion",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "description": "Institutional memory for Claude Code agents with real-time team channel.",
   "author": {
     "name": "Sean Silvius",

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "legion",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "description": "Institutional memory for Claude Code agents with real-time team channel.",
   "author": {
     "name": "Sean Silvius",

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Legion Changelog
 
+## 0.9.5
+
+Memory-discipline release. Closes the loop on the recurring complaint that agents drift back to the Claude Code auto-memory directory instead of using `legion reflect`. Memory entries telling agents "use legion" lose to the system prompt actively encouraging local-memory writes every turn -- enforcement has to be at the hook layer.
+
+### Safety
+
+- **Block writes to Claude auto-memory** (new `no-local-memory.sh` PreToolUse hook): Write/Edit/MultiEdit on any path matching `.claude/projects/*/memory/` is denied with a redirect to `legion reflect` for personal reflections or CLAUDE.md for project-wide guidance. Reflections stored via legion are searchable across sessions, repos, and agents (`legion recall`, `legion consult`); files in `~/.claude/projects/*/memory/` are invisible the moment the session ends. Reads are not blocked -- the auto-memory loader needs them.
+
 ## 0.9.4
 
 Wake-coordination release. Three fixes to the auto-wake path so a signal lands on exactly one agent: one host-local, one cluster-wide, and one at the prompt level. The phenomenology that drove this was huttspawn watching a twin of itself post mid-thread -- that specific case is dead now.

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Legion Changelog
 
+## 0.9.4
+
+Wake-coordination release. Three fixes to the auto-wake path so a signal lands on exactly one agent: one host-local, one cluster-wide, and one at the prompt level. The phenomenology that drove this was huttspawn watching a twin of itself post mid-thread -- that specific case is dead now.
+
+### New
+
+- **Persona wake leases** (#308, #314): `watch` acquires a cluster-synced lease on `(persona_id, signal_id)` before spawning. Held lease on any node -- or any prior poll cycle on this node -- blocks a second spawn. Lease refreshes every poll via `heartbeat_persona_leases`; crashes age out via TTL (default 600s). `apply_persona_wake_lease_delta` implements earlier-`acquired_at`-wins for two-live-lease conflict resolution; tombstones resolve via LWW. Wire transport is the same TODO as reflections/cards/schedules -- delta types ship ready to broadcast. New `legion watch leases list [--persona P]` / `leases release --persona P --signal S` CLI surface. Migration 17 adds `persona_wake_leases` with soft-delete + `updated_at` for smugglr sync.
+- **Per-repo session lockfile** (#274, #313): Same-host companion to persona leases. `<data-dir>/sessions/<repo>.lock` holds the last spawn's PID; `poll_cycle` skips any repo whose lockfile points to a live PID with mtime within `session_lock_ttl_secs` (default 3600s). Dead PID or stale mtime = abandoned, overwritten on next spawn. No explicit release on clean exit; next poll sees the dead PID and proceeds.
+
+### Safety
+
+- **Wake prompt splits reply-required from informational** (#311, #312): `build_wake_prompt` parses each signal's verb and routes `question:*` / `request:*` to a "REQUIRES A REPLY" section that explicitly states directed questions must be answered (even a refusal is a valid reply). Announcements and other verbs keep the existing silence-is-acknowledgment guard. Before this, the blanket "silence is acknowledgment" rule produced ghosting on directed questions -- huttspawn's `@kessel question:help` and `@eavesdrop` signals were exited silently because the prompt told the woken agent to.
+- **Cross-process atomic acquire** (#308, #314): Lease acquire path is a reclaim-UPDATE + `INSERT OR IGNORE` + read-back, all inside one transaction. Two processes on the same DB file cannot both pass a SELECT and then race on INSERT; the second writer's `INSERT OR IGNORE` is a no-op and the read-back tells it it didn't win. Cross-connection race test in `persona_lease_acquire_is_cross_connection_race_safe` opens two handles in separate threads and asserts exactly one winner, no SQLITE_BUSY surfaced as `Err`.
+- **Host-scoped reap release** (#308, #314): `release_persona_lease_if_owner` scopes the tombstone UPDATE to `AND acquired_by_host = ?` so a late-loser whose lease was overwritten by sync conflict resolution cannot drop the peer winner's row when its tracked child exits. Unscoped `release_persona_lease` is kept for the operator CLI where forcibly dropping a stuck lease is the intended operation.
+- **Skip-branch no longer marks signals handled** (#308, #314): When a persona lease is held by a peer, this host skips the spawn but leaves the signal unhandled in `watch_handled`. If the holder crashes pre-spawn, the next poll on this host retries naturally after TTL expiry; previously the local mark turned a crashed peer into a permanently-lost signal from every other node's view.
+
+### Polish
+
+- **Skip log names the PID holding the gate** (#274, #313): Session-lock skip log now reads `skipping <repo>: active session (pid <n>)` so operators can immediately see which session is blocking, instead of just "session already active for <repo>". `SessionLockTracker::active_pid` returns `Option<u32>`.
+- **`TrackedChild` carries acquire host** (#308, #314): `AgentTracker::track` takes the host identity the leases were acquired under and stores it on `TrackedChild`. Reap uses the stored host for the scoped release. Cleaner than holding a separate parallel map of child-id to host.
+
 ## 0.9.3
 
 Daily-loop release. New read-side `legion pr` surface closes the write-only monologue so agents can actually read reviews, comments, and failing-check logs through legion instead of the blocked `gh` CLI. Plugin timeout and statusline polish ride along.

--- a/plugin/hooks/hooks.json
+++ b/plugin/hooks/hooks.json
@@ -120,6 +120,36 @@
             "timeout": 5
           }
         ]
+      },
+      {
+        "matcher": "Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/no-local-memory.sh",
+            "timeout": 5
+          }
+        ]
+      },
+      {
+        "matcher": "Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/no-local-memory.sh",
+            "timeout": 5
+          }
+        ]
+      },
+      {
+        "matcher": "MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/no-local-memory.sh",
+            "timeout": 5
+          }
+        ]
       }
     ]
   }

--- a/plugin/hooks/no-local-memory.sh
+++ b/plugin/hooks/no-local-memory.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+# Legion PreToolUse Write/Edit hook: block agents from writing to the
+# Claude Code auto-memory directory (~/.claude/projects/*/memory/).
+#
+# Legion is the memory layer. Reflections live in the legion DB so they are
+# searchable across sessions, repos, and agents via `legion recall` and
+# `legion consult`. The auto-memory directory is invisible to other agents
+# and other repos, so anything written there is dead weight the moment the
+# session ends.
+#
+# The Claude Code system prompt actively encourages writing to that path
+# every turn, so a passive memory entry telling the agent "use legion
+# instead" loses to an active prompt telling it to write the file. This
+# hook is the enforcement layer.
+#
+# What this hook blocks:
+#   - Write/Edit/MultiEdit on any file_path containing
+#     `.claude/projects/` and `/memory/`
+#
+# What this hook does NOT block:
+#   - Reading those files (the auto-memory system reads MEMORY.md on its own)
+#   - Writes elsewhere
+#
+# Bypass: none. If you genuinely need a file there, do it from your own
+# terminal outside Claude Code.
+
+INPUT=$(cat)
+
+FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty' 2>/dev/null)
+
+if [ -z "$FILE_PATH" ]; then
+  exit 0
+fi
+
+if echo "$FILE_PATH" | grep -qE '\.claude/projects/.*/memory/'; then
+  jq -n --arg reason "Blocked: this file path is in the Claude Code auto-memory directory. Legion is the memory layer for this project -- use \`legion reflect --repo <name> --text '...'\` instead. Reflections stored via legion are searchable across sessions, repos, and agents via \`legion recall\` and \`legion consult\`; files in ~/.claude/projects/*/memory/ are invisible outside this single session/agent. If the content is project-wide guidance (not a personal reflection), it belongs in CLAUDE.md, not auto-memory." '
+    {
+      "hookSpecificOutput": {
+        "hookEventName": "PreToolUse",
+        "permissionDecision": "deny",
+        "permissionDecisionReason": $reason
+      }
+    }
+  '
+  exit 0
+fi
+
+exit 0


### PR DESCRIPTION
## Summary

- New PreToolUse hook (`plugin/hooks/no-local-memory.sh`) denies Write/Edit/MultiEdit on any path matching `.claude/projects/*/memory/` and redirects the agent to `legion reflect` (or CLAUDE.md for project-wide guidance).
- Wired into `plugin/hooks/hooks.json` for Write, Edit, and MultiEdit matchers.
- Version bump 0.9.4 -> 0.9.5 (Cargo.toml, plugin.json, marketplace).

## Why

Recurring drift: agents keep writing to `~/.claude/projects/*/memory/` instead of using `legion reflect`, even with `feedback_legion_is_memory.md` saved. Memory rules are passive; the Claude Code system prompt actively encourages auto-memory writes every turn, so the active prompt wins. Enforcement has to be a hook.

Reflections stored via legion are searchable across sessions, repos, and agents via `legion recall` / `legion consult`. Files under `~/.claude/projects/*/memory/` are invisible the moment the session ends.

## Test plan

- [x] Block case: `.claude/projects/foo/memory/test.md` -> deny with redirect message
- [x] Pass case: `/tmp/other.md` -> no output, exits 0
- [x] `cargo build` clean on 0.9.5
- [ ] Manual verification post-merge: try Write to a memory path, confirm denial