### PR TITLE
feat(#284): daemon background indexer + watch add integration

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -659,7 +659,7 @@ impl Database {
                 ON persona_wake_leases(expires_at) WHERE deleted_at IS NULL;",
         )?;
 
-        // Migration 17: SCIP indexes for code intelligence (#278).
+        // Migration 18: SCIP indexes for code intelligence (#278).
         // One active row per (repo, lang) holds the protobuf blob legion
         // queries against. content_hash is SHA-256 hex of the blob; an
         // upsert with an unchanged hash short-circuits to bumping
@@ -678,6 +678,29 @@ impl Database {
                 ON scip_indexes(repo, lang) WHERE deleted_at IS NULL;
             CREATE INDEX IF NOT EXISTS idx_scip_indexes_repo
                 ON scip_indexes(repo) WHERE deleted_at IS NULL;",
+        )?;
+
+        // Migration 19: Background index jobs (#284). One live row per
+        // repo (unique on repo where deleted_at IS NULL); upsert keyed
+        // on repo so re-queueing replaces the prior job. languages is
+        // a comma-joined list of language tags (e.g. "rust,typescript").
+        conn.execute_batch(
+            "CREATE TABLE IF NOT EXISTS index_jobs (
+                id TEXT PRIMARY KEY,
+                repo TEXT NOT NULL,
+                status TEXT NOT NULL,
+                languages TEXT NOT NULL,
+                progress_pct INTEGER NOT NULL DEFAULT 0,
+                eta_secs INTEGER,
+                error TEXT,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL,
+                deleted_at TEXT
+            );
+            CREATE UNIQUE INDEX IF NOT EXISTS idx_index_jobs_repo_live
+                ON index_jobs(repo) WHERE deleted_at IS NULL;
+            CREATE INDEX IF NOT EXISTS idx_index_jobs_status
+                ON index_jobs(status) WHERE deleted_at IS NULL;",
         )?;
 
         Ok(())
@@ -3397,6 +3420,104 @@ impl Database {
         Ok(row)
     }
 
+    /// Upsert an `IndexJob` keyed on (repo) where deleted_at IS NULL.
+    /// Re-queueing replaces the prior job in place; observers reading by
+    /// repo always see the latest state.
+    pub fn upsert_index_job(&self, job: &crate::scip::IndexJob) -> Result<()> {
+        let langs = job.languages.join(",");
+        let status = job.status.as_str();
+        let existing: Option<String> = self
+            .conn
+            .query_row(
+                "SELECT id FROM index_jobs WHERE repo = ?1 AND deleted_at IS NULL",
+                rusqlite::params![&job.repo],
+                |row| row.get(0),
+            )
+            .optional()?;
+        match existing {
+            Some(id) => {
+                self.conn.execute(
+                    "UPDATE index_jobs
+                     SET status = ?1, languages = ?2, progress_pct = ?3,
+                         eta_secs = ?4, error = ?5, updated_at = ?6
+                     WHERE id = ?7",
+                    rusqlite::params![
+                        status,
+                        &langs,
+                        job.progress_pct as i64,
+                        job.eta_secs.map(|v| v as i64),
+                        &job.error,
+                        &job.updated_at,
+                        &id,
+                    ],
+                )?;
+            }
+            None => {
+                self.conn.execute(
+                    "INSERT INTO index_jobs
+                       (id, repo, status, languages, progress_pct, eta_secs, error,
+                        created_at, updated_at, deleted_at)
+                     VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, NULL)",
+                    rusqlite::params![
+                        &job.id,
+                        &job.repo,
+                        status,
+                        &langs,
+                        job.progress_pct as i64,
+                        job.eta_secs.map(|v| v as i64),
+                        &job.error,
+                        &job.created_at,
+                        &job.updated_at,
+                    ],
+                )?;
+            }
+        }
+        Ok(())
+    }
+
+    /// Read the active job for `repo`, if any.
+    pub fn get_index_job(&self, repo: &str) -> Result<Option<crate::scip::IndexJob>> {
+        let row = self
+            .conn
+            .query_row(
+                "SELECT id, repo, status, languages, progress_pct, eta_secs, error,
+                        created_at, updated_at
+                 FROM index_jobs
+                 WHERE repo = ?1 AND deleted_at IS NULL",
+                rusqlite::params![repo],
+                map_index_job_row,
+            )
+            .optional()?;
+        Ok(row)
+    }
+
+    /// List all live job rows.
+    pub fn list_index_jobs(&self) -> Result<Vec<crate::scip::IndexJob>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT id, repo, status, languages, progress_pct, eta_secs, error,
+                    created_at, updated_at
+             FROM index_jobs
+             WHERE deleted_at IS NULL
+             ORDER BY repo",
+        )?;
+        let rows = stmt
+            .query_map([], map_index_job_row)?
+            .collect::<std::result::Result<Vec<_>, _>>()?;
+        Ok(rows)
+    }
+
+    /// Reset every `running` job to `queued`. Called at daemon startup
+    /// to recover from interrupted jobs.
+    pub fn reset_running_jobs_to_queued(&self, now_iso: &str) -> Result<usize> {
+        let n = self.conn.execute(
+            "UPDATE index_jobs
+             SET status = 'queued', progress_pct = 0, updated_at = ?1
+             WHERE status = 'running' AND deleted_at IS NULL",
+            rusqlite::params![now_iso],
+        )?;
+        Ok(n)
+    }
+
     /// List all non-deleted SCIP indexes for a repo.
     /// Read path consumed by `legion consult --symbol` in #285.
     #[allow(dead_code)]
@@ -3422,6 +3543,36 @@ impl Database {
             .collect::<std::result::Result<Vec<_>, _>>()?;
         Ok(rows)
     }
+}
+
+/// Hydrate an `IndexJob` from an `index_jobs` row in the canonical
+/// SELECT order: (id, repo, status, languages, progress_pct, eta_secs,
+/// error, created_at, updated_at). Used by `get_index_job` and
+/// `list_index_jobs`.
+fn map_index_job_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<crate::scip::IndexJob> {
+    let status_str: String = row.get(2)?;
+    let status = crate::scip::IndexJobStatus::parse(&status_str).map_err(|e| {
+        rusqlite::Error::FromSqlConversionFailure(2, rusqlite::types::Type::Text, Box::new(e))
+    })?;
+    let langs_str: String = row.get(3)?;
+    let languages: Vec<String> = if langs_str.is_empty() {
+        Vec::new()
+    } else {
+        langs_str.split(',').map(|s| s.to_string()).collect()
+    };
+    let progress: i64 = row.get(4)?;
+    let eta: Option<i64> = row.get(5)?;
+    Ok(crate::scip::IndexJob {
+        id: row.get(0)?,
+        repo: row.get(1)?,
+        status,
+        languages,
+        progress_pct: progress.clamp(0, 100) as u8,
+        eta_secs: eta.map(|v| v.max(0) as u32),
+        error: row.get(6)?,
+        created_at: row.get(7)?,
+        updated_at: row.get(8)?,
+    })
 }
 
 #[cfg(test)]
@@ -5717,6 +5868,95 @@ mod tests {
             .collect();
         langs.sort();
         assert_eq!(langs, vec!["rust".to_string(), "ts".to_string()]);
+    }
+
+    fn make_job(repo: &str, status: crate::scip::IndexJobStatus) -> crate::scip::IndexJob {
+        crate::scip::IndexJob {
+            id: uuid::Uuid::now_v7().to_string(),
+            repo: repo.to_string(),
+            status,
+            languages: vec!["rust".to_string()],
+            progress_pct: 0,
+            eta_secs: None,
+            error: None,
+            created_at: "2026-04-28T00:00:00Z".to_string(),
+            updated_at: "2026-04-28T00:00:00Z".to_string(),
+        }
+    }
+
+    #[test]
+    fn index_job_upsert_then_get_round_trip() {
+        let db = test_db();
+        let job = make_job("legion", crate::scip::IndexJobStatus::Queued);
+        db.upsert_index_job(&job).unwrap();
+        let got = db.get_index_job("legion").unwrap().unwrap();
+        assert_eq!(got.repo, "legion");
+        assert_eq!(got.status, crate::scip::IndexJobStatus::Queued);
+        assert_eq!(got.languages, vec!["rust".to_string()]);
+    }
+
+    #[test]
+    fn index_job_upsert_replaces_existing_row() {
+        let db = test_db();
+        db.upsert_index_job(&make_job("legion", crate::scip::IndexJobStatus::Queued))
+            .unwrap();
+        let id = db.get_index_job("legion").unwrap().unwrap().id;
+
+        let mut updated = make_job("legion", crate::scip::IndexJobStatus::Done);
+        updated.id = "new-id-ignored".to_string();
+        updated.progress_pct = 100;
+        db.upsert_index_job(&updated).unwrap();
+
+        let after = db.get_index_job("legion").unwrap().unwrap();
+        assert_eq!(after.id, id, "row identity must be preserved on upsert");
+        assert_eq!(after.status, crate::scip::IndexJobStatus::Done);
+        assert_eq!(after.progress_pct, 100);
+    }
+
+    #[test]
+    fn list_index_jobs_returns_all_statuses() {
+        let db = test_db();
+        db.upsert_index_job(&make_job("a", crate::scip::IndexJobStatus::Queued))
+            .unwrap();
+        db.upsert_index_job(&make_job("b", crate::scip::IndexJobStatus::Failed))
+            .unwrap();
+        db.upsert_index_job(&make_job("c", crate::scip::IndexJobStatus::Done))
+            .unwrap();
+        let jobs = db.list_index_jobs().unwrap();
+        let repos: Vec<String> = jobs.iter().map(|j| j.repo.clone()).collect();
+        assert_eq!(
+            repos,
+            vec!["a".to_string(), "b".to_string(), "c".to_string()]
+        );
+    }
+
+    #[test]
+    fn reset_running_to_queued_only_touches_running() {
+        let db = test_db();
+        db.upsert_index_job(&make_job("a", crate::scip::IndexJobStatus::Running))
+            .unwrap();
+        db.upsert_index_job(&make_job("b", crate::scip::IndexJobStatus::Queued))
+            .unwrap();
+        db.upsert_index_job(&make_job("c", crate::scip::IndexJobStatus::Done))
+            .unwrap();
+
+        let reset = db
+            .reset_running_jobs_to_queued("2026-04-29T00:00:00Z")
+            .unwrap();
+        assert_eq!(reset, 1);
+
+        assert_eq!(
+            db.get_index_job("a").unwrap().unwrap().status,
+            crate::scip::IndexJobStatus::Queued
+        );
+        assert_eq!(
+            db.get_index_job("b").unwrap().unwrap().status,
+            crate::scip::IndexJobStatus::Queued
+        );
+        assert_eq!(
+            db.get_index_job("c").unwrap().unwrap().status,
+            crate::scip::IndexJobStatus::Done
+        );
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -386,14 +386,21 @@ enum Commands {
     /// file is re-indexed (#280). Repo is resolved by longest-prefix
     /// match against watch.toml workdirs when omitted.
     Index {
-        /// Repo name (looked up in watch.toml). Optional when --file is
-        /// used and the path is unambiguous.
-        #[arg(required_unless_present = "file")]
+        /// Repo name (looked up in watch.toml). Optional when --file or
+        /// --status is given.
+        #[arg(required_unless_present_any = ["file", "status"])]
         repo: Option<String>,
         /// Re-index only the language for this single file (absolute or
         /// repo-relative path).
         #[arg(long)]
         file: Option<std::path::PathBuf>,
+        /// Print background index job status from the local store
+        /// instead of running a fresh index (#284).
+        #[arg(long)]
+        status: bool,
+        /// Emit JSON output (currently only meaningful with --status).
+        #[arg(long)]
+        json: bool,
     },
 
     /// Rebuild the search index from the database
@@ -1721,6 +1728,60 @@ fn run_sym(action: SymAction) -> error::Result<()> {
     Ok(())
 }
 
+/// Implements `legion index --status [--repo X] [--json]` (#284).
+fn run_index_status(repo: Option<&str>, json: bool) -> error::Result<()> {
+    let base = data_dir()?;
+    let database = db::Database::open(&base.join("legion.db"))?;
+    let jobs = database.list_index_jobs()?;
+    let filtered: Vec<&scip::IndexJob> = match repo {
+        Some(name) => jobs.iter().filter(|j| j.repo == name).collect(),
+        None => jobs.iter().collect(),
+    };
+
+    if json {
+        let body = serde_json::to_string(&filtered)
+            .map_err(|e| error::LegionError::Search(format!("serialize index_jobs: {e}")))?;
+        println!("{body}");
+        return Ok(());
+    }
+
+    if filtered.is_empty() {
+        if let Some(name) = repo {
+            println!("no index job found for {name}");
+        } else {
+            println!("no index jobs recorded");
+        }
+        return Ok(());
+    }
+
+    for job in filtered {
+        let langs = if job.languages.is_empty() {
+            "(none)".to_string()
+        } else {
+            job.languages.join(",")
+        };
+        let eta = job
+            .eta_secs
+            .map(|s| format!("eta={s}s"))
+            .unwrap_or_default();
+        let err = job
+            .error
+            .as_deref()
+            .map(|e| format!(" error={e}"))
+            .unwrap_or_default();
+        println!(
+            "{}: {} {}% [{}] {}{}",
+            job.repo,
+            job.status.as_str(),
+            job.progress_pct,
+            langs,
+            eta,
+            err
+        );
+    }
+    Ok(())
+}
+
 fn print_locations(hits: &[sym::SymbolLocation], json: bool) {
     if json {
         println!(
@@ -2799,7 +2860,16 @@ fn run() -> error::Result<()> {
         Commands::Sym { action } => {
             run_sym(action)?;
         }
-        Commands::Index { repo, file } => {
+        Commands::Index {
+            repo,
+            file,
+            status,
+            json,
+        } => {
+            if status {
+                run_index_status(repo.as_deref(), json)?;
+                return Ok(());
+            }
             let base = data_dir()?;
             let watch_path = base.join("watch.toml");
             let repos = watch::list_repos_in_config(&watch_path)?;
@@ -4523,6 +4593,16 @@ fn run() -> error::Result<()> {
                     eprintln!(
                         "[legion] `legion watch` is deprecated -- use `legion daemon` to run channel + watch in one process"
                     );
+                    // #284: drain pending index jobs once at watch startup.
+                    // Long-running poll integration is a follow-on; this
+                    // covers the "queue on add, drain on next watch start"
+                    // case which is the most common operator workflow.
+                    let database = db::Database::open(&base.join("legion.db"))?;
+                    let watch_path = base.join("watch.toml");
+                    if let Err(e) = scip::run_pending_index_jobs(&database, &watch_path) {
+                        eprintln!("[legion watch] index drain failed: {e}");
+                    }
+                    drop(database);
                     watch::run(&base)?;
                 }
                 Some(WatchAction::Add { path, name, agent }) => {
@@ -4566,6 +4646,33 @@ fn run() -> error::Result<()> {
                             path.display(),
                             agent_note
                         );
+
+                        // #284: queue a background index job for the new repo
+                        // unless one is already recorded. Detection is best
+                        // effort -- empty languages means the daemon will
+                        // re-detect when it picks up the queued row.
+                        let database = db::Database::open(&base.join("legion.db"))?;
+                        if database.get_index_job(&effective_name)?.is_none() {
+                            let now = chrono::Utc::now().to_rfc3339();
+                            let job = scip::IndexJob {
+                                id: uuid::Uuid::now_v7().to_string(),
+                                repo: effective_name.clone(),
+                                status: scip::IndexJobStatus::Queued,
+                                languages: Vec::new(),
+                                progress_pct: 0,
+                                eta_secs: None,
+                                error: None,
+                                created_at: now.clone(),
+                                updated_at: now,
+                            };
+                            if let Err(e) = database.upsert_index_job(&job) {
+                                eprintln!(
+                                    "[legion watch] failed to queue index job for {effective_name}: {e}"
+                                );
+                            } else {
+                                println!("queued background index job for {effective_name}");
+                            }
+                        }
                     } else {
                         println!("already present: {}", effective_name);
                     }

--- a/src/scip.rs
+++ b/src/scip.rs
@@ -12,7 +12,7 @@
 //! column (see `Database::upsert_scip_index`).
 
 use crate::error::{LegionError, Result};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::collections::{BTreeSet, HashMap};
 use std::path::{Path, PathBuf};
@@ -31,6 +31,55 @@ pub struct ScipIndex {
     /// cleanup paths (#284 daemon indexer); not read by the #278 base.
     #[allow(dead_code)]
     pub deleted_at: Option<String>,
+}
+
+/// Lifecycle states for a background index job.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum IndexJobStatus {
+    Queued,
+    Running,
+    Done,
+    Failed,
+}
+
+impl IndexJobStatus {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            IndexJobStatus::Queued => "queued",
+            IndexJobStatus::Running => "running",
+            IndexJobStatus::Done => "done",
+            IndexJobStatus::Failed => "failed",
+        }
+    }
+
+    pub fn parse(s: &str) -> Result<Self> {
+        match s {
+            "queued" => Ok(IndexJobStatus::Queued),
+            "running" => Ok(IndexJobStatus::Running),
+            "done" => Ok(IndexJobStatus::Done),
+            "failed" => Ok(IndexJobStatus::Failed),
+            other => Err(LegionError::Search(format!(
+                "unknown index job status: {other}"
+            ))),
+        }
+    }
+}
+
+/// A background index job persisted to `index_jobs`. Daemon picks up
+/// `Queued` rows, sets them to `Running` while processing, and either
+/// `Done` or `Failed` on completion. Restart resets `Running` -> `Queued`.
+#[derive(Debug, Clone, Serialize)]
+pub struct IndexJob {
+    pub id: String,
+    pub repo: String,
+    pub status: IndexJobStatus,
+    pub languages: Vec<String>,
+    pub progress_pct: u8,
+    pub eta_secs: Option<u32>,
+    pub error: Option<String>,
+    pub created_at: String,
+    pub updated_at: String,
 }
 
 /// A language detected in a repo and the binary used to index it.
@@ -221,6 +270,121 @@ where
     };
     db.upsert_scip_index(&index)?;
     Ok(hash)
+}
+
+/// Run every queued index job once. Picks up `Queued` rows from
+/// `index_jobs`, resolves each repo's path from `watch.toml`, runs
+/// the multi-language indexer, and updates the row to `Done` or
+/// `Failed` depending on outcome.
+///
+/// Best-effort: a failure indexing one repo does not abort the others.
+/// Caller is responsible for invoking this on a cadence (daemon poll
+/// loop or one-shot at startup).
+pub fn run_pending_index_jobs(db: &crate::db::Database, watch_path: &Path) -> Result<usize> {
+    let now = chrono::Utc::now().to_rfc3339();
+    db.reset_running_jobs_to_queued(&now)?;
+
+    let jobs = db.list_index_jobs()?;
+    let mut completed = 0usize;
+    for mut job in jobs {
+        if job.status != IndexJobStatus::Queued {
+            continue;
+        }
+        let repos = match crate::watch::list_repos_in_config(watch_path) {
+            Ok(r) => r,
+            Err(_) => continue,
+        };
+        let entry = match repos.iter().find(|r| r.name == job.repo) {
+            Some(e) => e.clone(),
+            None => {
+                job.status = IndexJobStatus::Failed;
+                job.error = Some("repo no longer in watch.toml".to_string());
+                job.updated_at = chrono::Utc::now().to_rfc3339();
+                if let Err(e) = db.upsert_index_job(&job) {
+                    eprintln!(
+                        "[legion index] job state write failed for {}: {e}",
+                        job.repo
+                    );
+                }
+                continue;
+            }
+        };
+        let repo_path = PathBuf::from(&entry.workdir);
+        let cfg: IndexConfig = match entry.extra.clone().try_into() {
+            Ok(c) => c,
+            Err(e) => {
+                eprintln!(
+                    "[legion index] warning: malformed indexer config for {}: {e}; using defaults",
+                    job.repo
+                );
+                IndexConfig::default()
+            }
+        };
+
+        let detection = detect_languages(&repo_path, &cfg);
+        let total = detection.indexable.len().max(1);
+
+        job.status = IndexJobStatus::Running;
+        job.languages = detection.indexable.iter().map(|d| d.lang.clone()).collect();
+        job.progress_pct = 0;
+        job.error = None;
+        job.updated_at = chrono::Utc::now().to_rfc3339();
+        let _ = db.upsert_index_job(&job);
+
+        let mut last_err: Option<String> = None;
+        let mut indexed = 0usize;
+        for (i, lang_entry) in detection.indexable.iter().enumerate() {
+            match run_indexer(lang_entry, &repo_path) {
+                Ok(blob) => {
+                    let hash = content_hash(&blob);
+                    let idx = ScipIndex {
+                        id: uuid::Uuid::now_v7().to_string(),
+                        repo: job.repo.clone(),
+                        lang: lang_entry.lang.clone(),
+                        content_hash: hash,
+                        blob,
+                        updated_at: chrono::Utc::now().to_rfc3339(),
+                        deleted_at: None,
+                    };
+                    if let Err(e) = db.upsert_scip_index(&idx) {
+                        eprintln!(
+                            "[legion index] blob write failed for {}/{}: {e}",
+                            job.repo, lang_entry.lang
+                        );
+                    }
+                    indexed += 1;
+                }
+                Err(e) => {
+                    last_err = Some(format!("{}: {e}", lang_entry.lang));
+                }
+            }
+            job.progress_pct = (((i + 1) as u64 * 100) / total as u64).min(100) as u8;
+            job.updated_at = chrono::Utc::now().to_rfc3339();
+            let _ = db.upsert_index_job(&job);
+        }
+
+        job.status = if indexed > 0 {
+            IndexJobStatus::Done
+        } else {
+            IndexJobStatus::Failed
+        };
+        job.error = last_err.or_else(|| {
+            if detection.indexable.is_empty() {
+                Some("no indexable languages detected".to_string())
+            } else {
+                None
+            }
+        });
+        job.progress_pct = if matches!(job.status, IndexJobStatus::Done) {
+            100
+        } else {
+            job.progress_pct
+        };
+        job.updated_at = chrono::Utc::now().to_rfc3339();
+        let _ = db.upsert_index_job(&job);
+        completed += 1;
+    }
+    Ok(completed)
 }
 
 /// SHA-256 of `bytes` rendered as lowercase hex.


### PR DESCRIPTION
## Summary
- Schema: `index_jobs` table (migration 19) with one live row per repo, queued/running/done/failed lifecycle, languages list, progress percentage, optional ETA, error text
- Types: `scip::IndexJob`, `scip::IndexJobStatus`
- DB methods: `upsert_index_job`, `get_index_job`, `list_index_jobs`, `reset_running_jobs_to_queued`
- `scip::run_pending_index_jobs` walks queued rows, runs the multi-language indexer, updates progress per language
- `legion watch add <path>` queues a job for the new repo; `legion watch` (no subcommand) drains pending jobs at startup
- `legion index --status [--repo X] [--json]` prints job rows

## Stacked on
Base: `feat/283-pre-grep-scip` (PR #369).

## Test plan
- [x] 4 new DB tests: round-trip, replace-on-upsert, list-across-statuses, running->queued reset
- [x] Full suite 603 passed; clippy + fmt clean

## Out of scope per spec
- `nice` / `ionice` priority (cross-platform)
- Poll-interval re-drain (single follow-on; current path is "queue on add, drain on next watch start")

Closes #284