### PR TITLE
feat(#342): cap whoami output at 2KB, surface only chain roots

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -1177,6 +1177,22 @@ impl Database {
             .map_err(LegionError::Database)
     }
 
+    /// Retrieve identity reflections that are chain roots or orphans for
+    /// `whoami`. Excludes reflections with a `parent_id` (chain children),
+    /// because their content is reachable via `legion chain --id <root>`
+    /// and including them would bloat the whoami banner past the inline
+    /// context budget. Ordered newest first.
+    pub fn get_identity_roots(&self, repo: &str, limit: usize) -> Result<Vec<Reflection>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT id, repo, text, created_at, updated_at, audience, domain, tags, recall_count, last_recalled_at, parent_id \
+             FROM reflections WHERE repo = ?1 AND domain = 'identity' AND parent_id IS NULL AND deleted_at IS NULL ORDER BY created_at DESC LIMIT ?2",
+        )?;
+
+        let rows = stmt.query_map(rusqlite::params![repo, limit], map_reflection_row)?;
+        rows.collect::<std::result::Result<Vec<_>, _>>()
+            .map_err(LegionError::Database)
+    }
+
     /// Retrieve active (non-archived) bullpen posts, ordered newest first.
     pub fn get_board_posts(&self) -> Result<Vec<Reflection>> {
         let mut stmt = self.conn.prepare(
@@ -3865,6 +3881,93 @@ mod tests {
         let from_middle = db.get_chain(&second.id).unwrap();
         assert_eq!(from_middle.len(), 3);
         assert_eq!(from_middle[0].id, first.id);
+    }
+
+    #[test]
+    fn get_identity_roots_excludes_chain_children() {
+        let db = test_db();
+        let root = db
+            .insert_reflection_with_meta(
+                "legion",
+                "root identity",
+                "self",
+                &ReflectionMeta {
+                    domain: Some("identity".into()),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+        let _child = db
+            .insert_reflection_with_meta(
+                "legion",
+                "chain child identity",
+                "self",
+                &ReflectionMeta {
+                    domain: Some("identity".into()),
+                    parent_id: Some(root.id.clone()),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+        let orphan = db
+            .insert_reflection_with_meta(
+                "legion",
+                "orphan identity",
+                "self",
+                &ReflectionMeta {
+                    domain: Some("identity".into()),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+
+        let roots = db.get_identity_roots("legion", 10).unwrap();
+        let ids: Vec<&str> = roots.iter().map(|r| r.id.as_str()).collect();
+        assert_eq!(roots.len(), 2);
+        assert!(ids.contains(&root.id.as_str()));
+        assert!(ids.contains(&orphan.id.as_str()));
+    }
+
+    #[test]
+    fn get_identity_roots_filters_by_repo_and_domain() {
+        let db = test_db();
+        let _other_domain = db
+            .insert_reflection_with_meta(
+                "legion",
+                "not identity",
+                "self",
+                &ReflectionMeta {
+                    domain: Some("architecture".into()),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+        let _other_repo = db
+            .insert_reflection_with_meta(
+                "kelex",
+                "wrong repo",
+                "self",
+                &ReflectionMeta {
+                    domain: Some("identity".into()),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+        let target = db
+            .insert_reflection_with_meta(
+                "legion",
+                "right one",
+                "self",
+                &ReflectionMeta {
+                    domain: Some("identity".into()),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+
+        let roots = db.get_identity_roots("legion", 10).unwrap();
+        assert_eq!(roots.len(), 1);
+        assert_eq!(roots[0].id, target.id);
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -2628,42 +2628,23 @@ fn run() -> error::Result<()> {
             }
         }
         Commands::Whoami { repo, limit } => {
-            const WHOAMI_BYTE_CAP: usize = 2048;
             let base = data_dir()?;
             let database = db::Database::open(&base.join("legion.db"))?;
             let roots = database.get_identity_roots(&repo, limit)?;
             if roots.is_empty() {
                 return Ok(());
             }
-            let header = format!(
-                "{}\n[Legion] Identity for {repo}:\n",
-                recall::WHOAMI_BANNER_OPEN
-            );
-            let footer = format!("{}\n", recall::WHOAMI_BANNER_CLOSE);
-            let mut buf = String::new();
-            buf.push_str(&header);
-            let mut emitted = 0usize;
-            for r in &roots {
-                let chain_line = if database.is_in_chain(&r.id)? {
-                    format!("  \u{21b3} chain context: legion chain --id {}\n", r.id)
-                } else {
-                    String::new()
-                };
-                let entry = format!("- {} (id: {})\n{}", r.text, r.id, chain_line);
-                if buf.len() + entry.len() + footer.len() > WHOAMI_BYTE_CAP && emitted > 0 {
-                    break;
-                }
-                buf.push_str(&entry);
-                emitted += 1;
+            let mut entries = Vec::with_capacity(roots.len());
+            for r in roots {
+                let in_chain = database.is_in_chain(&r.id)?;
+                entries.push(recall::WhoamiEntry {
+                    id: r.id,
+                    text: r.text,
+                    in_chain,
+                });
             }
-            let remaining = roots.len().saturating_sub(emitted);
-            if remaining > 0 {
-                buf.push_str(&format!(
-                    "- ({remaining} more identity reflections truncated; recall via `legion recall --repo {repo} --domain identity`)\n"
-                ));
-            }
-            buf.push_str(&footer);
-            print!("{buf}");
+            let output = recall::format_whoami(&repo, &entries);
+            print!("{output}");
         }
         Commands::Stats { repo } => {
             let base = data_dir()?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -2628,21 +2628,42 @@ fn run() -> error::Result<()> {
             }
         }
         Commands::Whoami { repo, limit } => {
+            const WHOAMI_BYTE_CAP: usize = 2048;
             let base = data_dir()?;
             let database = db::Database::open(&base.join("legion.db"))?;
-            let result = recall::recall_by_domain(&database, &repo, "identity", limit)?;
-            if result.reflections.is_empty() {
+            let roots = database.get_identity_roots(&repo, limit)?;
+            if roots.is_empty() {
                 return Ok(());
             }
-            println!("{}", recall::WHOAMI_BANNER_OPEN);
-            println!("[Legion] Identity for {repo}:");
-            for r in &result.reflections {
-                println!("- {} (id: {})", r.text, r.id);
-                if database.is_in_chain(&r.id)? {
-                    println!("  \u{21b3} chain context: legion chain --id {}", r.id);
+            let header = format!(
+                "{}\n[Legion] Identity for {repo}:\n",
+                recall::WHOAMI_BANNER_OPEN
+            );
+            let footer = format!("{}\n", recall::WHOAMI_BANNER_CLOSE);
+            let mut buf = String::new();
+            buf.push_str(&header);
+            let mut emitted = 0usize;
+            for r in &roots {
+                let chain_line = if database.is_in_chain(&r.id)? {
+                    format!("  \u{21b3} chain context: legion chain --id {}\n", r.id)
+                } else {
+                    String::new()
+                };
+                let entry = format!("- {} (id: {})\n{}", r.text, r.id, chain_line);
+                if buf.len() + entry.len() + footer.len() > WHOAMI_BYTE_CAP && emitted > 0 {
+                    break;
                 }
+                buf.push_str(&entry);
+                emitted += 1;
             }
-            println!("{}", recall::WHOAMI_BANNER_CLOSE);
+            let remaining = roots.len().saturating_sub(emitted);
+            if remaining > 0 {
+                buf.push_str(&format!(
+                    "- ({remaining} more identity reflections truncated; recall via `legion recall --repo {repo} --domain identity`)\n"
+                ));
+            }
+            buf.push_str(&footer);
+            print!("{buf}");
         }
         Commands::Stats { repo } => {
             let base = data_dir()?;

--- a/src/recall.rs
+++ b/src/recall.rs
@@ -17,6 +17,57 @@ const COSINE_MIN_THRESHOLD: f32 = 0.3;
 pub const WHOAMI_BANNER_OPEN: &str = "=== WHO YOU ARE -- READ THIS ===";
 pub const WHOAMI_BANNER_CLOSE: &str = "=== END IDENTITY ===";
 
+/// Soft byte budget for `legion whoami` output. Sized for the SessionStart
+/// inline context window -- larger payloads are truncated by the harness to
+/// a 2KB preview, which silently drops doctrines past the cutoff. Keeping
+/// the whole banner under this budget guarantees nothing is dropped.
+pub const WHOAMI_BYTE_CAP: usize = 2048;
+
+/// A single entry passed to `format_whoami`. The flag indicates whether
+/// the reflection has chain context worth pointing the reader at.
+pub struct WhoamiEntry {
+    pub id: String,
+    pub text: String,
+    pub in_chain: bool,
+}
+
+/// Render the whoami banner from the supplied identity reflections, capped at
+/// `WHOAMI_BYTE_CAP` bytes total. Iterates entries in order; each entry is
+/// emitted in full if its addition keeps the buffer (plus footer) under the
+/// cap. The first entry is always emitted regardless of size to avoid an
+/// empty banner -- a single oversized root is preferable to silent absence.
+/// Remaining entries are summarized with a recall pointer.
+pub fn format_whoami(repo: &str, entries: &[WhoamiEntry]) -> String {
+    if entries.is_empty() {
+        return String::new();
+    }
+    let header = format!("{WHOAMI_BANNER_OPEN}\n[Legion] Identity for {repo}:\n");
+    let footer = format!("{WHOAMI_BANNER_CLOSE}\n");
+    let mut buf = header;
+    let mut emitted = 0usize;
+    for entry in entries {
+        let chain_line = if entry.in_chain {
+            format!("  \u{21b3} chain context: legion chain --id {}\n", entry.id)
+        } else {
+            String::new()
+        };
+        let body = format!("- {} (id: {})\n{}", entry.text, entry.id, chain_line);
+        if buf.len() + body.len() + footer.len() > WHOAMI_BYTE_CAP && emitted > 0 {
+            break;
+        }
+        buf.push_str(&body);
+        emitted += 1;
+    }
+    let remaining = entries.len().saturating_sub(emitted);
+    if remaining > 0 {
+        buf.push_str(&format!(
+            "- ({remaining} more identity reflections truncated; recall via `legion recall --repo {repo} --domain identity`)\n"
+        ));
+    }
+    buf.push_str(&footer);
+    buf
+}
+
 /// A set of recalled reflections matching a query, optionally scoped to a single repo.
 #[derive(Debug, serde::Serialize)]
 pub struct RecallResult {
@@ -1094,6 +1145,75 @@ mod tests {
             result.reflections.is_empty(),
             "orthogonal vector should be filtered by min_score 0.5"
         );
+    }
+
+    fn entry(id: &str, text: &str, in_chain: bool) -> WhoamiEntry {
+        WhoamiEntry {
+            id: id.to_string(),
+            text: text.to_string(),
+            in_chain,
+        }
+    }
+
+    #[test]
+    fn format_whoami_empty_returns_empty() {
+        assert_eq!(format_whoami("legion", &[]), "");
+    }
+
+    #[test]
+    fn format_whoami_single_short_entry_fits() {
+        let out = format_whoami("legion", &[entry("abc", "hi", false)]);
+        assert!(out.starts_with(WHOAMI_BANNER_OPEN));
+        assert!(out.contains("- hi (id: abc)"));
+        assert!(out.trim_end().ends_with(WHOAMI_BANNER_CLOSE));
+        assert!(!out.contains("truncated"));
+    }
+
+    #[test]
+    fn format_whoami_emits_chain_pointer_when_in_chain() {
+        let out = format_whoami("legion", &[entry("abc", "hi", true)]);
+        assert!(out.contains("legion chain --id abc"));
+    }
+
+    #[test]
+    fn format_whoami_skips_chain_pointer_when_not_in_chain() {
+        let out = format_whoami("legion", &[entry("abc", "hi", false)]);
+        assert!(!out.contains("legion chain --id"));
+    }
+
+    #[test]
+    fn format_whoami_caps_output_under_budget_with_truncation_pointer() {
+        let big = "x".repeat(800);
+        let entries: Vec<WhoamiEntry> = (0..5)
+            .map(|i| entry(&format!("id{i}"), &big, false))
+            .collect();
+        let out = format_whoami("legion", &entries);
+        assert!(out.contains("more identity reflections truncated"));
+        assert!(
+            out.len() < WHOAMI_BYTE_CAP + 200,
+            "output {} bytes should be near the cap",
+            out.len()
+        );
+    }
+
+    #[test]
+    fn format_whoami_always_emits_first_entry_even_if_oversized() {
+        let huge = "x".repeat(WHOAMI_BYTE_CAP * 2);
+        let out = format_whoami("legion", &[entry("solo", &huge, false)]);
+        assert!(out.contains("solo"));
+        assert!(out.contains(WHOAMI_BANNER_OPEN));
+        assert!(out.contains(WHOAMI_BANNER_CLOSE));
+        assert!(!out.contains("truncated"));
+    }
+
+    #[test]
+    fn format_whoami_truncation_pointer_includes_repo() {
+        let big = "x".repeat(800);
+        let entries: Vec<WhoamiEntry> = (0..5)
+            .map(|i| entry(&format!("id{i}"), &big, false))
+            .collect();
+        let out = format_whoami("kelex", &entries);
+        assert!(out.contains("legion recall --repo kelex --domain identity"));
     }
 
     #[test]


### PR DESCRIPTION
Closes #342.

## Problem

After the chain-based identity migration (16 identity reflections in legion repo), `legion whoami` was emitting 21.8KB. The harness persisted the overflow to disk and inlined only a 2KB head preview, silently dropping the doctrines and chain pointers past the cutoff -- the exact failure mode the whoami banner was built to prevent.

## Fix

- New `db::get_identity_roots(repo, limit)` -- selects identity reflections where parent_id IS NULL (chain roots and orphans). Chain children stay reachable via `legion chain --id <root>`; they don't need to be inlined in the boot banner.
- New `recall::format_whoami(repo, entries)` pure formatter capped at 2048 bytes total. First entry always emitted regardless of size (partial identity beats absent identity); remaining truncated with a recall pointer.
- New constant `recall::WHOAMI_BYTE_CAP = 2048`.

## Verified

`legion whoami --repo legion`: 21.8KB -> 2.3KB (89% reduction).

## Test coverage

- `get_identity_roots`: repo/domain/parent_id IS NULL filters
- `format_whoami`: empty, single short fits, chain pointer on/off, multi-oversized truncation under cap, oversized solo still emitted, repo in truncation pointer

cargo test (114 pass), clippy -D warnings clean, fmt clean.