### PR TITLE
feat(#278): scip_indexes table + sha2 dep + single-lang index

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1463,6 +1463,7 @@ dependencies = [
  "rust-embed",
  "serde",
  "serde_json",
+ "sha2",
  "smugglr-core",
  "sysinfo",
  "tantivy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,10 @@ sysinfo = { version = "0.34", default-features = false, features = ["system", "c
 rlimit = "0.11"
 wait-timeout = "0.2"
 
+# SCIP code intelligence (#278+). The `scip` protobuf crate lands with
+# the query CLI in #282 -- this base only stores opaque blob bytes.
+sha2 = "0.10"
+
 # Multi-node sync via LAN broadcast
 smugglr-core = { git = "https://github.com/rafters-studio/smugglr", default-features = false, features = ["native"] }
 rand = "0.9"

--- a/src/db.rs
+++ b/src/db.rs
@@ -659,6 +659,27 @@ impl Database {
                 ON persona_wake_leases(expires_at) WHERE deleted_at IS NULL;",
         )?;
 
+        // Migration 17: SCIP indexes for code intelligence (#278).
+        // One active row per (repo, lang) holds the protobuf blob legion
+        // queries against. content_hash is SHA-256 hex of the blob; an
+        // upsert with an unchanged hash short-circuits to bumping
+        // updated_at without rewriting the blob bytes.
+        conn.execute_batch(
+            "CREATE TABLE IF NOT EXISTS scip_indexes (
+                id TEXT PRIMARY KEY,
+                repo TEXT NOT NULL,
+                lang TEXT NOT NULL,
+                content_hash TEXT NOT NULL,
+                blob BLOB NOT NULL,
+                updated_at TEXT NOT NULL,
+                deleted_at TEXT
+            );
+            CREATE UNIQUE INDEX IF NOT EXISTS idx_scip_indexes_repo_lang_live
+                ON scip_indexes(repo, lang) WHERE deleted_at IS NULL;
+            CREATE INDEX IF NOT EXISTS idx_scip_indexes_repo
+                ON scip_indexes(repo) WHERE deleted_at IS NULL;",
+        )?;
+
         Ok(())
     }
 
@@ -3299,6 +3320,110 @@ impl Database {
     }
 }
 
+impl Database {
+    /// Write or overwrite a SCIP index row identified by (repo, lang).
+    /// Idempotent on `content_hash`: when the stored hash matches the
+    /// incoming one, only `updated_at` is bumped. Otherwise the blob,
+    /// hash, and timestamp are all rewritten.
+    pub fn upsert_scip_index(&self, index: &crate::scip::ScipIndex) -> Result<()> {
+        let existing: Option<(String, String)> = self
+            .conn
+            .query_row(
+                "SELECT id, content_hash FROM scip_indexes
+                 WHERE repo = ?1 AND lang = ?2 AND deleted_at IS NULL",
+                rusqlite::params![&index.repo, &index.lang],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .optional()?;
+
+        match existing {
+            Some((id, hash)) if hash == index.content_hash => {
+                self.conn.execute(
+                    "UPDATE scip_indexes SET updated_at = ?1 WHERE id = ?2",
+                    rusqlite::params![&index.updated_at, &id],
+                )?;
+            }
+            Some((id, _)) => {
+                self.conn.execute(
+                    "UPDATE scip_indexes
+                     SET content_hash = ?1, blob = ?2, updated_at = ?3
+                     WHERE id = ?4",
+                    rusqlite::params![&index.content_hash, &index.blob, &index.updated_at, &id],
+                )?;
+            }
+            None => {
+                self.conn.execute(
+                    "INSERT INTO scip_indexes
+                     (id, repo, lang, content_hash, blob, updated_at, deleted_at)
+                     VALUES (?1, ?2, ?3, ?4, ?5, ?6, NULL)",
+                    rusqlite::params![
+                        &index.id,
+                        &index.repo,
+                        &index.lang,
+                        &index.content_hash,
+                        &index.blob,
+                        &index.updated_at,
+                    ],
+                )?;
+            }
+        }
+        Ok(())
+    }
+
+    /// Retrieve the active stored index for (repo, lang).
+    /// Read path consumed by the SCIP query CLI in #282.
+    #[allow(dead_code)]
+    pub fn get_scip_index(&self, repo: &str, lang: &str) -> Result<Option<crate::scip::ScipIndex>> {
+        let row = self
+            .conn
+            .query_row(
+                "SELECT id, repo, lang, content_hash, blob, updated_at, deleted_at
+                 FROM scip_indexes
+                 WHERE repo = ?1 AND lang = ?2 AND deleted_at IS NULL",
+                rusqlite::params![repo, lang],
+                |row| {
+                    Ok(crate::scip::ScipIndex {
+                        id: row.get(0)?,
+                        repo: row.get(1)?,
+                        lang: row.get(2)?,
+                        content_hash: row.get(3)?,
+                        blob: row.get(4)?,
+                        updated_at: row.get(5)?,
+                        deleted_at: row.get(6)?,
+                    })
+                },
+            )
+            .optional()?;
+        Ok(row)
+    }
+
+    /// List all non-deleted SCIP indexes for a repo.
+    /// Read path consumed by `legion consult --symbol` in #285.
+    #[allow(dead_code)]
+    pub fn list_scip_indexes(&self, repo: &str) -> Result<Vec<crate::scip::ScipIndex>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT id, repo, lang, content_hash, blob, updated_at, deleted_at
+             FROM scip_indexes
+             WHERE repo = ?1 AND deleted_at IS NULL
+             ORDER BY lang",
+        )?;
+        let rows = stmt
+            .query_map(rusqlite::params![repo], |row| {
+                Ok(crate::scip::ScipIndex {
+                    id: row.get(0)?,
+                    repo: row.get(1)?,
+                    lang: row.get(2)?,
+                    content_hash: row.get(3)?,
+                    blob: row.get(4)?,
+                    updated_at: row.get(5)?,
+                    deleted_at: row.get(6)?,
+                })
+            })?
+            .collect::<std::result::Result<Vec<_>, _>>()?;
+        Ok(rows)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -5519,5 +5644,107 @@ mod tests {
             got.into_iter().map(|s| (s.hostname.clone(), s)).collect();
         assert_eq!(by_host["Puck"].effective_tokens, 200);
         assert_eq!(by_host["laptop"].effective_tokens, 300);
+    }
+
+    fn make_scip(repo: &str, lang: &str, blob: &[u8]) -> crate::scip::ScipIndex {
+        crate::scip::ScipIndex {
+            id: uuid::Uuid::now_v7().to_string(),
+            repo: repo.to_string(),
+            lang: lang.to_string(),
+            content_hash: crate::scip::content_hash(blob),
+            blob: blob.to_vec(),
+            updated_at: "2026-04-28T00:00:00Z".to_string(),
+            deleted_at: None,
+        }
+    }
+
+    #[test]
+    fn scip_upsert_then_get_round_trip() {
+        let db = test_db();
+        let idx = make_scip("legion", "rust", b"hello scip");
+        db.upsert_scip_index(&idx).unwrap();
+
+        let got = db.get_scip_index("legion", "rust").unwrap().unwrap();
+        assert_eq!(got.content_hash, idx.content_hash);
+        assert_eq!(got.blob, idx.blob);
+        assert_eq!(got.lang, "rust");
+    }
+
+    #[test]
+    fn scip_upsert_idempotent_on_unchanged_hash() {
+        let db = test_db();
+        let mut idx = make_scip("legion", "rust", b"same bytes");
+        db.upsert_scip_index(&idx).unwrap();
+        let original_id = db.get_scip_index("legion", "rust").unwrap().unwrap().id;
+
+        // Second call with identical content_hash -- bumps updated_at
+        // but does not rewrite the row identity.
+        idx.updated_at = "2026-04-29T00:00:00Z".to_string();
+        db.upsert_scip_index(&idx).unwrap();
+
+        let after = db.get_scip_index("legion", "rust").unwrap().unwrap();
+        assert_eq!(after.id, original_id, "upsert must not replace the row");
+        assert_eq!(after.updated_at, "2026-04-29T00:00:00Z");
+    }
+
+    #[test]
+    fn scip_upsert_overwrites_blob_when_hash_changes() {
+        let db = test_db();
+        db.upsert_scip_index(&make_scip("legion", "rust", b"v1"))
+            .unwrap();
+        db.upsert_scip_index(&make_scip("legion", "rust", b"v2"))
+            .unwrap();
+
+        let got = db.get_scip_index("legion", "rust").unwrap().unwrap();
+        assert_eq!(got.blob, b"v2");
+    }
+
+    #[test]
+    fn scip_list_returns_all_languages_for_repo() {
+        let db = test_db();
+        db.upsert_scip_index(&make_scip("legion", "rust", b"r"))
+            .unwrap();
+        db.upsert_scip_index(&make_scip("legion", "ts", b"t"))
+            .unwrap();
+        db.upsert_scip_index(&make_scip("other", "rust", b"x"))
+            .unwrap();
+
+        let mut langs: Vec<String> = db
+            .list_scip_indexes("legion")
+            .unwrap()
+            .into_iter()
+            .map(|i| i.lang)
+            .collect();
+        langs.sort();
+        assert_eq!(langs, vec!["rust".to_string(), "ts".to_string()]);
+    }
+
+    #[test]
+    fn scip_soft_deleted_row_excluded_from_list() {
+        let db = test_db();
+        let idx = make_scip("legion", "rust", b"x");
+        db.upsert_scip_index(&idx).unwrap();
+        db.conn
+            .execute(
+                "UPDATE scip_indexes SET deleted_at = '2026-04-28T00:00:00Z' WHERE repo = 'legion'",
+                [],
+            )
+            .unwrap();
+
+        assert!(
+            db.list_scip_indexes("legion").unwrap().is_empty(),
+            "soft-deleted rows must not appear in list"
+        );
+        assert!(
+            db.get_scip_index("legion", "rust").unwrap().is_none(),
+            "soft-deleted rows must not appear in get"
+        );
+
+        // Raw row still present in the table.
+        let count: i64 = db
+            .conn
+            .query_row("SELECT COUNT(*) FROM scip_indexes", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(count, 1);
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -97,6 +97,14 @@ pub enum LegionError {
 
     #[error("mesh error: {0}")]
     Mesh(String),
+
+    #[error(
+        "indexer not found: '{binary}' is not on PATH (required for {lang} indexing). Install per the SCIP ecosystem docs (e.g. https://github.com/sourcegraph/scip-rust for Rust)."
+    )]
+    IndexerNotFound { lang: String, binary: String },
+
+    #[error("indexer failed for {lang}: {stderr}")]
+    IndexerFailed { lang: String, stderr: String },
 }
 
 pub type Result<T> = std::result::Result<T, LegionError>;

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,6 +15,7 @@ mod mesh;
 mod pr_view;
 mod recall;
 mod reflect;
+mod scip;
 mod search;
 mod serve;
 mod signal;
@@ -362,6 +363,17 @@ enum Commands {
         /// Maximum number of identity reflections to return
         #[arg(long, default_value_t = 50)]
         limit: usize,
+    },
+
+    /// Build or refresh the SCIP code-intelligence index for a repo (#278).
+    ///
+    /// Resolves the repo path from `watch.toml`, detects the dominant
+    /// language, runs the corresponding SCIP indexer (e.g. `scip-rust`)
+    /// as a subprocess, and stores the resulting protobuf blob keyed
+    /// on (repo, lang). Idempotent on content hash.
+    Index {
+        /// Repo name (must be present in watch.toml)
+        repo: String,
     },
 
     /// Rebuild the search index from the database
@@ -2561,6 +2573,47 @@ fn run() -> error::Result<()> {
                     }
                 }
             }
+        }
+        Commands::Index { repo } => {
+            let base = data_dir()?;
+            let watch_path = base.join("watch.toml");
+            let repos = watch::list_repos_in_config(&watch_path)?;
+            let entry = repos.iter().find(|r| r.name == repo).ok_or_else(|| {
+                error::LegionError::WatchConfig(format!(
+                    "repo '{repo}' not in watch.toml. Add it with `legion watch add {repo} <path>`."
+                ))
+            })?;
+            let repo_path = std::path::PathBuf::from(&entry.workdir);
+
+            let lang = scip::detect_language(&repo_path).ok_or_else(|| {
+                error::LegionError::WatchConfig(format!(
+                    "no supported language detected at {}",
+                    repo_path.display()
+                ))
+            })?;
+
+            let blob = scip::run_indexer(lang, &repo_path)?;
+            let hash = scip::content_hash(&blob);
+            let now = chrono::Utc::now().to_rfc3339();
+            let index = scip::ScipIndex {
+                id: uuid::Uuid::now_v7().to_string(),
+                repo: repo.clone(),
+                lang: lang.to_string(),
+                content_hash: hash,
+                blob,
+                updated_at: now,
+                deleted_at: None,
+            };
+
+            let database = db::Database::open(&base.join("legion.db"))?;
+            database.upsert_scip_index(&index)?;
+            eprintln!(
+                "[legion] indexed {} ({}): {} bytes, hash {}",
+                repo,
+                lang,
+                index.blob.len(),
+                &index.content_hash[..16]
+            );
         }
         Commands::Reindex => {
             let base = data_dir()?;

--- a/src/scip.rs
+++ b/src/scip.rs
@@ -1,0 +1,148 @@
+//! SCIP (Source Code Intelligence Protocol) indexing for legion.
+//!
+//! This module is the storage and dispatch layer for SCIP protobuf blobs.
+//! Per repo, per language, legion holds one active blob in the
+//! `scip_indexes` table; query operations on top of those blobs land in
+//! later issues (#282 query CLI, #285 cross-repo).
+//!
+//! The protobuf bytes themselves are never parsed at write time -- the
+//! blob is opaque to legion until a query path needs it. We do compute
+//! a SHA-256 over the bytes so an upsert with unchanged content can
+//! short-circuit to bumping `updated_at` without rewriting the BLOB
+//! column (see `Database::upsert_scip_index`).
+
+use crate::error::{LegionError, Result};
+use sha2::{Digest, Sha256};
+use std::path::Path;
+use std::process::Command;
+
+/// A stored SCIP index for one (repo, lang) pair.
+#[derive(Debug, Clone)]
+pub struct ScipIndex {
+    pub id: String,
+    pub repo: String,
+    pub lang: String,
+    pub content_hash: String,
+    pub blob: Vec<u8>,
+    pub updated_at: String,
+    /// Soft-delete tombstone for smugglr sync. Populated by future
+    /// cleanup paths (#284 daemon indexer); not read by the #278 base.
+    #[allow(dead_code)]
+    pub deleted_at: Option<String>,
+}
+
+/// SHA-256 of `bytes` rendered as lowercase hex.
+pub fn content_hash(bytes: &[u8]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    let digest = hasher.finalize();
+    hex::encode(digest)
+}
+
+/// Detect the dominant language of a repo by looking for marker files.
+/// Returns the language tag legion uses internally (e.g. "rust"), or
+/// None when no indexer-supported language is recognized.
+///
+/// This issue (#278) only handles Rust. Multi-language detection lives
+/// in #279; this function exists here so the dispatch path is already
+/// shaped correctly.
+pub fn detect_language(repo_path: &Path) -> Option<&'static str> {
+    if repo_path.join("Cargo.toml").is_file() {
+        return Some("rust");
+    }
+    None
+}
+
+/// Run the appropriate SCIP indexer for `lang` against `repo_path` and
+/// return the resulting protobuf bytes.
+///
+/// Errors:
+/// - `IndexerNotFound` when the binary is missing from PATH
+/// - `IndexerFailed` when the subprocess exits non-zero (carries stderr)
+/// - `Io` when the protobuf output file cannot be read
+pub fn run_indexer(lang: &str, repo_path: &Path) -> Result<Vec<u8>> {
+    match lang {
+        "rust" => run_scip_rust(repo_path),
+        other => Err(LegionError::IndexerNotFound {
+            lang: other.to_string(),
+            binary: format!("scip-{other}"),
+        }),
+    }
+}
+
+/// Invoke `scip-rust index` against `repo_path` and read the resulting
+/// `index.scip` protobuf bytes from the repo root.
+fn run_scip_rust(repo_path: &Path) -> Result<Vec<u8>> {
+    let binary = "scip-rust";
+    let output = Command::new(binary)
+        .arg("index")
+        .current_dir(repo_path)
+        .output();
+
+    let output = match output {
+        Ok(o) => o,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            return Err(LegionError::IndexerNotFound {
+                lang: "rust".to_string(),
+                binary: binary.to_string(),
+            });
+        }
+        Err(e) => return Err(LegionError::Io(e)),
+    };
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+        return Err(LegionError::IndexerFailed {
+            lang: "rust".to_string(),
+            stderr,
+        });
+    }
+
+    let scip_path = repo_path.join("index.scip");
+    let bytes = std::fs::read(&scip_path)?;
+    Ok(bytes)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    #[test]
+    fn content_hash_is_deterministic_and_distinct() {
+        let a = content_hash(b"hello");
+        let b = content_hash(b"hello");
+        let c = content_hash(b"world");
+        assert_eq!(a, b);
+        assert_ne!(a, c);
+        assert_eq!(a.len(), 64); // 32 bytes -> 64 hex chars
+    }
+
+    #[test]
+    fn detect_language_rust_for_cargo_toml() {
+        let dir = TempDir::new().unwrap();
+        fs::write(dir.path().join("Cargo.toml"), "[package]\nname = \"x\"").unwrap();
+        assert_eq!(detect_language(dir.path()), Some("rust"));
+    }
+
+    #[test]
+    fn detect_language_none_for_unsupported() {
+        let dir = TempDir::new().unwrap();
+        fs::write(dir.path().join("README.md"), "hi").unwrap();
+        assert_eq!(detect_language(dir.path()), None);
+    }
+
+    #[test]
+    fn run_indexer_unsupported_language_errors() {
+        let dir = TempDir::new().unwrap();
+        let err = run_indexer("klingon", dir.path()).unwrap_err();
+        match err {
+            LegionError::IndexerNotFound { lang, binary } => {
+                assert_eq!(lang, "klingon");
+                assert_eq!(binary, "scip-klingon");
+            }
+            other => panic!("expected IndexerNotFound, got {other:?}"),
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- New `scip_indexes` table (migration 17) with (repo, lang) unique-on-live + repo index, soft-delete via `deleted_at` for smugglr sync
- `src/scip.rs`: `ScipIndex` struct, SHA-256 `content_hash`, `detect_language` (Cargo.toml -> rust), `run_indexer` dispatch shelling to `scip-rust`
- `Database::upsert_scip_index` idempotent on content_hash; `get_scip_index` / `list_scip_indexes` back the read paths #282/#285 will consume (tagged `#[allow(dead_code)]` until then)
- New error variants `IndexerNotFound { lang, binary }` and `IndexerFailed { lang, stderr }`
- CLI: `legion index <repo>` resolves the path from `watch.toml`, detects language, runs the indexer, persists the result

## Deviation from spec
Issue called for adding the `scip` protobuf crate. This base treats the blob as opaque bytes; adding the crate now would inflate build time without benefit. Deferred to #282 where the query CLI walks the proto.

## Test plan
- [x] 9 new tests (`cargo test`): round-trip, hash-idempotent upsert, hash-change overwrite, list filtering, soft-delete exclusion, hash determinism, language detection, unsupported-language error path
- [x] Full test suite: 582 passed, 0 failed
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt -- --check` clean

Closes #278