### PR TITLE
feat(#280): per-file incremental index via --file

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -367,13 +367,23 @@ enum Commands {
 
     /// Build or refresh the SCIP code-intelligence index for a repo (#278).
     ///
-    /// Resolves the repo path from `watch.toml`, detects the dominant
-    /// language, runs the corresponding SCIP indexer (e.g. `scip-rust`)
-    /// as a subprocess, and stores the resulting protobuf blob keyed
-    /// on (repo, lang). Idempotent on content hash.
+    /// Resolves the repo path from `watch.toml`, detects every supported
+    /// language present, runs each indexer (e.g. `scip-rust`) as a
+    /// subprocess, and stores one row per (repo, lang). Idempotent on
+    /// content hash.
+    ///
+    /// When `--file <path>` is given, only the single language for that
+    /// file is re-indexed (#280). Repo is resolved by longest-prefix
+    /// match against watch.toml workdirs when omitted.
     Index {
-        /// Repo name (must be present in watch.toml)
-        repo: String,
+        /// Repo name (looked up in watch.toml). Optional when --file is
+        /// used and the path is unambiguous.
+        #[arg(required_unless_present = "file")]
+        repo: Option<String>,
+        /// Re-index only the language for this single file (absolute or
+        /// repo-relative path).
+        #[arg(long)]
+        file: Option<std::path::PathBuf>,
     },
 
     /// Rebuild the search index from the database
@@ -2574,15 +2584,59 @@ fn run() -> error::Result<()> {
                 }
             }
         }
-        Commands::Index { repo } => {
+        Commands::Index { repo, file } => {
             let base = data_dir()?;
             let watch_path = base.join("watch.toml");
             let repos = watch::list_repos_in_config(&watch_path)?;
-            let entry = repos.iter().find(|r| r.name == repo).ok_or_else(|| {
-                error::LegionError::WatchConfig(format!(
-                    "repo '{repo}' not in watch.toml. Add it with `legion watch add {repo} <path>`."
-                ))
-            })?;
+
+            // When --file is given, resolve the enclosing repo by longest
+            // workdir prefix. Otherwise the repo arg is mandatory and
+            // looked up by name.
+            let entry = if let Some(file_arg) = &file {
+                let abs = if file_arg.is_absolute() {
+                    file_arg.clone()
+                } else {
+                    std::env::current_dir()?.join(file_arg)
+                };
+                let canon = std::fs::canonicalize(&abs).unwrap_or(abs);
+                let mut best: Option<&watch::WatchRepoConfig> = None;
+                let mut best_len = 0usize;
+                for r in &repos {
+                    let workdir = std::path::Path::new(&r.workdir);
+                    if canon.starts_with(workdir) && r.workdir.len() > best_len {
+                        best = Some(r);
+                        best_len = r.workdir.len();
+                    }
+                }
+                let chosen = best.ok_or_else(|| {
+                    error::LegionError::WatchConfig(format!(
+                        "no watch.toml repo encloses {}. Add the parent with `legion watch add <name> <path>`.",
+                        canon.display()
+                    ))
+                })?;
+                if let Some(name) = repo.as_deref()
+                    && name != chosen.name
+                {
+                    return Err(error::LegionError::WatchConfig(format!(
+                        "file path is under repo '{}', not '{name}'",
+                        chosen.name
+                    )));
+                }
+                chosen
+            } else {
+                let name = repo.as_deref().ok_or_else(|| {
+                    error::LegionError::WatchConfig(
+                        "repo name required when --file is not given".to_string(),
+                    )
+                })?;
+                repos.iter().find(|r| r.name == name).ok_or_else(|| {
+                    error::LegionError::WatchConfig(format!(
+                        "repo '{name}' not in watch.toml. Add it with `legion watch add {name} <path>`."
+                    ))
+                })?
+            };
+
+            let repo_name = entry.name.clone();
             let repo_path = std::path::PathBuf::from(&entry.workdir);
 
             // Per-repo IndexConfig lives in the watch.toml `extra` table
@@ -2593,11 +2647,33 @@ fn run() -> error::Result<()> {
                 Ok(c) => c,
                 Err(e) => {
                     eprintln!(
-                        "[legion index] warning: malformed indexer config for {repo}: {e}; using defaults"
+                        "[legion index] warning: malformed indexer config for {repo_name}: {e}; using defaults"
                     );
                     scip::IndexConfig::default()
                 }
             };
+
+            let database = db::Database::open(&base.join("legion.db"))?;
+
+            // --file branch: re-index the single language for the file.
+            if let Some(file_arg) = file {
+                let abs = if file_arg.is_absolute() {
+                    file_arg.clone()
+                } else {
+                    std::env::current_dir()?.join(&file_arg)
+                };
+                let canon = std::fs::canonicalize(&abs).unwrap_or(abs);
+                let hash =
+                    scip::incremental_index_file(&database, &repo_name, &repo_path, &canon, &cfg)?;
+                let hash_short: String = hash.chars().take(16).collect();
+                eprintln!(
+                    "[legion index] indexed {} (file: {}): hash {}",
+                    repo_name,
+                    canon.display(),
+                    hash_short
+                );
+                return Ok(());
+            }
 
             let detection = scip::detect_languages(&repo_path, &cfg);
 
@@ -2615,7 +2691,6 @@ fn run() -> error::Result<()> {
                 )));
             }
 
-            let database = db::Database::open(&base.join("legion.db"))?;
             let mut indexed = 0usize;
             let mut failed: Vec<(String, String)> = Vec::new();
 
@@ -2628,7 +2703,7 @@ fn run() -> error::Result<()> {
                         let hash_short = hash.chars().take(16).collect::<String>();
                         let index = scip::ScipIndex {
                             id: uuid::Uuid::now_v7().to_string(),
-                            repo: repo.clone(),
+                            repo: repo_name.clone(),
                             lang: lang_entry.lang.clone(),
                             content_hash: hash,
                             blob,
@@ -2651,7 +2726,7 @@ fn run() -> error::Result<()> {
 
             eprintln!(
                 "[legion index] summary {}: {} indexed, {} skipped, {} failed",
-                repo,
+                repo_name,
                 indexed,
                 detection.missing_binary.len(),
                 failed.len()

--- a/src/scip.rs
+++ b/src/scip.rs
@@ -114,6 +114,115 @@ const SKIP_DIRS: &[&str] = &[
 
 const SCAN_DEPTH: usize = 2;
 
+/// Resolve the language for a single file path by extension. Returns
+/// the canonical legion lang tag (e.g. "rust"). The built-in extension
+/// table is the single source of truth -- `IndexConfig.indexers`
+/// overrides binaries, not extension recognition.
+pub fn lang_for_path(path: &Path) -> Option<String> {
+    let ext = path.extension()?.to_str()?.to_lowercase();
+    for spec in LANG_TABLE {
+        if spec.extensions.iter().any(|e| *e == ext) {
+            return Some(spec.lang.to_string());
+        }
+    }
+    None
+}
+
+/// Resolve the binary used for a given language under `config`.
+fn binary_for_lang(lang: &str, config: &IndexConfig) -> Option<String> {
+    if let Some(map) = config.indexers.as_ref()
+        && let Some(b) = map.get(lang)
+    {
+        return Some(b.clone());
+    }
+    LANG_TABLE
+        .iter()
+        .find(|s| s.lang == lang)
+        .map(|s| s.default_binary.to_string())
+}
+
+/// Re-index the language for `file_path` and store the resulting blob
+/// against (repo, lang). When the language indexer does not support
+/// per-file mode, falls back to a single-language full repo index --
+/// the fallback emits a stderr warning so the operator knows the
+/// command did more work than the name suggests.
+///
+/// Returns the new content_hash on success.
+pub fn incremental_index_file(
+    db: &crate::db::Database,
+    repo: &str,
+    repo_path: &Path,
+    file_path: &Path,
+    config: &IndexConfig,
+) -> Result<String> {
+    incremental_index_file_with(db, repo, repo_path, file_path, config, run_indexer)
+}
+
+/// Internal entry point that lets tests inject a stub indexer instead
+/// of shelling out to `scip-<lang>`. Production callers go through
+/// [`incremental_index_file`].
+pub(crate) fn incremental_index_file_with<F>(
+    db: &crate::db::Database,
+    repo: &str,
+    repo_path: &Path,
+    file_path: &Path,
+    config: &IndexConfig,
+    runner: F,
+) -> Result<String>
+where
+    F: Fn(&DetectedLanguage, &Path) -> Result<Vec<u8>>,
+{
+    if !file_path.exists() {
+        return Err(LegionError::Io(std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            format!("file not found: {}", file_path.display()),
+        )));
+    }
+
+    let ext_for_msg = file_path
+        .extension()
+        .and_then(|e| e.to_str())
+        .unwrap_or("(none)")
+        .to_string();
+
+    let lang = lang_for_path(file_path).ok_or_else(|| LegionError::IndexerNotFound {
+        lang: ext_for_msg.clone(),
+        binary: "(unknown)".to_string(),
+    })?;
+
+    let binary = binary_for_lang(&lang, config).ok_or_else(|| LegionError::IndexerNotFound {
+        lang: lang.clone(),
+        binary: "(unknown)".to_string(),
+    })?;
+
+    // No scip-<lang> tool currently exposes a per-file mode legion can
+    // rely on -- spec acknowledges this by mandating a fallback path.
+    // Always log the fallback so operators understand the cost.
+    eprintln!(
+        "[legion index] fallback to full single-language re-index for {lang} (file: {})",
+        file_path.display()
+    );
+
+    let entry = DetectedLanguage {
+        lang: lang.clone(),
+        binary,
+    };
+    let blob = runner(&entry, repo_path)?;
+    let hash = content_hash(&blob);
+
+    let index = ScipIndex {
+        id: uuid::Uuid::now_v7().to_string(),
+        repo: repo.to_string(),
+        lang,
+        content_hash: hash.clone(),
+        blob,
+        updated_at: chrono::Utc::now().to_rfc3339(),
+        deleted_at: None,
+    };
+    db.upsert_scip_index(&index)?;
+    Ok(hash)
+}
+
 /// SHA-256 of `bytes` rendered as lowercase hex.
 pub fn content_hash(bytes: &[u8]) -> String {
     let mut hasher = Sha256::new();
@@ -342,6 +451,126 @@ mod tests {
                 assert_eq!(binary, "definitely-not-on-path-xyz");
             }
             other => panic!("expected IndexerNotFound, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn lang_for_path_recognises_known_extensions() {
+        assert_eq!(
+            lang_for_path(Path::new("src/main.rs")).as_deref(),
+            Some("rust")
+        );
+        assert_eq!(
+            lang_for_path(Path::new("app/handler.ts")).as_deref(),
+            Some("typescript")
+        );
+        assert_eq!(
+            lang_for_path(Path::new("scripts/run.py")).as_deref(),
+            Some("python")
+        );
+    }
+
+    #[test]
+    fn lang_for_path_returns_none_for_unknown() {
+        assert!(lang_for_path(Path::new("README.md")).is_none());
+        assert!(lang_for_path(Path::new("data.bin.unknown")).is_none());
+    }
+
+    fn open_test_db() -> crate::db::Database {
+        let dir = TempDir::new().unwrap();
+        let db = crate::db::Database::open(&dir.path().join("test.sqlite")).unwrap();
+        // TempDir would be dropped at end of expression; leak it so the
+        // sqlite file outlives the test.
+        std::mem::forget(dir);
+        db
+    }
+
+    #[test]
+    fn incremental_index_file_creates_row_then_updates_in_place() {
+        let db = open_test_db();
+        let repo_dir = TempDir::new().unwrap();
+        let file_path = repo_dir.path().join("main.rs");
+        fs::write(&file_path, "fn main() {}").unwrap();
+        let cfg = IndexConfig::default();
+
+        // First call: stub runner returns "v1" -- expect a fresh row.
+        let hash1 = incremental_index_file_with(
+            &db,
+            "testrepo",
+            repo_dir.path(),
+            &file_path,
+            &cfg,
+            |_, _| Ok(b"v1".to_vec()),
+        )
+        .unwrap();
+        let row1 = db.get_scip_index("testrepo", "rust").unwrap().unwrap();
+        assert_eq!(row1.content_hash, hash1);
+        assert_eq!(row1.blob, b"v1");
+
+        // Second call with identical bytes: hash unchanged, row id stable.
+        let hash2 = incremental_index_file_with(
+            &db,
+            "testrepo",
+            repo_dir.path(),
+            &file_path,
+            &cfg,
+            |_, _| Ok(b"v1".to_vec()),
+        )
+        .unwrap();
+        assert_eq!(hash1, hash2);
+        let row2 = db.get_scip_index("testrepo", "rust").unwrap().unwrap();
+        assert_eq!(row2.id, row1.id);
+
+        // Third call with different bytes: hash changes, row updates.
+        let hash3 = incremental_index_file_with(
+            &db,
+            "testrepo",
+            repo_dir.path(),
+            &file_path,
+            &cfg,
+            |_, _| Ok(b"v2".to_vec()),
+        )
+        .unwrap();
+        assert_ne!(hash3, hash1);
+        let row3 = db.get_scip_index("testrepo", "rust").unwrap().unwrap();
+        assert_eq!(row3.blob, b"v2");
+    }
+
+    #[test]
+    fn incremental_index_file_unknown_extension_errors_with_unknown_binary() {
+        let db = open_test_db();
+        let repo_dir = TempDir::new().unwrap();
+        let file_path = repo_dir.path().join("notes.txt");
+        fs::write(&file_path, "hello").unwrap();
+        let cfg = IndexConfig::default();
+        let err = incremental_index_file(&db, "r", repo_dir.path(), &file_path, &cfg).unwrap_err();
+        match err {
+            LegionError::IndexerNotFound { lang, binary } => {
+                assert_eq!(lang, "txt");
+                assert_eq!(binary, "(unknown)");
+            }
+            other => panic!("expected IndexerNotFound, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn incremental_index_file_missing_file_returns_io_not_found() {
+        let db = open_test_db();
+        let repo_dir = TempDir::new().unwrap();
+        let cfg = IndexConfig::default();
+        let err = incremental_index_file(
+            &db,
+            "r",
+            repo_dir.path(),
+            &repo_dir.path().join("ghost.rs"),
+            &cfg,
+        )
+        .unwrap_err();
+        match err {
+            LegionError::Io(e) => {
+                assert_eq!(e.kind(), std::io::ErrorKind::NotFound);
+            }
+            other => panic!("expected Io NotFound, got {other:?}"),
         }
     }
 }


### PR DESCRIPTION
## Summary
- `legion index --file <path>` re-indexes only the language for the named file
- Repo resolved by longest-prefix match against watch.toml workdirs when --repo omitted
- `lang_for_path(path)` resolves a language tag from extension; built-in table is the source of truth
- `incremental_index_file` falls back to a single-language full repo index (no scip-<lang> tool currently exposes a per-file mode); fallback emits stderr warning per spec
- Internal `incremental_index_file_with` accepts an injected runner so tests stub the indexer

## Stacked on
Base: `feat/279-multi-lang` (PR #365). Will rebase to main once #365 + #364 land.

## Test plan
- [x] 5 new tests: lang_for_path Some/None, create-then-update flow with stubbed runner (row identity preserved on unchanged hash, replaced on changed), unknown-extension -> IndexerNotFound("(unknown)"), missing-file -> Io NotFound
- [x] Full suite `cargo test`: 589 passed, 0 failed
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt -- --check` clean

Closes #280