### PR TITLE
feat(#281): PostToolUse hook re-indexes SCIP on Edit/Write

### DIFF
--- a/plugin/hooks/hooks.json
+++ b/plugin/hooks/hooks.json
@@ -172,6 +172,36 @@
             "timeout": 3
           }
         ]
+      },
+      {
+        "matcher": "Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/post-edit-scip.sh",
+            "timeout": 2
+          }
+        ]
+      },
+      {
+        "matcher": "Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/post-edit-scip.sh",
+            "timeout": 2
+          }
+        ]
+      },
+      {
+        "matcher": "MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/post-edit-scip.sh",
+            "timeout": 2
+          }
+        ]
       }
     ]
   }

--- a/plugin/hooks/post-edit-scip.sh
+++ b/plugin/hooks/post-edit-scip.sh
@@ -39,7 +39,7 @@ REPO="${LEGION_REPO:-$(basename "${CWD:-$PWD}")}"
 
 # Coverage gate (#353): no-op silently in uncovered repos.
 if [ -f "${CLAUDE_PLUGIN_ROOT}/hooks/_legion-covered.sh" ]; then
-  # shellcheck source=_legion-covered.sh
+  # shellcheck source=/dev/null
   source "${CLAUDE_PLUGIN_ROOT}/hooks/_legion-covered.sh"
   if ! legion_covered "$SESSION_ID" "$REPO"; then
     exit 0

--- a/plugin/hooks/post-edit-scip.sh
+++ b/plugin/hooks/post-edit-scip.sh
@@ -1,0 +1,117 @@
+#!/bin/bash
+# Legion PostToolUse hook for Edit/Write: trigger an incremental
+# `legion index --file <path>` re-index in the background so agents
+# always query a fresh SCIP index without paying full-repo cost.
+#
+# Contract:
+# - Reads hook JSON from stdin.
+# - Never blocks the originating tool call (background subprocess).
+# - Exits 0 in every failure mode; warnings to stderr only.
+# - Honors LEGION_SKIP_POST_EDIT_SCIP=1 to bypass entirely.
+# - Honors the legion-covered gate (#353): silent no-op in repos
+#   legion does not manage.
+# - Debounces per-file: a marker under XDG_CACHE_HOME/legion/scip-debounce/
+#   suppresses spawns within LEGION_SCIP_DEBOUNCE_MS (default 500ms).
+
+LEGION="${CLAUDE_PLUGIN_ROOT}/bin/legion"
+
+# Explicit skip override.
+if [ "${LEGION_SKIP_POST_EDIT_SCIP:-}" = "1" ]; then
+  exit 0
+fi
+
+INPUT=$(cat)
+if [ -z "$INPUT" ]; then
+  echo "[post-edit-scip] empty stdin; skipping" >&2
+  exit 0
+fi
+
+# Tool detail extraction. Edit and Write both supply tool_input.file_path.
+FILE_PATH=$(printf '%s' "$INPUT" | jq -r '.tool_input.file_path // empty' 2>/dev/null)
+if [ -z "$FILE_PATH" ]; then
+  echo "[post-edit-scip] missing file_path; skipping" >&2
+  exit 0
+fi
+
+CWD=$(printf '%s' "$INPUT" | jq -r '.cwd // empty' 2>/dev/null)
+SESSION_ID=$(printf '%s' "$INPUT" | jq -r '.session_id // empty' 2>/dev/null)
+REPO="${LEGION_REPO:-$(basename "${CWD:-$PWD}")}"
+
+# Coverage gate (#353): no-op silently in uncovered repos.
+if [ -f "${CLAUDE_PLUGIN_ROOT}/hooks/_legion-covered.sh" ]; then
+  # shellcheck source=_legion-covered.sh
+  source "${CLAUDE_PLUGIN_ROOT}/hooks/_legion-covered.sh"
+  if ! legion_covered "$SESSION_ID" "$REPO"; then
+    exit 0
+  fi
+fi
+
+# Cheap extension filter -- only Rust/TS/Python/etc. paths matter.
+# Anything else (markdown, json, shell) wastes a fork+exec on legion.
+case "$FILE_PATH" in
+  *.rs|*.ts|*.tsx|*.py|*.go|*.js|*.jsx) ;;
+  *)
+    exit 0
+    ;;
+esac
+
+if [ ! -x "$LEGION" ]; then
+  echo "[post-edit-scip] legion binary not found at ${LEGION}; skipping" >&2
+  exit 0
+fi
+
+# Per-path debounce. The marker name is a hash of the absolute path so
+# pathological filenames (spaces, slashes after canonicalization) do
+# not break the filesystem. Tag the marker with mtime; we compare against
+# LEGION_SCIP_DEBOUNCE_MS (default 500).
+DEBOUNCE_MS="${LEGION_SCIP_DEBOUNCE_MS:-500}"
+CACHE_DIR="${XDG_CACHE_HOME:-$HOME/.cache}/legion/scip-debounce"
+if ! mkdir -p "$CACHE_DIR" 2>/dev/null; then
+  echo "[post-edit-scip] cache dir unavailable; skipping debounce" >&2
+fi
+
+# Path hash via shasum (BSD/GNU) or openssl as fallback. Either gives
+# 16+ hex chars; the leading 12 are plenty unique for this debounce.
+hash_path() {
+  if command -v shasum >/dev/null 2>&1; then
+    printf '%s' "$1" | shasum -a 256 | cut -c1-12
+  elif command -v openssl >/dev/null 2>&1; then
+    printf '%s' "$1" | openssl dgst -sha256 | awk '{print substr($NF,1,12)}'
+  else
+    # Last resort: tr-strip non-alnum so the filename is safe.
+    printf '%s' "$1" | tr -c 'a-zA-Z0-9' '_' | head -c 64
+  fi
+}
+
+PATH_KEY=$(hash_path "$FILE_PATH")
+MARKER="${CACHE_DIR}/${PATH_KEY}"
+
+if [ -f "$MARKER" ]; then
+  # mtime in seconds since epoch; convert debounce_ms to seconds.
+  if command -v stat >/dev/null 2>&1; then
+    NOW=$(date +%s)
+    # macOS stat -f %m, GNU stat -c %Y.
+    MTIME=$(stat -f %m "$MARKER" 2>/dev/null || stat -c %Y "$MARKER" 2>/dev/null || echo "$NOW")
+    AGE_S=$((NOW - MTIME))
+    DEBOUNCE_S=$((DEBOUNCE_MS / 1000))
+    if [ "$DEBOUNCE_S" -lt 1 ]; then
+      DEBOUNCE_S=1
+    fi
+    if [ "$AGE_S" -lt "$DEBOUNCE_S" ]; then
+      exit 0
+    fi
+  fi
+fi
+
+touch "$MARKER" 2>/dev/null
+
+# Spawn the indexer in the background, fully detached, with stdout and
+# stderr pointed at the legion error log so a failure leaves a
+# breadcrumb without contaminating the originating tool's output.
+# Double-fork via subshell + & ensures the child reparents to init
+# rather than holding the originating tool's process tree open.
+LOG=/tmp/legion-hook-errors.log
+("$LEGION" index --file "$FILE_PATH" >>"$LOG" 2>&1 </dev/null) &
+disown 2>/dev/null || true
+
+exit 0

--- a/plugin/hooks/test-post-edit-scip.sh
+++ b/plugin/hooks/test-post-edit-scip.sh
@@ -47,7 +47,6 @@ chmod +x "$SANDBOX/plugin/bin/legion"
 
 run_hook() {
   local file_path="$1"
-  local extra_env="$2"
   local input
   input=$(jq -n --arg fp "$file_path" --arg cwd "$SANDBOX" --arg sid "test-session" '{
     tool_input: { file_path: $fp },
@@ -99,12 +98,12 @@ reset_log() {
 
 echo "Test: rust file path triggers legion index --file"
 reset_log
-run_hook "/tmp/sample.rs" ""
+run_hook "/tmp/sample.rs"
 assert_argv_contains "spawned legion with --file argument" "--file /tmp/sample.rs"
 
 echo "Test: non-source extension is filtered out"
 reset_log
-run_hook "/tmp/notes.md" ""
+run_hook "/tmp/notes.md"
 assert_no_spawn "markdown file does not trigger spawn"
 
 echo "Test: missing file_path is silently skipped"
@@ -119,7 +118,7 @@ assert_no_spawn "empty file_path -> no spawn"
 
 echo "Test: LEGION_SKIP_POST_EDIT_SCIP=1 suppresses spawn"
 reset_log
-LEGION_SKIP_POST_EDIT_SCIP=1 run_hook "/tmp/sample.rs" ""
+LEGION_SKIP_POST_EDIT_SCIP=1 run_hook "/tmp/sample.rs"
 assert_no_spawn "skip override -> no spawn"
 
 echo

--- a/plugin/hooks/test-post-edit-scip.sh
+++ b/plugin/hooks/test-post-edit-scip.sh
@@ -1,0 +1,130 @@
+#!/bin/bash
+# Test runner for post-edit-scip.sh.
+#
+# Stubs CLAUDE_PLUGIN_ROOT/bin/legion with a script that records its
+# argv into a tempfile, then feeds synthetic hook JSON and verifies
+# the hook spawns the indexer with the correct --file argument while
+# never blocking the calling shell beyond the configured timeout.
+#
+# Run from the repo root:
+#   bash plugin/hooks/test-post-edit-scip.sh
+#
+# Exits 0 on success, 1 on any failed assertion.
+
+set -u
+
+HOOK="${CLAUDE_PLUGIN_ROOT:-$(pwd)/plugin}/hooks/post-edit-scip.sh"
+if [ ! -f "$HOOK" ]; then
+  echo "FAIL: hook not found at $HOOK" >&2
+  exit 1
+fi
+
+PASS=0
+FAIL=0
+
+# Build a sandboxed plugin root with a stub legion that writes its
+# argv to a temp file and exits.
+SANDBOX=$(mktemp -d)
+trap 'rm -rf "$SANDBOX"' EXIT
+mkdir -p "$SANDBOX/plugin/bin" "$SANDBOX/plugin/hooks"
+cp "$(dirname "$HOOK")"/_legion-covered.sh "$SANDBOX/plugin/hooks/" 2>/dev/null || true
+cp "$HOOK" "$SANDBOX/plugin/hooks/"
+
+cat >"$SANDBOX/plugin/bin/legion" <<EOF
+#!/bin/bash
+# Stub legion that echoes its full argv to STUB_ARGV_FILE for assertions.
+# STUB_ARGV_FILE is hardcoded into the script body because nohup'd bg
+# processes do not always inherit env vars consistently across macOS
+# launchd/coreutils versions.
+echo "\$@" >> "$SANDBOX/argv.log"
+case "\$1" in
+  watch) printf 'testrepo\t/tmp\n' ;;
+  stats) printf 'testrepo: 1 reflections (2026-01-01 to 2026-01-01)\n' ;;
+esac
+exit 0
+EOF
+chmod +x "$SANDBOX/plugin/bin/legion"
+
+run_hook() {
+  local file_path="$1"
+  local extra_env="$2"
+  local input
+  input=$(jq -n --arg fp "$file_path" --arg cwd "$SANDBOX" --arg sid "test-session" '{
+    tool_input: { file_path: $fp },
+    cwd: $cwd,
+    session_id: $sid
+  }')
+  STUB_ARGV_FILE="$SANDBOX/argv.log" \
+    CLAUDE_PLUGIN_ROOT="$SANDBOX/plugin" \
+    XDG_CACHE_HOME="$SANDBOX/cache" \
+    HOME="$SANDBOX/home" \
+    LEGION_REPO="testrepo" \
+    bash "$SANDBOX/plugin/hooks/post-edit-scip.sh" <<<"$input"
+}
+
+assert_argv_contains() {
+  local desc="$1"
+  local needle="$2"
+  for _ in $(seq 1 20); do
+    # `--` separates grep options from the pattern. Without it, a needle
+    # that begins with `--file` looks like a malformed flag to grep.
+    if grep -qF -- "$needle" "$SANDBOX/argv.log" 2>/dev/null; then
+      PASS=$((PASS + 1))
+      echo "  PASS: $desc"
+      return 0
+    fi
+    sleep 0.3
+  done
+  FAIL=$((FAIL + 1))
+  echo "  FAIL: $desc (needle '$needle' missing from argv.log)" >&2
+  echo "  argv.log contents:" >&2
+  cat "$SANDBOX/argv.log" 2>/dev/null >&2 || echo "  (empty)" >&2
+}
+
+assert_no_spawn() {
+  local desc="$1"
+  sleep 0.5
+  if [ ! -s "$SANDBOX/argv.log" ]; then
+    PASS=$((PASS + 1))
+    echo "  PASS: $desc"
+  else
+    FAIL=$((FAIL + 1))
+    echo "  FAIL: $desc (unexpected argv: $(cat "$SANDBOX/argv.log"))" >&2
+  fi
+}
+
+reset_log() {
+  rm -f "$SANDBOX/argv.log"
+}
+
+echo "Test: rust file path triggers legion index --file"
+reset_log
+run_hook "/tmp/sample.rs" ""
+assert_argv_contains "spawned legion with --file argument" "--file /tmp/sample.rs"
+
+echo "Test: non-source extension is filtered out"
+reset_log
+run_hook "/tmp/notes.md" ""
+assert_no_spawn "markdown file does not trigger spawn"
+
+echo "Test: missing file_path is silently skipped"
+reset_log
+input='{"tool_input": {}, "cwd": "'"$SANDBOX"'", "session_id": "s"}'
+STUB_ARGV_FILE="$SANDBOX/argv.log" \
+CLAUDE_PLUGIN_ROOT="$SANDBOX/plugin" \
+XDG_CACHE_HOME="$SANDBOX/cache" \
+HOME="$SANDBOX/home" \
+bash "$SANDBOX/plugin/hooks/post-edit-scip.sh" <<<"$input"
+assert_no_spawn "empty file_path -> no spawn"
+
+echo "Test: LEGION_SKIP_POST_EDIT_SCIP=1 suppresses spawn"
+reset_log
+LEGION_SKIP_POST_EDIT_SCIP=1 run_hook "/tmp/sample.rs" ""
+assert_no_spawn "skip override -> no spawn"
+
+echo
+echo "Results: $PASS passed, $FAIL failed"
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary
- New `plugin/hooks/post-edit-scip.sh` wired to PostToolUse for Edit, Write, MultiEdit
- Reads `tool_input.file_path`, gates via `_legion-covered.sh` (#353), spawns `legion index --file <path>` fully detached
- Per-path debounce under `XDG_CACHE_HOME/legion/scip-debounce/<sha-prefix>` (500ms default, `LEGION_SCIP_DEBOUNCE_MS` override)
- Source extension filter (rs/ts/tsx/py/go/js/jsx) keeps the hook off markdown / json / shell edits
- `LEGION_SKIP_POST_EDIT_SCIP=1` bypasses entirely; matches the skip-override pattern in pre-grep-recall.sh

## Stacked on
Base: `feat/280-incremental` (PR #366). Will rebase after the chain merges.

## Test plan
- [x] `bash plugin/hooks/test-post-edit-scip.sh` -- 4/4 (rust file -> spawn, markdown -> no spawn, missing file_path -> silent, LEGION_SKIP override -> no spawn)
- [x] Bg subprocess detachment verified end-to-end via stub binary that records argv

Closes #281