### PR TITLE
fix: remove phantom submodule entry blocking checkout@v5 cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,9 @@ node_modules/
 
 # Runtime artifacts written by bin/legion wrapper or setup-binary.sh
 plugin/.legion-binary-path
+
+# Agent worktrees created by the Task tool's worktree isolation mode.
+# These contain .git references back to the parent and must never be
+# committed -- a stray gitlink mode 160000 entry will break checkout@v5
+# submodule cleanup on Windows runners.
+.claude/worktrees/


### PR DESCRIPTION
## Symptom

After bumping to `actions/checkout@v5` (#349), Windows CI started failing in post-job cleanup:

```
fatal: No url found for submodule path
'.claude/worktrees/agent-a564c870' in .gitmodules
Warning: The process 'C:\Program Files\Git\bin\git.exe' failed with exit code 128
```

## Cause

`.claude/worktrees/agent-a564c870` is committed at gitlink mode 160000 (submodule) but has no entry in `.gitmodules`. Got there via #214 (a stray Task-tool worktree dir was added with the rest of that PR). `checkout@v4` ignored the inconsistency; `checkout@v5` runs submodule cleanup more aggressively and aborts.

## Fix

- `git rm --cached .claude/worktrees/agent-a564c870` -- untracks the phantom gitlink. Local empty directory stays; the index entry is gone.
- Add `.claude/worktrees/` to .gitignore so the Task tool's worktree isolation mode can never reintroduce the same problem.

## Verified

`git ls-files -s .claude/worktrees/` returns empty after the fix. CI on this branch should pass cleanly.