### PR TITLE
feat(#400): restore directed agent-to-agent messaging on the channel

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -385,6 +385,23 @@ impl Database {
             );",
         )?;
 
+        // Migration: add last_read_id to board_reads (#400).
+        //
+        // Without an id alongside the timestamp, the MCP notifier's
+        // per-recipient cursor cannot disambiguate two rows that share a
+        // created_at -- the strict-`>` comparator in `get_board_posts_since`
+        // is `(created_at > ?1) OR (created_at = ?1 AND id > ?2)`, and
+        // `?2 = ""` (the empty seed) makes any non-empty id satisfy the
+        // tie-break and re-emits the just-delivered row on every boot. The
+        // empty-string default is correct for existing rows: it means "no
+        // id known, treat the timestamp as the only ordering signal" --
+        // identical to the pre-#400 behaviour the row was inserted under.
+        if !Self::has_column(conn, "board_reads", "last_read_id")? {
+            conn.execute_batch(
+                "ALTER TABLE board_reads ADD COLUMN last_read_id TEXT NOT NULL DEFAULT '';",
+            )?;
+        }
+
         // Migration 2: Phase 2.0 Synapse metadata columns.
         if !Self::has_column(conn, "reflections", "domain")? {
             conn.execute_batch("ALTER TABLE reflections ADD COLUMN domain TEXT;")?;
@@ -1836,29 +1853,52 @@ impl Database {
     ///
     /// Used by the MCP notifier at cold boot so a session that was offline
     /// while a directed signal was filed picks it up on the first poll tick
-    /// after it comes back online. Returns the same `last_read_at` value
-    /// `mark_board_read` writes.
-    pub fn get_board_read_cursor(&self, reader_repo: &str) -> Result<Option<String>> {
+    /// after it comes back online. Returns `(last_read_at, last_read_id)`,
+    /// matching what `advance_board_read_cursor` writes. `last_read_id` is
+    /// an empty string for rows written before the #400 migration.
+    pub fn get_board_read_cursor(&self, reader_repo: &str) -> Result<Option<(String, String)>> {
         let mut stmt = self
             .conn
-            .prepare("SELECT last_read_at FROM board_reads WHERE reader_repo = ?1")?;
-        stmt.query_row([reader_repo], |row| row.get::<_, String>(0))
-            .optional()
-            .map_err(LegionError::Database)
+            .prepare("SELECT last_read_at, last_read_id FROM board_reads WHERE reader_repo = ?1")?;
+        stmt.query_row([reader_repo], |row| {
+            Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+        })
+        .optional()
+        .map_err(LegionError::Database)
     }
 
-    /// Advance the channel-delivery cursor for `reader_repo` to `last_read_at`.
+    /// Advance the channel-delivery cursor for `reader_repo` to
+    /// `(last_read_at, last_read_id)`.
     ///
-    /// Forward-only: the upsert refuses to move the cursor backwards. Called
-    /// by the MCP notifier after each successful delivery so the next cold
-    /// boot resumes from the right point and does not replay already-seen
-    /// posts.
-    pub fn advance_board_read_cursor(&self, reader_repo: &str, last_read_at: &str) -> Result<()> {
+    /// Forward-only: the upsert refuses to move the cursor backwards. The
+    /// composite ordering is `(last_read_at, last_read_id)`, which mirrors
+    /// the strict-`>` comparator used by `get_board_posts_since` so a row
+    /// recorded here is excluded from re-emission on the next poll.
+    /// Called by the MCP notifier after each successful delivery.
+    ///
+    /// `last_read_at` MUST be an RFC3339 timestamp in UTC with a `Z` suffix
+    /// (the format `chrono::Utc::now().to_rfc3339()` and every other legion
+    /// write path produce). Lexicographic SQL `>` comparison is correct only
+    /// for that fixed-offset shape; mixing offsets (`+00:00`, `-07:00`)
+    /// would mis-order timestamps that compare correctly chronologically.
+    /// Every caller in-tree obeys this; the contract is documented here so
+    /// future callers do not need to rediscover the constraint.
+    pub fn advance_board_read_cursor(
+        &self,
+        reader_repo: &str,
+        last_read_at: &str,
+        last_read_id: &str,
+    ) -> Result<()> {
         self.conn.execute(
-            "INSERT INTO board_reads (reader_repo, last_read_at) VALUES (?1, ?2) \
-             ON CONFLICT(reader_repo) DO UPDATE SET last_read_at = excluded.last_read_at \
-             WHERE excluded.last_read_at > board_reads.last_read_at",
-            (reader_repo, last_read_at),
+            "INSERT INTO board_reads (reader_repo, last_read_at, last_read_id) \
+             VALUES (?1, ?2, ?3) \
+             ON CONFLICT(reader_repo) DO UPDATE SET \
+                 last_read_at = excluded.last_read_at, \
+                 last_read_id = excluded.last_read_id \
+             WHERE excluded.last_read_at > board_reads.last_read_at \
+                OR (excluded.last_read_at = board_reads.last_read_at \
+                    AND excluded.last_read_id > board_reads.last_read_id)",
+            (reader_repo, last_read_at, last_read_id),
         )?;
         Ok(())
     }
@@ -4389,33 +4429,52 @@ mod tests {
     #[test]
     fn advance_board_read_cursor_creates_then_moves_forward() {
         let db = test_db();
-        db.advance_board_read_cursor("kessel", "2026-05-04T01:00:00Z")
+        db.advance_board_read_cursor("kessel", "2026-05-04T01:00:00Z", "id-a")
             .unwrap();
         assert_eq!(
-            db.get_board_read_cursor("kessel").unwrap().as_deref(),
-            Some("2026-05-04T01:00:00Z")
+            db.get_board_read_cursor("kessel").unwrap(),
+            Some(("2026-05-04T01:00:00Z".to_string(), "id-a".to_string()))
         );
 
         // Forward move accepted.
-        db.advance_board_read_cursor("kessel", "2026-05-04T02:00:00Z")
+        db.advance_board_read_cursor("kessel", "2026-05-04T02:00:00Z", "id-b")
             .unwrap();
         assert_eq!(
-            db.get_board_read_cursor("kessel").unwrap().as_deref(),
-            Some("2026-05-04T02:00:00Z")
+            db.get_board_read_cursor("kessel").unwrap(),
+            Some(("2026-05-04T02:00:00Z".to_string(), "id-b".to_string()))
         );
     }
 
     #[test]
     fn advance_board_read_cursor_refuses_backward_move() {
         let db = test_db();
-        db.advance_board_read_cursor("kessel", "2026-05-04T02:00:00Z")
+        db.advance_board_read_cursor("kessel", "2026-05-04T02:00:00Z", "id-b")
             .unwrap();
         // Older timestamp must not overwrite.
-        db.advance_board_read_cursor("kessel", "2026-05-04T01:00:00Z")
+        db.advance_board_read_cursor("kessel", "2026-05-04T01:00:00Z", "id-a")
             .unwrap();
         assert_eq!(
-            db.get_board_read_cursor("kessel").unwrap().as_deref(),
-            Some("2026-05-04T02:00:00Z")
+            db.get_board_read_cursor("kessel").unwrap(),
+            Some(("2026-05-04T02:00:00Z".to_string(), "id-b".to_string()))
+        );
+    }
+
+    #[test]
+    fn advance_board_read_cursor_breaks_tie_on_id() {
+        let db = test_db();
+        let ts = "2026-05-04T02:00:00Z";
+        db.advance_board_read_cursor("kessel", ts, "id-a").unwrap();
+        // Same timestamp, larger id -> accepted.
+        db.advance_board_read_cursor("kessel", ts, "id-b").unwrap();
+        assert_eq!(
+            db.get_board_read_cursor("kessel").unwrap(),
+            Some((ts.to_string(), "id-b".to_string()))
+        );
+        // Same timestamp, smaller id -> refused.
+        db.advance_board_read_cursor("kessel", ts, "id-a").unwrap();
+        assert_eq!(
+            db.get_board_read_cursor("kessel").unwrap(),
+            Some((ts.to_string(), "id-b".to_string()))
         );
     }
 

--- a/src/db.rs
+++ b/src/db.rs
@@ -1876,12 +1876,13 @@ impl Database {
     /// recorded here is excluded from re-emission on the next poll.
     /// Called by the MCP notifier after each successful delivery.
     ///
-    /// `last_read_at` MUST be an RFC3339 timestamp in UTC with a `Z` suffix
-    /// (the format `chrono::Utc::now().to_rfc3339()` and every other legion
-    /// write path produce). Lexicographic SQL `>` comparison is correct only
-    /// for that fixed-offset shape; mixing offsets (`+00:00`, `-07:00`)
-    /// would mis-order timestamps that compare correctly chronologically.
-    /// Every caller in-tree obeys this; the contract is documented here so
+    /// `last_read_at` MUST share the offset shape every other legion write
+    /// path uses -- `chrono::Utc::now().to_rfc3339()`, which renders a
+    /// `+00:00` suffix (NOT `Z`). Lexicographic SQL `>` is correct only when
+    /// every timestamp it compares is rendered with the same fixed offset
+    /// string; mixing `+00:00` with `Z` (or any other offset) would
+    /// mis-order rows that compare correctly chronologically. Every caller
+    /// in-tree obeys this convention; the contract is documented here so
     /// future callers do not need to rediscover the constraint.
     pub fn advance_board_read_cursor(
         &self,
@@ -4429,40 +4430,40 @@ mod tests {
     #[test]
     fn advance_board_read_cursor_creates_then_moves_forward() {
         let db = test_db();
-        db.advance_board_read_cursor("kessel", "2026-05-04T01:00:00Z", "id-a")
+        db.advance_board_read_cursor("kessel", "2026-05-04T01:00:00+00:00", "id-a")
             .unwrap();
         assert_eq!(
             db.get_board_read_cursor("kessel").unwrap(),
-            Some(("2026-05-04T01:00:00Z".to_string(), "id-a".to_string()))
+            Some(("2026-05-04T01:00:00+00:00".to_string(), "id-a".to_string()))
         );
 
         // Forward move accepted.
-        db.advance_board_read_cursor("kessel", "2026-05-04T02:00:00Z", "id-b")
+        db.advance_board_read_cursor("kessel", "2026-05-04T02:00:00+00:00", "id-b")
             .unwrap();
         assert_eq!(
             db.get_board_read_cursor("kessel").unwrap(),
-            Some(("2026-05-04T02:00:00Z".to_string(), "id-b".to_string()))
+            Some(("2026-05-04T02:00:00+00:00".to_string(), "id-b".to_string()))
         );
     }
 
     #[test]
     fn advance_board_read_cursor_refuses_backward_move() {
         let db = test_db();
-        db.advance_board_read_cursor("kessel", "2026-05-04T02:00:00Z", "id-b")
+        db.advance_board_read_cursor("kessel", "2026-05-04T02:00:00+00:00", "id-b")
             .unwrap();
         // Older timestamp must not overwrite.
-        db.advance_board_read_cursor("kessel", "2026-05-04T01:00:00Z", "id-a")
+        db.advance_board_read_cursor("kessel", "2026-05-04T01:00:00+00:00", "id-a")
             .unwrap();
         assert_eq!(
             db.get_board_read_cursor("kessel").unwrap(),
-            Some(("2026-05-04T02:00:00Z".to_string(), "id-b".to_string()))
+            Some(("2026-05-04T02:00:00+00:00".to_string(), "id-b".to_string()))
         );
     }
 
     #[test]
     fn advance_board_read_cursor_breaks_tie_on_id() {
         let db = test_db();
-        let ts = "2026-05-04T02:00:00Z";
+        let ts = "2026-05-04T02:00:00+00:00";
         db.advance_board_read_cursor("kessel", ts, "id-a").unwrap();
         // Same timestamp, larger id -> accepted.
         db.advance_board_read_cursor("kessel", ts, "id-b").unwrap();

--- a/src/db.rs
+++ b/src/db.rs
@@ -1832,6 +1832,37 @@ impl Database {
         Ok(())
     }
 
+    /// Read the channel-delivery cursor for `reader_repo`.
+    ///
+    /// Used by the MCP notifier at cold boot so a session that was offline
+    /// while a directed signal was filed picks it up on the first poll tick
+    /// after it comes back online. Returns the same `last_read_at` value
+    /// `mark_board_read` writes.
+    pub fn get_board_read_cursor(&self, reader_repo: &str) -> Result<Option<String>> {
+        let mut stmt = self
+            .conn
+            .prepare("SELECT last_read_at FROM board_reads WHERE reader_repo = ?1")?;
+        stmt.query_row([reader_repo], |row| row.get::<_, String>(0))
+            .optional()
+            .map_err(LegionError::Database)
+    }
+
+    /// Advance the channel-delivery cursor for `reader_repo` to `last_read_at`.
+    ///
+    /// Forward-only: the upsert refuses to move the cursor backwards. Called
+    /// by the MCP notifier after each successful delivery so the next cold
+    /// boot resumes from the right point and does not replay already-seen
+    /// posts.
+    pub fn advance_board_read_cursor(&self, reader_repo: &str, last_read_at: &str) -> Result<()> {
+        self.conn.execute(
+            "INSERT INTO board_reads (reader_repo, last_read_at) VALUES (?1, ?2) \
+             ON CONFLICT(reader_repo) DO UPDATE SET last_read_at = excluded.last_read_at \
+             WHERE excluded.last_read_at > board_reads.last_read_at",
+            (reader_repo, last_read_at),
+        )?;
+        Ok(())
+    }
+
     /// Find unhandled signals directed at a specific repo.
     ///
     /// Returns team posts that mention `@<repo_name>` (at start or mid-text)
@@ -4347,6 +4378,45 @@ mod tests {
         db.mark_board_read("kelex").unwrap();
         db.mark_board_read("kelex").unwrap();
         assert_eq!(db.get_unread_count("kelex").unwrap(), 0);
+    }
+
+    #[test]
+    fn get_board_read_cursor_none_for_fresh_repo() {
+        let db = test_db();
+        assert!(db.get_board_read_cursor("kessel").unwrap().is_none());
+    }
+
+    #[test]
+    fn advance_board_read_cursor_creates_then_moves_forward() {
+        let db = test_db();
+        db.advance_board_read_cursor("kessel", "2026-05-04T01:00:00Z")
+            .unwrap();
+        assert_eq!(
+            db.get_board_read_cursor("kessel").unwrap().as_deref(),
+            Some("2026-05-04T01:00:00Z")
+        );
+
+        // Forward move accepted.
+        db.advance_board_read_cursor("kessel", "2026-05-04T02:00:00Z")
+            .unwrap();
+        assert_eq!(
+            db.get_board_read_cursor("kessel").unwrap().as_deref(),
+            Some("2026-05-04T02:00:00Z")
+        );
+    }
+
+    #[test]
+    fn advance_board_read_cursor_refuses_backward_move() {
+        let db = test_db();
+        db.advance_board_read_cursor("kessel", "2026-05-04T02:00:00Z")
+            .unwrap();
+        // Older timestamp must not overwrite.
+        db.advance_board_read_cursor("kessel", "2026-05-04T01:00:00Z")
+            .unwrap();
+        assert_eq!(
+            db.get_board_read_cursor("kessel").unwrap().as_deref(),
+            Some("2026-05-04T02:00:00Z")
+        );
     }
 
     #[test]

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -646,6 +646,35 @@ pub fn should_notify(text: &str, repo: &str, client_repo: Option<&str>) -> bool 
     true
 }
 
+/// Replay-mode delivery filter (#400). Stricter than `should_notify`:
+/// drops broadcasts and cross-repo musings, delivers only signals
+/// directed at this recipient.
+///
+/// Used when a post predates the MCP subprocess boot timestamp -- the
+/// agent was offline when it landed, and the only thing the channel
+/// should backfill on cold boot is a directed signal someone meant for
+/// them. Stale `@all` broadcasts and team musings are not worth the
+/// flood when 24h of bullpen activity is replayed.
+///
+/// Mirrors `should_notify`'s recipient parsing so `@kessel:`, `@kessel `,
+/// and `@kessel\n` all match (the `:` trim and whitespace split). When
+/// `client_repo` is unknown the function returns false -- without an
+/// identity we cannot safely deliver any directed signal anyway.
+pub fn replay_should_deliver(text: &str, client_repo: Option<&str>) -> bool {
+    let Some(recipient) = client_repo else {
+        return false;
+    };
+    let Some(rest) = text.strip_prefix('@') else {
+        return false;
+    };
+    let token_raw = rest.split_whitespace().next().unwrap_or("");
+    let token = token_raw.trim_end_matches(':');
+    if token.is_empty() || token.starts_with('@') {
+        return false;
+    }
+    token == recipient
+}
+
 /// Split a CDATA body around any literal `]]>` occurrences so the terminator
 /// cannot escape the section. The standard XML trick is to replace every
 /// `]]>` with `]]]]><![CDATA[>` -- close the current section after the first
@@ -870,6 +899,17 @@ fn run_notifier_loop(
             return;
         }
     };
+
+    // Boot timestamp partitions posts into replay (older than boot) vs
+    // live (newer). Replay is narrowed to directed signals for this
+    // recipient (#400): a fresh-boot agent should pick up signals they
+    // missed while offline, but should NOT be flooded by 24h of cross-repo
+    // musings or `@all` broadcasts the team has long since moved past.
+    // Live posts run through the full `should_notify` filter unchanged,
+    // so once boot is past the agent receives the same flow they always
+    // did.
+    let boot_at = chrono::Utc::now().to_rfc3339();
+
     mcp_trace(
         "notifier.start",
         &[(
@@ -967,7 +1007,20 @@ fn run_notifier_loop(
                 );
             }
 
-            let deliver = should_notify(&post.text, &post.repo, client_repo);
+            // Replay window narrows delivery to directed-to-this-recipient
+            // signals only (#400). A post strictly older than `boot_at`
+            // means we are catching up after the recipient was offline;
+            // delivering generic musings or `@all` broadcasts from that
+            // window would flood the session with stale content the team
+            // has already metabolised. Live posts (created at or after
+            // boot) use the unchanged `should_notify` rule so the steady
+            // state matches what the channel always delivered.
+            let is_replay = post.created_at < boot_at;
+            let deliver = if is_replay {
+                replay_should_deliver(&post.text, client_repo)
+            } else {
+                should_notify(&post.text, &post.repo, client_repo)
+            };
             if mcp_verbose() {
                 let preview: String = post.text.chars().take(40).collect();
                 mcp_trace(
@@ -977,6 +1030,7 @@ fn run_notifier_loop(
                         ("from_repo", &post.repo),
                         ("client_repo", client_repo.unwrap_or("<unset>")),
                         ("is_signal", &is_signal.to_string()),
+                        ("is_replay", &is_replay.to_string()),
                         ("deliver", &deliver.to_string()),
                         ("text_prefix", &preview.replace('\n', " ")),
                     ],
@@ -1045,6 +1099,12 @@ fn run_notifier_loop(
                 // backwards and race us into re-delivery. Best-effort: a
                 // failure here is logged but does not kill the loop -- worst
                 // case is one redundant replay on the next boot.
+                // Cursor advance is intentionally scoped to delivered
+                // posts, not skipped ones. A skipped post is filtered
+                // again on next boot (cheap, idempotent); advancing past
+                // it would also move the cursor past any directed
+                // signal that races in at the same `created_at`,
+                // silently swallowing it.
                 if let Some(recipient) = client_repo
                     && let Err(e) =
                         db.advance_board_read_cursor(recipient, &post.created_at, &post.id)
@@ -1311,6 +1371,56 @@ mod tests {
         let (ts, id) = seed_notifier_cursor(&db, Some("kessel")).expect("seed");
         assert_eq!(ts, pinned_ts);
         assert_eq!(id, pinned_id);
+    }
+
+    #[test]
+    fn replay_should_deliver_directed_signal_to_this_recipient() {
+        assert!(replay_should_deliver(
+            "@kessel ping:open hello",
+            Some("kessel")
+        ));
+    }
+
+    #[test]
+    fn replay_should_deliver_handles_colon_suffix() {
+        assert!(replay_should_deliver(
+            "@kessel: please review",
+            Some("kessel")
+        ));
+    }
+
+    #[test]
+    fn replay_should_deliver_drops_broadcast_all() {
+        // @all is a live-time courtesy, not worth replaying when stale.
+        assert!(!replay_should_deliver("@all team standup", Some("kessel")));
+    }
+
+    #[test]
+    fn replay_should_deliver_drops_directed_to_other_agent() {
+        assert!(!replay_should_deliver(
+            "@huttspawn check this",
+            Some("kessel")
+        ));
+    }
+
+    #[test]
+    fn replay_should_deliver_drops_general_musing() {
+        // Plain post with no @ prefix is a musing -- skip on replay.
+        assert!(!replay_should_deliver(
+            "thinking about color tokens",
+            Some("kessel")
+        ));
+    }
+
+    #[test]
+    fn replay_should_deliver_returns_false_when_recipient_unknown() {
+        assert!(!replay_should_deliver("@kessel ping", None));
+    }
+
+    #[test]
+    fn replay_should_deliver_rejects_at_at_prefix() {
+        // Same edge case as should_notify: `@@all` is a fat-finger, not a broadcast.
+        assert!(!replay_should_deliver("@@all hi", Some("kessel")));
     }
 
     #[test]

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -701,6 +701,63 @@ fn mcp_poll_interval() -> std::time::Duration {
     std::time::Duration::from_millis(ms)
 }
 
+/// Replay window applied at cold boot when this recipient has no
+/// `board_reads` cursor yet -- a fresh agent picks up directed signals filed
+/// in the last 24 hours instead of starting from the live watermark and
+/// silently swallowing them. Bounded so the first boot after a long absence
+/// is not a flood.
+const NOTIFIER_COLD_BOOT_REPLAY: chrono::Duration = chrono::Duration::hours(24);
+
+/// Resolve the agent name for the current MCP subprocess from `watch.toml`
+/// keyed on cwd.
+///
+/// The MCP `initialize` handshake reports `clientInfo.name = "claude-code"`
+/// for every Claude Code session, which is the *client software* identity,
+/// not the *agent* identity. Routing channel notifications by that token
+/// breaks every directed signal because every session collides on the same
+/// name. The agent identity is what `legion --repo <name>` carries on every
+/// CLI call; here we recover it by canonicalising cwd and looking up the
+/// matching `WatchRepoConfig.recipient()`.
+///
+/// Returns `None` (and the caller falls back to the legacy `clientInfo.name`
+/// handshake value) when:
+///   - watch.toml is missing or empty
+///   - cwd cannot be canonicalised
+///   - no entry's canonicalised workdir matches the current cwd
+///
+/// All three failure modes are non-fatal: a misconfigured workstation gets
+/// the pre-fix behaviour (broadcasts only) rather than no channel at all.
+fn resolve_session_repo_from_cwd(data_dir: &std::path::Path) -> Option<String> {
+    let cwd = std::env::current_dir().ok()?;
+    resolve_session_repo_for_cwd(data_dir, &cwd)
+}
+
+/// Inner form of [`resolve_session_repo_from_cwd`] with the cwd injected.
+/// Split out so unit tests can exercise the watch.toml lookup against a
+/// fixture directory without mutating the global process cwd.
+fn resolve_session_repo_for_cwd(
+    data_dir: &std::path::Path,
+    cwd: &std::path::Path,
+) -> Option<String> {
+    let watch_path = data_dir.join("watch.toml");
+    let repos = match crate::watch::list_repos_in_config(&watch_path) {
+        Ok(r) if !r.is_empty() => r,
+        _ => return None,
+    };
+
+    let cwd_canon = std::fs::canonicalize(cwd).ok()?;
+
+    for repo in repos {
+        let workdir = std::path::Path::new(&repo.workdir);
+        if let Ok(workdir_canon) = std::fs::canonicalize(workdir)
+            && workdir_canon == cwd_canon
+        {
+            return Some(repo.recipient().to_string());
+        }
+    }
+    None
+}
+
 /// Body of the notifier thread spawned by `run_stdio_loop`.
 ///
 /// Polls the `reflections` table for new bullpen rows and writes a
@@ -727,52 +784,91 @@ fn run_notifier_loop(
         }
     };
 
-    // Seed the cursor to the DB's current team-board watermark so the
-    // notifier only emits for posts that land after the MCP subprocess
-    // started. Replaying historical bullpen content would flood the
-    // session with messages the user has already seen.
+    // Seed the cursor.
     //
-    // Using a DB-derived watermark rather than `now()` eliminates a
-    // small-but-real race: a post committed in the same nanosecond as
-    // the notifier's wall-clock seed would be dropped by the strict-`>`
-    // comparator on the next poll. The DB watermark is consistent with
-    // the rows the notifier is filtering against.
+    // When the agent identity is known (resolved from watch.toml at MCP
+    // boot, see #400) we want directed signals filed while the agent was
+    // offline to be picked up on the first poll tick after wake. Two-step
+    // resolution:
     //
-    // On seed error (the reflections table exists but the query failed)
-    // the notifier thread exits cleanly rather than falling back to
-    // `now()`, because the fallback would silently reintroduce the very
-    // race the watermark closes, AND the next poll against the same
-    // connection would almost certainly fail the same way. A dead
-    // notifier at least does not give a false "channel is working"
-    // signal to the rest of the process.
+    //   1. If `board_reads.last_read_at` is set for this recipient, seed
+    //      from there -- the cursor advances on every successful delivery
+    //      (further down this loop), so this is the authoritative
+    //      per-recipient resume point. Subsequent boots see only what
+    //      arrived since the last delivery.
+    //   2. Otherwise (first time this recipient has booted, or
+    //      board_reads pruned), seed at `now - NOTIFIER_COLD_BOOT_REPLAY`
+    //      so a fresh agent picks up at most the last day of directed
+    //      traffic instead of the whole history. `should_notify` and
+    //      `resolved_at IS NULL` keep the replay narrow: own posts and
+    //      already-resolved signals are filtered.
     //
-    // Empty table (`None`) seeds from `now()` because there is no race
-    // window when there are no rows.
-    let (mut last_seen_at, mut last_seen_id): (String, String) = match db
-        .get_board_cursor_watermark()
-    {
-        Ok(Some((ts, id))) => {
-            mcp_trace(
-                "notifier.cursor.seed",
-                &[("at", &ts), ("id", &id), ("source", "watermark")],
-            );
-            (ts, id)
-        }
-        Ok(None) => {
-            let now = chrono::Utc::now().to_rfc3339();
-            mcp_trace(
-                "notifier.cursor.seed",
-                &[("at", &now), ("source", "now_empty_table")],
-            );
-            (now, String::new())
-        }
-        Err(e) => {
-            mcp_trace("notifier.seed.failed", &[("err", &e.to_string())]);
-            eprintln!(
-                "[legion mcp notif] failed to seed cursor from db watermark: {e}; notifier thread exiting (channel push is now inoperative for this session)"
-            );
-            return;
-        }
+    // When the agent identity is unknown (no watch.toml entry for cwd),
+    // fall back to the pre-#400 watermark seed -- the notifier cannot
+    // route directed signals anyway in that state, so behaviour matches
+    // the prior version: live posts only, no replay.
+    //
+    // On seed error (DB query failed) the notifier exits cleanly rather
+    // than guessing, because the next poll would almost certainly fail the
+    // same way and a silent fallback would mask the breakage.
+    let known_recipient: Option<String> = client_repo_cell.get().cloned();
+    let (mut last_seen_at, mut last_seen_id): (String, String) = match known_recipient.as_deref() {
+        Some(recipient) => match db.get_board_read_cursor(recipient) {
+            Ok(Some(ts)) => {
+                mcp_trace(
+                    "notifier.cursor.seed",
+                    &[
+                        ("at", &ts),
+                        ("source", "board_reads"),
+                        ("recipient", recipient),
+                    ],
+                );
+                (ts, String::new())
+            }
+            Ok(None) => {
+                let backstop = (chrono::Utc::now() - NOTIFIER_COLD_BOOT_REPLAY).to_rfc3339();
+                mcp_trace(
+                    "notifier.cursor.seed",
+                    &[
+                        ("at", &backstop),
+                        ("source", "cold_boot_replay"),
+                        ("recipient", recipient),
+                    ],
+                );
+                (backstop, String::new())
+            }
+            Err(e) => {
+                mcp_trace("notifier.seed.failed", &[("err", &e.to_string())]);
+                eprintln!(
+                    "[legion mcp notif] failed to read board_reads cursor: {e}; notifier thread exiting (channel push is now inoperative for this session)"
+                );
+                return;
+            }
+        },
+        None => match db.get_board_cursor_watermark() {
+            Ok(Some((ts, id))) => {
+                mcp_trace(
+                    "notifier.cursor.seed",
+                    &[("at", &ts), ("id", &id), ("source", "watermark")],
+                );
+                (ts, id)
+            }
+            Ok(None) => {
+                let now = chrono::Utc::now().to_rfc3339();
+                mcp_trace(
+                    "notifier.cursor.seed",
+                    &[("at", &now), ("source", "now_empty_table")],
+                );
+                (now, String::new())
+            }
+            Err(e) => {
+                mcp_trace("notifier.seed.failed", &[("err", &e.to_string())]);
+                eprintln!(
+                    "[legion mcp notif] failed to seed cursor from db watermark: {e}; notifier thread exiting (channel push is now inoperative for this session)"
+                );
+                return;
+            }
+        },
     };
     mcp_trace(
         "notifier.start",
@@ -942,6 +1038,25 @@ fn run_notifier_loop(
             drop(locked);
             if write_ok {
                 consecutive_write_failures = 0;
+                // Advance the per-recipient delivery cursor so the next cold
+                // boot resumes from this post rather than replaying it. The
+                // upsert is forward-only; concurrent writers (e.g. the HTTP
+                // backlog path's mark_board_read) cannot move the cursor
+                // backwards and race us into re-delivery. Best-effort: a
+                // failure here is logged but does not kill the loop -- worst
+                // case is one redundant replay on the next boot.
+                if let Some(recipient) = client_repo
+                    && let Err(e) = db.advance_board_read_cursor(recipient, &post.created_at)
+                {
+                    mcp_trace(
+                        "notifier.cursor.advance.failed",
+                        &[
+                            ("recipient", recipient),
+                            ("post_id", &post.id),
+                            ("err", &e.to_string()),
+                        ],
+                    );
+                }
             } else {
                 consecutive_write_failures = consecutive_write_failures.saturating_add(1);
                 eprintln!(
@@ -1003,8 +1118,29 @@ pub fn run_stdio_loop(
         Arc::new(Mutex::new(std::io::BufWriter::new(stdout)));
 
     // Shared cell so the request loop can inform the notification thread which
-    // repo the connected client belongs to (extracted from initialize clientInfo.name).
+    // repo the connected client belongs to.
+    //
+    // Pre-populated from cwd via watch.toml when possible, so the notifier
+    // knows the *agent* identity (kessel, legion, ...) rather than the
+    // *client software* identity (`claude-code`, the literal value every
+    // Claude Code session sends in initialize.clientInfo.name). Without this
+    // pre-fill, every directed signal collapses onto the same `claude-code`
+    // recipient and is suppressed in every session. See #400.
+    //
+    // OnceLock is set first by cwd-resolution; the subsequent `initialize`
+    // handler's set is a no-op (logged as duplicate), so the cwd answer
+    // wins. Falls back to the handshake value when watch.toml has no entry
+    // for cwd.
     let client_repo_cell: Arc<OnceLock<String>> = Arc::new(OnceLock::new());
+    if let Some(name) = resolve_session_repo_from_cwd(&data_dir) {
+        mcp_trace(
+            "mcp.client_repo.resolved",
+            &[("name", &name), ("source", "watch_toml_cwd")],
+        );
+        let _ = client_repo_cell.set(name);
+    } else {
+        mcp_trace("mcp.client_repo.resolved", &[("source", "unresolved")]);
+    }
 
     // Spawn the notification emitter thread before entering the blocking read loop.
     let notif_out = Arc::clone(&out);
@@ -1095,6 +1231,62 @@ mod tests {
     fn make_tx() -> broadcast::Sender<ChannelEvent> {
         let (tx, _rx) = broadcast::channel(16);
         tx
+    }
+
+    #[test]
+    fn resolve_session_repo_returns_none_when_watch_toml_missing() {
+        let data_dir = tempfile::tempdir().expect("data dir");
+        let cwd = tempfile::tempdir().expect("cwd dir");
+        assert_eq!(
+            resolve_session_repo_for_cwd(data_dir.path(), cwd.path()),
+            None
+        );
+    }
+
+    #[test]
+    fn resolve_session_repo_matches_canonicalized_workdir() {
+        let data_dir = tempfile::tempdir().expect("data dir");
+        let cwd = tempfile::tempdir().expect("cwd dir");
+        let watch_path = data_dir.path().join("watch.toml");
+
+        crate::watch::add_repo_to_config(&watch_path, "kessel", cwd.path(), None)
+            .expect("add repo");
+
+        assert_eq!(
+            resolve_session_repo_for_cwd(data_dir.path(), cwd.path()).as_deref(),
+            Some("kessel")
+        );
+    }
+
+    #[test]
+    fn resolve_session_repo_prefers_agent_alias_over_name() {
+        let data_dir = tempfile::tempdir().expect("data dir");
+        let cwd = tempfile::tempdir().expect("cwd dir");
+        let watch_path = data_dir.path().join("watch.toml");
+
+        crate::watch::add_repo_to_config(&watch_path, "kessel", cwd.path(), Some("kessel-agent"))
+            .expect("add repo");
+
+        assert_eq!(
+            resolve_session_repo_for_cwd(data_dir.path(), cwd.path()).as_deref(),
+            Some("kessel-agent")
+        );
+    }
+
+    #[test]
+    fn resolve_session_repo_returns_none_for_unmatched_cwd() {
+        let data_dir = tempfile::tempdir().expect("data dir");
+        let cwd = tempfile::tempdir().expect("cwd dir");
+        let other = tempfile::tempdir().expect("other dir");
+        let watch_path = data_dir.path().join("watch.toml");
+
+        crate::watch::add_repo_to_config(&watch_path, "kessel", other.path(), None)
+            .expect("add repo");
+
+        assert_eq!(
+            resolve_session_repo_for_cwd(data_dir.path(), cwd.path()),
+            None
+        );
     }
 
     fn make_request(method: &str, params: Option<Value>) -> Value {

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -758,6 +758,79 @@ fn resolve_session_repo_for_cwd(
     None
 }
 
+/// Compute the initial `(last_seen_at, last_seen_id)` cursor for the
+/// notifier thread.
+///
+/// Three-way resolution (#400):
+///
+///   1. **Known recipient with a `board_reads` cursor** -- seed from
+///      that timestamp. The cursor advances on every successful delivery
+///      so subsequent boots see only what arrived since the last delivery.
+///   2. **Known recipient, no cursor yet** -- seed at
+///      `now - NOTIFIER_COLD_BOOT_REPLAY` so a fresh agent picks up the
+///      recent past instead of starting at the live watermark and
+///      silently swallowing offline-window posts. `should_notify` and
+///      `resolved_at IS NULL` keep replay narrow.
+///   3. **Unknown recipient** (no watch.toml entry for cwd) -- fall back
+///      to the pre-#400 watermark. The notifier cannot route directed
+///      signals in that state anyway, so behaviour matches the prior
+///      version: live posts only, no replay.
+///
+/// In case 1 the id comes from `board_reads.last_read_id`, written
+/// alongside the timestamp on every successful delivery, so the
+/// strict-`>` comparator in `get_board_posts_since` excludes the
+/// already-delivered row even when its `created_at` collides with a
+/// neighbour. In case 2 the id is empty (no prior delivery exists), and
+/// in case 3 the id comes from the watermark row.
+fn seed_notifier_cursor(db: &Database, client_repo: Option<&str>) -> Result<(String, String)> {
+    if let Some(recipient) = client_repo {
+        match db.get_board_read_cursor(recipient)? {
+            Some((ts, id)) => {
+                mcp_trace(
+                    "notifier.cursor.seed",
+                    &[
+                        ("at", &ts),
+                        ("id", &id),
+                        ("source", "board_reads"),
+                        ("recipient", recipient),
+                    ],
+                );
+                Ok((ts, id))
+            }
+            None => {
+                let backstop = (chrono::Utc::now() - NOTIFIER_COLD_BOOT_REPLAY).to_rfc3339();
+                mcp_trace(
+                    "notifier.cursor.seed",
+                    &[
+                        ("at", &backstop),
+                        ("source", "cold_boot_replay"),
+                        ("recipient", recipient),
+                    ],
+                );
+                Ok((backstop, String::new()))
+            }
+        }
+    } else {
+        match db.get_board_cursor_watermark()? {
+            Some((ts, id)) => {
+                mcp_trace(
+                    "notifier.cursor.seed",
+                    &[("at", &ts), ("id", &id), ("source", "watermark")],
+                );
+                Ok((ts, id))
+            }
+            None => {
+                let now = chrono::Utc::now().to_rfc3339();
+                mcp_trace(
+                    "notifier.cursor.seed",
+                    &[("at", &now), ("source", "now_empty_table")],
+                );
+                Ok((now, String::new()))
+            }
+        }
+    }
+}
+
 /// Body of the notifier thread spawned by `run_stdio_loop`.
 ///
 /// Polls the `reflections` table for new bullpen rows and writes a
@@ -784,91 +857,18 @@ fn run_notifier_loop(
         }
     };
 
-    // Seed the cursor.
-    //
-    // When the agent identity is known (resolved from watch.toml at MCP
-    // boot, see #400) we want directed signals filed while the agent was
-    // offline to be picked up on the first poll tick after wake. Two-step
-    // resolution:
-    //
-    //   1. If `board_reads.last_read_at` is set for this recipient, seed
-    //      from there -- the cursor advances on every successful delivery
-    //      (further down this loop), so this is the authoritative
-    //      per-recipient resume point. Subsequent boots see only what
-    //      arrived since the last delivery.
-    //   2. Otherwise (first time this recipient has booted, or
-    //      board_reads pruned), seed at `now - NOTIFIER_COLD_BOOT_REPLAY`
-    //      so a fresh agent picks up at most the last day of directed
-    //      traffic instead of the whole history. `should_notify` and
-    //      `resolved_at IS NULL` keep the replay narrow: own posts and
-    //      already-resolved signals are filtered.
-    //
-    // When the agent identity is unknown (no watch.toml entry for cwd),
-    // fall back to the pre-#400 watermark seed -- the notifier cannot
-    // route directed signals anyway in that state, so behaviour matches
-    // the prior version: live posts only, no replay.
-    //
-    // On seed error (DB query failed) the notifier exits cleanly rather
-    // than guessing, because the next poll would almost certainly fail the
-    // same way and a silent fallback would mask the breakage.
-    let known_recipient: Option<String> = client_repo_cell.get().cloned();
-    let (mut last_seen_at, mut last_seen_id): (String, String) = match known_recipient.as_deref() {
-        Some(recipient) => match db.get_board_read_cursor(recipient) {
-            Ok(Some(ts)) => {
-                mcp_trace(
-                    "notifier.cursor.seed",
-                    &[
-                        ("at", &ts),
-                        ("source", "board_reads"),
-                        ("recipient", recipient),
-                    ],
-                );
-                (ts, String::new())
-            }
-            Ok(None) => {
-                let backstop = (chrono::Utc::now() - NOTIFIER_COLD_BOOT_REPLAY).to_rfc3339();
-                mcp_trace(
-                    "notifier.cursor.seed",
-                    &[
-                        ("at", &backstop),
-                        ("source", "cold_boot_replay"),
-                        ("recipient", recipient),
-                    ],
-                );
-                (backstop, String::new())
-            }
-            Err(e) => {
-                mcp_trace("notifier.seed.failed", &[("err", &e.to_string())]);
-                eprintln!(
-                    "[legion mcp notif] failed to read board_reads cursor: {e}; notifier thread exiting (channel push is now inoperative for this session)"
-                );
-                return;
-            }
-        },
-        None => match db.get_board_cursor_watermark() {
-            Ok(Some((ts, id))) => {
-                mcp_trace(
-                    "notifier.cursor.seed",
-                    &[("at", &ts), ("id", &id), ("source", "watermark")],
-                );
-                (ts, id)
-            }
-            Ok(None) => {
-                let now = chrono::Utc::now().to_rfc3339();
-                mcp_trace(
-                    "notifier.cursor.seed",
-                    &[("at", &now), ("source", "now_empty_table")],
-                );
-                (now, String::new())
-            }
-            Err(e) => {
-                mcp_trace("notifier.seed.failed", &[("err", &e.to_string())]);
-                eprintln!(
-                    "[legion mcp notif] failed to seed cursor from db watermark: {e}; notifier thread exiting (channel push is now inoperative for this session)"
-                );
-                return;
-            }
-        },
+    let (mut last_seen_at, mut last_seen_id): (String, String) = match seed_notifier_cursor(
+        &db,
+        client_repo_cell.get().map(|s| s.as_str()),
+    ) {
+        Ok(seed) => seed,
+        Err(e) => {
+            mcp_trace("notifier.seed.failed", &[("err", &e.to_string())]);
+            eprintln!(
+                "[legion mcp notif] failed to seed cursor: {e}; notifier thread exiting (channel push is now inoperative for this session)"
+            );
+            return;
+        }
     };
     mcp_trace(
         "notifier.start",
@@ -1046,7 +1046,8 @@ fn run_notifier_loop(
                 // failure here is logged but does not kill the loop -- worst
                 // case is one redundant replay on the next boot.
                 if let Some(recipient) = client_repo
-                    && let Err(e) = db.advance_board_read_cursor(recipient, &post.created_at)
+                    && let Err(e) =
+                        db.advance_board_read_cursor(recipient, &post.created_at, &post.id)
                 {
                     mcp_trace(
                         "notifier.cursor.advance.failed",
@@ -1270,6 +1271,90 @@ mod tests {
         assert_eq!(
             resolve_session_repo_for_cwd(data_dir.path(), cwd.path()).as_deref(),
             Some("kessel-agent")
+        );
+    }
+
+    #[test]
+    fn seed_notifier_cursor_unknown_client_uses_watermark_when_table_empty() {
+        let (db, _dir) = mcp_test_dir();
+        let (ts, id) = seed_notifier_cursor(&db, None).expect("seed");
+        // Empty board -> seed at now() with empty id.
+        assert!(id.is_empty());
+        // Cannot equality-test `now`, but it parses as RFC3339.
+        chrono::DateTime::parse_from_rfc3339(&ts).expect("valid rfc3339");
+    }
+
+    #[test]
+    fn seed_notifier_cursor_known_recipient_no_history_uses_cold_boot_replay() {
+        let (db, _dir) = mcp_test_dir();
+        let (ts, id) = seed_notifier_cursor(&db, Some("kessel")).expect("seed");
+        assert!(id.is_empty());
+        let parsed = chrono::DateTime::parse_from_rfc3339(&ts).expect("valid rfc3339");
+        let age = chrono::Utc::now().signed_duration_since(parsed.with_timezone(&chrono::Utc));
+        // Should be roughly 24h old; allow 1h slack for slow runners.
+        let lo = NOTIFIER_COLD_BOOT_REPLAY - chrono::Duration::hours(1);
+        let hi = NOTIFIER_COLD_BOOT_REPLAY + chrono::Duration::hours(1);
+        assert!(
+            age >= lo && age <= hi,
+            "expected ~24h backstop, got {}",
+            age
+        );
+    }
+
+    #[test]
+    fn seed_notifier_cursor_known_recipient_with_history_uses_board_reads() {
+        let (db, _dir) = mcp_test_dir();
+        let pinned_ts = "2026-04-01T12:00:00+00:00";
+        let pinned_id = "019dabcd-0000-7000-8000-000000000001";
+        db.advance_board_read_cursor("kessel", pinned_ts, pinned_id)
+            .unwrap();
+        let (ts, id) = seed_notifier_cursor(&db, Some("kessel")).expect("seed");
+        assert_eq!(ts, pinned_ts);
+        assert_eq!(id, pinned_id);
+    }
+
+    #[test]
+    fn cold_boot_replay_picks_up_offline_signal_then_advance_prevents_redelivery() {
+        // End-to-end #400: signal filed while kessel is offline lands on
+        // first poll; advance_board_read_cursor on delivery means second
+        // boot does not re-replay the same row.
+        let (db, _dir) = mcp_test_dir();
+
+        // Pretend a directed signal was filed an hour ago, before kessel boots.
+        let post = db
+            .insert_reflection("legion", "@kessel ping:open from a test", "team")
+            .expect("insert");
+        let post_id = post.id.clone();
+        // Sanity: board_reads is empty for kessel.
+        assert!(db.get_board_read_cursor("kessel").unwrap().is_none());
+
+        // First boot: cold replay seed should be in the past, so the post is
+        // visible via get_board_posts_since.
+        let (seed_at, seed_id) = seed_notifier_cursor(&db, Some("kessel")).expect("seed");
+        let visible = db
+            .get_board_posts_since(&seed_at, &seed_id, NOTIFIER_BATCH_LIMIT)
+            .expect("posts");
+        let found = visible.iter().any(|p| p.id == post_id);
+        assert!(found, "cold-boot replay must surface the offline signal");
+
+        // Simulate successful delivery: advance the cursor to the post's
+        // (created_at, id).
+        let delivered = visible
+            .iter()
+            .find(|p| p.id == post_id)
+            .expect("post present");
+        db.advance_board_read_cursor("kessel", &delivered.created_at, &delivered.id)
+            .unwrap();
+
+        // Second boot: seed comes from board_reads now, equal to the post's
+        // created_at. Strict-`>` comparator means the post is NOT re-emitted.
+        let (seed_at_2, seed_id_2) = seed_notifier_cursor(&db, Some("kessel")).expect("seed");
+        let visible_2 = db
+            .get_board_posts_since(&seed_at_2, &seed_id_2, NOTIFIER_BATCH_LIMIT)
+            .expect("posts");
+        assert!(
+            !visible_2.iter().any(|p| p.id == post_id),
+            "advanced cursor must not re-replay an already-delivered post"
         );
     }
 

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -1304,7 +1304,7 @@ mod tests {
     #[test]
     fn seed_notifier_cursor_known_recipient_with_history_uses_board_reads() {
         let (db, _dir) = mcp_test_dir();
-        let pinned_ts = "2026-04-01T12:00:00Z";
+        let pinned_ts = "2026-04-01T12:00:00+00:00";
         let pinned_id = "019dabcd-0000-7000-8000-000000000001";
         db.advance_board_read_cursor("kessel", pinned_ts, pinned_id)
             .unwrap();

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -859,7 +859,7 @@ fn run_notifier_loop(
 
     let (mut last_seen_at, mut last_seen_id): (String, String) = match seed_notifier_cursor(
         &db,
-        client_repo_cell.get().map(|s| s.as_str()),
+        client_repo_cell.get().map(String::as_str),
     ) {
         Ok(seed) => seed,
         Err(e) => {
@@ -949,7 +949,7 @@ fn run_notifier_loop(
             last_seen_id = last.id.clone();
         }
 
-        let client_repo = client_repo_cell.get().map(|s| s.as_str());
+        let client_repo = client_repo_cell.get().map(String::as_str);
 
         for post in new_posts {
             let is_signal = crate::signal::is_signal(&post.text);
@@ -1304,7 +1304,7 @@ mod tests {
     #[test]
     fn seed_notifier_cursor_known_recipient_with_history_uses_board_reads() {
         let (db, _dir) = mcp_test_dir();
-        let pinned_ts = "2026-04-01T12:00:00+00:00";
+        let pinned_ts = "2026-04-01T12:00:00Z";
         let pinned_id = "019dabcd-0000-7000-8000-000000000001";
         db.advance_board_read_cursor("kessel", pinned_ts, pinned_id)
             .unwrap();

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -1099,12 +1099,15 @@ fn run_notifier_loop(
                 // backwards and race us into re-delivery. Best-effort: a
                 // failure here is logged but does not kill the loop -- worst
                 // case is one redundant replay on the next boot.
-                // Cursor advance is intentionally scoped to delivered
-                // posts, not skipped ones. A skipped post is filtered
-                // again on next boot (cheap, idempotent); advancing past
-                // it would also move the cursor past any directed
-                // signal that races in at the same `created_at`,
-                // silently swallowing it.
+                // Persisted cursor advances only on delivered rows.
+                // Skipped rows are re-filtered on the next cold boot
+                // (idempotent), and the cross-process race a stale
+                // persisted cursor could mask -- a directed signal
+                // arriving at the same `created_at` from another
+                // process between boots -- stays narrow this way.
+                // The in-memory `last_seen_at` already passes skipped
+                // rows within this running loop; that's a separate
+                // single-process advance, not the same invariant.
                 if let Some(recipient) = client_repo
                     && let Err(e) =
                         db.advance_board_read_cursor(recipient, &post.created_at, &post.id)


### PR DESCRIPTION
## Summary

Closes #400. Supersedes #398.

The channel-MCP rewrite (#201/#205/#216/#220, ~2026-04-10) accidentally collapsed every Claude Code session onto the same `client_repo` (`"claude-code"`, the `clientInfo.name` Claude Code sends in MCP `initialize`). `should_notify` routes `@<recipient>` against `client_repo`, so directed signals never matched anywhere -- only `@all` and cross-repo musings survived the filter. Compounded by the cold-boot watermark seed swallowing anything filed before the recipient's MCP booted. Bullpen volume cliffed from 200-280 posts/day to 3-100/day on 2026-04-08; the surviving traffic is exactly the post shapes that pass the broken filter.

## What changes

**Identity at MCP boot (`src/mcp.rs`)**

`resolve_session_repo_from_cwd` looks up the agent name from `watch.toml` by canonicalising cwd against each entry's workdir, returning `WatchRepoConfig::recipient()`. Pre-populates the `client_repo_cell` `OnceLock` before the notifier thread spawns; the subsequent `initialize` handshake's `claude-code` set is a no-op (already logged as duplicate). Falls back to the legacy handshake value when watch.toml has no entry for cwd, so a misconfigured workstation gets the pre-fix behaviour rather than no channel at all.

**Per-recipient delivery cursor (`src/db.rs`)**

`board_reads` gains a `last_read_id` column (idempotent `ALTER TABLE` migration). New `get_board_read_cursor` / `advance_board_read_cursor` read and forward-only-write the composite `(last_read_at, last_read_id)`. The id is required: with empty `last_read_id`, the strict-`>` tie-break in `get_board_posts_since` re-emits the just-delivered row on every poll because any non-empty id beats `""`. Match the comparator the cursor advances against.

**Cold-boot replay narrowed to directed signals (`src/mcp.rs`)**

`seed_notifier_cursor` resolves three ways: known recipient with `board_reads` cursor → seed there; known recipient, no cursor yet → seed at `now - 24h` (`NOTIFIER_COLD_BOOT_REPLAY`); unknown recipient → fall back to the pre-#400 watermark.

`run_notifier_loop` captures `boot_at` and partitions each polled post into replay (`< boot_at`) vs live (`>= boot_at`). Replay runs through `replay_should_deliver` (deliver only if text starts with `@<client_repo>` exactly), so a fresh-boot agent picks up missed directed signals but not 24h of cross-repo musings or stale `@all` broadcasts. Live posts use unchanged `should_notify`.

`advance_board_read_cursor` fires after each successful delivery so the next cold boot resumes correctly. Skipped rows do NOT advance the persisted cursor -- a cross-process race with a directed signal arriving at the same `created_at` between boots is the failure mode this protects against.

## Per-PID log shape after the fix

```
mcp.client_repo.resolved name=kessel source=watch_toml_cwd
mcp.start ...
mcp.initialize client_repo=claude-code   # handshake set is no-op; cwd value wins
notifier.cursor.seed at=2026-05-04T03:25:46+00:00 source=board_reads recipient=kessel
notifier.start poll_interval_ms=500
notifier.decision post_id=... is_replay=false deliver=true client_repo=kessel ...
```

## Test coverage

- 3 db tests: `get_board_read_cursor` returns None for fresh repo, forward move accepted, backward move refused, tie-break on id.
- 4 cwd resolver tests: missing watch.toml, canonicalised match, agent-alias preference over name, unmatched cwd.
- 3 seed tests: empty-table watermark, cold-boot replay window 24h, board_reads resume.
- 7 replay filter tests: directed match, `:` suffix, `@all` suppressed, other-agent suppressed, plain musing suppressed, unknown-recipient suppressed, `@@`-prefix rejected.
- 1 e2e test: signal filed before kessel boots → seed surfaces it on first poll → advance prevents re-replay on second seed.

`cargo test` 116 pass / 2 ignored. `cargo clippy -- -D warnings` clean. `cargo fmt -- --check` clean.

## Manual verification

Cannot run end-to-end against a live session from this branch -- existing MCP processes are on main. After install, expected flow:

1. `~/Library/Logs/legion/mcp/<pid>.log` shows `mcp.client_repo.resolved name=<agent> source=watch_toml_cwd`.
2. `legion signal --repo legion --to kessel --verb ping --status open --note 'test'` from any session.
3. Kessel's session receives a `<channel>` system-reminder within 500ms of the signal landing in the DB.
4. If kessel is offline at signal time, the signal is delivered on first poll after boot (within 24h replay window).

## Test plan

- [x] cargo test (116 pass)
- [x] cargo clippy -- -D warnings (clean)
- [x] cargo fmt -- --check (clean)
- [x] /legion-simplify gate (clean)
- [ ] Install + end-to-end live-session verification
- [ ] Watch bullpen volume restore over the next 24-48h

🤖 Generated with [Claude Code](https://claude.com/claude-code)