### PR TITLE
chore: release v0.9.8

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
     {
       "name": "legion",
       "description": "Agent memory layer with recall, reflect, consult, bullpen, and cross-agent coordination. Includes health monitoring and auto-wake. Hooks wire legion into every session automatically.",
-      "version": "0.9.7",
+      "version": "0.9.8",
       "author": {
         "name": "Sean Silvius",
         "email": "sean@silvius.me"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1444,7 +1444,7 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "legion"
-version = "0.9.7"
+version = "0.9.8"
 dependencies = [
  "async-stream",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "legion"
-version = "0.9.7"
+version = "0.9.8"
 edition = "2024"
 description = "Agent specialization through deliberate practice"
 

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "legion",
-  "version": "0.9.7",
+  "version": "0.9.8",
   "description": "Institutional memory for Claude Code agents with real-time team channel.",
   "author": {
     "name": "Sean Silvius",

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Legion Changelog
 
+## 0.9.8
+
+Boot-context cleanup release. Sampled rafters' SessionStart shape and discovered identity was being drowned under 100KB of pending-reply framing, the Stop hook was prompting reflections on prose-only Q&A sessions, and the legion project CLAUDE.md was 290 lines of reference material every session re-read. All addressed.
+
+### New
+
+- **`/legion:migrate-memory` skill** (#339): walks the agent's auto-memory directory (`~/.claude/projects/<encoded-cwd>/memory/`), categorizes each file by prefix and content, and proposes a migration plan into legion reflections (identity / regular / snooze / reference) plus a /tmp/ proposals file for technical invariants. Default `--dry-run`. CLAUDE.md never auto-written. `user_*` files never touched. Frame: "this is so you can live on any node" -- auto-memory binds you to one laptop; legion reflections sync via the cluster.
+- **PostToolUse `mark-work.sh` hook**: touches `/tmp/legion-work-<md5(cwd)>` on actual tool use. The Stop hook's reflect prompt now fires only when the session did real work; prose-only Q&A sessions skip it.
+
+### Changed
+
+- **SessionStart identity-first ordering** (#338, #340): additionalContext now leads with the whoami banner, then pending-replies, then snooze, then kanban. Rafters has a 600-word first-person identity chain that shipped in v0.9.7 but was buried under pending-reply framing on a fresh session, so the agent defaulted to generic Claude prose. Identity informs the reply voice -- it has to land first.
+- **Pending-replies cap**: `build_wake_prompt` truncates each bucket (10 reply-required, 5 informational) with a tail line pointing at `legion bullpen --signals`. Caps prevent the SessionStart block from being drowned by deep backlogs (rafters' pending block was 100KB pre-cap).
+- **Project CLAUDE.md trim**: legion's own CLAUDE.md from 290 -> 38 lines. Architecture, command catalog, hook integration, project layout, phase plan all moved to docs/site/ -- recall on demand instead of every-session dump. Identity prose, voice, doctrine, and universal rules live in identity reflections (whoami banner) per the new doctrine. Dogfood pass for the broader 12-repo trim.
+
 ## 0.9.7
 
 Session-boundary release. Auto-compaction was silently dropping consolidation work, and the SessionStart identity block was easy to skim past. Both fixed.


### PR DESCRIPTION
## Summary

Cuts v0.9.8.

- /legion:migrate-memory skill (#339)
- SessionStart identity-first ordering (#338, #340)
- Stop hook gated on real tool use via PostToolUse mark-work.sh
- Pending-replies cap (10/5 with tail line)
- Project CLAUDE.md trim (290 -> 38 lines)

Cargo.toml + plugin.json + marketplace.json bumped 0.9.7 -> 0.9.8. CHANGELOG entry written.

## Test plan

- [x] cargo build clean on 0.9.8
- [x] sync-version pre-commit hook bumped plugin.json + marketplace.json
- [x] hooks (session-start.sh, mark-work.sh, hooks.json) already deployed to active plugin cache for live testing