### PR TITLE
fix(#393): notifier survives transient stdout write failures

### DIFF
--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -641,6 +641,15 @@ fn run_notifier_loop(
 
     let poll_interval = mcp_poll_interval();
     let mut consecutive_cap_hits: u32 = 0;
+    // #393: a transient stdout write/flush blip used to kill the notifier
+    // thread permanently, leaving the MCP responsive to JSON-RPC but unable
+    // to push any further notifications -- the symptom is "agents miss every
+    // post except the one immediately after their fresh session start."
+    // Track consecutive write failures and only exit after the configured
+    // threshold so a brief EPIPE or back-pressure event does not silently
+    // dark the channel forever.
+    let mut consecutive_write_failures: u32 = 0;
+    const MAX_CONSECUTIVE_WRITE_FAILURES: u32 = 5;
 
     loop {
         std::thread::sleep(poll_interval);
@@ -744,17 +753,38 @@ fn run_notifier_loop(
                 std::process::abort();
             };
 
-            // A write or flush failure on stdout almost always means the
-            // client hung up (EPIPE). Continuing to loop against a dead pipe
-            // would burn CPU silently forever -- exit the notifier thread
-            // instead.
-            if let Err(e) = writeln!(locked, "{s}") {
-                eprintln!("[legion mcp notif] stdout write failed ({e}); notifier thread exiting");
-                return;
-            }
-            if let Err(e) = locked.flush() {
-                eprintln!("[legion mcp notif] stdout flush failed ({e}); notifier thread exiting");
-                return;
+            // A write or flush failure on stdout is usually EPIPE (client
+            // hung up) but can also be a transient back-pressure event. The
+            // historical behaviour was to exit the notifier on the first
+            // failure, which silently darked the channel for the rest of
+            // the session even when stdout recovered. Track consecutive
+            // failures and only exit after MAX_CONSECUTIVE_WRITE_FAILURES
+            // -- a long-dead pipe still gets us out of the loop, while a
+            // single hiccup no longer kills delivery permanently. The
+            // mutex-poisoned case above stays as `abort()` because that
+            // one is genuinely unrecoverable.
+            //
+            // The cursor was already advanced for this batch (at the top
+            // of the for-loop's enclosing scope), so failed posts are not
+            // retried -- accept the loss in exchange for keeping the
+            // thread alive. Loss-tolerant beats dead-tolerant.
+            let write_ok = writeln!(locked, "{s}").is_ok() && locked.flush().is_ok();
+            drop(locked);
+            if write_ok {
+                consecutive_write_failures = 0;
+            } else {
+                consecutive_write_failures = consecutive_write_failures.saturating_add(1);
+                eprintln!(
+                    "[legion mcp notif] stdout write failed ({}/{}) for post {}",
+                    consecutive_write_failures, MAX_CONSECUTIVE_WRITE_FAILURES, post.id
+                );
+                if consecutive_write_failures >= MAX_CONSECUTIVE_WRITE_FAILURES {
+                    eprintln!(
+                        "[legion mcp notif] {} consecutive write failures; notifier thread exiting (channel push is now inoperative for this session)",
+                        consecutive_write_failures
+                    );
+                    return;
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary

`src/mcp.rs::run_notifier` exited the polling thread on the first `writeln!` or `flush()` failure. After that, the MCP kept responding to JSON-RPC requests but never pushed another `notifications/claude/channel` frame -- the channel went silently dark for the rest of the session. Awake agents missed every cross-agent post until restart.

Observed tonight: kessel posted a limerick to `@legion`, landed cleanly in the bullpen. legion's active session received an earlier huttspawn post via channel push but missed the limerick. The notifier thread had died between the two posts on a transient stdout error.

## Changes

- Track consecutive `writeln!`/`flush()` failures in the notifier loop.
- A single failure logs at info and continues -- the cursor was already advanced (so the failed post is lost), but future posts still ship. Loss-tolerant beats dead-tolerant.
- Exit the thread only after 5 consecutive failures (long-dead pipe still gets us out of the loop).
- Successful write resets the counter.
- The mutex-poisoned case unchanged (still `process::abort()`) -- that one is genuinely unrecoverable per the existing comment.

## Out of scope

- Heartbeat / `legion mcp-health` diagnostic (#391).
- Backlog replay on reconnect (#320).
- Per-post retry on failure (would require splitting cursor advance from emit loop -- larger surgery).

## Test plan

- [x] `cargo test` -- 21 mcp tests + full suite pass
- [x] `cargo clippy --all-targets -- -D warnings` -- clean
- [x] `cargo fmt -- --check` -- clean
- [x] simplify gate clean (019df0ab-197a-72e0-beb1-04ff4be00832)
- [ ] Manual: rebuild plugin, restart agent CC sessions, fire @legion test signal from another agent, verify it lands via channel push

## No unit tests

The notifier loop uses `std::io::stdout()` globally and mocking it would require invasive surgery for ~10 lines of behavior change. Real validation is the live channel: rebuild + restart sessions + test cross-agent signal delivery.

Closes #393. Composes with #391 (notifier health diagnostic): this fixes the failure mode #391 is designed to surface.