### PR TITLE
feat(#318): surface pending request-shaped signals at SessionStart

### DIFF
--- a/plugin/hooks/session-start.sh
+++ b/plugin/hooks/session-start.sh
@@ -84,6 +84,21 @@ ${KANBAN}"
   fi
 fi
 
+# 4. Pending request-shaped signals -- directed asks waiting on a reply.
+# Surfaces with strong "REQUIRES A REPLY" framing so the additionalContext
+# system-reminder wrapper does not cause the agent to no-op the way platform
+# did on the smugglr-fence RFC review on 2026-04-26 (issue #318).
+PENDING=$("$LEGION" pending-replies --repo "$REPO" 2>>"$LOG")
+legion_check $? "pending-replies"
+if [ -n "$PENDING" ]; then
+  # Prepend so reply obligations land first in the context block.
+  if [ -n "$OUTPUT" ]; then
+    OUTPUT="${PENDING}"$'\n\n'"${OUTPUT}"
+  else
+    OUTPUT="$PENDING"
+  fi
+fi
+
 # Prepend warning block if any legion call failed
 WARN=$(legion_warnings_block)
 if [ -n "$WARN" ]; then

--- a/src/main.rs
+++ b/src/main.rs
@@ -301,6 +301,18 @@ enum Commands {
         tags: Option<String>,
     },
 
+    /// Print a wake-prompt for pending request-shaped signals.
+    ///
+    /// Used by SessionStart hooks to surface directed questions/requests with
+    /// strong "REQUIRES A REPLY" framing that survives the additionalContext
+    /// system-reminder wrapper. Prints nothing (and exits 0) if there are no
+    /// pending reply-required signals targeting this repo.
+    PendingReplies {
+        /// Repository name (the recipient)
+        #[arg(long)]
+        repo: String,
+    },
+
     /// Read the bullpen or check for unread posts
     #[command(alias = "bp", alias = "board")]
     Bullpen {
@@ -2400,6 +2412,32 @@ fn run() -> error::Result<()> {
                 if n > 0 {
                     info!("[legion] embedded {} signals", n);
                 }
+            }
+        }
+        Commands::PendingReplies { repo } => {
+            let base = data_dir()?;
+            let database = db::Database::open(&base.join("legion.db"))?;
+
+            // Recipient is the agent name when configured via watch.toml,
+            // else the repo name. Fall back to repo for un-watched callers.
+            let recipient = watch::load_config(&base.join("watch.toml"))
+                .ok()
+                .and_then(|cfg| {
+                    cfg.repos
+                        .iter()
+                        .find(|r| r.name == repo)
+                        .map(|r| r.recipient().to_string())
+                })
+                .unwrap_or_else(|| repo.clone());
+
+            let signals = watch::find_pending_signals(&database, &repo, &recipient, None)?;
+            let reply_required: Vec<(String, String, String)> = signals
+                .into_iter()
+                .filter(|(_, text, _)| watch::signal_requires_reply(text))
+                .collect();
+
+            if !reply_required.is_empty() {
+                print!("{}", watch::build_wake_prompt(&repo, &reply_required));
             }
         }
         Commands::Boost { id } => {

--- a/src/watch.rs
+++ b/src/watch.rs
@@ -653,14 +653,20 @@ pub fn find_pending_signals(
 
 // -- Agent Spawning ----------------------------------------------------------
 
-/// Signal verbs that require the recipient to reply, even if the reply is a refusal.
+/// Signals that require the recipient to reply, even if the reply is a refusal.
 ///
-/// A directed question or request without a reply is ghosting. Every other verb
-/// (announce, update, review:approved, etc.) falls under the wake-storm guard:
-/// silence is acknowledgment unless the agent has something substantive to add.
-fn signal_requires_reply(text: &str) -> bool {
+/// A directed question or request without a reply is ghosting. The trigger is
+/// either a request-shaped verb (`question`, `request`) OR a request-shaped
+/// status on any verb (e.g. `review:request`, `help:request`). Approval-shaped
+/// statuses (`approved`, `done`, `blocked`) and bare informational verbs
+/// (`announce`, `update`) fall under the wake-storm guard: silence is
+/// acknowledgment unless the agent has something substantive to add.
+pub fn signal_requires_reply(text: &str) -> bool {
     match signal::parse_signal(text) {
-        Some(sig) => matches!(sig.verb.as_str(), "question" | "request"),
+        Some(sig) => {
+            matches!(sig.verb.as_str(), "question" | "request")
+                || matches!(sig.status.as_deref(), Some("request" | "help"))
+        }
         None => false,
     }
 }
@@ -1467,6 +1473,52 @@ workdir = "/tmp"
         let reply_idx = prompt.find("REQUIRES A REPLY").expect("reply section");
         let info_idx = prompt.find("INFORMATIONAL").expect("info section");
         assert!(reply_idx < info_idx, "reply-required must come first");
+    }
+
+    #[test]
+    fn build_wake_prompt_treats_request_status_as_reply_required() {
+        // review:request -- a directed RFC review ask. Pre-fix this fell into
+        // INFORMATIONAL because the verb was `review`, not `question`/`request`.
+        // Real incident: smugglr asked platform to review an RFC, watch woke
+        // platform, prompt said "silence is acknowledgment", platform no-opped.
+        let signals = vec![
+            (
+                "id-rev".to_string(),
+                "@platform review:request {doc: rfc.md} -- review please".to_string(),
+                "smugglr".to_string(),
+            ),
+            (
+                "id-help".to_string(),
+                "@legion request:help -- need a hand".to_string(),
+                "kelex".to_string(),
+            ),
+            (
+                "id-ok".to_string(),
+                "@legion review:approved -- LGTM".to_string(),
+                "smugglr".to_string(),
+            ),
+        ];
+
+        let prompt = build_wake_prompt("platform", &signals);
+
+        assert!(prompt.contains("REQUIRES A REPLY"));
+        assert!(
+            prompt.contains("id-rev"),
+            "review:request must require reply"
+        );
+        assert!(
+            prompt.contains("id-help"),
+            "request:help must require reply"
+        );
+
+        // Approvals stay informational -- silence is acknowledgment.
+        assert!(prompt.contains("INFORMATIONAL"));
+        let reply_section = &prompt
+            [prompt.find("REQUIRES A REPLY").unwrap()..prompt.find("INFORMATIONAL").unwrap()];
+        assert!(
+            !reply_section.contains("id-ok"),
+            "review:approved must not require reply"
+        );
     }
 
     #[test]

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -4564,3 +4564,92 @@ fn mesh_stale_cutoff_env_override_is_respected() {
         "stale env-override path must surface the same no-fresh-host error, got: {stderr}"
     );
 }
+
+#[test]
+fn pending_replies_emits_wake_prompt_for_request_signals() {
+    let dir = tempfile::tempdir().unwrap();
+
+    // smugglr asks platform to review an RFC -- the exact signal shape that
+    // dropped on 2026-04-26.
+    let out = legion_cmd(dir.path())
+        .args([
+            "signal",
+            "--repo",
+            "smugglr",
+            "--to",
+            "platform",
+            "--verb",
+            "review",
+            "--status",
+            "request",
+            "--note",
+            "RFC at vault-2026/projects/smuggler/fence/rfc.md",
+        ])
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+
+    // legion announces shipping -- informational, must NOT trip pending-replies.
+    let out = legion_cmd(dir.path())
+        .args([
+            "signal",
+            "--repo",
+            "legion",
+            "--to",
+            "platform",
+            "--verb",
+            "announce",
+            "--note",
+            "v0.9.5 shipped",
+        ])
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+
+    let out = legion_cmd(dir.path())
+        .args(["pending-replies", "--repo", "platform"])
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "pending-replies failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("REQUIRES A REPLY"),
+        "review:request must surface as reply-required, got: {stdout}"
+    );
+    assert!(
+        stdout.contains("review:request"),
+        "expected the signal text in the prompt, got: {stdout}"
+    );
+    assert!(
+        !stdout.contains("v0.9.5 shipped"),
+        "informational announce must not appear in pending-replies, got: {stdout}"
+    );
+}
+
+#[test]
+fn pending_replies_silent_when_nothing_pending() {
+    let dir = tempfile::tempdir().unwrap();
+
+    let out = legion_cmd(dir.path())
+        .args([
+            "signal", "--repo", "legion", "--to", "platform", "--verb", "announce", "--note", "fyi",
+        ])
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+
+    let out = legion_cmd(dir.path())
+        .args(["pending-replies", "--repo", "platform"])
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+    assert!(
+        out.stdout.is_empty(),
+        "pending-replies should print nothing when no reply-required signals exist, got: {}",
+        String::from_utf8_lossy(&out.stdout)
+    );
+}


### PR DESCRIPTION
Closes #318.

## Why

Live channel pushes work -- they arrive mid-turn as JSON-RPC notifications and agents act on them. The failure mode is **wake replay**: when an agent comes back from snooze (or watch auto-spawns one), pending directed signals either:
- never get surfaced at all (interactive resume -- SessionStart only injected identity / snooze / kanban), or
- get classified as informational and the wake prompt explicitly tells the agent "silence is acknowledgment" (watch auto-spawn -- the gate only matched `verb=question/request`).

Real incident driving this: 2026-04-26, smugglr posted `@platform review:request` for the smugglr-fence RFC, watch woke platform, platform's wake prompt classified the RFC review as informational, platform no-opped. The post sat unread until the human noticed.

## What

1. **`signal_requires_reply` now also matches request-shaped status.** A directed ask is reply-required whether it lands as `verb=request` or `verb=review status=request` (or `help`). Approval-shaped statuses (`approved`, `done`, `blocked`) and bare informational verbs (`announce`, `update`) keep the silence-is-acknowledgment treatment.

2. **New `legion pending-replies --repo <name>` command.** Emits the same `REQUIRES A REPLY` block `legion watch` builds, but only for pending reply-required signals. Empty stdout when nothing's pending.

3. **SessionStart hook calls it.** When pending request-shaped signals exist, they're prepended to `additionalContext` so reply obligations land first. The strong framing inside the block is robust enough to survive the `system-reminder` wrapper that otherwise causes agents to skim.

## Tests

- `build_wake_prompt_treats_request_status_as_reply_required` -- unit test, exact incident shape (`review:request`, `request:help`, `review:approved`).
- `pending_replies_emits_wake_prompt_for_request_signals` -- integration test, full CLI roundtrip including informational-signal exclusion.
- `pending_replies_silent_when_nothing_pending` -- integration test, empty stdout when no reply-required signals.

All 565 tests pass. clippy + fmt clean.