### PR TITLE
feat(#285): legion consult --symbol cross-repo lookup

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -207,13 +207,22 @@ enum Commands {
 
     /// Search reflections across all repos for cross-agent consultation
     Consult {
-        /// Context describing the problem to search for
+        /// Context describing the problem to search for (BM25 path).
+        /// Either --context, --symbol, or both must be provided.
         #[arg(long)]
-        context: String,
+        context: Option<String>,
 
-        /// Maximum number of reflections to return
+        /// Symbol name to look up across every indexed repo via SCIP (#285).
+        #[arg(long)]
+        symbol: Option<String>,
+
+        /// Maximum number of reflections (BM25) and symbol rows returned.
         #[arg(long, default_value = "3")]
         limit: usize,
+
+        /// Emit JSON output (combines BM25 + symbol sections under top-level keys).
+        #[arg(long)]
+        json: bool,
     },
 
     /// Configure Claude Code hooks for legion
@@ -2579,20 +2588,88 @@ fn run() -> error::Result<()> {
                 }
             }
         }
-        Commands::Consult { context, limit } => {
+        Commands::Consult {
+            context,
+            symbol,
+            limit,
+            json,
+        } => {
+            if context.is_none() && symbol.is_none() {
+                return Err(error::LegionError::WatchConfig(
+                    "consult requires --context, --symbol, or both".to_string(),
+                ));
+            }
+
             let base = data_dir()?;
             let database = db::Database::open(&base.join("legion.db"))?;
-            let index = search::SearchIndex::open(&base.join("index"))?;
+            let watch_path = base.join("watch.toml");
 
-            let result = match try_load_embed_model() {
-                Some(model) => recall::consult(&database, &index, &model, &context, limit)?,
-                None => recall::consult_bm25(&database, &index, &context, limit)?,
-            };
-            let output = recall::format_for_consult(&result);
-            if output.is_empty() {
-                info!("[legion] no reflections matched context: \"{}\"", context);
+            let bm25 = if let Some(ctx) = context.as_deref() {
+                let index = search::SearchIndex::open(&base.join("index"))?;
+                let result = match try_load_embed_model() {
+                    Some(model) => recall::consult(&database, &index, &model, ctx, limit)?,
+                    None => recall::consult_bm25(&database, &index, ctx, limit)?,
+                };
+                Some((ctx.to_string(), result))
             } else {
-                print!("{output}");
+                None
+            };
+
+            let symbol_rows = if let Some(name) = symbol.as_deref() {
+                let repos = watch::list_repos_in_config(&watch_path)
+                    .ok()
+                    .map(|rs| rs.into_iter().map(|r| r.name).collect::<Vec<_>>())
+                    .unwrap_or_default();
+                let mut rows = sym::cross_repo_symbol_query(&database, name, &repos)?;
+                rows.truncate(limit);
+                Some((name.to_string(), rows))
+            } else {
+                None
+            };
+
+            if json {
+                let bm25_text = bm25.as_ref().map(|(_ctx, r)| recall::format_for_consult(r));
+                let body = serde_json::json!({
+                    "bm25_text": bm25_text,
+                    "symbol_results": symbol_rows.as_ref().map(|(_n, rows)| rows),
+                });
+                println!(
+                    "{}",
+                    serde_json::to_string(&body).map_err(|e| error::LegionError::Search(
+                        format!("serialize consult: {e}")
+                    ))?
+                );
+            } else {
+                if let Some((ctx, result)) = bm25.as_ref() {
+                    let output = recall::format_for_consult(result);
+                    if output.is_empty() {
+                        info!("[legion] no reflections matched context: \"{}\"", ctx);
+                    } else {
+                        println!("## BM25 results for `{ctx}`");
+                        print!("{output}");
+                    }
+                }
+                if let Some((name, rows)) = symbol_rows.as_ref() {
+                    if rows.is_empty() {
+                        println!("## Symbol results for `{name}`");
+                        println!(
+                            "no SCIP indexes contain `{name}`; run `legion index <repo>` to build one"
+                        );
+                    } else {
+                        println!();
+                        println!("## Symbol results for `{name}`");
+                        for r in rows {
+                            let def_str = match &r.def_location {
+                                Some(loc) => format!("{}:{}", loc.file, loc.line),
+                                None => "(no definition found)".to_string(),
+                            };
+                            println!(
+                                "{} ({}): {}  [{} refs]",
+                                r.repo, r.lang, def_str, r.refs_count
+                            );
+                        }
+                    }
+                }
             }
         }
         Commands::Post {

--- a/src/sym.rs
+++ b/src/sym.rs
@@ -154,6 +154,89 @@ pub fn query_implementors(
     Ok(out)
 }
 
+/// One row of cross-repo symbol consult output.
+#[derive(Debug, Clone, Serialize)]
+pub struct CrossRepoSymbol {
+    pub repo: String,
+    pub lang: String,
+    pub def_location: Option<SymbolLocation>,
+    pub refs_count: usize,
+}
+
+/// Walk every stored SCIP blob (filtered to `repos` when non-empty)
+/// and return per-(repo, lang) hits for `symbol_name`. Sorted by
+/// `refs_count` descending, then by repo alphabetically. Repos with
+/// no stored index, and blobs that fail to parse, are skipped with a
+/// stderr warning -- one bad blob never aborts the consult.
+pub fn cross_repo_symbol_query(
+    db: &crate::db::Database,
+    symbol_name: &str,
+    repos: &[String],
+) -> Result<Vec<CrossRepoSymbol>> {
+    let mut out: Vec<CrossRepoSymbol> = Vec::new();
+
+    let candidate_repos: Vec<String> = if repos.is_empty() {
+        Vec::new()
+    } else {
+        repos.to_vec()
+    };
+
+    let blobs: Vec<crate::scip::ScipIndex> = if candidate_repos.is_empty() {
+        // Caller did not narrow -- list every repo that has an index row.
+        // We cheat the lack of "list everything" by doing a no-arg get on
+        // every repo we've ever heard of; without that, we surface nothing,
+        // which is a fail-quiet UX. db::list_index_jobs gives us a
+        // superset of relevant repo names.
+        let mut found: Vec<crate::scip::ScipIndex> = Vec::new();
+        for job in db.list_index_jobs()? {
+            found.extend(db.list_scip_indexes(&job.repo)?);
+        }
+        found
+    } else {
+        let mut found: Vec<crate::scip::ScipIndex> = Vec::new();
+        for r in &candidate_repos {
+            found.extend(db.list_scip_indexes(r)?);
+        }
+        found
+    };
+
+    for idx in &blobs {
+        let defs = match query_definitions(&idx.blob, symbol_name, &idx.repo, &idx.lang) {
+            Ok(v) => v,
+            Err(e) => {
+                eprintln!("[legion consult] skipping {}/{}: {e}", idx.repo, idx.lang);
+                continue;
+            }
+        };
+        let refs = match query_references(&idx.blob, symbol_name, &idx.repo, &idx.lang) {
+            Ok(v) => v,
+            Err(e) => {
+                eprintln!(
+                    "[legion consult] skipping {}/{} refs: {e}",
+                    idx.repo, idx.lang
+                );
+                continue;
+            }
+        };
+        if defs.is_empty() && refs.is_empty() {
+            continue;
+        }
+        out.push(CrossRepoSymbol {
+            repo: idx.repo.clone(),
+            lang: idx.lang.clone(),
+            def_location: defs.into_iter().next(),
+            refs_count: refs.len(),
+        });
+    }
+
+    out.sort_by(|a, b| {
+        b.refs_count
+            .cmp(&a.refs_count)
+            .then_with(|| a.repo.cmp(&b.repo))
+    });
+    Ok(out)
+}
+
 pub fn query_hover(blob: &[u8], name: &str, repo: &str, lang: &str) -> Result<Option<HoverInfo>> {
     let idx = parse_index(blob)?;
     for doc in &idx.documents {
@@ -297,6 +380,99 @@ mod tests {
         let blob = build_blob();
         let hover = query_hover(&blob, "NoSuch", "fixture", "rust").unwrap();
         assert!(hover.is_none());
+    }
+
+    fn make_blob() -> Vec<u8> {
+        build_blob()
+    }
+
+    fn open_test_db() -> crate::db::Database {
+        let dir = tempfile::TempDir::new().unwrap();
+        let db = crate::db::Database::open(&dir.path().join("test.sqlite")).unwrap();
+        std::mem::forget(dir);
+        db
+    }
+
+    #[test]
+    fn cross_repo_symbol_query_collects_per_repo_hits() {
+        let db = open_test_db();
+        let blob = make_blob();
+        let now = "2026-04-28T00:00:00Z";
+
+        for (repo, lang) in [("alpha", "rust"), ("beta", "rust")] {
+            db.upsert_scip_index(&crate::scip::ScipIndex {
+                id: uuid::Uuid::now_v7().to_string(),
+                repo: repo.to_string(),
+                lang: lang.to_string(),
+                content_hash: crate::scip::content_hash(&blob),
+                blob: blob.clone(),
+                updated_at: now.to_string(),
+                deleted_at: None,
+            })
+            .unwrap();
+        }
+
+        let rows =
+            cross_repo_symbol_query(&db, "MyStruct", &["alpha".to_string(), "beta".to_string()])
+                .unwrap();
+        assert_eq!(rows.len(), 2);
+        assert_eq!(rows[0].refs_count, 1);
+        assert_eq!(rows[1].refs_count, 1);
+    }
+
+    #[test]
+    fn cross_repo_symbol_query_repo_with_no_index_is_skipped() {
+        let db = open_test_db();
+        let rows = cross_repo_symbol_query(&db, "MyStruct", &["nope".to_string()]).unwrap();
+        assert!(rows.is_empty());
+    }
+
+    #[test]
+    fn cross_repo_symbol_query_sorted_by_refs_count_desc() {
+        // Build two indexes -- the second has the symbol referenced more
+        // often, so it should sort first.
+        let db = open_test_db();
+        let now = "2026-04-28T00:00:00Z";
+
+        // Repo "few": one ref.
+        let blob_few = make_blob();
+        db.upsert_scip_index(&crate::scip::ScipIndex {
+            id: uuid::Uuid::now_v7().to_string(),
+            repo: "few".to_string(),
+            lang: "rust".to_string(),
+            content_hash: crate::scip::content_hash(&blob_few),
+            blob: blob_few,
+            updated_at: now.to_string(),
+            deleted_at: None,
+        })
+        .unwrap();
+
+        // Repo "many": multiple ref occurrences for the same symbol.
+        let mut idx = build_index();
+        for i in 0..3 {
+            let mut occ = scip::types::Occurrence::new();
+            occ.symbol = "rust . crate . `fixture` . MyStruct#".to_string();
+            occ.range = vec![100 + i, 0, 100 + i, 5];
+            occ.symbol_roles = 0;
+            idx.documents[0].occurrences.push(occ);
+        }
+        let blob_many = idx.write_to_bytes().unwrap();
+        db.upsert_scip_index(&crate::scip::ScipIndex {
+            id: uuid::Uuid::now_v7().to_string(),
+            repo: "many".to_string(),
+            lang: "rust".to_string(),
+            content_hash: crate::scip::content_hash(&blob_many),
+            blob: blob_many,
+            updated_at: now.to_string(),
+            deleted_at: None,
+        })
+        .unwrap();
+
+        let rows =
+            cross_repo_symbol_query(&db, "MyStruct", &["few".to_string(), "many".to_string()])
+                .unwrap();
+        assert_eq!(rows[0].repo, "many");
+        assert!(rows[0].refs_count > rows[1].refs_count);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Extends `legion consult` with `--symbol <name>`. Either `--context`, `--symbol`, or both required
- New `sym::CrossRepoSymbol` + `sym::cross_repo_symbol_query` walks every stored SCIP blob (filtered by watch.toml repos, or all if unspecified), returns per-(repo, lang) rows sorted by refs_count desc
- `--json` emits `{ bm25_text, symbol_results }` shape; human format prints two labeled sections
- Corrupt blob for one repo logs and continues; never aborts the whole consult

## Stacked on
Base: `feat/284-daemon-indexer` (PR #370).

## Test plan
- [x] 3 new tests in `src/sym.rs`: per-repo collection, missing-index repo skipped, refs_count desc sort
- [x] Full suite 606 passed; clippy + fmt clean

Closes #285