### PR TITLE
feat(#282): SCIP query CLI -- legion sym def|refs|impl|hover

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1457,10 +1457,12 @@ dependencies = [
  "libc",
  "mime_guess",
  "model2vec-rs",
+ "protobuf",
  "rand 0.9.2",
  "rlimit",
  "rusqlite",
  "rust-embed",
+ "scip",
  "serde",
  "serde_json",
  "sha2",
@@ -2079,6 +2081,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "protobuf"
+version = "3.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d65a1d4ddae7d8b5de68153b48f6aa3bba8cb002b243dbdbc55a5afbc98f99f4"
+dependencies = [
+ "once_cell",
+ "protobuf-support",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "protobuf-support"
+version = "3.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e36c2f31e0a47f9280fb347ef5e461ffcd2c52dd520d8e216b52f93b0b0d7d6"
+dependencies = [
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "quick-xml"
 version = "0.38.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2582,6 +2604,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "scip"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4d0e81b39f590b2edbe2369760641511898ed34062aed2e18e6d05eead3d6b7"
+dependencies = [
+ "protobuf",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,8 +28,10 @@ sysinfo = { version = "0.34", default-features = false, features = ["system", "c
 rlimit = "0.11"
 wait-timeout = "0.2"
 
-# SCIP code intelligence (#278+). The `scip` protobuf crate lands with
-# the query CLI in #282 -- this base only stores opaque blob bytes.
+# SCIP code intelligence (#278+). The `scip` protobuf crate parses
+# stored blobs in the query CLI (#282).
+scip = "0.7"
+protobuf = "3"
 sha2 = "0.10"
 
 # Multi-node sync via LAN broadcast

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,6 +23,7 @@ mod stats;
 mod status;
 mod statusline;
 mod surface;
+mod sym;
 mod sync;
 mod sync_actor;
 mod task;
@@ -363,6 +364,15 @@ enum Commands {
         /// Maximum number of identity reflections to return
         #[arg(long, default_value_t = 50)]
         limit: usize,
+    },
+
+    /// Symbol queries against stored SCIP indexes (#282).
+    ///
+    /// Answers def/refs/impl/hover questions by parsing the protobuf
+    /// blobs written by `legion index` -- bytes, not full file loads.
+    Sym {
+        #[command(subcommand)]
+        action: SymAction,
     },
 
     /// Build or refresh the SCIP code-intelligence index for a repo (#278).
@@ -709,6 +719,54 @@ enum TaskAction {
         /// Task ID
         #[arg(long)]
         id: String,
+    },
+}
+
+#[derive(Subcommand)]
+enum SymAction {
+    /// Print definition locations for the given symbol name.
+    Def {
+        name: String,
+        /// Restrict to a single repo. Default scans every stored index.
+        #[arg(long)]
+        repo: Option<String>,
+        /// Restrict to a single language.
+        #[arg(long)]
+        lang: Option<String>,
+        /// Emit JSON instead of human-readable file:line lines.
+        #[arg(long)]
+        json: bool,
+    },
+    /// Print reference locations (call sites) for the given name.
+    Refs {
+        name: String,
+        #[arg(long)]
+        repo: Option<String>,
+        #[arg(long)]
+        lang: Option<String>,
+        #[arg(long)]
+        json: bool,
+    },
+    /// Print structs/types that implement the named trait or interface.
+    Impl {
+        #[arg(value_name = "TRAIT")]
+        name: String,
+        #[arg(long)]
+        repo: Option<String>,
+        #[arg(long)]
+        lang: Option<String>,
+        #[arg(long)]
+        json: bool,
+    },
+    /// Print signature + docstring for the symbol.
+    Hover {
+        name: String,
+        #[arg(long)]
+        repo: Option<String>,
+        #[arg(long)]
+        lang: Option<String>,
+        #[arg(long)]
+        json: bool,
     },
 }
 
@@ -1522,6 +1580,160 @@ pub(crate) fn data_dir() -> error::Result<PathBuf> {
 
     let _ = CACHED.set(path.clone());
     Ok(path)
+}
+
+/// Dispatch `legion sym <action>` against the local SCIP index store.
+fn run_sym(action: SymAction) -> error::Result<()> {
+    let base = data_dir()?;
+    let database = db::Database::open(&base.join("legion.db"))?;
+
+    let watch_path = base.join("watch.toml");
+    let blobs_for =
+        |repo: Option<&str>, lang: Option<&str>| -> error::Result<Vec<scip::ScipIndex>> {
+            let mut out: Vec<scip::ScipIndex> = Vec::new();
+            if let Some(r) = repo {
+                if let Some(l) = lang {
+                    if let Some(idx) = database.get_scip_index(r, l)? {
+                        out.push(idx);
+                    }
+                } else {
+                    out.extend(database.list_scip_indexes(r)?);
+                }
+            } else {
+                let repos = watch::list_repos_in_config(&watch_path)?;
+                for entry in repos {
+                    let mut for_repo = database.list_scip_indexes(&entry.name)?;
+                    if let Some(l) = lang {
+                        for_repo.retain(|i| i.lang == l);
+                    }
+                    out.append(&mut for_repo);
+                }
+            }
+            Ok(out)
+        };
+
+    let ensure_some =
+        |blobs: &[scip::ScipIndex], repo: Option<&str>, lang: Option<&str>| -> error::Result<()> {
+            if blobs.is_empty() {
+                let r = repo.unwrap_or("(any)");
+                let l = lang.unwrap_or("(any)");
+                return Err(error::LegionError::Search(format!(
+                    "no SCIP index found for {r}/{l}; run `legion index <repo>` first"
+                )));
+            }
+            Ok(())
+        };
+
+    match action {
+        SymAction::Def {
+            name,
+            repo,
+            lang,
+            json,
+        } => {
+            let blobs = blobs_for(repo.as_deref(), lang.as_deref())?;
+            ensure_some(&blobs, repo.as_deref(), lang.as_deref())?;
+            let mut hits: Vec<sym::SymbolLocation> = Vec::new();
+            for idx in &blobs {
+                hits.extend(sym::query_definitions(
+                    &idx.blob, &name, &idx.repo, &idx.lang,
+                )?);
+            }
+            print_locations(&hits, json);
+        }
+        SymAction::Refs {
+            name,
+            repo,
+            lang,
+            json,
+        } => {
+            let blobs = blobs_for(repo.as_deref(), lang.as_deref())?;
+            ensure_some(&blobs, repo.as_deref(), lang.as_deref())?;
+            let mut hits: Vec<sym::SymbolLocation> = Vec::new();
+            for idx in &blobs {
+                hits.extend(sym::query_references(
+                    &idx.blob, &name, &idx.repo, &idx.lang,
+                )?);
+            }
+            print_locations(&hits, json);
+        }
+        SymAction::Impl {
+            name,
+            repo,
+            lang,
+            json,
+        } => {
+            let blobs = blobs_for(repo.as_deref(), lang.as_deref())?;
+            ensure_some(&blobs, repo.as_deref(), lang.as_deref())?;
+            let mut hits: Vec<sym::SymbolLocation> = Vec::new();
+            for idx in &blobs {
+                hits.extend(sym::query_implementors(
+                    &idx.blob, &name, &idx.repo, &idx.lang,
+                )?);
+            }
+            if hits.is_empty() {
+                eprintln!(
+                    "[legion sym impl] no implementors found for '{name}' (note: only languages whose SCIP indexer emits is_implementation relationships will return results)"
+                );
+                return Ok(());
+            }
+            print_locations(&hits, json);
+        }
+        SymAction::Hover {
+            name,
+            repo,
+            lang,
+            json,
+        } => {
+            let blobs = blobs_for(repo.as_deref(), lang.as_deref())?;
+            ensure_some(&blobs, repo.as_deref(), lang.as_deref())?;
+            let mut hover: Option<sym::HoverInfo> = None;
+            for idx in &blobs {
+                if let Some(h) = sym::query_hover(&idx.blob, &name, &idx.repo, &idx.lang)? {
+                    hover = Some(h);
+                    break;
+                }
+            }
+            match (hover, json) {
+                (Some(h), true) => println!(
+                    "{}",
+                    // HoverInfo has only String/Option<String> fields, so
+                    // serde_json::to_string cannot fail in practice; the
+                    // fallback is defensive against future shape changes.
+                    serde_json::to_string(&h).unwrap_or_else(|_| "{}".to_string())
+                ),
+                (Some(h), false) => {
+                    println!("{}", h.symbol);
+                    if let Some(sig) = h.signature.as_deref() {
+                        println!("{sig}");
+                    }
+                    if let Some(doc) = h.docstring.as_deref() {
+                        println!();
+                        println!("{doc}");
+                    }
+                }
+                (None, _) => {
+                    eprintln!("[legion sym hover] no info found for '{name}'");
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+fn print_locations(hits: &[sym::SymbolLocation], json: bool) {
+    if json {
+        println!(
+            "{}",
+            // SymbolLocation has only string + integer fields, so this
+            // serializer call is effectively infallible.
+            serde_json::to_string(hits).unwrap_or_else(|_| "[]".to_string())
+        );
+        return;
+    }
+    for h in hits {
+        println!("{}:{}:{} ({}/{})", h.file, h.line, h.column, h.repo, h.lang);
+    }
 }
 
 /// Migrate legion state from the plugin data dir back to the ProjectDirs target.
@@ -2583,6 +2795,9 @@ fn run() -> error::Result<()> {
                     }
                 }
             }
+        }
+        Commands::Sym { action } => {
+            run_sym(action)?;
         }
         Commands::Index { repo, file } => {
             let base = data_dir()?;

--- a/src/sym.rs
+++ b/src/sym.rs
@@ -1,0 +1,315 @@
+//! SCIP symbol query CLI (#282).
+//!
+//! Provides four query primitives over stored SCIP protobuf blobs:
+//! `def`, `refs`, `impl`, and `hover`. Blobs are parsed in-process via
+//! the `scip` crate; the data layer is read-only here -- writes happen
+//! through `legion index` (#278/#279/#280).
+//!
+//! Symbol matching is name-based: SCIP encodes a fully qualified
+//! identifier (`rust-analyzer cargo foo 1.0 src/lib.rs/Foo#`) and we
+//! treat the user's `<name>` argument as a substring match on that
+//! identifier. Exact matching by descriptor is a future refinement.
+
+use crate::error::{LegionError, Result};
+use protobuf::Message;
+use serde::Serialize;
+
+/// A definition or reference location resolved from a SCIP index.
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct SymbolLocation {
+    pub file: String,
+    pub line: u32,
+    pub column: u32,
+    pub repo: String,
+    pub lang: String,
+}
+
+/// Hover info: signature text + concatenated docstring.
+#[derive(Debug, Clone, Serialize)]
+pub struct HoverInfo {
+    pub symbol: String,
+    pub signature: Option<String>,
+    pub docstring: Option<String>,
+    pub repo: String,
+    pub lang: String,
+}
+
+/// Bitmask value for the `Definition` symbol role. Listed alongside the
+/// proto-generated enum in scip-0.7.1 as `SymbolRole::Definition = 1`.
+const ROLE_DEFINITION: i32 = 1;
+
+fn parse_index(blob: &[u8]) -> Result<scip::types::Index> {
+    scip::types::Index::parse_from_bytes(blob)
+        .map_err(|e| LegionError::Search(format!("scip parse error: {e}")))
+}
+
+/// Half-open SCIP ranges encode `[startLine, startCharacter, endLine, endCharacter]`
+/// or `[startLine, startCharacter, endCharacter]`. Either way we want the
+/// (1-indexed) start line and column.
+fn occurrence_position(range: &[i32]) -> Option<(u32, u32)> {
+    let start_line = (*range.first()?).max(0) as u32 + 1;
+    let start_col = (*range.get(1)?).max(0) as u32 + 1;
+    Some((start_line, start_col))
+}
+
+/// Iterate every occurrence in `index`, collecting locations whose
+/// `symbol` string contains `name` and whose role matches `want_def`
+/// (true => Definition, false => any non-definition reference).
+fn collect_locations(
+    index: &scip::types::Index,
+    name: &str,
+    repo: &str,
+    lang: &str,
+    want_def: bool,
+) -> Vec<SymbolLocation> {
+    let mut out: Vec<SymbolLocation> = Vec::new();
+    for doc in &index.documents {
+        for occ in &doc.occurrences {
+            if !occ.symbol.contains(name) {
+                continue;
+            }
+            let is_def = (occ.symbol_roles & ROLE_DEFINITION) != 0;
+            if want_def != is_def {
+                continue;
+            }
+            if let Some((line, column)) = occurrence_position(&occ.range) {
+                out.push(SymbolLocation {
+                    file: doc.relative_path.clone(),
+                    line,
+                    column,
+                    repo: repo.to_string(),
+                    lang: lang.to_string(),
+                });
+            }
+        }
+    }
+    out.sort_by(|a, b| a.file.cmp(&b.file).then_with(|| a.line.cmp(&b.line)));
+    out
+}
+
+pub fn query_definitions(
+    blob: &[u8],
+    name: &str,
+    repo: &str,
+    lang: &str,
+) -> Result<Vec<SymbolLocation>> {
+    let idx = parse_index(blob)?;
+    Ok(collect_locations(&idx, name, repo, lang, true))
+}
+
+pub fn query_references(
+    blob: &[u8],
+    name: &str,
+    repo: &str,
+    lang: &str,
+) -> Result<Vec<SymbolLocation>> {
+    let idx = parse_index(blob)?;
+    Ok(collect_locations(&idx, name, repo, lang, false))
+}
+
+/// Implementors are encoded via SymbolInformation.relationships where
+/// `is_implementation == true`. We collect every Document occurrence
+/// whose `symbol` matches a SymbolInformation that declares an
+/// implementation relationship to a target symbol containing `trait_name`.
+pub fn query_implementors(
+    blob: &[u8],
+    trait_name: &str,
+    repo: &str,
+    lang: &str,
+) -> Result<Vec<SymbolLocation>> {
+    use std::collections::HashSet;
+    let idx = parse_index(blob)?;
+    let mut implementor_symbols: HashSet<String> = HashSet::new();
+    for doc in &idx.documents {
+        for sym in &doc.symbols {
+            for rel in &sym.relationships {
+                if rel.is_implementation && rel.symbol.contains(trait_name) {
+                    implementor_symbols.insert(sym.symbol.clone());
+                }
+            }
+        }
+    }
+
+    let mut out: Vec<SymbolLocation> = Vec::new();
+    for doc in &idx.documents {
+        for occ in &doc.occurrences {
+            if !implementor_symbols.contains(&occ.symbol) {
+                continue;
+            }
+            if (occ.symbol_roles & ROLE_DEFINITION) == 0 {
+                continue;
+            }
+            if let Some((line, column)) = occurrence_position(&occ.range) {
+                out.push(SymbolLocation {
+                    file: doc.relative_path.clone(),
+                    line,
+                    column,
+                    repo: repo.to_string(),
+                    lang: lang.to_string(),
+                });
+            }
+        }
+    }
+    out.sort_by(|a, b| a.file.cmp(&b.file).then_with(|| a.line.cmp(&b.line)));
+    Ok(out)
+}
+
+pub fn query_hover(blob: &[u8], name: &str, repo: &str, lang: &str) -> Result<Option<HoverInfo>> {
+    let idx = parse_index(blob)?;
+    for doc in &idx.documents {
+        for sym in &doc.symbols {
+            if !sym.symbol.contains(name) {
+                continue;
+            }
+            let signature = sym
+                .signature_documentation
+                .as_ref()
+                .map(|d| d.text.clone())
+                .filter(|t| !t.is_empty());
+            let docstring = if sym.documentation.is_empty() {
+                None
+            } else {
+                Some(sym.documentation.join("\n"))
+            };
+            return Ok(Some(HoverInfo {
+                symbol: sym.symbol.clone(),
+                signature,
+                docstring,
+                repo: repo.to_string(),
+                lang: lang.to_string(),
+            }));
+        }
+    }
+    Ok(None)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use scip::types::{Document, Index, Occurrence, Relationship, SymbolInformation};
+
+    fn build_index() -> Index {
+        let mut def_occ = Occurrence::new();
+        def_occ.symbol = "rust . crate . `fixture` . MyStruct#".to_string();
+        def_occ.range = vec![9, 4, 9, 12]; // line 10, col 5
+        def_occ.symbol_roles = ROLE_DEFINITION;
+
+        let mut ref_occ = Occurrence::new();
+        ref_occ.symbol = "rust . crate . `fixture` . MyStruct#".to_string();
+        ref_occ.range = vec![19, 8, 19, 16]; // line 20, col 9
+        ref_occ.symbol_roles = 0;
+
+        let mut other_occ = Occurrence::new();
+        other_occ.symbol = "rust . crate . `fixture` . OtherThing#".to_string();
+        other_occ.range = vec![1, 0, 1, 5];
+        other_occ.symbol_roles = ROLE_DEFINITION;
+
+        let mut sym_info = SymbolInformation::new();
+        sym_info.symbol = "rust . crate . `fixture` . MyStruct#".to_string();
+        sym_info.documentation = vec!["A test struct.".to_string()];
+
+        let mut impl_rel = Relationship::new();
+        impl_rel.symbol = "rust . crate . std . MyTrait#".to_string();
+        impl_rel.is_implementation = true;
+        sym_info.relationships = vec![impl_rel];
+
+        let mut doc = Document::new();
+        doc.relative_path = "src/lib.rs".to_string();
+        doc.occurrences = vec![def_occ, ref_occ, other_occ];
+        doc.symbols = vec![sym_info];
+
+        let mut idx = Index::new();
+        idx.documents = vec![doc];
+        idx
+    }
+
+    fn build_blob() -> Vec<u8> {
+        build_index().write_to_bytes().unwrap()
+    }
+
+    #[test]
+    fn query_definitions_finds_definition_only() {
+        let blob = build_blob();
+        let hits = query_definitions(&blob, "MyStruct", "fixture", "rust").unwrap();
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].file, "src/lib.rs");
+        assert_eq!(hits[0].line, 10);
+        assert_eq!(hits[0].column, 5);
+    }
+
+    #[test]
+    fn query_definitions_empty_blob_returns_empty() {
+        let hits = query_definitions(&[], "Foo", "r", "rust").unwrap();
+        assert!(hits.is_empty());
+    }
+
+    #[test]
+    fn query_definitions_corrupt_blob_returns_search_error() {
+        let err = query_definitions(&[1u8, 2, 3, 4, 5, 6, 7, 8], "x", "r", "rust").unwrap_err();
+        match err {
+            LegionError::Search(msg) => assert!(msg.contains("scip parse error")),
+            other => panic!("expected Search, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn query_references_excludes_definitions() {
+        let blob = build_blob();
+        let hits = query_references(&blob, "MyStruct", "fixture", "rust").unwrap();
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].line, 20);
+    }
+
+    #[test]
+    fn query_references_unknown_name_returns_empty() {
+        let blob = build_blob();
+        let hits = query_references(&blob, "DoesNotExist", "fixture", "rust").unwrap();
+        assert!(hits.is_empty());
+    }
+
+    #[test]
+    fn query_implementors_returns_struct_that_implements_named_trait() {
+        let blob = build_blob();
+        let hits = query_implementors(&blob, "MyTrait", "fixture", "rust").unwrap();
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].line, 10);
+    }
+
+    #[test]
+    fn query_implementors_no_match_returns_empty() {
+        let blob = build_blob();
+        let hits = query_implementors(&blob, "UnrelatedTrait", "fixture", "rust").unwrap();
+        assert!(hits.is_empty());
+    }
+
+    #[test]
+    fn query_hover_returns_docstring_for_known_symbol() {
+        let blob = build_blob();
+        let hover = query_hover(&blob, "MyStruct", "fixture", "rust")
+            .unwrap()
+            .unwrap();
+        assert!(hover.symbol.contains("MyStruct"));
+        assert_eq!(hover.docstring.as_deref(), Some("A test struct."));
+    }
+
+    #[test]
+    fn query_hover_unknown_symbol_returns_none() {
+        let blob = build_blob();
+        let hover = query_hover(&blob, "NoSuch", "fixture", "rust").unwrap();
+        assert!(hover.is_none());
+    }
+
+    #[test]
+    fn json_serialization_round_trips_array() {
+        let loc = SymbolLocation {
+            file: "a.rs".into(),
+            line: 1,
+            column: 1,
+            repo: "r".into(),
+            lang: "rust".into(),
+        };
+        let v = serde_json::to_string(&[&loc]).unwrap();
+        assert!(v.starts_with('[') && v.ends_with(']'));
+        assert!(v.contains("\"file\":\"a.rs\""));
+    }
+}


### PR DESCRIPTION
## Summary
- New `src/sym.rs` parses stored SCIP protobuf blobs in-process via the `scip` crate; answers def/refs/impl/hover queries
- `legion sym def|refs|impl|hover <name> [--repo X] [--lang Y] [--json]`
- Empty selection (no rows for the requested filter) exits non-zero pointing at `legion index <repo>`
- `--json` emits a JSON array of `SymbolLocation` (or `HoverInfo` object); human format prints `file:line:col (repo/lang)`
- Cross-repo scan (no `--repo`) walks every `watch.toml` entry; #285 will replace this with a dedicated `legion consult --symbol`

## Stacked on
Base: `feat/281-reindex-hook` (PR #367). Will rebase after the chain merges.

## Test plan
- [x] 10 new tests in `src/sym.rs`: def/refs/impl/hover happy paths, corrupt-blob parse error, empty-blob handling, JSON serialization shape
- [x] Full suite 599 passed; clippy + fmt clean

Closes #282