### PR TITLE
feat(#389): agent session outcome log + diagnostic surface

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -819,6 +819,29 @@ impl Database {
                  WHERE audience = 'team' AND archived_at IS NULL AND deleted_at IS NULL;",
         )?;
 
+        // Migration 20: Agent session log (#389).
+        //
+        // Watch spawns an agent for one or more signals, marks them handled
+        // at spawn time, then has no further accounting for what the agent
+        // did. Productive vs unproductive sessions look identical on the
+        // outside (exit_code 0). This table records every spawn outcome so
+        // `legion status` can surface "shingle: 3 sessions today, 0
+        // produced output." Classification happens at reap, comparing
+        // bullpen posts and reflections written within the session window.
+        conn.execute_batch(
+            "CREATE TABLE IF NOT EXISTS agent_session_log (
+                session_id TEXT PRIMARY KEY,
+                recipient TEXT NOT NULL,
+                signal_ids TEXT NOT NULL,
+                spawn_at TEXT NOT NULL,
+                exit_at TEXT NOT NULL,
+                exit_status TEXT NOT NULL,
+                outcome TEXT NOT NULL
+            );
+            CREATE INDEX IF NOT EXISTS idx_agent_session_log_recipient_exit \
+                ON agent_session_log(recipient, exit_at);",
+        )?;
+
         Ok(())
     }
 
@@ -903,6 +926,173 @@ impl Database {
             rusqlite::params![&now, resolved_by_reflection_id, post_id],
         )?;
         Ok(rows > 0)
+    }
+
+    /// Outcome of a watch-spawned agent session (#389).
+    ///
+    /// "Productive" means the recipient posted to the bullpen or stored a
+    /// reflection within the session window. "Unproductive" means the
+    /// session exited cleanly but produced no observable artifact.
+    /// "Errored" means the process exited non-zero.
+    ///
+    /// Strings used directly as the `outcome` column value.
+    pub const OUTCOME_PRODUCTIVE: &'static str = "productive";
+    pub const OUTCOME_UNPRODUCTIVE: &'static str = "unproductive";
+    pub const OUTCOME_ERRORED: &'static str = "errored";
+
+    /// Classify whether a watch-spawned agent session produced observable
+    /// work for any of its signal_ids (#389). Productive iff:
+    ///   - the recipient posted a bullpen entry within (spawn_at, exit_at), OR
+    ///   - the recipient stored a reflection whose `parent_id` matches any of
+    ///     the spawn's signal_ids within the window.
+    ///
+    /// Window endpoints are inclusive at start, exclusive at end so a
+    /// reflection committed in the same RFC3339 millisecond as exit is
+    /// still attributed to the session.
+    pub fn classify_session(
+        &self,
+        recipient: &str,
+        signal_ids: &[String],
+        spawn_at: &str,
+        exit_at: &str,
+    ) -> Result<bool> {
+        let bullpen_count: i64 = self.conn.query_row(
+            "SELECT COUNT(*) FROM reflections \
+             WHERE repo = ?1 AND audience = 'team' AND deleted_at IS NULL \
+               AND created_at >= ?2 AND created_at <= ?3",
+            rusqlite::params![recipient, spawn_at, exit_at],
+            |row| row.get(0),
+        )?;
+        if bullpen_count > 0 {
+            return Ok(true);
+        }
+        if signal_ids.is_empty() {
+            return Ok(false);
+        }
+        // Reflection-with-parent_id linking back to any tracked signal.
+        // Build a parameter list dynamically; signal_ids is bounded by
+        // the wake batch (legion watch only ever wakes a few at once).
+        let placeholders = (0..signal_ids.len())
+            .map(|i| format!("?{}", i + 4))
+            .collect::<Vec<_>>()
+            .join(",");
+        let sql = format!(
+            "SELECT COUNT(*) FROM reflections \
+             WHERE repo = ?1 AND deleted_at IS NULL \
+               AND created_at >= ?2 AND created_at <= ?3 \
+               AND parent_id IN ({placeholders})"
+        );
+        let mut params: Vec<Box<dyn rusqlite::ToSql>> = vec![
+            Box::new(recipient.to_string()),
+            Box::new(spawn_at.to_string()),
+            Box::new(exit_at.to_string()),
+        ];
+        for id in signal_ids {
+            params.push(Box::new(id.clone()));
+        }
+        let param_refs: Vec<&dyn rusqlite::ToSql> = params.iter().map(|p| p.as_ref()).collect();
+        let reflection_count: i64 =
+            self.conn
+                .query_row(sql.as_str(), param_refs.as_slice(), |row| row.get(0))?;
+        Ok(reflection_count > 0)
+    }
+
+    /// Persist an agent session outcome (#389). One row per spawn-and-exit.
+    #[allow(clippy::too_many_arguments)]
+    pub fn record_session_outcome(
+        &self,
+        session_id: &str,
+        recipient: &str,
+        signal_ids: &[String],
+        spawn_at: &str,
+        exit_at: &str,
+        exit_status: &str,
+        outcome: &str,
+    ) -> Result<()> {
+        let signal_ids_json = serde_json::to_string(signal_ids).map_err(|e| {
+            LegionError::Database(rusqlite::Error::ToSqlConversionFailure(Box::new(e)))
+        })?;
+        self.conn.execute(
+            "INSERT OR REPLACE INTO agent_session_log \
+                 (session_id, recipient, signal_ids, spawn_at, exit_at, exit_status, outcome) \
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+            rusqlite::params![
+                session_id,
+                recipient,
+                signal_ids_json,
+                spawn_at,
+                exit_at,
+                exit_status,
+                outcome
+            ],
+        )?;
+        Ok(())
+    }
+
+    /// Per-recipient session counts since the given timestamp (#389).
+    /// Returns (recipient, total, productive, unproductive, errored, last_unproductive_signal_id).
+    /// Used by `legion status` to surface "shingle: 3 sessions today, 0 productive."
+    #[allow(clippy::type_complexity)]
+    pub fn agent_session_counts_since(
+        &self,
+        since: &str,
+    ) -> Result<Vec<(String, i64, i64, i64, i64, Option<String>, Option<String>)>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT recipient, \
+                    COUNT(*) as total, \
+                    SUM(CASE WHEN outcome = 'productive' THEN 1 ELSE 0 END) as productive, \
+                    SUM(CASE WHEN outcome = 'unproductive' THEN 1 ELSE 0 END) as unproductive, \
+                    SUM(CASE WHEN outcome = 'errored' THEN 1 ELSE 0 END) as errored \
+             FROM agent_session_log \
+             WHERE exit_at >= ?1 \
+             GROUP BY recipient \
+             ORDER BY total DESC",
+        )?;
+        let core: Vec<(String, i64, i64, i64, i64)> = stmt
+            .query_map([since], |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get::<_, i64>(1)?,
+                    row.get::<_, i64>(2)?,
+                    row.get::<_, i64>(3)?,
+                    row.get::<_, i64>(4)?,
+                ))
+            })?
+            .collect::<std::result::Result<Vec<_>, _>>()
+            .map_err(LegionError::Database)?;
+        drop(stmt);
+
+        let mut out = Vec::with_capacity(core.len());
+        for (recipient, total, productive, unproductive, errored) in core {
+            let last_unproductive: Option<(String, String)> = self
+                .conn
+                .query_row(
+                    "SELECT signal_ids, exit_at FROM agent_session_log \
+                     WHERE recipient = ?1 AND outcome = 'unproductive' AND exit_at >= ?2 \
+                     ORDER BY exit_at DESC LIMIT 1",
+                    rusqlite::params![&recipient, since],
+                    |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?)),
+                )
+                .optional()
+                .map_err(LegionError::Database)?;
+            let (last_signal, last_exit_at) = match last_unproductive {
+                Some((ids_json, exit_at)) => {
+                    let ids: Vec<String> = serde_json::from_str(&ids_json).unwrap_or_default();
+                    (ids.into_iter().next(), Some(exit_at))
+                }
+                None => (None, None),
+            };
+            out.push((
+                recipient,
+                total,
+                productive,
+                unproductive,
+                errored,
+                last_signal,
+                last_exit_at,
+            ));
+        }
+        Ok(out)
     }
 
     /// Store an embedding BLOB for an existing reflection.
@@ -6344,5 +6534,156 @@ mod tests {
             .unwrap();
         assert_eq!(expires_at, None, "self audience never expires");
         assert_eq!(evergreen, 0);
+    }
+
+    // -- Agent session log (#389) ---------------------------------------
+
+    fn within_window() -> (String, String) {
+        let now = Utc::now();
+        (
+            (now - chrono::Duration::seconds(30)).to_rfc3339(),
+            (now + chrono::Duration::seconds(30)).to_rfc3339(),
+        )
+    }
+
+    #[test]
+    fn classify_session_productive_via_bullpen_reply() {
+        let db = test_db();
+        let (spawn_at, exit_at) = within_window();
+        // Recipient posts to bullpen during the session window.
+        db.insert_reflection("shingle", "@huttspawn ack:done -- reviewed", "team")
+            .unwrap();
+        let productive = db
+            .classify_session("shingle", &["sig-1".to_string()], &spawn_at, &exit_at)
+            .unwrap();
+        assert!(
+            productive,
+            "bullpen reply within window must classify productive"
+        );
+    }
+
+    #[test]
+    fn classify_session_productive_via_reflection_link() {
+        let db = test_db();
+        let (spawn_at, exit_at) = within_window();
+        // Signal post owned by some other repo; recipient links to it.
+        let signal = db
+            .insert_reflection("huttspawn", "@shingle review:open", "team")
+            .unwrap();
+        let meta = ReflectionMeta {
+            domain: None,
+            tags: None,
+            parent_id: Some(signal.id.clone()),
+        };
+        db.insert_reflection_with_meta("shingle", "thinking through review", "self", &meta)
+            .unwrap();
+        let productive = db
+            .classify_session("shingle", &[signal.id], &spawn_at, &exit_at)
+            .unwrap();
+        assert!(
+            productive,
+            "linked reflection within window must classify productive"
+        );
+    }
+
+    #[test]
+    fn classify_session_unproductive_when_silent() {
+        let db = test_db();
+        let (spawn_at, exit_at) = within_window();
+        let signal = db
+            .insert_reflection("huttspawn", "@shingle review:open", "team")
+            .unwrap();
+        let productive = db
+            .classify_session("shingle", &[signal.id], &spawn_at, &exit_at)
+            .unwrap();
+        assert!(
+            !productive,
+            "no bullpen reply, no linked reflection -> unproductive"
+        );
+    }
+
+    #[test]
+    fn classify_session_ignores_outside_window() {
+        let db = test_db();
+        // Spawn/exit window in the past; recipient posts now (after window).
+        let spawn_at = "2026-01-01T00:00:00+00:00".to_string();
+        let exit_at = "2026-01-01T00:01:00+00:00".to_string();
+        db.insert_reflection("shingle", "@huttspawn ack:done", "team")
+            .unwrap();
+        let productive = db
+            .classify_session("shingle", &["sig-1".to_string()], &spawn_at, &exit_at)
+            .unwrap();
+        assert!(
+            !productive,
+            "post outside the spawn-exit window must not count"
+        );
+    }
+
+    #[test]
+    fn record_session_outcome_persists_row() {
+        let db = test_db();
+        let (spawn_at, exit_at) = within_window();
+        db.record_session_outcome(
+            "session-1",
+            "shingle",
+            &["sig-1".to_string(), "sig-2".to_string()],
+            &spawn_at,
+            &exit_at,
+            "ok",
+            Database::OUTCOME_UNPRODUCTIVE,
+        )
+        .unwrap();
+        let counts = db
+            .agent_session_counts_since("2026-01-01T00:00:00+00:00")
+            .unwrap();
+        let row = counts.iter().find(|r| r.0 == "shingle").expect("row");
+        assert_eq!(row.1, 1, "total");
+        assert_eq!(row.2, 0, "productive");
+        assert_eq!(row.3, 1, "unproductive");
+        assert_eq!(row.5.as_deref(), Some("sig-1"), "last unproductive signal");
+    }
+
+    #[test]
+    fn agent_session_counts_aggregates_by_recipient() {
+        let db = test_db();
+        let (spawn_at, exit_at) = within_window();
+        db.record_session_outcome(
+            "s-1",
+            "shingle",
+            &["a".to_string()],
+            &spawn_at,
+            &exit_at,
+            "ok",
+            Database::OUTCOME_PRODUCTIVE,
+        )
+        .unwrap();
+        db.record_session_outcome(
+            "s-2",
+            "shingle",
+            &["b".to_string()],
+            &spawn_at,
+            &exit_at,
+            "ok",
+            Database::OUTCOME_UNPRODUCTIVE,
+        )
+        .unwrap();
+        db.record_session_outcome(
+            "s-3",
+            "shingle",
+            &["c".to_string()],
+            &spawn_at,
+            &exit_at,
+            "error",
+            Database::OUTCOME_ERRORED,
+        )
+        .unwrap();
+        let counts = db
+            .agent_session_counts_since("2026-01-01T00:00:00+00:00")
+            .unwrap();
+        let row = counts.iter().find(|r| r.0 == "shingle").unwrap();
+        assert_eq!(row.1, 3, "total = 3");
+        assert_eq!(row.2, 1, "productive = 1");
+        assert_eq!(row.3, 1, "unproductive = 1");
+        assert_eq!(row.4, 1, "errored = 1");
     }
 }

--- a/src/status.rs
+++ b/src/status.rs
@@ -26,6 +26,10 @@ pub struct StatusOutput {
     pub active_task_count: usize,
     /// Subset of `active_task_count` that are currently blocked.
     pub blocked_task_count: usize,
+    /// Watch session diagnostic for the past 24h (#389). Surfaces when an
+    /// agent has had unproductive watch wakes (spawned, exited, no
+    /// observable artifact). `None` when there is nothing to report.
+    pub session_health: Option<String>,
 }
 
 /// Hours to look back for team posts in status output.
@@ -48,6 +52,8 @@ pub fn get_status(db: &Database, repo: &str) -> Result<StatusOutput> {
     let (team_needs, seen_ids) = get_team_needs(&posts, repo);
     let what_changed = get_what_changed(&posts, repo, &seen_ids);
 
+    let session_health = session_health_line(db, repo)?;
+
     Ok(StatusOutput {
         repo: repo.to_string(),
         your_work,
@@ -55,7 +61,42 @@ pub fn get_status(db: &Database, repo: &str) -> Result<StatusOutput> {
         what_changed,
         active_task_count,
         blocked_task_count,
+        session_health,
     })
+}
+
+/// Build the watch-session diagnostic line for `repo` (#389). Returns
+/// `Some(...)` when there has been at least one unproductive session in the
+/// last 24 hours, otherwise `None`. Productive-only or no-sessions stays
+/// silent so the status surface does not grow noise during normal operation.
+fn session_health_line(db: &Database, repo: &str) -> Result<Option<String>> {
+    let since = (Utc::now() - chrono::Duration::hours(24)).to_rfc3339();
+    let counts = db.agent_session_counts_since(&since)?;
+    let row = counts.into_iter().find(|r| r.0 == repo);
+    let Some((_, total, productive, unproductive, errored, last_signal, last_exit_at)) = row else {
+        return Ok(None);
+    };
+    if unproductive == 0 && errored == 0 {
+        return Ok(None);
+    }
+    let mut line =
+        format!("{total} sessions/24h: {productive} productive, {unproductive} unproductive");
+    if errored > 0 {
+        line.push_str(&format!(", {errored} errored"));
+    }
+    if let (Some(sig), Some(exit_at)) = (last_signal, last_exit_at) {
+        line.push_str(&format!(
+            " (last unproductive: signal {}, {})",
+            short_id(&sig),
+            relative_time(&exit_at)
+        ));
+    }
+    Ok(Some(line))
+}
+
+/// First 8 hex chars of a UUID -- enough to look the row up by prefix in CLI.
+fn short_id(id: &str) -> String {
+    id.chars().take(8).collect()
 }
 
 /// Result of a `legion done` operation.
@@ -137,7 +178,10 @@ pub fn format_summary(output: &StatusOutput) -> StatusSummary {
 
 /// Format status output for terminal display.
 pub fn format_status(output: &StatusOutput) -> String {
-    if output.your_work.is_empty() && output.team_needs.is_empty() && output.what_changed.is_empty()
+    if output.your_work.is_empty()
+        && output.team_needs.is_empty()
+        && output.what_changed.is_empty()
+        && output.session_health.is_none()
     {
         return String::new();
     }
@@ -146,6 +190,10 @@ pub fn format_status(output: &StatusOutput) -> String {
     format_section(&mut out, "YOUR WORK", &output.your_work);
     format_section(&mut out, "TEAM NEEDS YOU", &output.team_needs);
     format_section(&mut out, "WHAT CHANGED", &output.what_changed);
+    if let Some(line) = &output.session_health {
+        out.push_str("\nSESSION HEALTH:\n");
+        out.push_str(&format!("  {line}\n"));
+    }
     out
 }
 
@@ -499,6 +547,7 @@ mod tests {
             what_changed: vec![],
             active_task_count: 0,
             blocked_task_count: 0,
+            session_health: None,
         };
         assert!(format_status(&output).is_empty());
     }
@@ -527,6 +576,7 @@ mod tests {
             }],
             active_task_count: 1,
             blocked_task_count: 0,
+            session_health: None,
         };
         let formatted = format_status(&output);
         assert!(formatted.contains("[Legion] Status for kelex:"));
@@ -634,6 +684,7 @@ mod tests {
             }],
             active_task_count: 3,
             blocked_task_count: 1,
+            session_health: None,
         };
 
         let summary = format_summary(&output);

--- a/src/watch.rs
+++ b/src/watch.rs
@@ -777,6 +777,14 @@ pub struct TrackedChild {
     /// host-scoped release so a sync-resolved late-loser cannot drop the
     /// peer winner's row.
     pub host: String,
+    /// UUIDv7 session id for the agent_session_log row (#389).
+    pub session_id: String,
+    /// RFC3339 timestamp of spawn -- defines the lower bound of the
+    /// classification window for productive vs unproductive outcome.
+    pub spawn_at: String,
+    /// All signal ids bundled into this wake. Used to look up
+    /// reflection-parent_id matches at reap time.
+    pub signal_ids: Vec<String>,
 }
 
 pub struct AgentTracker {
@@ -792,18 +800,25 @@ impl AgentTracker {
 
     /// Record a spawned child process together with the leases it holds and
     /// the host identity under which they were acquired.
+    #[allow(clippy::too_many_arguments)]
     pub fn track(
         &mut self,
         repo: String,
         child: Child,
         held_leases: Vec<(String, String)>,
         host: String,
+        session_id: String,
+        spawn_at: String,
+        signal_ids: Vec<String>,
     ) {
         self.children.push(TrackedChild {
             repo,
             child,
             held_leases,
             host,
+            session_id,
+            spawn_at,
+            signal_ids,
         });
     }
 
@@ -831,6 +846,49 @@ impl AgentTracker {
                                     persona, signal_id, e
                                 );
                             }
+                        }
+
+                        // #389: classify and persist the session outcome.
+                        // Defensive: errors here log to stderr but never break
+                        // the reap loop -- a missed log row is recoverable, a
+                        // panic in the watch thread is not.
+                        let exit_at = chrono::Utc::now().to_rfc3339();
+                        let exit_status = if status.success() { "ok" } else { "error" };
+                        let outcome = if !status.success() {
+                            Database::OUTCOME_ERRORED
+                        } else {
+                            match db.classify_session(
+                                &tracked.repo,
+                                &tracked.signal_ids,
+                                &tracked.spawn_at,
+                                &exit_at,
+                            ) {
+                                Ok(true) => Database::OUTCOME_PRODUCTIVE,
+                                Ok(false) => Database::OUTCOME_UNPRODUCTIVE,
+                                Err(e) => {
+                                    eprintln!(
+                                        "[legion watch] classify failed for {} ({}): {}",
+                                        tracked.repo, tracked.session_id, e
+                                    );
+                                    // Conservative: do not record an unknown
+                                    // outcome as productive. Skip the row.
+                                    return false;
+                                }
+                            }
+                        };
+                        if let Err(e) = db.record_session_outcome(
+                            &tracked.session_id,
+                            &tracked.repo,
+                            &tracked.signal_ids,
+                            &tracked.spawn_at,
+                            &exit_at,
+                            exit_status,
+                            outcome,
+                        ) {
+                            eprintln!(
+                                "[legion watch] failed to record session outcome for {} ({}): {}",
+                                tracked.repo, tracked.session_id, e
+                            );
                         }
                     }
                     false // remove from list
@@ -1053,7 +1111,18 @@ pub fn poll_cycle(
                     );
                 }
                 let track_host = lease_gate.map(|g| g.host.to_string()).unwrap_or_default();
-                tracker.track(repo.name.clone(), child, held_leases, track_host);
+                let session_id = uuid::Uuid::now_v7().to_string();
+                let spawn_at = chrono::Utc::now().to_rfc3339();
+                let signal_ids: Vec<String> = signals.iter().map(|(id, _, _)| id.clone()).collect();
+                tracker.track(
+                    repo.name.clone(),
+                    child,
+                    held_leases,
+                    track_host,
+                    session_id,
+                    spawn_at,
+                    signal_ids,
+                );
                 cooldown.record_wake(&repo.name);
                 spawned += 1;
                 eprintln!("[legion watch] spawned agent for {}", repo.name);


### PR DESCRIPTION
## Summary

Watch spawns an agent for one or more signals, marks them handled at spawn time (`src/watch.rs:1040`), then exits with no further accounting for what the agent did. Productive vs unproductive sessions look identical to the operator -- `exit_code == 0` for both. Today shingle was woken multiple times for huttspawn `@shingle review:open` (post `019dee69`) and other signals, exited `ok` every time, produced zero reflection or bullpen reply, and Sean had to sneaker-net the conversation.

## Design correction (vs #389 as filed)

The issue originally proposed checking `watch_handled` to classify outcomes and suppressing re-fire after N unproductive wakes. Both wrong: `mark_signal_handled_for_repo` fires *at spawn time*, so `watch_handled` is always true, and there is no re-fire loop to suppress. Comment on #389 captures the discovery. Adjusted scope: diagnostic-only, no behavior change.

## Changes

- **Schema (migration 20):** `agent_session_log(session_id, recipient, signal_ids JSON, spawn_at, exit_at, exit_status, outcome)`, indexed on `(recipient, exit_at)`.
- **`Database::classify_session(recipient, signal_ids, spawn_at, exit_at)`** -- productive iff within the spawn-exit window: recipient posted to bullpen OR stored a reflection whose `parent_id` matches any tracked `signal_id`.
- **`Database::record_session_outcome(...)`** -- one row per spawn, idempotent on `session_id` via `INSERT OR REPLACE`.
- **`Database::agent_session_counts_since(since)`** -- aggregates per-recipient totals plus the most recent unproductive `signal_id` for the surface.
- **`TrackedChild`** now carries `session_id`, `spawn_at`, `signal_ids`. `AgentTracker::reap_finished` classifies on exit and writes the row. Errored sessions skip classification. Classifier errors log and skip the row -- defensive, never blocks the watch reap loop.
- **`legion status`** grows a `SESSION HEALTH` section that fires only when there is at least one unproductive or errored session in the last 24h. Format: `3 sessions/24h: 1 productive, 1 unproductive, 1 errored (last unproductive: signal 019dee69, 4m ago)`. Productive-only days stay silent.

## Out of scope (separate issues if wanted)

- Changing `mark_signal_handled_for_repo` to fire at exit-when-productive instead of at spawn -- behavior change with team blast radius, not unilateral.
- Killing in-flight unproductive sessions.
- Auto-resolve after N unproductive sessions for the same recipient.

## Tests (6 new)

- `classify_session_productive_via_bullpen_reply`
- `classify_session_productive_via_reflection_link`
- `classify_session_unproductive_when_silent`
- `classify_session_ignores_outside_window`
- `record_session_outcome_persists_row`
- `agent_session_counts_aggregates_by_recipient`

## Test plan

- [x] `cargo test` -- 624 lib + 116 integration pass
- [x] `cargo clippy --all-targets -- -D warnings` -- clean
- [x] `cargo fmt -- --check` -- clean
- [x] simplify gate clean
- [ ] Manual: rebuild plugin, restart daemon, fire an @shingle signal, observe shingle session classified unproductive in `legion status`

Closes #389.