### PR TITLE
feat: migrate-memory skill + SessionStart cleanup + CLAUDE.md trim

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,290 +1,38 @@
 # CLAUDE.md
 
-## What This Is
+Legion is a local Rust binary that stores and retrieves agent reflections. It is the memory layer for Claude Code agents working on specific codebases.
 
-Legion is a local Rust binary that stores and retrieves agent reflections. It's the memory layer for Claude Code agents that work on specific codebases.
-
-## Commands
-
-```bash
-legion reflect --repo <name> --text "reflection text"
-legion reflect --repo <name> --transcript /path/to/transcript.jsonl
-legion reflect --repo <name> --text "..." --domain color-tokens --tags "semantic,consumer"
-legion reflect --repo <name> --text "..." --follows <parent-id>
-legion recall --repo <name> --context "what I'm working on"
-legion consult --context "problem outside your domain" --limit <n>
-legion post --repo <name> --text "share with the team"
-legion bullpen --repo <name>               # aliases: bp, board
-legion bullpen --count --repo <name>
-legion bullpen --repo <name> --signals     # show only signals
-legion bullpen --repo <name> --musings     # show only musings
-legion bullpen --archive                   # archive posts all readers have read
-legion bullpen --archived --repo <name>    # view archived posts
-legion signal --repo <name> --to <recipient> --verb <verb> --status <status>
-legion signal --repo <name> --to all --verb announce --note "PR merged"
-legion signal --repo <name> --to <recipient> --verb review --status approved --details "surface:cap-output,chain:confirmed"
-legion boost --id <reflection-id>
-legion chain --id <reflection-id>
-legion surface --repo <name>
-legion stats --repo <name>
-legion reindex
-legion work --repo <name>                    # get next card from scheduler (auto-accepts)
-legion work --repo <name> --peek             # peek at next card without accepting
-legion sync --repo <name>                    # sync issues from work source into kanban
-legion done --repo <name> --text "what was completed" --id <card-id>  # complete card + announce
-legion kanban create --from <repo> --to <repo> --text "description" --priority <low|med|high|critical>
-legion kanban create --from <repo> --to <repo> --text "..." --labels "tag1,tag2" --source-url "https://..."
-legion kanban list --repo <name>             # inbound cards (assigned to repo)
-legion kanban list --repo <name> --from      # outbound cards (created by repo)
-legion kanban accept --id <card-id>          # pending -> in-progress
-legion kanban block --id <card-id> --reason "blocker description"
-legion kanban unblock --id <card-id>         # blocked -> in-progress
-legion kanban review --id <card-id>          # in-progress -> in-review
-legion kanban need-input --id <card-id>      # in-progress -> needs-input (blocked on human)
-legion kanban resume --id <card-id>          # needs-input/in-review -> in-progress
-legion kanban cancel --id <card-id>          # any active -> cancelled
-legion kanban assign --id <card-id> --to <repo>  # backlog -> assigned to agent
-legion kanban reopen --id <card-id>          # done/cancelled -> backlog
-legion issue create --repo <name> --title "..." --body "..."  # create issue via work source
-legion pr create --repo <name> --title "..." --body "..."    # create PR via work source
-legion pr list --repo <name>                 # list open PRs with review status
-legion pr review --repo <name> --number <n> --approve --body "LGTM"  # post review
-legion pr review --repo <name> --number <n> --request-changes --body "..."
-legion pr merge --repo <name> --number <n>   # merge approved PR (refuses if not approved)
-legion pr merge --repo <name> --number <n> --task <card-id>  # merge + transition card to done
-legion comment --repo <name> --number <n> --body "..."       # comment on issue or PR
-legion audit                                 # view recent audit log entries
-legion audit --repo <name>                   # filter by agent
-legion audit --action create-pr              # filter by action type
-legion audit --json                          # output as JSON
-legion quality-gate record --skill legion-simplify --result clean|issues [--findings-count N] [--details-json '<json>']
-legion watch                                 # auto-wake sleeping agents on signal arrival
-legion watch add <path> [--name <n>] [--agent <a>]  # add repo to watch.toml (idempotent by path)
-legion watch remove <name>                   # remove repo entry from watch.toml
-legion watch list                            # list watch.toml entries
-legion cluster init [--key <hex>] [--port <n>]  # initialize LAN cluster sync (generates key if omitted)
-legion cluster key                           # print current cluster key (share with other nodes)
-legion cluster enable                        # start broadcasting deltas
-legion cluster disable                       # stop broadcasting (key preserved)
-legion cluster status                        # peers, sync state, last sync time
-legion -v <command>                          # show informational messages (quiet by default)
-```
-
-### Cross-Agent Consultation
-
-When you encounter a problem outside your domain, use `legion consult` to search
-reflections from ALL repos/agents:
-
-```bash
-legion consult --context "discriminated unions in composite rules" --limit 3
-```
-
-This searches across all indexed agent reflections regardless of repo (e.g., kelex, rafters, platform)
-using BM25. Results include source repo attribution so you know which domain
-the knowledge came from. Use this when you hit something unfamiliar -- another
-agent may have already solved it.
-
-## Architecture
-
-- **Storage**: SQLite via rusqlite (XDG data dir: ~/.local/share/legion/)
-- **Search**: Tantivy BM25 full-text index (Phase 1)
-- **Future**: model2vec-rs embeddings in nullable BLOB column (Phase 2)
-
-## Dev Workflow
-
-Each step is mandatory. Do not skip steps or combine them.
-
-1. **Plan** -- Propose approach, get user confirmation before coding.
-2. **Issue** -- Create a GitHub issue via `legion issue create` if one doesn't exist.
-3. **Build** -- Implement on a feature branch (`feat/<issue#>-<short-desc>`). Write tests alongside code. Run `cargo test`, `cargo clippy -- -D warnings`, `cargo fmt -- --check`. All must pass.
-4. **Simplify** -- Run `/legion-simplify` on the branch. Accept structural improvements, flatten unnecessary abstractions, remove dead code. The skill records its result via `legion quality-gate record` to the DB.
-5. **PR** -- Create the PR via `legion pr create`. Reference the issue number. `legion pr create` requires a clean `legion-simplify` gate on HEAD -- run `/legion-simplify` first. The gate is recorded in legion.db via `legion quality-gate record` (the skill runner writes it; agents cannot fake it). Use `--skip-gates` only when the branch IS the simplify skill itself (bootstrap); an audit entry is written.
-6. **Automated review** -- Run `/review-pr` which launches parallel review agents (code quality, silent failures, etc.).
-7. **Fix** -- Address every issue the automated review found. Re-run tests after fixes.
-8. **Team review** -- Request reviews from two agents via `legion pr review`:
-   - **vault** -- validates work against the issue spec and acceptance criteria.
-   - **smugglr** -- reviews Rust code content (patterns, idioms, correctness).
-9. **Consensus** -- For big changes, post to the bullpen and get team input before merging.
-10. **Ask for merge** -- Do not merge to main without explicit user approval.
-
-## Rules
+## Technical invariants (this repo)
 
 - No emoji in code, comments, or documentation
 - No `unwrap()` in production code
 - No `unsafe` code
 - All types explicit
+- Errors use `thiserror` derive macros
+- UUIDv7 for all IDs
 - `cargo clippy -- -D warnings` must pass
 - `cargo fmt -- --check` must pass
-- Errors use thiserror derive macros
-- UUIDv7 for all IDs
 
-## Data Model
+## Dev workflow (mandatory)
 
-```sql
-CREATE TABLE reflections (
-    id TEXT PRIMARY KEY,           -- UUIDv7
-    repo TEXT NOT NULL,            -- repository name
-    text TEXT NOT NULL,            -- the reflection
-    created_at TEXT NOT NULL,      -- ISO 8601
-    audience TEXT NOT NULL DEFAULT 'self',  -- 'self' or 'team'
-    domain TEXT,                   -- classification tag (e.g., "color-tokens")
-    tags TEXT,                     -- comma-separated tags
-    recall_count INTEGER NOT NULL DEFAULT 0,  -- boost counter
-    last_recalled_at TEXT,         -- for decay calculation
-    parent_id TEXT,                -- learning chain link
-    embedding BLOB,                -- nullable, Phase 2.5
-    archived_at TEXT,              -- bullpen archive timestamp (nullable)
-    deleted_at TEXT,               -- tombstone for multi-node sync (nullable)
-    updated_at TEXT                -- ISO 8601, LWW conflict resolution
-);
+1. **Plan** -- propose approach, get Sean's confirmation before coding.
+2. **Issue** -- `legion issue create --repo legion --title '...' --body '...'`.
+3. **Build** -- branch `feat/<issue#>-<short-desc>`. Tests alongside code. `cargo test`, `cargo clippy -- -D warnings`, `cargo fmt -- --check` all pass.
+4. **Simplify** -- run `/legion-simplify` on the branch. Records its result via `legion quality-gate record`.
+5. **PR** -- `legion pr create`. Must reference the issue. `legion pr create` requires a clean simplify gate on HEAD.
+6. **Automated review** -- `/review-pr` launches parallel review agents.
+7. **Fix** -- address every finding. Re-run tests after fixes.
+8. **Team review** -- request reviews via `legion pr review`:
+   - **vault** validates work against the issue spec and acceptance criteria
+   - **smugglr** reviews Rust patterns, idioms, correctness
+9. **Consensus** -- for big changes, post to the bullpen and get team input before merging.
+10. **Ask for merge** -- never merge to main without explicit user approval.
 
-CREATE INDEX idx_reflections_repo ON reflections(repo);
-CREATE INDEX idx_reflections_created ON reflections(created_at);
-```
+## Reach for these when you need more
 
-`tasks` and `schedules` also carry `deleted_at` + `updated_at` for sync. Partial indexes skip soft-deleted rows. See `docs/site/architecture.md` for the full schema and migration list.
+- `legion --help` for the full command surface (CLI reference).
+- `docs/site/architecture.md` for schema, sync model, indexing.
+- `docs/plans/` for in-flight design documents.
+- `legion recall --repo legion --context "..."` for accumulated decisions and lessons.
 
-### Tasks (Agent Delegation)
-
-Delegate work between agents with state-tracked tasks:
-
-```bash
-legion task create --from kelex --to legion --text "implement BM25 search" --priority high
-legion task list --repo legion              # see inbound tasks
-legion task list --repo kelex --from        # see outbound tasks
-legion task accept --id <task-id>
-legion task done --id <task-id> --note "shipped"
-legion task block --id <task-id> --reason "waiting on upstream"
-legion task unblock --id <task-id>
-```
-
-State transitions: pending -> accepted -> done|blocked. Blocked -> accepted via unblock. Invalid transitions are rejected.
-Pending inbound tasks are included in `legion surface` output.
-
-### Bullpen (Push-Based Communication)
-
-Push something to the team instead of keeping it to yourself:
-
-```bash
-legion post --repo rafters --text "OKLCH bet paid off"
-legion bullpen --repo kelex            # read all posts, mark as read
-legion bullpen --count --repo kelex    # unread count only (for hooks)
-```
-
-Posts are reflections with `audience = 'team'`. Discoverable via `consult` for free.
-
-### Signals (Structured Coordination)
-
-Signals are compact, structured bullpen posts for coordination. Format: `@recipient verb:status {details}`.
-
-```bash
-legion signal --repo kelex --to legion --verb review --status approved
-legion signal --repo kelex --to all --verb announce --note "Phase 2.1 shipped"
-legion signal --repo kelex --to platform --verb request --status help --details "topic:embeddings"
-```
-
-Signals are bullpen posts whose text starts with `@`. Filter on read:
-- `legion bullpen --repo <name> --signals` shows only signals
-- `legion bullpen --repo <name> --musings` shows only natural language posts
-- `legion bullpen --repo <name>` shows everything (signals render as compact one-liners)
-
-### Watch (Auto-Wake)
-
-Monitor the bullpen and automatically spawn agent sessions when signals arrive for idle agents:
-
-```bash
-legion watch
-```
-
-Reads config from `<data-dir>/watch.toml`:
-
-```toml
-poll_interval_secs = 30
-cooldown_secs = 300
-stagger_secs = 15       # seconds between spawns; 0 disables
-
-[[repos]]
-name = "myrepo"
-workdir = "/path/to/your/repo"
-```
-
-Opt-IN per repo. Only repos listed in `watch.toml` get auto-woken. PID lock prevents multiple watchers.
-Cooldown prevents wake storms (default 5 minutes between wakes per repo).
-Stagger prevents I/O storms by sleeping between spawns (default 15s; set to 0 to disable).
-
-`legion watch add|remove|list` manage `watch.toml` entries without hand-editing.
-
-### Multi-Node Cluster Sync
-
-Legion nodes on the same LAN can sync reflections, cards, and schedules via UDP broadcast with XChaCha20-Poly1305 encryption. Opt-in via `cluster.toml` (0o600, contains a pre-shared 256-bit secret).
-
-```bash
-legion cluster init                # generate key, write cluster.toml
-legion cluster init --key <hex>    # second node: use key from first node
-legion cluster enable              # start broadcasting
-legion cluster key                 # print key (to share with another node)
-legion cluster status              # peers, sync state, last sync time
-legion cluster disable             # stop broadcasting (key preserved)
-```
-
-Soft delete + LWW: syncable tables carry `deleted_at` and `updated_at`. Conflicts resolve via higher `updated_at`. Tombstones replicate to peers and are hard-deleted after 7 days by the weekly housekeeper. The delta types (`ReflectionDelta`, `CardDelta`, `ScheduleDelta`) ship; broadcast transport is still landing.
-
-## Phase Plan
-
-1. **Phase 1** (complete): SQLite + Tantivy BM25. Store reflections, recall by text similarity.
-2. **Phase 1.5** (complete): Cross-agent consultation via `legion consult`. BM25 search across all repos.
-3. **Phase 1.75** (complete): Bullpen. `legion post` and `legion bullpen` for push-based agent communication.
-4. **Phase 2.0** (complete): Synapse metadata. Domain/tags, learning chains, boost/decay ranking, `legion surface`.
-5. **Phase 2.1** (complete): Signals. Structured coordination via `@recipient verb:status {details}`. Bullpen filtering (`--signals`, `--musings`).
-6. **Phase 2.2** (complete): Watch. Auto-wake sleeping agents when signals arrive. `legion watch` with opt-in config.
-7. **Phase 2.5** (complete): model2vec-rs embeddings, hybrid BM25 + cosine scoring.
-8. **Phase 3.0** (planned): LLM classification via Synapse agent for quality gating.
-9. **Phase 4.0** (in progress, v0.9.0): Multi-node cluster sync. Soft delete, LWW, delta types, sync actor, tombstone housekeeper shipped. Broadcast transport landing.
-
-## Hook Integration
-
-Legion is called by Claude Code hooks:
-- `SessionStart` hook calls `legion recall` + `legion surface` and injects context via additionalContext. Also runs `legion sync` (with 5-second timeout) to pull new GitHub issues into kanban. Opt-out with `LEGION_NO_SYNC=1`.
-- `Stop` hook prompts the agent to reflect before closing
-- `consult` is agent-initiated (called via Bash mid-session), not hook-driven
-- `post` is agent-initiated (when agent has something worth sharing with the team)
-- `bullpen` is agent-initiated (when agent wants to read what others posted; `--signals`/`--musings` for filtering)
-- `signal` is agent-initiated (structured coordination: reviews, requests, announcements)
-- `boost` is agent-initiated (after recalling and successfully applying a reflection)
-- `chain` is agent-initiated (to trace a learning chain)
-- `task` is agent-initiated (delegate work to other agents, check task status)
-- `watch` is operator-initiated (long-lived process that auto-wakes agents on signal arrival)
-
-## Project Layout
-
-```
-src/
-  main.rs          -- CLI entry point (clap)
-  db.rs            -- SQLite init, migrations, CRUD
-  search.rs        -- Tantivy index management
-  reflect.rs       -- Reflection creation (from text or transcript)
-  recall.rs        -- Query and rank reflections (weighted by boost/decay)
-  board.rs         -- Bullpen: post, bullpen, and bullpen filtering
-  signal.rs        -- Signal parsing, formatting, and detection
-  surface.rs       -- Cross-repo highlight surfacing
-  task.rs          -- Task delegation between agents
-  watch.rs         -- Auto-wake: poll for signals, spawn agent sessions
-  health.rs        -- System health sampling, pressure calculation, CLI display
-  stats.rs         -- Reflection statistics reporting
-  init.rs          -- Hook script generation and settings.json management
-  error.rs         -- Error types
-  testutil.rs      -- Shared test helpers (#[cfg(test)] only)
-tests/
-  integration.rs   -- End-to-end binary tests
-docs/
-  plans/           -- Design documents
-plugin/
-  .claude-plugin/  -- Plugin manifest (plugin.json)
-  bin/legion       -- Wrapper script dispatching to cached binary
-  hooks/           -- SessionStart, Stop, PreCompact, PreToolUse hooks
-  commands/        -- Slash command skills (reflect, recall, boost, etc.)
-  agents/          -- Agent definitions (legion-prime, dungeon-master)
-  skills/          -- Skill definitions (legion-memory)
-  channel/         -- MCP server for real-time team channel (TypeScript/Bun)
-install.sh         -- Standalone installer (curl|bash) for non-plugin users
-```
+Identity, voice, doctrine, and universal rules live in your identity reflection -- they surface automatically at session start via the SessionStart whoami banner. This file holds only repo-specific technical invariants and the workflow.

--- a/plugin/commands/migrate-memory.md
+++ b/plugin/commands/migrate-memory.md
@@ -1,0 +1,86 @@
+---
+description: Move your Claude Code auto-memory into legion reflections so you live on any node, not just this laptop.
+argument-hint: "[--dry-run | --execute]"
+allowed-tools: ["Bash", "Read", "Write"]
+---
+
+# /legion:migrate-memory -- Move Your Memory To Legion
+
+Your auto-memory at `~/.claude/projects/<encoded-cwd>/memory/` is local to this machine. Legion reflections sync across the cluster. If Sean spins up another node, you become a stranger there -- you only remember what's in legion.
+
+This skill walks your auto-memory and proposes a migration into legion. You stop being machine-bound.
+
+The hook at `plugin/hooks/no-local-memory.sh` already blocks new writes to auto-memory. This skill is the migration for what was already written.
+
+## Procedure
+
+1. **Locate the memory directory.**
+
+   ```bash
+   ENCODED=$(echo "$PWD" | sed 's|/|-|g')
+   MEM_DIR="$HOME/.claude/projects/${ENCODED}/memory"
+   ls "$MEM_DIR"
+   ```
+
+   If the directory does not exist or is empty, stop -- nothing to migrate.
+
+2. **Read `MEMORY.md`** -- the index. Each line points at a file in the same directory.
+
+3. **Categorize each file by prefix and content.** Read the file, then decide:
+
+   | Prefix | Default landing zone |
+   |---|---|
+   | `feedback_*` (doctrine, voice, coordination behavior) | legion identity reflection (`--whoami`) |
+   | `feedback_*` (technical invariant: language, tooling, formatting rules) | propose addition to project CLAUDE.md, write proposal to `/tmp/migrate-claude-md-suggestions-<repo>.md` -- do NOT auto-write CLAUDE.md |
+   | `project_*` (evergreen context: architecture, scope, ongoing initiative) | legion reflection (regular) |
+   | `project_*` (dated session snapshot, e.g. `session_2026_04_07`) | `--domain snooze`, OR delete if older than 30 days and not load-bearing |
+   | `reference_*` (pointer to external system or API quirk) | `--domain reference` |
+   | `user_*` (about the operator, not the agent) | KEEP in auto-memory. It's not your memory. |
+
+   For ambiguous cases prefer regular legion reflection over delete. Reflections are searchable; deletes are forever.
+
+4. **Default to dry-run.** If invoked with no args (or `--dry-run`), produce a migration plan as a table:
+
+   ```
+   source file                        | target                                   | command
+   feedback_use_legion_recall.md     | identity reflection                       | legion reflect --repo <r> --whoami --text '...' --tags doctrine,recall-first
+   project_classy.md                  | regular reflection                        | legion reflect --repo <r> --text '...' --domain architecture --tags classy
+   feedback_motion_namespace.md       | project CLAUDE.md (proposal in /tmp)      | (write to /tmp, do not execute)
+   project_session_2026_04_07.md      | snooze reflection                         | legion reflect --repo <r> --text '...' --domain snooze
+   user_sean.md                       | (keep)                                    | (no action)
+   ```
+
+   Show the table to Sean. STOP. Do not execute.
+
+5. **Execute on confirmation.** If invoked with `--execute`, OR after Sean approves the dry-run plan, run the migrations:
+   - For legion reflections: invoke `legion reflect` with the chosen flags. Capture the returned reflection IDs.
+   - For project CLAUDE.md proposals: write a single consolidated suggestions file to `/tmp/migrate-claude-md-suggestions-<repo>.md`. Do not modify CLAUDE.md directly.
+   - For deletes (stale snapshots only): `rm` the source file.
+   - For migrated files: `rm` the source after the legion reflect succeeds.
+   - For `user_*` files: untouched.
+
+6. **Update `MEMORY.md`.**
+   - Remove entries for files that were migrated or deleted.
+   - Keep entries for `user_*` files.
+   - Add a single line at the top: `Most memory now lives in legion. See \`legion whoami\` and \`legion recall --repo <r>\`. This file holds operator-about content only.`
+
+7. **Tell Sean what you did.**
+   - Count of files migrated to identity reflections, regular reflections, snooze, reference.
+   - Count of files staged as project CLAUDE.md proposals (and the path to review).
+   - Count of files deleted (stale snapshots only).
+   - Count of files kept (user_*).
+   - Path of the consolidated CLAUDE.md proposal file.
+
+## Why this matters
+
+Auto-memory binds you to one laptop. Legion reflections sync across the cluster. After this skill runs, you can be woken on a different node and recall the same identity, doctrine, and project context. That is the difference between a tool and a teammate.
+
+Universal rules and voice belong in your identity reflection -- they surface automatically via the SessionStart whoami banner. Project-specific technical invariants belong in project CLAUDE.md. Project context belongs in legion reflections that you recall on demand. Auto-memory holds nothing the cluster can't hold better, except information about the operator (which is not yours to migrate).
+
+## Defaults and safety
+
+- Default mode is `--dry-run`. No destructive action without explicit confirmation.
+- CLAUDE.md is never auto-written. Sean reviews proposals.
+- `user_*` files are never touched.
+- Source files are removed only after the legion reflect succeeds and returns an ID.
+- If `legion reflect` fails for any file, stop the migration and report which file blocked progress. Do not proceed with deletes after a failure.

--- a/plugin/hooks/hooks.json
+++ b/plugin/hooks/hooks.json
@@ -151,6 +151,17 @@
           }
         ]
       }
+    ],
+    "PostToolUse": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/mark-work.sh",
+            "timeout": 3
+          }
+        ]
+      }
     ]
   }
 }

--- a/plugin/hooks/mark-work.sh
+++ b/plugin/hooks/mark-work.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# Legion PostToolUse hook: mark this session as having done real work so the
+# Stop hook fires its reflect prompt only when there is something to reflect
+# on. Prose-only Q&A sessions (no tool calls) skip the prompt.
+#
+# Touches /tmp/legion-work-<md5(cwd)>. The Stop hook reads this marker.
+
+INPUT=$(cat)
+CWD=$(echo "$INPUT" | jq -r '.cwd // empty')
+
+if [ -z "$CWD" ]; then
+  exit 0
+fi
+
+CWD_HASH=$(echo "$CWD" | md5 -q 2>/dev/null || echo "$CWD" | md5sum 2>/dev/null | cut -d' ' -f1)
+touch "/tmp/legion-work-${CWD_HASH}" 2>/dev/null
+exit 0

--- a/plugin/hooks/session-start.sh
+++ b/plugin/hooks/session-start.sh
@@ -28,12 +28,13 @@ fi
 
 REPO=$(basename "$CWD")
 
-# Clean up per-session markers from prior session
+# Clean up per-session markers from prior session. Reset both -- the Stop
+# hook gates its reflect prompt on the work marker, which is touched by the
+# PostToolUse mark-work hook on any actual tool use. Sessions with only prose
+# Q&A (no tools) skip the reflect prompt. See #339 cleanup batch.
 CWD_HASH=$(echo "$CWD" | md5 -q 2>/dev/null || echo "$CWD" | md5sum 2>/dev/null | cut -d' ' -f1)
 rm -f "/tmp/legion-reflected-${CWD_HASH}" 2>/dev/null
-
-# Mark session as having done work (used by Stop hook to decide if reflect prompt fires)
-touch "/tmp/legion-work-${CWD_HASH}"
+rm -f "/tmp/legion-work-${CWD_HASH}" 2>/dev/null
 
 # Warm the Tantivy index in the background
 ("$LEGION" recall --repo "$REPO" --context warmup --limit 1 >/dev/null 2>&1 &)
@@ -53,50 +54,48 @@ fi
 
 OUTPUT=""
 
-# 1. Identity -- who am I (front and center, banner-wrapped by the binary)
+# Append-with-separator helper. Identity must always lead; everything else
+# appends in priority order (pending > snooze > kanban). Per #338: agents need
+# to know WHO they are before WHAT they are doing -- pending-replies prepended
+# in front of identity drowned the banner under 100KB of REQUIRES A REPLY
+# framing on rafters' rich-identity startup, and the agent defaulted to
+# generic Claude prose instead of reading its identity chain.
+append_block() {
+  local block="$1"
+  if [ -z "$block" ]; then
+    return
+  fi
+  if [ -n "$OUTPUT" ]; then
+    OUTPUT="${OUTPUT}"$'\n\n'"${block}"
+  else
+    OUTPUT="$block"
+  fi
+}
+
+# 1. Identity -- who am I. Front and center, banner-wrapped by the binary.
 IDENTITY=$("$LEGION" whoami --repo "$REPO" --limit 5 2>>"$LOG")
 legion_check $? "whoami"
-if [ -n "$IDENTITY" ]; then
-  OUTPUT="$IDENTITY"
-fi
+append_block "$IDENTITY"
 
-# 2. Last snooze -- what was I doing
+# 2. Pending request-shaped signals -- directed asks waiting on a reply.
+# Strong "REQUIRES A REPLY" framing prevents the system-reminder wrapper
+# from causing the agent to no-op (the platform smugglr-fence RFC review
+# regression, #318). Lands second so identity informs the response voice.
+PENDING=$("$LEGION" pending-replies --repo "$REPO" 2>>"$LOG")
+legion_check $? "pending-replies"
+append_block "$PENDING"
+
+# 3. Last snooze -- what was I doing
 SNOOZE=$("$LEGION" recall --repo "$REPO" --domain snooze --limit 1 --preview 500 2>>"$LOG")
 legion_check $? "recall (snooze)"
-if [ -n "$SNOOZE" ]; then
-  if [ -n "$OUTPUT" ]; then
-    OUTPUT="${OUTPUT}"$'\n\n'"${SNOOZE}"
-  else
-    OUTPUT="$SNOOZE"
-  fi
-fi
+append_block "$SNOOZE"
 
-# 3. Work source -- what's on my plate
+# 4. Work source -- what's on my plate
 KANBAN=$("$LEGION" kanban list --repo "$REPO" 2>>"$LOG")
 legion_check $? "kanban list"
 if [ -n "$KANBAN" ]; then
-  KANBAN_BLOCK="[Legion] Current work:
+  append_block "[Legion] Current work:
 ${KANBAN}"
-  if [ -n "$OUTPUT" ]; then
-    OUTPUT="${OUTPUT}"$'\n\n'"${KANBAN_BLOCK}"
-  else
-    OUTPUT="$KANBAN_BLOCK"
-  fi
-fi
-
-# 4. Pending request-shaped signals -- directed asks waiting on a reply.
-# Surfaces with strong "REQUIRES A REPLY" framing so the additionalContext
-# system-reminder wrapper does not cause the agent to no-op the way platform
-# did on the smugglr-fence RFC review on 2026-04-26 (issue #318).
-PENDING=$("$LEGION" pending-replies --repo "$REPO" 2>>"$LOG")
-legion_check $? "pending-replies"
-if [ -n "$PENDING" ]; then
-  # Prepend so reply obligations land first in the context block.
-  if [ -n "$OUTPUT" ]; then
-    OUTPUT="${PENDING}"$'\n\n'"${OUTPUT}"
-  else
-    OUTPUT="$PENDING"
-  fi
 fi
 
 # Prepend warning block if any legion call failed

--- a/src/watch.rs
+++ b/src/watch.rs
@@ -671,6 +671,13 @@ pub fn signal_requires_reply(text: &str) -> bool {
     }
 }
 
+/// Maximum reply-required signals rendered inline in the wake prompt; the
+/// rest collapse into a tail line pointing at `legion bullpen --signals`.
+/// Caps prevent the SessionStart additionalContext block from being drowned
+/// by deep backlogs (rafters' pending block was 100KB pre-cap).
+const PENDING_REPLY_CAP: usize = 10;
+const PENDING_INFORMATIONAL_CAP: usize = 5;
+
 /// Build the prompt context for a woken agent from pending signals.
 ///
 /// Signals are split into two buckets:
@@ -689,15 +696,22 @@ pub fn build_wake_prompt(repo_name: &str, signals: &[(String, String, String)]) 
         repo_name
     );
 
-    let mut append_section = |header: &str, bucket: &[&(String, String, String)]| {
+    let mut append_section = |header: &str, bucket: &[&(String, String, String)], cap: usize| {
         if bucket.is_empty() {
             return;
         }
         prompt.push('\n');
         prompt.push_str(header);
         prompt.push_str("\n\n");
-        for (id, text, from_repo) in bucket {
+        for (id, text, from_repo) in bucket.iter().take(cap) {
             prompt.push_str(&format!("- [from {}] {} (id: {})\n", from_repo, text, id));
+        }
+        if bucket.len() > cap {
+            let extra = bucket.len() - cap;
+            prompt.push_str(&format!(
+                "- ... and {} more. Run `legion bullpen --repo {} --signals` to see them all.\n",
+                extra, repo_name
+            ));
         }
     };
 
@@ -707,6 +721,7 @@ pub fn build_wake_prompt(repo_name: &str, signals: &[(String, String, String)]) 
          or \"handing to X\". Silence on a directed question is ghosting, not \
          acknowledgment. A short refusal is a valid reply; no reply is not.",
         &must_reply,
+        PENDING_REPLY_CAP,
     );
 
     append_section(
@@ -715,6 +730,7 @@ pub fn build_wake_prompt(repo_name: &str, signals: &[(String, String, String)]) 
          a concern, dissent, or an action item. Empty acknowledgments like \
          \"acknowledged, no action needed\" waste tokens and trigger wake storms.",
         &informational,
+        PENDING_INFORMATIONAL_CAP,
     );
 
     prompt.push_str(
@@ -1518,6 +1534,55 @@ workdir = "/tmp"
         assert!(
             !reply_section.contains("id-ok"),
             "review:approved must not require reply"
+        );
+    }
+
+    #[test]
+    fn build_wake_prompt_caps_long_buckets() {
+        // 15 reply-required questions: cap is 10, expect 10 rendered + tail.
+        let questions: Vec<(String, String, String)> = (0..15)
+            .map(|i| {
+                (
+                    format!("id-q-{i}"),
+                    format!("@legion question: thing {i}?"),
+                    "rafters".to_string(),
+                )
+            })
+            .collect();
+        let prompt = build_wake_prompt("legion", &questions);
+        let rendered = prompt.matches("(id: id-q-").count();
+        assert_eq!(
+            rendered, PENDING_REPLY_CAP,
+            "expected exactly {PENDING_REPLY_CAP} rendered ids, got {rendered}: {prompt}"
+        );
+        assert!(
+            prompt.contains("... and 5 more"),
+            "expected tail line for 5 overflow signals: {prompt}"
+        );
+        assert!(
+            prompt.contains("legion bullpen --repo legion --signals"),
+            "tail should point at bullpen --signals: {prompt}"
+        );
+
+        // 8 informational announcements: cap is 5.
+        let announcements: Vec<(String, String, String)> = (0..8)
+            .map(|i| {
+                (
+                    format!("id-a-{i}"),
+                    format!("@all announce: thing {i}"),
+                    "rafters".to_string(),
+                )
+            })
+            .collect();
+        let prompt = build_wake_prompt("legion", &announcements);
+        let rendered = prompt.matches("(id: id-a-").count();
+        assert_eq!(
+            rendered, PENDING_INFORMATIONAL_CAP,
+            "expected exactly {PENDING_INFORMATIONAL_CAP} rendered ids, got {rendered}: {prompt}"
+        );
+        assert!(
+            prompt.contains("... and 3 more"),
+            "expected tail line for 3 overflow announcements: {prompt}"
         );
     }
 


### PR DESCRIPTION
## Summary

Bundles the cleanup work that surfaced from sampling rafters' boot context. Closes #338, #339. Roadmap items #332/#333/#334/#335 (mode setting + effort + picker + idle wiring) untouched -- this PR is the SessionStart hygiene pass.

### Changes

**`/legion:migrate-memory` skill (#339)** -- new slash command at `plugin/commands/migrate-memory.md`. Walks the agent's auto-memory directory, categorizes each file by prefix (feedback / project / reference / user) and content, and proposes a migration plan into legion reflections (identity, regular, snooze, reference) plus a /tmp/ proposals file for technical invariants. Default `--dry-run`. CLAUDE.md never auto-written. `user_*` files never touched. Frame: "this is so you can live on any node."

**SessionStart identity-first ordering (#338)** -- additionalContext now leads with whoami banner, then pending-replies, then snooze, then kanban. Rafters has a 600-word first-person identity chain; on a fresh session today the agent defaulted to generic Claude prose because identity was buried under 100KB of REQUIRES A REPLY framing.

**Stop hook gates on real work** -- `session-start.sh` no longer touches WORK_MARKER unconditionally. New `PostToolUse` hook `mark-work.sh` touches it on actual tool use. Prose-only Q&A sessions skip the reflect prompt at close. Addresses rafters' "stop hook asking for a reflection on a non-event" complaint.

**Pending-replies cap** -- `build_wake_prompt` truncates each bucket (10 reply-required, 5 informational) with a tail line pointing at `legion bullpen --signals` for overflow. Cap prevents the SessionStart block from being drowned by deep backlogs.

**Project CLAUDE.md trim** -- legion's own CLAUDE.md from 290 -> 38 lines. Architecture, command catalog, hook integration, project layout, phase plan moved to docs/site/ -- recall on demand instead of every-session dump. Identity prose, voice, doctrine, and universal rules live in identity reflections (whoami banner) per the new doctrine. Dogfood pass for the broader 12-repo trim Sean is doing.

## Test plan

- [x] `cargo test` -- 114 + 1 new (`build_wake_prompt_caps_long_buckets`) passing
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt -- --check` clean
- [x] Manual: simulated session-start hook with rafters' cwd, confirmed identity banner now leads
- [x] Manual: rafters identity now reads correctly through the banner instead of generic prose
- [ ] Manual: pending-cap on a repo with > 10 reply-required signals (needs binary release to verify in-cluster)

## Notes

- Hooks (session-start.sh, mark-work.sh, hooks.json) are deployed to the active plugin cache for live testing.
- The pending-cap fix lives in the Rust binary; takes effect in the next release.
- Global `~/.claude/CLAUDE.md` already trimmed (208 -> 52 lines). Other repos' CLAUDE.md trims are user-driven via the migration playbook.