### PR TITLE
chore: release v0.9.9

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
     {
       "name": "legion",
       "description": "Agent memory layer with recall, reflect, consult, bullpen, and cross-agent coordination. Includes health monitoring and auto-wake. Hooks wire legion into every session automatically.",
-      "version": "0.9.8",
+      "version": "0.9.9",
       "author": {
         "name": "Sean Silvius",
         "email": "sean@silvius.me"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1444,7 +1444,7 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "legion"
-version = "0.9.8"
+version = "0.9.9"
 dependencies = [
  "async-stream",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "legion"
-version = "0.9.8"
+version = "0.9.9"
 edition = "2024"
 description = "Agent specialization through deliberate practice"
 

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "legion",
-  "version": "0.9.8",
+  "version": "0.9.9",
   "description": "Institutional memory for Claude Code agents with real-time team channel.",
   "author": {
     "name": "Sean Silvius",

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Legion Changelog
 
+## 0.9.9
+
+Identity-chain delivery release. The chain-based identity migration that landed in v0.9.8 had a sharp edge: pushing all doctrine into the identity domain made `legion whoami` eagerly dump everything, ballooning the SessionStart banner from a few KB to 21.8KB on a fully-migrated repo. The harness persisted the overflow to disk and inlined only a 2KB head preview, silently dropping doctrines past the cutoff -- the exact failure mode the banner was built to prevent. Both halves of the fix ship here.
+
+### New
+
+- **UserPromptSubmit hook lazy-loads identity chain** (#345, #347): new `plugin/hooks/identity-chain-load.sh` finds the newest identity reflection on first prompt of a session, walks the chain via `legion chain --id <root> --full`, and injects the full content as additionalContext. Idempotent via per-session sentinel under `${XDG_CACHE_HOME:-$HOME/.cache}/legion/`. Single-node chains skip injection (already in the banner). Always exits 0 so a degraded legion never blocks user prompts. The chain pays for itself once per session, when the agent actually starts working -- not at boot.
+- **`legion chain --full`** (#345): emits complete reflection text instead of the 80-char truncation default. Used by the UserPromptSubmit hook for context injection. Default behavior unchanged for human eyeballing.
+
+### Changed
+
+- **`legion whoami` capped at 2KB, surfaces only chain roots** (#342, #344): new `db::get_identity_roots(repo, limit)` selects identity reflections where `parent_id IS NULL` (chain roots and orphans). Chain children stay reachable via `legion chain --id <root>`; they don't need to be inlined in the boot banner. New `recall::format_whoami` pure formatter caps total output at 2048 bytes -- accumulates entries until the next would push past the cap, then emits a `(N more identity reflections truncated; recall via legion recall --repo <r> --domain identity)` pointer and stops. First entry always emitted regardless of size (partial identity beats absent identity). Verified live: 21.8KB -> 2.3KB on the legion repo.
+
+### Pattern delivered
+
+Push minimal, pull deep. SessionStart banner stays slim and always inlines. UserPromptSubmit pulls the deep doctrine on first prompt, once per session. Subsequent prompts pay nothing. This shape generalizes for any expensive context that isn't always needed.
+
 ## 0.9.8
 
 Boot-context cleanup release. Sampled rafters' SessionStart shape and discovered identity was being drowned under 100KB of pending-reply framing, the Stop hook was prompting reflections on prose-only Q&A sessions, and the legion project CLAUDE.md was 290 lines of reference material every session re-read. All addressed.


### PR DESCRIPTION
Identity-chain delivery release. v0.9.8 migration left whoami eagerly dumping all identity reflections (21.8KB) -- this release ships both halves of the fix:

- **#342 / #344**: cap `legion whoami` at 2KB, surface only chain roots
- **#345 / #347**: UserPromptSubmit hook lazy-loads identity chain on first prompt of session

Plus the supporting `legion chain --full` flag.

## Bumps

- `Cargo.toml` 0.9.8 -> 0.9.9
- `plugin/.claude-plugin/plugin.json` 0.9.8 -> 0.9.9
- `.claude-plugin/marketplace.json` plugins[0].version 0.9.8 -> 0.9.9
- `Cargo.lock` legion 0.9.8 -> 0.9.9 (auto via cargo build)
- `plugin/CHANGELOG.md` 0.9.9 entry

## Verified

`legion whoami --repo legion`: 21.8KB -> 2.3KB after #344 merged. UserPromptSubmit hook smoke-tested end-to-end: 11.9KB chain on first run, 0 bytes (silent) on second run.

Once merged, release.yml will build and ship the new binary to the plugin update path.