### PR TITLE
ci: run on every PR regardless of base branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,9 @@ name: CI
 on:
   push:
     branches: [main]
+  # Run on every PR regardless of base branch so stacked PRs (whose base
+  # is a sibling feat/* branch, not main) still gate on CI before merge.
   pull_request:
-    branches: [main]
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
## Summary
Drops the `pull_request: branches: [main]` filter so stacked PRs (feat/N -> feat/N-1 -> ... -> main) gate on CI before merge. Without this, the v0.10 SCIP stack (#363-#372) skips CI entirely until each PR's base is retargeted to main, which defeats the point of stacked review.

The push filter still pins main for the release workflow.

## Test plan
- [x] Self-test: this PR itself targets main and should fire the CI workflow on push