### PR TITLE
chore: release v0.9.7

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
     {
       "name": "legion",
       "description": "Agent memory layer with recall, reflect, consult, bullpen, and cross-agent coordination. Includes health monitoring and auto-wake. Hooks wire legion into every session automatically.",
-      "version": "0.9.6",
+      "version": "0.9.7",
       "author": {
         "name": "Sean Silvius",
         "email": "sean@silvius.me"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1444,7 +1444,7 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "legion"
-version = "0.9.6"
+version = "0.9.7"
 dependencies = [
  "async-stream",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "legion"
-version = "0.9.6"
+version = "0.9.7"
 edition = "2024"
 description = "Agent specialization through deliberate practice"
 

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "legion",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "Institutional memory for Claude Code agents with real-time team channel.",
   "author": {
     "name": "Sean Silvius",

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Legion Changelog
 
+## 0.9.7
+
+Session-boundary release. Auto-compaction was silently dropping consolidation work, and the SessionStart identity block was easy to skim past. Both fixed.
+
+### Changed
+
+- **PreCompact blocks auto-compaction** (#329, #330): The `precompact.sh` hook now emits `{decision: block, reason: ...}` to halt auto-compaction and surface a message telling the operator to run `/snooze` then `/clear`. Auto-compaction is mechanical -- it drops everything not in the transcript tail. `/snooze` does real consolidation: boost reflections that helped, write a domain=snooze summary the next session recalls, cross-pollinate to the bullpen. The transcript-tail checkpoint reflection stays as a safety net (#209 invariant preserved). Static heredoc replaces `jq -n` so the block decision cannot silently fail if jq is missing.
+- **SessionStart whoami front-and-center** (#331, #336): `legion whoami` output is now wrapped in a `=== WHO YOU ARE -- READ THIS ===` banner so identity is visually unmissable. Same framing pattern that fixed #318's reply ghosting. Identity reflections that participate in a learning chain (`parent_id` set or live descendants) get a `legion chain --id <id>` pointer appended so agents discover their chains at startup. SessionStart hook bumps `whoami --limit` from 1 to 5 so the full picture lands. New `Database::is_in_chain` is a single soft-delete-safe query.
+
 ## 0.9.6
 
 Identity-affordance release. Agents intuitively reach for `legion whoami` at session start; this release makes the command real and routes the SessionStart hook through it for a clearer header.


### PR DESCRIPTION
## Summary

Cuts v0.9.7. Two changes since v0.9.6:

- **#329 / #330** — PreCompact blocks auto-compaction, prompts `/snooze` then `/clear`. Static heredoc replaces `jq -n` to remove a silent-failure path. Transcript-tail checkpoint reflection stays as a safety net.
- **#331 / #336** — SessionStart whoami banner (`=== WHO YOU ARE -- READ THIS ===`), chain pointers for identity reflections that participate in a chain, `whoami --limit` bumped from 1 to 5. New `Database::is_in_chain` single-query soft-delete-safe lookup.

Cargo.toml + plugin.json + marketplace.json bumped 0.9.6 → 0.9.7. CHANGELOG entry covers both changes.

## Test plan

- [x] `cargo build` clean
- [x] `cargo test` (114 passing on main, no regressions from version bump)
- [x] sync-version pre-commit hook bumped plugin.json + marketplace.json