### PR TITLE
feat(#345): UserPromptSubmit hook lazy-loads identity chain on first prompt

### DIFF
--- a/plugin/hooks/hooks.json
+++ b/plugin/hooks/hooks.json
@@ -152,6 +152,17 @@
         ]
       }
     ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/identity-chain-load.sh",
+            "timeout": 8
+          }
+        ]
+      }
+    ],
     "PostToolUse": [
       {
         "hooks": [

--- a/plugin/hooks/identity-chain-load.sh
+++ b/plugin/hooks/identity-chain-load.sh
@@ -1,0 +1,102 @@
+#!/bin/bash
+# Legion UserPromptSubmit hook: lazy-load the identity chain on the first
+# user prompt of a session. Pairs with the 2KB SessionStart whoami banner
+# (#342) -- the banner stays slim, the chain pays for itself once when the
+# agent actually starts working.
+#
+# Idempotency: per-session sentinel at /tmp/legion-chain-loaded-${SESSION_ID}.
+# First prompt walks the chain and injects it; subsequent prompts short-circuit
+# and exit silently.
+#
+# Error handling: legion failures are logged to /tmp/legion-hook-errors.log.
+# The hook always exits 0 so a degraded legion never blocks user prompts.
+
+LEGION="${CLAUDE_PLUGIN_ROOT}/bin/legion"
+LOG=/tmp/legion-hook-errors.log
+
+# Shared warning helper.
+# shellcheck source=_legion-warn.sh
+source "${CLAUDE_PLUGIN_ROOT}/hooks/_legion-warn.sh"
+
+INPUT=$(cat)
+CWD=$(echo "$INPUT" | jq -r '.cwd // empty')
+SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // empty')
+
+if [ -z "$CWD" ] || [ -z "$SESSION_ID" ]; then
+  exit 0
+fi
+
+# Sanitize session id for use as a filename component. Use printf, not echo,
+# to avoid the trailing newline being mapped to '_' by tr.
+SAFE_SESSION=$(printf '%s' "$SESSION_ID" | tr -c 'a-zA-Z0-9_-' '_')
+
+# Sentinel lives under a user-scoped cache dir, not /tmp, so a shared host
+# cannot pre-create the path (or a symlink to a sensitive file) to either
+# suppress chain load or redirect the touch.
+CACHE_DIR="${XDG_CACHE_HOME:-$HOME/.cache}/legion"
+mkdir -p "$CACHE_DIR" 2>/dev/null
+SENTINEL="${CACHE_DIR}/chain-loaded-${SAFE_SESSION}"
+
+# Already loaded for this session -- nothing to do.
+if [ -f "$SENTINEL" ]; then
+  exit 0
+fi
+
+REPO=$(basename "$CWD")
+
+# Find the newest identity reflection. legion chain --id walks both backward
+# and forward from any node, so any identity reflection ID gets the whole
+# chain. The newest reflection is most likely to be the active root. Capture
+# legion's exit status separately from the pipeline so a missing match (grep
+# exit 1) does not get reported as a recall failure.
+RECALL_OUT=$("$LEGION" recall --repo "$REPO" --domain identity --limit 1 --preview 60 2>>"$LOG")
+RECALL_RC=$?
+legion_check "$RECALL_RC" "recall (identity root)"
+ROOT_LINE=$(printf '%s\n' "$RECALL_OUT" | grep -oE '\(id: [0-9a-f-]+' | head -1)
+
+if [ -z "$ROOT_LINE" ]; then
+  # No identity reflections -- nothing to chain. Touch sentinel so we don't
+  # retry on every prompt this session.
+  touch "$SENTINEL"
+  exit 0
+fi
+
+ROOT_ID="${ROOT_LINE#(id: }"
+
+CHAIN=$("$LEGION" chain --id "$ROOT_ID" --full 2>>"$LOG")
+legion_check $? "chain"
+
+# Mark loaded regardless of chain content -- a single-node chain (no children)
+# returns just the root, which the agent already saw via whoami. No need to
+# inject again.
+touch "$SENTINEL"
+
+# Single-reflection chains contain only the root, which is already in the
+# SessionStart banner. Skip injection in that case to avoid redundancy.
+LINK_COUNT=$(echo "$CHAIN" | grep -c '^--- ')
+if [ "$LINK_COUNT" -lt 2 ]; then
+  exit 0
+fi
+
+WARN=$(legion_warnings_block)
+
+CTX="[Legion] Identity chain (deeper doctrine, walked once per session):
+
+${CHAIN}
+This chain extends the identity banner you saw at session start. The root reflection appears first; subsequent links carry doctrine in decreasing importance order. Internalize the rules, do not just acknowledge them."
+
+if [ -n "$WARN" ]; then
+  CTX="${WARN}"$'\n\n'"${CTX}"
+fi
+
+jq -n --arg ctx "$CTX" '{
+  "hookSpecificOutput": {
+    "hookEventName": "UserPromptSubmit",
+    "additionalContext": $ctx
+  }
+}' 2>>"$LOG" || true
+
+# Always exit 0 so a degraded legion (or jq failure) never blocks user
+# prompts. The script either injected context or it didn't; either way the
+# user's prompt should still flow.
+exit 0

--- a/src/main.rs
+++ b/src/main.rs
@@ -260,6 +260,11 @@ enum Commands {
         /// Any reflection ID in the chain
         #[arg(long)]
         id: String,
+        /// Emit full reflection text instead of the 80-char preview. Used by
+        /// hooks that inject chain content into agent context, where the
+        /// truncated visualization is insufficient.
+        #[arg(long)]
+        full: bool,
     },
 
     /// Send a structured signal to another agent
@@ -2461,13 +2466,29 @@ fn run() -> error::Result<()> {
                 eprintln!("[legion] reflection not found: {}", id);
             }
         }
-        Commands::Chain { id } => {
+        Commands::Chain { id, full } => {
             let base = data_dir()?;
             let database = db::Database::open(&base.join("legion.db"))?;
 
             let chain = database.get_chain(&id)?;
             if chain.is_empty() {
                 info!("[legion] no chain found for {}", id);
+            } else if full {
+                // Boundary marker `--- ` is parsed by the
+                // identity-chain-load.sh UserPromptSubmit hook (#345) to
+                // count chain links. Do not change the prefix without
+                // updating the hook script.
+                for r in &chain {
+                    let date = db::format_date(&r.created_at);
+                    let domain_tag = r
+                        .domain
+                        .as_deref()
+                        .map(|d| format!(" [{}]", d))
+                        .unwrap_or_default();
+                    println!("--- {} {}{} (id: {}) ---", r.repo, date, domain_tag, r.id);
+                    println!("{}", r.text);
+                    println!();
+                }
             } else {
                 for (i, r) in chain.iter().enumerate() {
                     let prefix = if i == 0 {

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1360,6 +1360,92 @@ fn chain_with_follows() {
 }
 
 #[test]
+fn chain_full_single_node_emits_one_boundary() {
+    // The identity-chain-load.sh hook (#345) counts boundary markers to
+    // decide whether to skip injection (single-node chains are redundant
+    // with the SessionStart banner). Lock the contract: lone-root chain
+    // emits exactly one `--- ` line.
+    let dir = tempfile::tempdir().unwrap();
+
+    let out = legion_cmd(dir.path())
+        .args(["reflect", "--repo", "kelex", "--text", "lone root"])
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+    let id = String::from_utf8_lossy(&out.stdout).trim().to_string();
+
+    let out = legion_cmd(dir.path())
+        .args(["chain", "--id", &id, "--full"])
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let boundary_count = stdout.lines().filter(|l| l.starts_with("--- ")).count();
+    assert_eq!(
+        boundary_count, 1,
+        "single-node chain should emit exactly one boundary marker, got: {stdout}"
+    );
+}
+
+#[test]
+fn chain_full_emits_complete_text() {
+    let dir = tempfile::tempdir().unwrap();
+    let long_text = "A".repeat(500);
+
+    let out = legion_cmd(dir.path())
+        .args(["reflect", "--repo", "kelex", "--text", &long_text])
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+    let parent_id = String::from_utf8_lossy(&out.stdout).trim().to_string();
+
+    let child_text = "B".repeat(400);
+    let out = legion_cmd(dir.path())
+        .args([
+            "reflect",
+            "--repo",
+            "kelex",
+            "--text",
+            &child_text,
+            "--follows",
+            &parent_id,
+        ])
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+
+    let default_output = legion_cmd(dir.path())
+        .args(["chain", "--id", &parent_id])
+        .output()
+        .unwrap();
+    let default_stdout = String::from_utf8_lossy(&default_output.stdout);
+    assert!(
+        default_stdout.contains("..."),
+        "default chain output should show truncation ellipsis"
+    );
+    assert!(!default_stdout.contains(&long_text));
+
+    let full_output = legion_cmd(dir.path())
+        .args(["chain", "--id", &parent_id, "--full"])
+        .output()
+        .unwrap();
+    assert!(full_output.status.success());
+    let full_stdout = String::from_utf8_lossy(&full_output.stdout);
+    assert!(
+        full_stdout.contains(&long_text),
+        "--full should emit complete parent text"
+    );
+    assert!(
+        full_stdout.contains(&child_text),
+        "--full should emit complete child text"
+    );
+    assert!(
+        full_stdout.contains("--- "),
+        "--full should use the boundary marker between reflections"
+    );
+}
+
+#[test]
 fn boost_nonexistent_id() {
     let dir = tempfile::tempdir().unwrap();
 


### PR DESCRIPTION
Closes #345.

Pairs with PR #344 to fully deliver the chain-based identity migration.

## Mechanism

- New `plugin/hooks/identity-chain-load.sh`: reads cwd + session_id from the hook input, finds the newest identity reflection ID via `legion recall`, walks the chain via `legion chain --id <root> --full`, and injects the full chain content as additionalContext.
- Idempotency: per-session sentinel at `${XDG_CACHE_HOME:-$HOME/.cache}/legion/chain-loaded-${SAFE_SESSION}`. First prompt walks and injects; subsequent prompts find the sentinel and exit silently with zero output.
- Single-node chains skip injection -- the root is already in the SessionStart banner; redundant injection adds noise.
- Wired in `plugin/hooks/hooks.json` under UserPromptSubmit with an 8s timeout.
- Always exits 0 so a degraded legion or jq failure never blocks user prompts.

## Supporting CLI change

`legion chain` gains a `--full` flag that emits complete reflection text instead of the 80-char preview truncation. Default visualization is unchanged. The `--- ` boundary marker is documented as load-bearing for the hook parser.

## Smoke test

Verified end-to-end against the live legion identity chain (12 links from #342 migration):

- First run: 11.9KB chain content injected as additionalContext
- Second run with same session_id: 0 bytes (sentinel hit, silent exit)

## Tests

- `chain_full_emits_complete_text`: confirms `--full` bypasses 80-char truncation, emits complete text for both root and child reflections, uses `--- ` boundary marker
- `chain_full_single_node_emits_one_boundary`: locks the boundary-count contract the hook's `LINK_COUNT < 2` skip depends on

## Hardening from inline review

- Sentinel moved from `/tmp` to user-scoped `~/.cache/legion/` to avoid shared-host symlink attacks
- `legion recall` exit status captured separately from the parse pipeline so a missing match (grep exit 1) does not get reported as a recall failure
- `jq` stderr routed to `/tmp/legion-hook-errors.log` so silent failures are diagnosable
- Explicit `exit 0` after `jq` to honor the always-exit-0 contract

## Followups not in this PR

- bats/shellcheck test infrastructure for the hook script itself (sentinel idempotency, malformed input, missing fields)
- multi-node boundary-count regression test (single-node case is locked; multi-node implicitly via existing test)
- #346 fixes the `truncate_chars` underflow this PR worked around

cargo test (116 pass), clippy -D warnings clean, fmt clean.