### PR TITLE
feat(#331): SessionStart whoami banner, chain pointers, limit 5

### DIFF
--- a/plugin/hooks/session-start.sh
+++ b/plugin/hooks/session-start.sh
@@ -53,8 +53,8 @@ fi
 
 OUTPUT=""
 
-# 1. Identity -- who am I
-IDENTITY=$("$LEGION" whoami --repo "$REPO" --limit 1 2>>"$LOG")
+# 1. Identity -- who am I (front and center, banner-wrapped by the binary)
+IDENTITY=$("$LEGION" whoami --repo "$REPO" --limit 5 2>>"$LOG")
 legion_check $? "whoami"
 if [ -n "$IDENTITY" ]; then
   OUTPUT="$IDENTITY"

--- a/src/db.rs
+++ b/src/db.rs
@@ -852,23 +852,24 @@ impl Database {
         Ok(chain)
     }
 
-    /// True if this reflection participates in a chain -- either it has a
-    /// parent or at least one child. Used by `whoami` to decide whether to
-    /// surface a `legion chain --id <id>` pointer without forcing callers to
-    /// walk the full chain.
+    /// True if this reflection (live, not soft-deleted) participates in a
+    /// chain -- either it has a parent or at least one live child. Used by
+    /// `whoami` to decide whether to surface a `legion chain --id <id>`
+    /// pointer without forcing callers to walk the full chain.
     pub fn is_in_chain(&self, id: &str) -> Result<bool> {
         let row: Option<i64> = self
             .conn
             .query_row(
-                "SELECT 1 FROM reflections WHERE id = ?1 AND parent_id IS NOT NULL AND deleted_at IS NULL",
+                "SELECT 1 FROM reflections r \
+                 WHERE r.id = ?1 AND r.deleted_at IS NULL \
+                   AND (r.parent_id IS NOT NULL \
+                        OR EXISTS (SELECT 1 FROM reflections c \
+                                   WHERE c.parent_id = r.id AND c.deleted_at IS NULL))",
                 [id],
                 |row| row.get(0),
             )
             .optional()?;
-        if row.is_some() {
-            return Ok(true);
-        }
-        Ok(self.find_child(id)?.is_some())
+        Ok(row.is_some())
     }
 
     /// Find the child reflection that follows the given parent ID.

--- a/src/db.rs
+++ b/src/db.rs
@@ -852,6 +852,25 @@ impl Database {
         Ok(chain)
     }
 
+    /// True if this reflection participates in a chain -- either it has a
+    /// parent or at least one child. Used by `whoami` to decide whether to
+    /// surface a `legion chain --id <id>` pointer without forcing callers to
+    /// walk the full chain.
+    pub fn is_in_chain(&self, id: &str) -> Result<bool> {
+        let row: Option<i64> = self
+            .conn
+            .query_row(
+                "SELECT 1 FROM reflections WHERE id = ?1 AND parent_id IS NOT NULL AND deleted_at IS NULL",
+                [id],
+                |row| row.get(0),
+            )
+            .optional()?;
+        if row.is_some() {
+            return Ok(true);
+        }
+        Ok(self.find_child(id)?.is_some())
+    }
+
     /// Find the child reflection that follows the given parent ID.
     fn find_child(&self, parent_id: &str) -> Result<Option<String>> {
         let mut stmt = self.conn.prepare(

--- a/src/main.rs
+++ b/src/main.rs
@@ -2634,7 +2634,7 @@ fn run() -> error::Result<()> {
             if result.reflections.is_empty() {
                 return Ok(());
             }
-            println!("=== WHO YOU ARE -- READ THIS ===");
+            println!("{}", recall::WHOAMI_BANNER_OPEN);
             println!("[Legion] Identity for {repo}:");
             for r in &result.reflections {
                 println!("- {} (id: {})", r.text, r.id);
@@ -2642,7 +2642,7 @@ fn run() -> error::Result<()> {
                     println!("  \u{21b3} chain context: legion chain --id {}", r.id);
                 }
             }
-            println!("=== END IDENTITY ===");
+            println!("{}", recall::WHOAMI_BANNER_CLOSE);
         }
         Commands::Stats { repo } => {
             let base = data_dir()?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -2634,10 +2634,15 @@ fn run() -> error::Result<()> {
             if result.reflections.is_empty() {
                 return Ok(());
             }
+            println!("=== WHO YOU ARE -- READ THIS ===");
             println!("[Legion] Identity for {repo}:");
             for r in &result.reflections {
                 println!("- {} (id: {})", r.text, r.id);
+                if database.is_in_chain(&r.id)? {
+                    println!("  \u{21b3} chain context: legion chain --id {}", r.id);
+                }
             }
+            println!("=== END IDENTITY ===");
         }
         Commands::Stats { repo } => {
             let base = data_dir()?;

--- a/src/recall.rs
+++ b/src/recall.rs
@@ -11,6 +11,12 @@ use crate::search::{SearchIndex, SearchResult};
 /// Prevents noise from weak semantic matches when BM25 found nothing.
 const COSINE_MIN_THRESHOLD: f32 = 0.3;
 
+/// Banner that wraps `legion whoami` output. Identity is the first thing an
+/// agent sees on session start, and the banner is what makes it impossible
+/// to skim past.
+pub const WHOAMI_BANNER_OPEN: &str = "=== WHO YOU ARE -- READ THIS ===";
+pub const WHOAMI_BANNER_CLOSE: &str = "=== END IDENTITY ===";
+
 /// A set of recalled reflections matching a query, optionally scoped to a single repo.
 #[derive(Debug, serde::Serialize)]
 pub struct RecallResult {

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -445,6 +445,86 @@ fn whoami_subcommand_respects_limit() {
     );
 }
 
+#[test]
+fn whoami_subcommand_emits_banner_and_chain_pointer() {
+    let dir = tempfile::tempdir().unwrap();
+
+    // Standalone identity reflection -- no chain.
+    let out = legion_cmd(dir.path())
+        .args([
+            "reflect",
+            "--repo",
+            "test",
+            "--whoami",
+            "--text",
+            "standalone identity",
+        ])
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+
+    // Chain head: identity reflection plus a follow-up that links via --follows.
+    let out = legion_cmd(dir.path())
+        .args([
+            "reflect",
+            "--repo",
+            "test",
+            "--whoami",
+            "--text",
+            "chained identity",
+        ])
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+    let head_id = String::from_utf8(out.stdout).unwrap().trim().to_owned();
+
+    let out = legion_cmd(dir.path())
+        .args([
+            "reflect",
+            "--repo",
+            "test",
+            "--text",
+            "follow-up reflection",
+            "--follows",
+            &head_id,
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "follow-up reflect failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let out = legion_cmd(dir.path())
+        .args(["whoami", "--repo", "test"])
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+    let stdout = String::from_utf8(out.stdout).unwrap();
+
+    assert!(
+        stdout.contains("=== WHO YOU ARE -- READ THIS ==="),
+        "missing opening banner: {stdout}"
+    );
+    assert!(
+        stdout.contains("=== END IDENTITY ==="),
+        "missing closing banner: {stdout}"
+    );
+    assert!(
+        stdout.contains(&format!("legion chain --id {head_id}")),
+        "missing chain pointer for chain head {head_id}: {stdout}"
+    );
+    let chain_lines = stdout
+        .lines()
+        .filter(|l| l.contains("legion chain --id"))
+        .count();
+    assert_eq!(
+        chain_lines, 1,
+        "expected exactly one chain pointer (only the chained reflection), got {chain_lines}: {stdout}"
+    );
+}
+
 /// Validate that a string looks like a UUIDv7 (36 chars, 4 hyphens).
 fn assert_uuid_format(s: &str) {
     let trimmed = s.trim();


### PR DESCRIPTION
## Summary

- Wrap `legion whoami` output in a `=== WHO YOU ARE -- READ THIS ===` banner so the SessionStart identity block is visually unmissable. Same framing pattern that fixed #318's reply ghosting.
- Surface chain pointers inline: any identity reflection that has a `parent_id` or live descendants gets a `legion chain --id <id>` pointer appended so agents discover their learning chains at startup.
- Bump the SessionStart hook's whoami `--limit` from 1 to 5 so multiple identity reflections land.
- New `Database::is_in_chain` method, single-query, soft-delete-safe.
- Banner strings as `recall` module consts (`WHOAMI_BANNER_OPEN` / `WHOAMI_BANNER_CLOSE`) so future drift hits a single source of truth.

## Why

Identity was buried in the additionalContext block alongside snooze + kanban + pending — same visual weight, easy to skim. Chains existed in the schema but were invisible at startup. Sean called this out: agents need to know who they are first, then what they are doing, and they need to find their chains without being reminded.

## Closes

#331

## Roadmap context

This is (a) of the autonomous-on-no-signal initiative. Follow-ups tracked at #332 (mode), #333 (effort), #334 (picker), #335 (SessionStart wiring).

## Test plan

- [x] `cargo test` (114 passed; new `whoami_subcommand_emits_banner_and_chain_pointer` covers banner presence and chain pointer count for both standalone and chained reflections)
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt -- --check` clean
- [ ] Manual: open a session, confirm the banner is unmissable and chain pointers appear when applicable