### PR TITLE
chore: bump GitHub Actions to Node 24-targeting versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     name: Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - run: cargo check
@@ -23,7 +23,7 @@ jobs:
     name: Format
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt
@@ -33,7 +33,7 @@ jobs:
     name: Clippy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
@@ -44,7 +44,7 @@ jobs:
     name: ShellCheck
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - run: shellcheck install.sh plugin/bin/legion plugin/hooks/*.sh scripts/*.sh
 
   test:
@@ -54,7 +54,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - run: cargo test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
             ext: zip
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: dtolnay/rust-toolchain@stable
         with:
@@ -59,7 +59,7 @@ jobs:
           7z a ../../../${{ matrix.artifact }}.${{ matrix.ext }} legion.exe
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ${{ matrix.artifact }}
           path: ${{ matrix.artifact }}.${{ matrix.ext }}
@@ -71,10 +71,10 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           path: artifacts
 
@@ -85,7 +85,7 @@ jobs:
             xargs -0 sha256sum | sed 's|  \./[^/]*/|  |' > ../checksums.txt
 
       - name: Create Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           generate_release_notes: true
           files: |


### PR DESCRIPTION
Node 20 reaches EOL April 2026; GitHub Actions runners default to Node 24 starting June 2, 2026 ([changelog](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)). Audited workflows and bumped each pinned action to its first Node 24 major.

## Bumps

`release.yml`:
- `actions/checkout@v4` -> `v5`
- `actions/upload-artifact@v4` -> `v6`
- `actions/download-artifact@v4` -> `v7`
- `softprops/action-gh-release@v2` -> `v3`

`ci.yml`:
- `actions/checkout@v4` -> `v5`

## Unchanged (already Node 24)

- `Swatinem/rust-cache@v2` -- floating major, on Node 24 since v2.9.0
- `dtolnay/rust-toolchain@stable` -- composite action, no Node runtime

## Notes

- upload-artifact v6 and download-artifact v7 paired correctly; v4+ changed artifact behavior so they must move together.
- Conservative version pinning (first Node 24 major, not latest). Latest stable for these actions is checkout v6, upload v7, download v8 -- left for a follow-up bump after this lands cleanly.