### PR TITLE
chore: release v0.9.10

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
     {
       "name": "legion",
       "description": "Agent memory layer with recall, reflect, consult, bullpen, and cross-agent coordination. Includes health monitoring and auto-wake. Hooks wire legion into every session automatically.",
-      "version": "0.9.9",
+      "version": "0.9.10",
       "author": {
         "name": "Sean Silvius",
         "email": "sean@silvius.me"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1444,7 +1444,7 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "legion"
-version = "0.9.9"
+version = "0.9.10"
 dependencies = [
  "async-stream",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "legion"
-version = "0.9.9"
+version = "0.9.10"
 edition = "2024"
 description = "Agent specialization through deliberate practice"
 

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "legion",
-  "version": "0.9.9",
+  "version": "0.9.10",
   "description": "Institutional memory for Claude Code agents with real-time team channel.",
   "author": {
     "name": "Sean Silvius",

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Legion Changelog
 
+## 0.9.10
+
+CI maintenance release. Node 20 reaches EOL April 2026 and GitHub Actions runners default to Node 24 starting June 2, 2026; the bump uncovered a phantom submodule entry that had been quietly poisoning the index since #214.
+
+### Changed
+
+- **GitHub Actions bumped to Node 24-targeting versions** (#349): \`actions/checkout@v4 -> v5\`, \`actions/upload-artifact@v4 -> v6\`, \`actions/download-artifact@v4 -> v7\`, \`softprops/action-gh-release@v2 -> v3\`. \`Swatinem/rust-cache@v2\` floats; already on Node 24 via v2.9.0. Each action versions independently -- the first-Node-24 major differs per action and they cannot be assumed in lockstep.
+
+### Fixed
+
+- **Phantom submodule entry blocking checkout@v5 cleanup** (#350): \`.claude/worktrees/agent-a564c870\` was committed at gitlink mode 160000 in #214 with no entry in \`.gitmodules\`. \`checkout@v4\` ignored the inconsistency; \`checkout@v5\`'s post-job submodule deinit failed with \"No url found for submodule path\" on Windows runners. Untracked the phantom and added \`.claude/worktrees/\` to \`.gitignore\` so the Task tool's worktree isolation mode cannot reintroduce the same problem.
+
 ## 0.9.9
 
 Identity-chain delivery release. The chain-based identity migration that landed in v0.9.8 had a sharp edge: pushing all doctrine into the identity domain made `legion whoami` eagerly dump everything, ballooning the SessionStart banner from a few KB to 21.8KB on a fully-migrated repo. The harness persisted the overflow to disk and inlined only a 2KB head preview, silently dropping doctrines past the cutoff -- the exact failure mode the banner was built to prevent. Both halves of the fix ship here.


### PR DESCRIPTION
CI maintenance release. Bundles #349 (Node 24 actions bump) and #350 (phantom-submodule fix).

## Bumps

- `Cargo.toml` 0.9.9 -> 0.9.10
- `plugin/.claude-plugin/plugin.json` 0.9.9 -> 0.9.10
- `.claude-plugin/marketplace.json` plugins[0].version 0.9.9 -> 0.9.10
- `Cargo.lock` legion 0.9.9 -> 0.9.10
- `plugin/CHANGELOG.md` 0.9.10 entry

## Why now

Node 20 EOL is April 2026, runners flip default to Node 24 on June 2, 2026. Bumping to Node-24-targeting action versions ahead of the cutover, with the phantom-submodule fix that the bump uncovered, lands as a single coherent release.

Once merged, push the v0.9.10 tag to fire release.yml and ship the binary.