### PR TITLE
feat(#353): gate enforcement hooks on legion-covered repos

### DIFF
--- a/plugin/hooks/_legion-covered.sh
+++ b/plugin/hooks/_legion-covered.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+# Shared helper: decide whether a repo is "legion-covered" so universal
+# enforcement hooks can short-circuit cleanly in repos that legion does
+# not manage. A repo is covered if either:
+#
+#   1. It has an entry in `legion watch list` (the operator told legion
+#      "this is one of mine"), OR
+#   2. It has at least one reflection in the legion DB (legion has been
+#      used here before, so accumulated context exists).
+#
+# Either signal alone is enough -- a brand-new repo added to watch.toml
+# but with no reflections yet should still be covered, and a repo that
+# was reflected on but never added to watch.toml (rare but possible)
+# should also count.
+#
+# The answer is cached per (session, repo) under XDG_CACHE_HOME so the
+# coverage probe pays one fork+exec per repo per session, not per hook
+# fire. Cache file contents: "1" = covered, "0" = not covered.
+#
+# Usage from a hook script:
+#
+#   source "${CLAUDE_PLUGIN_ROOT}/hooks/_legion-covered.sh"
+#
+#   if ! legion_covered "$SESSION_ID" "$REPO"; then
+#     exit 0
+#   fi
+#
+# The function never writes to stdout; diagnostic noise goes to stderr
+# only on hard failures (missing legion binary, etc), and even then the
+# function returns "covered" (0) by default so a degraded legion does
+# not silently disable enforcement everywhere.
+
+LEGION_COVERED_BIN="${CLAUDE_PLUGIN_ROOT}/bin/legion"
+
+# legion_covered SESSION_ID REPO -> exit 0 if covered, 1 if not.
+legion_covered() {
+  local session_id="${1:-}"
+  local repo="${2:-}"
+  if [ -z "$repo" ]; then
+    return 0
+  fi
+
+  local safe_session
+  safe_session=$(printf '%s' "$session_id" | tr -c 'a-zA-Z0-9_-' '_')
+  local safe_repo
+  safe_repo=$(printf '%s' "$repo" | tr -c 'a-zA-Z0-9_-' '_')
+
+  local cache_dir="${XDG_CACHE_HOME:-$HOME/.cache}/legion"
+  mkdir -p "$cache_dir" 2>/dev/null
+  local cache_file="${cache_dir}/covered-${safe_session}-${safe_repo}"
+
+  if [ -f "$cache_file" ]; then
+    if [ "$(cat "$cache_file" 2>/dev/null)" = "1" ]; then
+      return 0
+    fi
+    return 1
+  fi
+
+  if [ ! -x "$LEGION_COVERED_BIN" ]; then
+    # Legion binary missing -- err on the side of "covered" so we don't
+    # silently disable enforcement when the user has just installed but
+    # not yet built. The hook itself will fail open elsewhere anyway.
+    return 0
+  fi
+
+  local covered=0
+
+  # 1. watch list match.
+  if "$LEGION_COVERED_BIN" watch list 2>/dev/null \
+       | awk '{print $1}' \
+       | grep -qx "$repo"; then
+    covered=1
+  fi
+
+  # 2. reflections present (only check if not already proven covered).
+  if [ "$covered" -eq 0 ]; then
+    if "$LEGION_COVERED_BIN" stats --repo "$repo" 2>/dev/null \
+         | grep -qE "^${repo}: [0-9]+ reflections"; then
+      covered=1
+    fi
+  fi
+
+  printf '%s' "$covered" > "$cache_file" 2>/dev/null
+
+  if [ "$covered" -eq 1 ]; then
+    return 0
+  fi
+  return 1
+}

--- a/plugin/hooks/no-direct-db.sh
+++ b/plugin/hooks/no-direct-db.sh
@@ -38,6 +38,18 @@ if [ -z "$CMD" ]; then
   exit 0
 fi
 
+# Skip enforcement in repos legion does not cover (#353).
+CWD=$(echo "$INPUT" | jq -r '.cwd // empty' 2>/dev/null)
+SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // empty' 2>/dev/null)
+REPO="${LEGION_REPO:-$(basename "${CWD:-$PWD}")}"
+if [ -f "${CLAUDE_PLUGIN_ROOT}/hooks/_legion-covered.sh" ]; then
+  # shellcheck source=_legion-covered.sh
+  source "${CLAUDE_PLUGIN_ROOT}/hooks/_legion-covered.sh"
+  if ! legion_covered "$SESSION_ID" "$REPO"; then
+    exit 0
+  fi
+fi
+
 if echo "$CMD" | grep -qE 'legion\.db'; then
   jq -n --arg reason "Blocked: this command references \`legion.db\` directly. Use the \`legion\` CLI instead. Legion is the sole API for legion state -- direct DB access bypasses migrations, constraints, and the audit log. Commands like \`legion kanban view\`, \`legion recall\`, \`legion bullpen\`, \`legion reflect\`, and \`legion status\` expose structured fields through the binary. If you need something the CLI does not expose, file an issue for a new CLI command or JSON output flag -- do not reach past the binary." '
     {

--- a/plugin/hooks/no-gh.sh
+++ b/plugin/hooks/no-gh.sh
@@ -8,6 +8,18 @@ if [ -z "$COMMAND" ]; then
   exit 0
 fi
 
+# Skip enforcement in repos legion does not cover (#353).
+CWD=$(echo "$INPUT" | jq -r '.cwd // empty' 2>/dev/null)
+SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // empty' 2>/dev/null)
+REPO="${LEGION_REPO:-$(basename "${CWD:-$PWD}")}"
+if [ -f "${CLAUDE_PLUGIN_ROOT}/hooks/_legion-covered.sh" ]; then
+  # shellcheck source=_legion-covered.sh
+  source "${CLAUDE_PLUGIN_ROOT}/hooks/_legion-covered.sh"
+  if ! legion_covered "$SESSION_ID" "$REPO"; then
+    exit 0
+  fi
+fi
+
 # Check if the command starts with gh (ignoring leading whitespace)
 TRIMMED="${COMMAND#"${COMMAND%%[![:space:]]*}"}"
 case "$TRIMMED" in

--- a/plugin/hooks/no-local-memory.sh
+++ b/plugin/hooks/no-local-memory.sh
@@ -32,6 +32,18 @@ if [ -z "$FILE_PATH" ]; then
   exit 0
 fi
 
+# Skip enforcement in repos legion does not cover (#353).
+CWD=$(echo "$INPUT" | jq -r '.cwd // empty' 2>/dev/null)
+SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // empty' 2>/dev/null)
+REPO="${LEGION_REPO:-$(basename "${CWD:-$PWD}")}"
+if [ -f "${CLAUDE_PLUGIN_ROOT}/hooks/_legion-covered.sh" ]; then
+  # shellcheck source=_legion-covered.sh
+  source "${CLAUDE_PLUGIN_ROOT}/hooks/_legion-covered.sh"
+  if ! legion_covered "$SESSION_ID" "$REPO"; then
+    exit 0
+  fi
+fi
+
 if echo "$FILE_PATH" | grep -qE '\.claude/projects/.*/memory/'; then
   jq -n --arg reason "Blocked: this file path is in the Claude Code auto-memory directory. Legion is the memory layer for this project -- use \`legion reflect --repo <name> --text '...'\` instead. Reflections stored via legion are searchable across sessions, repos, and agents via \`legion recall\` and \`legion consult\`; files in ~/.claude/projects/*/memory/ are invisible outside this single session/agent. If the content is project-wide guidance (not a personal reflection), it belongs in CLAUDE.md, not auto-memory." '
     {

--- a/plugin/hooks/pre-grep-recall.sh
+++ b/plugin/hooks/pre-grep-recall.sh
@@ -61,6 +61,17 @@ if [ -z "$REPO" ]; then
   exit 0
 fi
 
+# Skip injection in repos legion does not cover (#353).
+SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // empty' 2>/dev/null)
+if [ -f "${CLAUDE_PLUGIN_ROOT}/hooks/_legion-covered.sh" ]; then
+  # shellcheck source=_legion-covered.sh
+  source "${CLAUDE_PLUGIN_ROOT}/hooks/_legion-covered.sh"
+  if ! legion_covered "$SESSION_ID" "$REPO"; then
+    echo "[legion-pre-grep] skipped (repo not legion-covered: ${REPO})" >&2
+    exit 0
+  fi
+fi
+
 # Extract a semantic query from the tool input based on the tool type.
 QUERY=""
 case "$TOOL" in

--- a/plugin/hooks/recall-first.sh
+++ b/plugin/hooks/recall-first.sh
@@ -37,6 +37,16 @@ fi
 
 REPO=$(basename "$CWD")
 
+# Skip injection in repos legion does not cover (#353).
+SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // empty' 2>/dev/null)
+if [ -f "${CLAUDE_PLUGIN_ROOT}/hooks/_legion-covered.sh" ]; then
+  # shellcheck source=_legion-covered.sh
+  source "${CLAUDE_PLUGIN_ROOT}/hooks/_legion-covered.sh"
+  if ! legion_covered "$SESSION_ID" "$REPO"; then
+    exit 0
+  fi
+fi
+
 # Check the clamp list -- skip recall for tools that burn tokens without value
 CLAMP_FILE="${CLAUDE_PLUGIN_ROOT}/hooks/recall-clamp.conf"
 if [ -f "$CLAMP_FILE" ] && grep -qx "$TOOL" "$CLAMP_FILE"; then

--- a/plugin/hooks/test-legion-covered.sh
+++ b/plugin/hooks/test-legion-covered.sh
@@ -1,0 +1,131 @@
+#!/bin/bash
+# Test runner for _legion-covered.sh.
+#
+# Stubs the legion binary with a fixture that returns deterministic
+# `watch list` and `stats --repo` output, then exercises the helper
+# across the three coverage cases: in watch.toml, has reflections,
+# neither.
+#
+# Run from the repo root:
+#   bash plugin/hooks/test-legion-covered.sh
+#
+# Exits 0 on success, 1 on any failed assertion.
+
+set -u
+
+HELPER="${CLAUDE_PLUGIN_ROOT:-$(pwd)/plugin}/hooks/_legion-covered.sh"
+if [ ! -f "$HELPER" ]; then
+  echo "FAIL: helper not found at $HELPER" >&2
+  exit 1
+fi
+
+PASS=0
+FAIL=0
+
+# Build a fake legion binary in a temp dir. The fixture answers two
+# subcommands: `watch list` and `stats --repo NAME`. Subcommand and repo
+# fixtures are fed via FAKE_WATCH and FAKE_STATS env vars at call time.
+FAKE_DIR=$(mktemp -d)
+trap 'rm -rf "$FAKE_DIR"' EXIT
+
+cat >"$FAKE_DIR/legion" <<'EOF'
+#!/bin/bash
+case "$1" in
+  watch)
+    if [ "$2" = "list" ]; then
+      printf '%s\n' "${FAKE_WATCH:-}"
+    fi
+    ;;
+  stats)
+    # Args: stats --repo NAME
+    repo="$3"
+    case "${FAKE_STATS:-}" in
+      "$repo:"*)
+        n="${FAKE_STATS#*:}"
+        printf '%s: %s reflections (2026-01-01 to 2026-01-01)\n' "$repo" "$n"
+        ;;
+      *)
+        printf 'no reflections stored yet\n'
+        ;;
+    esac
+    ;;
+esac
+EOF
+chmod +x "$FAKE_DIR/legion"
+
+mkdir -p "$FAKE_DIR/plugin/bin" "$FAKE_DIR/plugin/hooks"
+cp "$FAKE_DIR/legion" "$FAKE_DIR/plugin/bin/legion"
+cp "$HELPER" "$FAKE_DIR/plugin/hooks/_legion-covered.sh"
+
+# Each test uses a fresh XDG_CACHE_HOME so cache files don't leak between cases.
+fresh_cache() {
+  local d
+  d=$(mktemp -d)
+  echo "$d"
+}
+
+run_helper() {
+  local session="$1"
+  local repo="$2"
+  local watch_fixture="$3"
+  local stats_fixture="$4"
+  local cache="$5"
+  CLAUDE_PLUGIN_ROOT="$FAKE_DIR/plugin" \
+  XDG_CACHE_HOME="$cache" \
+  FAKE_WATCH="$watch_fixture" \
+  FAKE_STATS="$stats_fixture" \
+  bash -c "source '$FAKE_DIR/plugin/hooks/_legion-covered.sh'; legion_covered '$session' '$repo'"
+}
+
+assert() {
+  local desc="$1"
+  local expected_rc="$2"
+  local actual_rc="$3"
+  if [ "$actual_rc" -eq "$expected_rc" ]; then
+    PASS=$((PASS + 1))
+    echo "  PASS: $desc"
+  else
+    FAIL=$((FAIL + 1))
+    echo "  FAIL: $desc (expected rc=$expected_rc, got rc=$actual_rc)" >&2
+  fi
+}
+
+echo "Test: in watch.toml -> covered"
+CACHE=$(fresh_cache)
+run_helper "sess1" "myrepo" "myrepo	/path/to/myrepo" "" "$CACHE"
+assert "watch list contains repo" 0 $?
+rm -rf "$CACHE"
+
+echo "Test: has reflections -> covered"
+CACHE=$(fresh_cache)
+run_helper "sess2" "myrepo" "" "myrepo:42" "$CACHE"
+assert "stats reports reflections" 0 $?
+rm -rf "$CACHE"
+
+echo "Test: neither -> not covered"
+CACHE=$(fresh_cache)
+run_helper "sess3" "myrepo" "otherrepo	/path" "otherrepo:5" "$CACHE"
+assert "no watch entry, no reflections" 1 $?
+rm -rf "$CACHE"
+
+echo "Test: cache hit returns cached value without re-probing"
+CACHE=$(fresh_cache)
+mkdir -p "$CACHE/legion"
+printf '0' > "$CACHE/legion/covered-sess4-myrepo"
+# Even with watch entry that would say "covered", cache says "not covered".
+run_helper "sess4" "myrepo" "myrepo	/path" "myrepo:99" "$CACHE"
+assert "cache pin overrides probe" 1 $?
+rm -rf "$CACHE"
+
+echo "Test: empty repo arg -> covered (defensive default)"
+CACHE=$(fresh_cache)
+run_helper "sess5" "" "" "" "$CACHE"
+assert "empty repo defaults to covered" 0 $?
+rm -rf "$CACHE"
+
+echo
+echo "Results: $PASS passed, $FAIL failed"
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary
- Add `_legion-covered.sh` helper: returns true when current repo is in `legion watch list` OR has reflections in legion DB
- Five gated PreToolUse hooks (no-direct-db, no-gh, no-local-memory, pre-grep-recall, recall-first) short-circuit silently in uncovered repos
- Coverage cached per (session, repo) under `XDG_CACHE_HOME` -- one fork+exec per repo per session

## Test plan
- [x] `bash plugin/hooks/test-legion-covered.sh` -- 5/5 (watch-list, has-reflections, neither, cache-hit, defensive default)
- [x] `bash plugin/hooks/test-pre-grep-recall.sh` -- 15/15 (existing tests unchanged)
- [x] E2E real binary: legion -> covered, bogus-repo -> not covered

Closes #353