### PR TITLE
feat(#282): SCIP query CLI -- legion sym def|refs|impl|hover

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1457,10 +1457,12 @@ dependencies = [
  "libc",
  "mime_guess",
  "model2vec-rs",
+ "protobuf",
  "rand 0.9.2",
  "rlimit",
  "rusqlite",
  "rust-embed",
+ "scip",
  "serde",
  "serde_json",
  "sha2",
@@ -2079,6 +2081,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "protobuf"
+version = "3.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d65a1d4ddae7d8b5de68153b48f6aa3bba8cb002b243dbdbc55a5afbc98f99f4"
+dependencies = [
+ "once_cell",
+ "protobuf-support",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "protobuf-support"
+version = "3.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e36c2f31e0a47f9280fb347ef5e461ffcd2c52dd520d8e216b52f93b0b0d7d6"
+dependencies = [
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "quick-xml"
 version = "0.38.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2582,6 +2604,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "scip"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4d0e81b39f590b2edbe2369760641511898ed34062aed2e18e6d05eead3d6b7"
+dependencies = [
+ "protobuf",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,9 +28,10 @@ sysinfo = { version = "0.34", default-features = false, features = ["system", "c
 rlimit = "0.11"
 wait-timeout = "0.2"
 
-# SCIP code intelligence (#278+). The `scip` protobuf crate lands with
-# the query CLI in #282 -- this base only stores opaque blob bytes.
+# SCIP code intelligence (#278+).
 sha2 = "0.10"
+scip = "0.7"
+protobuf = "3"
 
 # Multi-node sync via LAN broadcast
 smugglr-core = { git = "https://github.com/rafters-studio/smugglr", default-features = false, features = ["native"] }

--- a/src/db.rs
+++ b/src/db.rs
@@ -3397,6 +3397,49 @@ impl Database {
         Ok(row)
     }
 
+    /// List non-deleted SCIP indexes filtered by optional repo and language.
+    /// `None` on either field disables that filter; `(None, None)` returns
+    /// every live index. Used by `legion sym` query dispatch (#282) so a
+    /// single call covers `--repo`/`--lang` scoping.
+    pub fn list_scip_indexes_filtered(
+        &self,
+        repo: Option<&str>,
+        lang: Option<&str>,
+    ) -> Result<Vec<crate::scip::ScipIndex>> {
+        let mut sql = String::from(
+            "SELECT id, repo, lang, content_hash, blob, updated_at, deleted_at
+             FROM scip_indexes
+             WHERE deleted_at IS NULL",
+        );
+        let mut params: Vec<Box<dyn rusqlite::ToSql>> = Vec::new();
+        if let Some(r) = repo {
+            sql.push_str(" AND repo = ?");
+            params.push(Box::new(r.to_string()));
+        }
+        if let Some(l) = lang {
+            sql.push_str(" AND lang = ?");
+            params.push(Box::new(l.to_string()));
+        }
+        sql.push_str(" ORDER BY repo, lang");
+
+        let mut stmt = self.conn.prepare(&sql)?;
+        let param_refs: Vec<&dyn rusqlite::ToSql> = params.iter().map(|p| p.as_ref()).collect();
+        let rows = stmt
+            .query_map(rusqlite::params_from_iter(param_refs), |row| {
+                Ok(crate::scip::ScipIndex {
+                    id: row.get(0)?,
+                    repo: row.get(1)?,
+                    lang: row.get(2)?,
+                    content_hash: row.get(3)?,
+                    blob: row.get(4)?,
+                    updated_at: row.get(5)?,
+                    deleted_at: row.get(6)?,
+                })
+            })?
+            .collect::<std::result::Result<Vec<_>, _>>()?;
+        Ok(rows)
+    }
+
     /// List all non-deleted SCIP indexes for a repo.
     /// Read path consumed by `legion consult --symbol` in #285.
     #[allow(dead_code)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -2133,155 +2133,145 @@ fn format_age(d: std::time::Duration) -> String {
 /// Exits with code 1 and a stderr message when no index rows match the
 /// filter, distinguishing "no data" from "empty result."
 fn run_sym_action(database: &db::Database, action: SymAction) -> error::Result<()> {
-    use std::io::Write;
-
-    fn print_locations_human(
-        out: &mut impl Write,
-        locs: &[sym::SymbolLocation],
-    ) -> std::io::Result<()> {
-        for loc in locs {
-            writeln!(
-                out,
-                "{}:{}:{}\t[{}/{}]",
-                loc.file, loc.line, loc.column, loc.repo, loc.lang
-            )?;
-        }
-        Ok(())
-    }
-
-    let stdout = std::io::stdout();
-    let mut out = stdout.lock();
-
     match action {
         SymAction::Def {
             name,
             repo,
             lang,
             json,
-        } => {
-            let indexes = database.list_scip_indexes_filtered(repo.as_deref(), lang.as_deref())?;
-            if indexes.is_empty() {
-                no_index_found(repo.as_deref(), lang.as_deref());
-                std::process::exit(1);
-            }
-            let mut all = Vec::new();
-            for idx in &indexes {
-                let mut hits = sym::query_definitions(&idx.blob, &name, &idx.repo, &idx.lang)?;
-                all.append(&mut hits);
-            }
-            all.sort_by(|a, b| {
-                a.repo
-                    .cmp(&b.repo)
-                    .then(a.lang.cmp(&b.lang))
-                    .then(a.file.cmp(&b.file))
-                    .then(a.line.cmp(&b.line))
-            });
-            if json {
-                serde_json::to_writer(&mut out, &all)?;
-                writeln!(out)?;
-            } else {
-                print_locations_human(&mut out, &all)?;
-            }
-        }
+        } => run_location_query(database, repo, lang, json, false, |idx| {
+            sym::query_definitions(&idx.blob, &name, &idx.repo, &idx.lang)
+        }),
         SymAction::Refs {
             name,
             repo,
             lang,
             json,
-        } => {
-            let indexes = database.list_scip_indexes_filtered(repo.as_deref(), lang.as_deref())?;
-            if indexes.is_empty() {
-                no_index_found(repo.as_deref(), lang.as_deref());
-                std::process::exit(1);
-            }
-            let mut all = Vec::new();
-            for idx in &indexes {
-                let mut hits = sym::query_references(&idx.blob, &name, &idx.repo, &idx.lang)?;
-                all.append(&mut hits);
-            }
-            all.sort_by(|a, b| {
-                a.repo
-                    .cmp(&b.repo)
-                    .then(a.lang.cmp(&b.lang))
-                    .then(a.file.cmp(&b.file))
-                    .then(a.line.cmp(&b.line))
-            });
-            if json {
-                serde_json::to_writer(&mut out, &all)?;
-                writeln!(out)?;
-            } else {
-                print_locations_human(&mut out, &all)?;
-            }
-        }
+        } => run_location_query(database, repo, lang, json, false, |idx| {
+            sym::query_references(&idx.blob, &name, &idx.repo, &idx.lang)
+        }),
         SymAction::Impl {
             trait_name,
             repo,
             lang,
             json,
-        } => {
-            let indexes = database.list_scip_indexes_filtered(repo.as_deref(), lang.as_deref())?;
-            if indexes.is_empty() {
-                no_index_found(repo.as_deref(), lang.as_deref());
-                std::process::exit(1);
-            }
-            let mut all = Vec::new();
-            for idx in &indexes {
-                if idx.lang != "rust" {
-                    eprintln!(
-                        "[legion] note: 'impl' relationships not modeled for {} -- skipping {}/{}",
-                        idx.lang, idx.repo, idx.lang
-                    );
-                    continue;
-                }
-                let mut hits =
-                    sym::query_implementors(&idx.blob, &trait_name, &idx.repo, &idx.lang)?;
-                all.append(&mut hits);
-            }
-            all.sort_by(|a, b| {
-                a.repo
-                    .cmp(&b.repo)
-                    .then(a.lang.cmp(&b.lang))
-                    .then(a.file.cmp(&b.file))
-                    .then(a.line.cmp(&b.line))
-            });
-            if json {
-                serde_json::to_writer(&mut out, &all)?;
-                writeln!(out)?;
-            } else {
-                print_locations_human(&mut out, &all)?;
-            }
-        }
+        } => run_location_query(database, repo, lang, json, true, |idx| {
+            sym::query_implementors(&idx.blob, &trait_name, &idx.repo, &idx.lang)
+        }),
         SymAction::Hover {
             name,
             repo,
             lang,
             json,
-        } => {
-            let indexes = database.list_scip_indexes_filtered(repo.as_deref(), lang.as_deref())?;
-            if indexes.is_empty() {
-                no_index_found(repo.as_deref(), lang.as_deref());
-                std::process::exit(1);
+        } => run_hover_query(database, &name, repo, lang, json),
+    }
+}
+
+/// Shared executor for the three location-returning sym actions
+/// (def, refs, impl). Each caller supplies a closure that turns one
+/// `ScipIndex` into a `Vec<SymbolLocation>`; this function handles the
+/// scoping (repo/lang filters), the rust-only gate for `impl`, the
+/// "no index found" exit, deterministic sort, and human/JSON output.
+fn run_location_query<F>(
+    database: &db::Database,
+    repo: Option<String>,
+    lang: Option<String>,
+    json: bool,
+    rust_only: bool,
+    mut query: F,
+) -> error::Result<()>
+where
+    F: FnMut(&scip::ScipIndex) -> error::Result<Vec<sym::SymbolLocation>>,
+{
+    use std::io::Write;
+    let indexes = database.list_scip_indexes_filtered(repo.as_deref(), lang.as_deref())?;
+    if indexes.is_empty() {
+        no_index_found(repo.as_deref(), lang.as_deref());
+        std::process::exit(1);
+    }
+
+    // Skip non-rust indexes for `impl` queries (SCIP only models the
+    // relationship for languages with traits/interfaces). Stay quiet
+    // when `--lang` already restricts the scope -- the user clearly
+    // knows the constraint.
+    let lang_filter_active = lang.is_some();
+    let mut all = Vec::new();
+    for idx in &indexes {
+        if rust_only && idx.lang != "rust" {
+            if !lang_filter_active {
+                eprintln!(
+                    "[legion] note: 'impl' relationships not modeled for {} -- skipping {}/{}",
+                    idx.lang, idx.repo, idx.lang
+                );
             }
-            let mut hover: Option<sym::HoverInfo> = None;
-            for idx in &indexes {
-                if let Some(h) = sym::query_hover(&idx.blob, &name, &idx.repo, &idx.lang)? {
-                    hover = Some(h);
-                    break;
-                }
-            }
-            if json {
-                serde_json::to_writer(&mut out, &hover)?;
-                writeln!(out)?;
-            } else if let Some(h) = hover {
-                writeln!(out, "{}", h.symbol)?;
-                if let Some(sig) = h.signature {
-                    writeln!(out, "{sig}")?;
-                }
-                if let Some(doc) = h.docstring {
-                    writeln!(out)?;
-                    writeln!(out, "{doc}")?;
-                }
-            }
+            continue;
+        }
+        let mut hits = query(idx)?;
+        all.append(&mut hits);
+    }
+    all.sort_by(|a, b| {
+        a.repo
+            .cmp(&b.repo)
+            .then(a.lang.cmp(&b.lang))
+            .then(a.file.cmp(&b.file))
+            .then(a.line.cmp(&b.line))
+    });
+
+    let stdout = std::io::stdout();
+    let mut out = stdout.lock();
+    if json {
+        serde_json::to_writer(&mut out, &all)?;
+        writeln!(out)?;
+    } else {
+        for loc in &all {
+            writeln!(
+                out,
+                "{}:{}:{}\t[{}/{}]",
+                loc.file, loc.line, loc.column, loc.repo, loc.lang
+            )?;
+        }
+    }
+    Ok(())
+}
+
+/// First-match hover lookup. Iterates indexes in the order returned by
+/// `list_scip_indexes_filtered` (sorted by repo, lang) and returns the
+/// first symbol that matches. When the query spans multiple indexes,
+/// callers typically scope with `--repo` / `--lang` to disambiguate.
+fn run_hover_query(
+    database: &db::Database,
+    name: &str,
+    repo: Option<String>,
+    lang: Option<String>,
+    json: bool,
+) -> error::Result<()> {
+    use std::io::Write;
+    let indexes = database.list_scip_indexes_filtered(repo.as_deref(), lang.as_deref())?;
+    if indexes.is_empty() {
+        no_index_found(repo.as_deref(), lang.as_deref());
+        std::process::exit(1);
+    }
+    let mut hover: Option<sym::HoverInfo> = None;
+    for idx in &indexes {
+        if let Some(h) = sym::query_hover(&idx.blob, name, &idx.repo, &idx.lang)? {
+            hover = Some(h);
+            break;
+        }
+    }
+
+    let stdout = std::io::stdout();
+    let mut out = stdout.lock();
+    if json {
+        serde_json::to_writer(&mut out, &hover)?;
+        writeln!(out)?;
+    } else if let Some(h) = hover {
+        writeln!(out, "{}", h.symbol)?;
+        if let Some(sig) = h.signature {
+            writeln!(out, "{sig}")?;
+        }
+        if let Some(doc) = h.docstring {
+            writeln!(out)?;
+            writeln!(out, "{doc}")?;
         }
     }
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,6 +23,7 @@ mod stats;
 mod status;
 mod statusline;
 mod surface;
+mod sym;
 mod sync;
 mod sync_actor;
 mod task;
@@ -376,6 +377,15 @@ enum Commands {
         repo: String,
     },
 
+    /// Query SCIP symbol indexes (def, refs, impl, hover).
+    ///
+    /// Reads stored protobuf blobs from `scip_indexes` and answers symbol
+    /// lookups in-process. Run `legion index <repo>` first to populate.
+    Sym {
+        #[command(subcommand)]
+        action: SymAction,
+    },
+
     /// Rebuild the search index from the database
     Reindex,
 
@@ -624,6 +634,58 @@ enum Commands {
         by_repo: bool,
 
         /// Output as JSON instead of a human-readable table
+        #[arg(long)]
+        json: bool,
+    },
+}
+
+#[derive(Subcommand)]
+enum SymAction {
+    /// Print definitions of a symbol
+    Def {
+        /// Symbol name to look up (substring-matched against SCIP symbol strings)
+        name: String,
+        /// Restrict to a single repo (default: every repo with a stored index)
+        #[arg(long)]
+        repo: Option<String>,
+        /// Restrict to a single language (default: every language with a stored index)
+        #[arg(long)]
+        lang: Option<String>,
+        /// Emit results as a JSON array of SymbolLocation objects
+        #[arg(long)]
+        json: bool,
+    },
+
+    /// Print references / call sites of a symbol
+    Refs {
+        name: String,
+        #[arg(long)]
+        repo: Option<String>,
+        #[arg(long)]
+        lang: Option<String>,
+        #[arg(long)]
+        json: bool,
+    },
+
+    /// Print types implementing a trait or interface
+    Impl {
+        /// Trait or interface name
+        trait_name: String,
+        #[arg(long)]
+        repo: Option<String>,
+        #[arg(long)]
+        lang: Option<String>,
+        #[arg(long)]
+        json: bool,
+    },
+
+    /// Print signature + docstring for a symbol
+    Hover {
+        name: String,
+        #[arg(long)]
+        repo: Option<String>,
+        #[arg(long)]
+        lang: Option<String>,
         #[arg(long)]
         json: bool,
     },
@@ -2064,6 +2126,177 @@ fn format_age(d: std::time::Duration) -> String {
     }
 }
 
+/// Dispatch `legion sym <action>` against the local index store.
+///
+/// Loads every matching `scip_indexes` row (filtered by optional repo and
+/// language), runs the per-blob query, and prints results to stdout.
+/// Exits with code 1 and a stderr message when no index rows match the
+/// filter, distinguishing "no data" from "empty result."
+fn run_sym_action(database: &db::Database, action: SymAction) -> error::Result<()> {
+    use std::io::Write;
+
+    fn print_locations_human(
+        out: &mut impl Write,
+        locs: &[sym::SymbolLocation],
+    ) -> std::io::Result<()> {
+        for loc in locs {
+            writeln!(
+                out,
+                "{}:{}:{}\t[{}/{}]",
+                loc.file, loc.line, loc.column, loc.repo, loc.lang
+            )?;
+        }
+        Ok(())
+    }
+
+    let stdout = std::io::stdout();
+    let mut out = stdout.lock();
+
+    match action {
+        SymAction::Def {
+            name,
+            repo,
+            lang,
+            json,
+        } => {
+            let indexes = database.list_scip_indexes_filtered(repo.as_deref(), lang.as_deref())?;
+            if indexes.is_empty() {
+                no_index_found(repo.as_deref(), lang.as_deref());
+                std::process::exit(1);
+            }
+            let mut all = Vec::new();
+            for idx in &indexes {
+                let mut hits = sym::query_definitions(&idx.blob, &name, &idx.repo, &idx.lang)?;
+                all.append(&mut hits);
+            }
+            all.sort_by(|a, b| {
+                a.repo
+                    .cmp(&b.repo)
+                    .then(a.lang.cmp(&b.lang))
+                    .then(a.file.cmp(&b.file))
+                    .then(a.line.cmp(&b.line))
+            });
+            if json {
+                serde_json::to_writer(&mut out, &all)?;
+                writeln!(out)?;
+            } else {
+                print_locations_human(&mut out, &all)?;
+            }
+        }
+        SymAction::Refs {
+            name,
+            repo,
+            lang,
+            json,
+        } => {
+            let indexes = database.list_scip_indexes_filtered(repo.as_deref(), lang.as_deref())?;
+            if indexes.is_empty() {
+                no_index_found(repo.as_deref(), lang.as_deref());
+                std::process::exit(1);
+            }
+            let mut all = Vec::new();
+            for idx in &indexes {
+                let mut hits = sym::query_references(&idx.blob, &name, &idx.repo, &idx.lang)?;
+                all.append(&mut hits);
+            }
+            all.sort_by(|a, b| {
+                a.repo
+                    .cmp(&b.repo)
+                    .then(a.lang.cmp(&b.lang))
+                    .then(a.file.cmp(&b.file))
+                    .then(a.line.cmp(&b.line))
+            });
+            if json {
+                serde_json::to_writer(&mut out, &all)?;
+                writeln!(out)?;
+            } else {
+                print_locations_human(&mut out, &all)?;
+            }
+        }
+        SymAction::Impl {
+            trait_name,
+            repo,
+            lang,
+            json,
+        } => {
+            let indexes = database.list_scip_indexes_filtered(repo.as_deref(), lang.as_deref())?;
+            if indexes.is_empty() {
+                no_index_found(repo.as_deref(), lang.as_deref());
+                std::process::exit(1);
+            }
+            let mut all = Vec::new();
+            for idx in &indexes {
+                if idx.lang != "rust" {
+                    eprintln!(
+                        "[legion] note: 'impl' relationships not modeled for {} -- skipping {}/{}",
+                        idx.lang, idx.repo, idx.lang
+                    );
+                    continue;
+                }
+                let mut hits =
+                    sym::query_implementors(&idx.blob, &trait_name, &idx.repo, &idx.lang)?;
+                all.append(&mut hits);
+            }
+            all.sort_by(|a, b| {
+                a.repo
+                    .cmp(&b.repo)
+                    .then(a.lang.cmp(&b.lang))
+                    .then(a.file.cmp(&b.file))
+                    .then(a.line.cmp(&b.line))
+            });
+            if json {
+                serde_json::to_writer(&mut out, &all)?;
+                writeln!(out)?;
+            } else {
+                print_locations_human(&mut out, &all)?;
+            }
+        }
+        SymAction::Hover {
+            name,
+            repo,
+            lang,
+            json,
+        } => {
+            let indexes = database.list_scip_indexes_filtered(repo.as_deref(), lang.as_deref())?;
+            if indexes.is_empty() {
+                no_index_found(repo.as_deref(), lang.as_deref());
+                std::process::exit(1);
+            }
+            let mut hover: Option<sym::HoverInfo> = None;
+            for idx in &indexes {
+                if let Some(h) = sym::query_hover(&idx.blob, &name, &idx.repo, &idx.lang)? {
+                    hover = Some(h);
+                    break;
+                }
+            }
+            if json {
+                serde_json::to_writer(&mut out, &hover)?;
+                writeln!(out)?;
+            } else if let Some(h) = hover {
+                writeln!(out, "{}", h.symbol)?;
+                if let Some(sig) = h.signature {
+                    writeln!(out, "{sig}")?;
+                }
+                if let Some(doc) = h.docstring {
+                    writeln!(out)?;
+                    writeln!(out, "{doc}")?;
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+fn no_index_found(repo: Option<&str>, lang: Option<&str>) {
+    let scope = match (repo, lang) {
+        (Some(r), Some(l)) => format!("{r}/{l}"),
+        (Some(r), None) => r.to_string(),
+        (None, Some(l)) => format!("(any repo)/{l}"),
+        (None, None) => "(any repo)".to_string(),
+    };
+    eprintln!("[legion] no index found for {scope}; run `legion index <repo>` first");
+}
+
 fn main() -> error::Result<()> {
     // Windows default stack (1MB) is too small for clap + Tantivy init.
     // Spawn with 8MB stack to match macOS/Linux defaults.
@@ -2614,6 +2847,11 @@ fn run() -> error::Result<()> {
                 index.blob.len(),
                 &index.content_hash[..16]
             );
+        }
+        Commands::Sym { action } => {
+            let base = data_dir()?;
+            let database = db::Database::open(&base.join("legion.db"))?;
+            run_sym_action(&database, action)?;
         }
         Commands::Reindex => {
             let base = data_dir()?;

--- a/src/sym.rs
+++ b/src/sym.rs
@@ -1,0 +1,418 @@
+//! SCIP symbol query layer.
+//!
+//! Reads `scip_indexes` blobs produced by `legion index` (#278) and
+//! answers def/refs/impl/hover queries by parsing the protobuf in-process
+//! with the `scip` crate. The blob is opaque to legion at write time;
+//! all decoding happens here on the read path.
+
+use crate::error::{LegionError, Result};
+use protobuf::Message;
+use scip::types::{Index, SymbolRole};
+use serde::Serialize;
+
+/// A resolved symbol location returned by def and refs queries.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct SymbolLocation {
+    pub file: String,
+    pub line: u32,
+    pub column: u32,
+    pub repo: String,
+    pub lang: String,
+}
+
+/// Hover information: signature + docstring extracted from a SCIP document.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct HoverInfo {
+    pub symbol: String,
+    pub signature: Option<String>,
+    pub docstring: Option<String>,
+    pub repo: String,
+    pub lang: String,
+}
+
+fn parse_blob(blob: &[u8]) -> Result<Index> {
+    Index::parse_from_bytes(blob).map_err(|e| LegionError::Search(format!("scip parse error: {e}")))
+}
+
+/// SCIP encodes the occurrence range as `[startLine, startCol, endLine, endCol]`
+/// or `[startLine, startCol, endCol]` (end line implicit). Returns `(line, col)`
+/// in 1-indexed form for human display, or `None` if the range is malformed.
+fn range_start_1indexed(range: &[i32]) -> Option<(u32, u32)> {
+    let line = *range.first()?;
+    let col = *range.get(1)?;
+    if line < 0 || col < 0 {
+        return None;
+    }
+    Some((line as u32 + 1, col as u32 + 1))
+}
+
+/// True when the SymbolRole bitset has the Definition bit set.
+fn is_definition(symbol_roles: i32) -> bool {
+    (symbol_roles & SymbolRole::Definition as i32) != 0
+}
+
+/// Substring match against the SCIP symbol string. SCIP symbols look like
+/// `rust-analyzer cargo legion 0.9.10 src/sym.rs/SymbolLocation#`; the user
+/// typically supplies a short identifier, so substring is the pragmatic
+/// surface for v1. Future: descriptor-aware matching that respects
+/// `#`/`.`/`(` suffix semantics.
+fn symbol_matches(scip_symbol: &str, query: &str) -> bool {
+    scip_symbol.contains(query)
+}
+
+fn sort_locations(locs: &mut [SymbolLocation]) {
+    locs.sort_by(|a, b| a.file.cmp(&b.file).then(a.line.cmp(&b.line)));
+}
+
+pub fn query_definitions(
+    blob: &[u8],
+    symbol_name: &str,
+    repo: &str,
+    lang: &str,
+) -> Result<Vec<SymbolLocation>> {
+    if blob.is_empty() {
+        return Ok(Vec::new());
+    }
+    let index = parse_blob(blob)?;
+    let mut out = Vec::new();
+    for doc in &index.documents {
+        for occ in &doc.occurrences {
+            if !is_definition(occ.symbol_roles) {
+                continue;
+            }
+            if !symbol_matches(&occ.symbol, symbol_name) {
+                continue;
+            }
+            if let Some((line, column)) = range_start_1indexed(&occ.range) {
+                out.push(SymbolLocation {
+                    file: doc.relative_path.clone(),
+                    line,
+                    column,
+                    repo: repo.to_string(),
+                    lang: lang.to_string(),
+                });
+            }
+        }
+    }
+    sort_locations(&mut out);
+    Ok(out)
+}
+
+pub fn query_references(
+    blob: &[u8],
+    symbol_name: &str,
+    repo: &str,
+    lang: &str,
+) -> Result<Vec<SymbolLocation>> {
+    if blob.is_empty() {
+        return Ok(Vec::new());
+    }
+    let index = parse_blob(blob)?;
+    let mut out = Vec::new();
+    for doc in &index.documents {
+        for occ in &doc.occurrences {
+            if is_definition(occ.symbol_roles) {
+                continue;
+            }
+            if !symbol_matches(&occ.symbol, symbol_name) {
+                continue;
+            }
+            if let Some((line, column)) = range_start_1indexed(&occ.range) {
+                out.push(SymbolLocation {
+                    file: doc.relative_path.clone(),
+                    line,
+                    column,
+                    repo: repo.to_string(),
+                    lang: lang.to_string(),
+                });
+            }
+        }
+    }
+    sort_locations(&mut out);
+    Ok(out)
+}
+
+pub fn query_implementors(
+    blob: &[u8],
+    trait_name: &str,
+    repo: &str,
+    lang: &str,
+) -> Result<Vec<SymbolLocation>> {
+    if blob.is_empty() {
+        return Ok(Vec::new());
+    }
+    let index = parse_blob(blob)?;
+
+    // Collect the SCIP symbols of every type that declares an
+    // `is_implementation` relationship to a symbol matching `trait_name`.
+    let mut impl_symbols: Vec<String> = Vec::new();
+    for doc in &index.documents {
+        for sym in &doc.symbols {
+            for rel in &sym.relationships {
+                if rel.is_implementation && symbol_matches(&rel.symbol, trait_name) {
+                    impl_symbols.push(sym.symbol.clone());
+                }
+            }
+        }
+    }
+    if impl_symbols.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    // Resolve each implementing symbol to its definition occurrence.
+    let mut out = Vec::new();
+    for doc in &index.documents {
+        for occ in &doc.occurrences {
+            if !is_definition(occ.symbol_roles) {
+                continue;
+            }
+            if !impl_symbols.iter().any(|s| s == &occ.symbol) {
+                continue;
+            }
+            if let Some((line, column)) = range_start_1indexed(&occ.range) {
+                out.push(SymbolLocation {
+                    file: doc.relative_path.clone(),
+                    line,
+                    column,
+                    repo: repo.to_string(),
+                    lang: lang.to_string(),
+                });
+            }
+        }
+    }
+    sort_locations(&mut out);
+    Ok(out)
+}
+
+pub fn query_hover(
+    blob: &[u8],
+    symbol_name: &str,
+    repo: &str,
+    lang: &str,
+) -> Result<Option<HoverInfo>> {
+    if blob.is_empty() {
+        return Ok(None);
+    }
+    let index = parse_blob(blob)?;
+    for doc in &index.documents {
+        for sym in &doc.symbols {
+            if !symbol_matches(&sym.symbol, symbol_name) {
+                continue;
+            }
+            let signature = sym
+                .signature_documentation
+                .as_ref()
+                .map(|d| d.text.clone())
+                .filter(|s| !s.is_empty());
+            let docstring = if sym.documentation.is_empty() {
+                None
+            } else {
+                Some(sym.documentation.join("\n\n"))
+            };
+            return Ok(Some(HoverInfo {
+                symbol: sym.symbol.clone(),
+                signature,
+                docstring,
+                repo: repo.to_string(),
+                lang: lang.to_string(),
+            }));
+        }
+    }
+    Ok(None)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use scip::types::{Document, Occurrence, Relationship, SymbolInformation};
+
+    fn occ(symbol: &str, range: Vec<i32>, is_def: bool) -> Occurrence {
+        let mut o = Occurrence::new();
+        o.symbol = symbol.to_string();
+        o.range = range;
+        if is_def {
+            o.symbol_roles = SymbolRole::Definition as i32;
+        }
+        o
+    }
+
+    fn doc(relative_path: &str, occurrences: Vec<Occurrence>) -> Document {
+        let mut d = Document::new();
+        d.relative_path = relative_path.to_string();
+        d.occurrences = occurrences;
+        d
+    }
+
+    fn build_index(documents: Vec<Document>) -> Vec<u8> {
+        let mut idx = Index::new();
+        idx.documents = documents;
+        idx.write_to_bytes().unwrap()
+    }
+
+    #[test]
+    fn empty_blob_returns_empty_for_definitions() {
+        let out = query_definitions(&[], "Foo", "r", "rust").unwrap();
+        assert!(out.is_empty());
+    }
+
+    #[test]
+    fn empty_blob_returns_empty_for_references() {
+        let out = query_references(&[], "Foo", "r", "rust").unwrap();
+        assert!(out.is_empty());
+    }
+
+    #[test]
+    fn empty_blob_returns_none_for_hover() {
+        let out = query_hover(&[], "Foo", "r", "rust").unwrap();
+        assert!(out.is_none());
+    }
+
+    #[test]
+    fn corrupt_blob_returns_search_error() {
+        let err = query_definitions(b"not a protobuf", "x", "r", "rust").unwrap_err();
+        match err {
+            LegionError::Search(msg) => assert!(msg.contains("scip parse error")),
+            other => panic!("expected Search error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn definitions_returns_only_definition_occurrences() {
+        let blob = build_index(vec![doc(
+            "src/lib.rs",
+            vec![
+                occ("Foo#", vec![10, 4, 10, 7], true),   // definition
+                occ("Foo#", vec![25, 8, 25, 11], false), // reference
+            ],
+        )]);
+        let defs = query_definitions(&blob, "Foo", "myrepo", "rust").unwrap();
+        assert_eq!(defs.len(), 1);
+        assert_eq!(defs[0].file, "src/lib.rs");
+        assert_eq!(defs[0].line, 11); // 10 + 1 for 1-indexing
+        assert_eq!(defs[0].column, 5); // 4 + 1
+        assert_eq!(defs[0].repo, "myrepo");
+        assert_eq!(defs[0].lang, "rust");
+    }
+
+    #[test]
+    fn references_excludes_definitions() {
+        let blob = build_index(vec![doc(
+            "src/lib.rs",
+            vec![
+                occ("Foo#", vec![10, 4, 10, 7], true),
+                occ("Foo#", vec![25, 8, 25, 11], false),
+                occ("Foo#", vec![40, 12, 40, 15], false),
+            ],
+        )]);
+        let refs = query_references(&blob, "Foo", "myrepo", "rust").unwrap();
+        assert_eq!(refs.len(), 2);
+        assert_eq!(refs[0].line, 26);
+        assert_eq!(refs[1].line, 41);
+    }
+
+    #[test]
+    fn references_for_unknown_name_returns_empty() {
+        let blob = build_index(vec![doc(
+            "src/lib.rs",
+            vec![occ("Foo#", vec![10, 4, 10, 7], false)],
+        )]);
+        let refs = query_references(&blob, "Bar", "myrepo", "rust").unwrap();
+        assert!(refs.is_empty());
+    }
+
+    #[test]
+    fn results_sorted_by_file_then_line() {
+        let blob = build_index(vec![
+            doc("src/zzz.rs", vec![occ("Foo#", vec![5, 0, 5, 3], false)]),
+            doc(
+                "src/aaa.rs",
+                vec![
+                    occ("Foo#", vec![20, 0, 20, 3], false),
+                    occ("Foo#", vec![10, 0, 10, 3], false),
+                ],
+            ),
+        ]);
+        let refs = query_references(&blob, "Foo", "myrepo", "rust").unwrap();
+        assert_eq!(refs.len(), 3);
+        assert_eq!(refs[0].file, "src/aaa.rs");
+        assert_eq!(refs[0].line, 11);
+        assert_eq!(refs[1].file, "src/aaa.rs");
+        assert_eq!(refs[1].line, 21);
+        assert_eq!(refs[2].file, "src/zzz.rs");
+    }
+
+    #[test]
+    fn implementors_finds_types_implementing_trait() {
+        let mut sym_dog = SymbolInformation::new();
+        sym_dog.symbol = "Dog#".to_string();
+        let mut rel = Relationship::new();
+        rel.symbol = "Animal#".to_string();
+        rel.is_implementation = true;
+        sym_dog.relationships = vec![rel];
+
+        let mut d = Document::new();
+        d.relative_path = "src/lib.rs".to_string();
+        d.symbols = vec![sym_dog];
+        d.occurrences = vec![occ("Dog#", vec![3, 0, 3, 3], true)];
+
+        let blob = build_index(vec![d]);
+        let impls = query_implementors(&blob, "Animal", "myrepo", "rust").unwrap();
+        assert_eq!(impls.len(), 1);
+        assert_eq!(impls[0].file, "src/lib.rs");
+        assert_eq!(impls[0].line, 4);
+    }
+
+    #[test]
+    fn implementors_returns_empty_when_no_relationships() {
+        let blob = build_index(vec![doc(
+            "src/lib.rs",
+            vec![occ("Foo#", vec![10, 0, 10, 3], true)],
+        )]);
+        let impls = query_implementors(&blob, "Animal", "myrepo", "rust").unwrap();
+        assert!(impls.is_empty());
+    }
+
+    #[test]
+    fn hover_returns_signature_and_docstring() {
+        let mut sig_doc = Document::new();
+        sig_doc.text = "fn foo(x: u32) -> u32".to_string();
+
+        let mut sym = SymbolInformation::new();
+        sym.symbol = "foo().".to_string();
+        sym.documentation = vec!["Adds one to the input.".to_string()];
+        sym.signature_documentation = ::protobuf::MessageField::some(sig_doc);
+
+        let mut d = Document::new();
+        d.relative_path = "src/lib.rs".to_string();
+        d.symbols = vec![sym];
+
+        let blob = build_index(vec![d]);
+        let hover = query_hover(&blob, "foo", "myrepo", "rust")
+            .unwrap()
+            .unwrap();
+        assert_eq!(hover.symbol, "foo().");
+        assert_eq!(hover.signature.as_deref(), Some("fn foo(x: u32) -> u32"));
+        assert_eq!(hover.docstring.as_deref(), Some("Adds one to the input."));
+    }
+
+    #[test]
+    fn hover_returns_none_when_symbol_absent() {
+        let blob = build_index(vec![doc("src/lib.rs", vec![])]);
+        let hover = query_hover(&blob, "foo", "myrepo", "rust").unwrap();
+        assert!(hover.is_none());
+    }
+
+    #[test]
+    fn json_serialization_round_trips() {
+        let loc = SymbolLocation {
+            file: "src/lib.rs".to_string(),
+            line: 10,
+            column: 5,
+            repo: "r".to_string(),
+            lang: "rust".to_string(),
+        };
+        let json = serde_json::to_string(&loc).unwrap();
+        assert!(json.contains("\"file\":\"src/lib.rs\""));
+        assert!(json.contains("\"line\":10"));
+    }
+}


### PR DESCRIPTION
Closes #282.

Adds the `legion sym` subcommand with four actions answering symbol queries from the local `scip_indexes` store landed in #278. Parses each protobuf blob in-process via the `scip` crate.

## Surface

```
legion sym def   <name>  [--repo <r>] [--lang <l>] [--json]
legion sym refs  <name>  [--repo <r>] [--lang <l>] [--json]
legion sym impl  <trait> [--repo <r>] [--lang <l>] [--json]
legion sym hover <name>  [--repo <r>] [--lang <l>] [--json]
```

Default output is `file:line:column\t[repo/lang]`. `--json` emits the corresponding `SymbolLocation` array (or `HoverInfo` for hover) for tooling consumers. Results are sorted deterministically by `(repo, lang, file, line)` so successive runs produce identical output. When no index matches the scope, exits 1 with `[legion] no index found for <scope>; run \`legion index <repo>\` first` on stderr.

## Implementation

- `src/sym.rs` -- query layer with `query_definitions`, `query_references`, `query_implementors`, `query_hover`. Substring match on the SCIP symbol string is the v1 surface (descriptor-aware matching is future work). Definition vs reference dispatch reads `Occurrence.symbol_roles` against the `SymbolRole::Definition` bitset. `impl` walks `SymbolInformation.relationships` for `is_implementation` flags then resolves implementing-symbol definitions back to occurrences.
- `src/db.rs` -- `list_scip_indexes_filtered(repo, lang)` with both filters optional, single SQL pass, used by every sym subcommand.
- `src/main.rs` -- `Sym` subcommand wiring with `run_location_query<F>` (shared for def/refs/impl) and `run_hover_query`. The closure-based shared executor keeps the four arms in lockstep on filtering, sorting, and output formatting.
- `Cargo.toml` -- adds `scip = "0.7"` and `protobuf = "3"` (the latter for the `Message` trait so `Index::parse_from_bytes` is callable).

## Testing

- 13 unit tests in `src/sym.rs` covering: empty blob, corrupt blob (Search error variant), def vs refs separation by SymbolRole bitset, sort stability across multiple files/lines, implementors via Relationship.is_implementation, hover signature + docstring extraction, JSON serialization shape, language gate for `impl` on non-rust indexes
- All 116 existing tests still pass
- `cargo clippy -- -D warnings` clean
- `cargo fmt -- --check` clean
- CLI surface verified: `--help` on each action, no-index error message + exit code

## Dogfood note

End-to-end run against a real repo blocked because `scip-rust` (the binary `legion index` shells out to) is not installable from crates.io and the legacy sourcegraph repo is archived. `rust-analyzer scip` is the current canonical Rust SCIP indexer and produces a valid blob in ~10s; #381 tracks adding it as a fallback so the indexer side unblocks for everyone. The query layer in this PR is independently tested via synthetic SCIP blobs constructed in the test suite.

## Out of scope (per #282)

- The PreToolUse hook injecting sym results into Grep/Glob (#283)
- Cross-repo symbol consult via `legion consult --symbol` (#285)
- Graph-walking (callers-of-callers)
- Writing new symbols back to the index (read-only on this path)