### PR TITLE
chore: release v0.9.6

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
     {
       "name": "legion",
       "description": "Agent memory layer with recall, reflect, consult, bullpen, and cross-agent coordination. Includes health monitoring and auto-wake. Hooks wire legion into every session automatically.",
-      "version": "0.9.5",
+      "version": "0.9.6",
       "author": {
         "name": "Sean Silvius",
         "email": "sean@silvius.me"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1444,7 +1444,7 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "legion"
-version = "0.9.5"
+version = "0.9.6"
 dependencies = [
  "async-stream",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "legion"
-version = "0.9.5"
+version = "0.9.6"
 edition = "2024"
 description = "Agent specialization through deliberate practice"
 

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "legion",
-  "version": "0.9.5",
+  "version": "0.9.6",
   "description": "Institutional memory for Claude Code agents with real-time team channel.",
   "author": {
     "name": "Sean Silvius",

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Legion Changelog
 
+## 0.9.6
+
+Identity-affordance release. Agents intuitively reach for `legion whoami` at session start; this release makes the command real and routes the SessionStart hook through it for a clearer header.
+
+### New
+
+- **`legion whoami --repo <name>`** (#324, #325): Top-level subcommand that prints identity reflections (domain=identity) for a repo. Thin alias over the existing `recall_by_domain` primitive -- no new storage, no new logic. Output uses `[Legion] Identity for <repo>:` header (no score field) instead of the misleading `[Legion] Relevant reflections for <repo>:` that `recall --domain identity` produced. Tests cover happy path, empty case, missing-arg, cross-repo isolation, domain filtering, and `--limit`.
+- **SessionStart hook routes identity through `whoami`**: `plugin/hooks/session-start.sh` now calls `legion whoami --repo "$REPO" --limit 1` instead of `legion recall --repo "$REPO" --domain identity --limit 1`. Same query, cleaner header in the SessionStart additionalContext blob.
+
 ## 0.9.5
 
 Memory-discipline release. Closes the loop on the recurring complaint that agents drift back to the Claude Code auto-memory directory instead of using `legion reflect`. Memory entries telling agents "use legion" lose to the system prompt actively encouraging local-memory writes every turn -- enforcement has to be at the hook layer.

--- a/plugin/hooks/session-start.sh
+++ b/plugin/hooks/session-start.sh
@@ -54,8 +54,8 @@ fi
 OUTPUT=""
 
 # 1. Identity -- who am I
-IDENTITY=$("$LEGION" recall --repo "$REPO" --domain identity --limit 1 2>>"$LOG")
-legion_check $? "recall (identity)"
+IDENTITY=$("$LEGION" whoami --repo "$REPO" --limit 1 2>>"$LOG")
+legion_check $? "whoami"
 if [ -n "$IDENTITY" ]; then
   OUTPUT="$IDENTITY"
 fi


### PR DESCRIPTION
## Summary

- Bump version to 0.9.6 (Cargo.toml, plugin.json, marketplace.json auto-synced)
- Route SessionStart identity through \`legion whoami\` -- cleaner header
- CHANGELOG entry for 0.9.6

The whoami subcommand itself (#324) shipped in #325. This PR is the release prep -- version bump, hook routing change that depends on the new command, and changelog.

## Test plan

- [x] cargo build clean at 0.9.6
- [x] \`./target/debug/legion --version\` reports 0.9.6
- [x] \`./target/debug/legion whoami --repo legion\` produces \"[Legion] Identity for legion:\" header
- [x] cargo test (10 whoami tests pass; full suite green)
- [x] cargo clippy -D warnings clean
- [x] cargo fmt --check clean