### PR TITLE
feat(#324): add legion whoami subcommand

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -336,6 +336,17 @@ enum Commands {
         repo: String,
     },
 
+    /// Print identity reflections for a repo (alias for recall --domain identity)
+    Whoami {
+        /// Repository name
+        #[arg(long)]
+        repo: String,
+
+        /// Maximum number of identity reflections to return
+        #[arg(long, default_value_t = 50)]
+        limit: usize,
+    },
+
     /// Rebuild the search index from the database
     Reindex,
 
@@ -2576,6 +2587,18 @@ fn run() -> error::Result<()> {
             let output = surface::format_surface(&result, &repo);
             if !output.is_empty() {
                 print!("{output}");
+            }
+        }
+        Commands::Whoami { repo, limit } => {
+            let base = data_dir()?;
+            let database = db::Database::open(&base.join("legion.db"))?;
+            let result = recall::recall_by_domain(&database, &repo, "identity", limit)?;
+            if result.reflections.is_empty() {
+                return Ok(());
+            }
+            println!("[Legion] Identity for {repo}:");
+            for r in &result.reflections {
+                println!("- {} (id: {})", r.text, r.id);
             }
         }
         Commands::Stats { repo } => {

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -291,6 +291,67 @@ fn whoami_works_with_compound_repo() {
     }
 }
 
+#[test]
+fn whoami_subcommand_returns_identity_reflections() {
+    let dir = tempfile::tempdir().unwrap();
+
+    let out = legion_cmd(dir.path())
+        .args([
+            "reflect",
+            "--repo",
+            "test",
+            "--whoami",
+            "--text",
+            "I am the test agent",
+        ])
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+
+    let out = legion_cmd(dir.path())
+        .args(["whoami", "--repo", "test"])
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "whoami subcommand failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8(out.stdout).unwrap();
+    assert!(
+        stdout.contains("[Legion] Identity for test:"),
+        "expected identity header, got: {stdout}"
+    );
+    assert!(
+        stdout.contains("I am the test agent"),
+        "expected identity text, got: {stdout}"
+    );
+}
+
+#[test]
+fn whoami_subcommand_silent_when_no_identity() {
+    let dir = tempfile::tempdir().unwrap();
+
+    let out = legion_cmd(dir.path())
+        .args(["whoami", "--repo", "empty"])
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+    assert!(
+        out.stdout.is_empty(),
+        "expected empty output, got: {}",
+        String::from_utf8_lossy(&out.stdout)
+    );
+}
+
+#[test]
+fn whoami_subcommand_requires_repo() {
+    let dir = tempfile::tempdir().unwrap();
+
+    let out = legion_cmd(dir.path()).args(["whoami"]).output().unwrap();
+    assert!(!out.status.success());
+}
+
 /// Validate that a string looks like a UUIDv7 (36 chars, 4 hyphens).
 fn assert_uuid_format(s: &str) {
     let trimmed = s.trim();

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -352,6 +352,99 @@ fn whoami_subcommand_requires_repo() {
     assert!(!out.status.success());
 }
 
+#[test]
+fn whoami_subcommand_isolates_by_repo() {
+    let dir = tempfile::tempdir().unwrap();
+
+    for (repo, text) in [("alpha", "alpha identity"), ("beta", "beta identity")] {
+        let out = legion_cmd(dir.path())
+            .args(["reflect", "--repo", repo, "--whoami", "--text", text])
+            .output()
+            .unwrap();
+        assert!(out.status.success());
+    }
+
+    let out = legion_cmd(dir.path())
+        .args(["whoami", "--repo", "alpha"])
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+    let stdout = String::from_utf8(out.stdout).unwrap();
+    assert!(stdout.contains("alpha identity"));
+    assert!(
+        !stdout.contains("beta identity"),
+        "whoami leaked beta identity into alpha repo: {stdout}"
+    );
+}
+
+#[test]
+fn whoami_subcommand_filters_to_identity_domain() {
+    let dir = tempfile::tempdir().unwrap();
+
+    let out = legion_cmd(dir.path())
+        .args([
+            "reflect",
+            "--repo",
+            "test",
+            "--whoami",
+            "--text",
+            "I am identity",
+        ])
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+
+    let out = legion_cmd(dir.path())
+        .args([
+            "reflect",
+            "--repo",
+            "test",
+            "--text",
+            "plain non-identity reflection",
+        ])
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+
+    let out = legion_cmd(dir.path())
+        .args(["whoami", "--repo", "test"])
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+    let stdout = String::from_utf8(out.stdout).unwrap();
+    assert!(stdout.contains("I am identity"));
+    assert!(
+        !stdout.contains("plain non-identity reflection"),
+        "whoami included non-identity reflection: {stdout}"
+    );
+}
+
+#[test]
+fn whoami_subcommand_respects_limit() {
+    let dir = tempfile::tempdir().unwrap();
+
+    for i in 0..3 {
+        let text = format!("identity reflection {i}");
+        let out = legion_cmd(dir.path())
+            .args(["reflect", "--repo", "test", "--whoami", "--text", &text])
+            .output()
+            .unwrap();
+        assert!(out.status.success());
+    }
+
+    let out = legion_cmd(dir.path())
+        .args(["whoami", "--repo", "test", "--limit", "1"])
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+    let stdout = String::from_utf8(out.stdout).unwrap();
+    let bullet_count = stdout.lines().filter(|l| l.starts_with("- ")).count();
+    assert_eq!(
+        bullet_count, 1,
+        "expected 1 bullet, got {bullet_count}: {stdout}"
+    );
+}
+
 /// Validate that a string looks like a UUIDv7 (36 chars, 4 hyphens).
 fn assert_uuid_format(s: &str) {
     let trimmed = s.trim();


### PR DESCRIPTION
## Summary

- New \`legion whoami --repo <name>\` subcommand that prints identity reflections (domain=identity)
- Thin alias over existing \`recall::recall_by_domain\` -- no new storage, no new logic
- Agents intuitively reach for \`whoami\` at session start; this provides the affordance

Closes #324.

## Test plan

- [x] \`legion whoami --repo legion\` prints identity reflections
- [x] Empty result is silent (no banner)
- [x] Missing \`--repo\` fails with clap error
- [x] cargo test (108 passed)
- [x] cargo clippy -- -D warnings clean
- [x] cargo fmt --check clean