### PR TITLE
feat(#404): verb-driven wake gate; posts never wake; status no longer routes

### DIFF
--- a/src/watch.rs
+++ b/src/watch.rs
@@ -653,22 +653,38 @@ pub fn find_pending_signals(
 
 // -- Agent Spawning ----------------------------------------------------------
 
-/// Signals that require the recipient to reply, even if the reply is a refusal.
+/// Verbs whose presence in a directed signal triggers a watch wake (#404).
 ///
-/// A directed question or request without a reply is ghosting. The trigger is
-/// either a request-shaped verb (`question`, `request`) OR a request-shaped
-/// status on any verb (e.g. `review:request`, `help:request`). Approval-shaped
-/// statuses (`approved`, `done`, `blocked`) and bare informational verbs
-/// (`announce`, `update`) fall under the wake-storm guard: silence is
-/// acknowledgment unless the agent has something substantive to add.
-pub fn signal_requires_reply(text: &str) -> bool {
+/// `--verb` was designed to express intent; this set is the subsection of
+/// intents that warrant spawning an asleep recipient. Other verbs
+/// (`announce`, `ack`, `info`, `answer`, bare `review`) deliver to live
+/// sessions via the channel push but do not page an asleep agent.
+///
+/// Posts (text without a leading `@recipient`) never wake -- posts are
+/// broadcasts; the `legion signal --to <agent> --verb <wake-worthy>`
+/// primitive is the agent equivalent of a tweet at someone.
+pub const WAKE_WORTHY_VERBS: &[&str] = &["question", "request", "help", "blocker"];
+
+/// Whether a signal text triggers a wake under the verb-driven gate.
+///
+/// Returns `false` for posts, malformed signals, and signals whose verb is
+/// outside [`WAKE_WORTHY_VERBS`]. The decision is verb-only -- status is
+/// decoration that downstream tools may use, but the wake gate ignores it.
+pub fn is_wake_worthy(text: &str) -> bool {
     match signal::parse_signal(text) {
-        Some(sig) => {
-            matches!(sig.verb.as_str(), "question" | "request")
-                || matches!(sig.status.as_deref(), Some("request" | "help"))
-        }
+        Some(sig) => WAKE_WORTHY_VERBS.contains(&sig.verb.as_str()),
         None => false,
     }
+}
+
+/// Signals that require the recipient to reply, even if the reply is a refusal.
+///
+/// Same gate as [`is_wake_worthy`] -- the wake decision and the
+/// REQUIRES A REPLY routing in [`build_wake_prompt`] use one verb cut so a
+/// signal that woke the agent always lands in the section the agent must
+/// answer.
+pub fn signal_requires_reply(text: &str) -> bool {
+    is_wake_worthy(text)
 }
 
 /// Maximum reply-required signals rendered inline in the wake prompt; the
@@ -1030,6 +1046,24 @@ pub fn poll_cycle(
         let recipient = repo.recipient();
         let signals = find_pending_signals(db, &repo.name, recipient, since)?;
         if signals.is_empty() {
+            continue;
+        }
+
+        // Verb-driven wake gate (#404). Only spawn when at least one signal
+        // carries a wake-worthy verb. Informational signals targeting this
+        // repo (announce/ack/info/answer/review-without-request) are marked
+        // handled here so they do not re-poll forever; they remain visible
+        // via `legion bullpen` and were already delivered to live sessions
+        // by the channel push.
+        if !signals.iter().any(|(_, text, _)| is_wake_worthy(text)) {
+            for (id, _, _) in &signals {
+                if let Err(e) = db.mark_signal_handled_for_repo(id, &repo.name) {
+                    eprintln!(
+                        "[legion watch] failed to mark informational signal {} as handled for {}: {}",
+                        id, repo.name, e
+                    );
+                }
+            }
             continue;
         }
 
@@ -1561,25 +1595,32 @@ workdir = "/tmp"
     }
 
     #[test]
-    fn build_wake_prompt_treats_request_status_as_reply_required() {
-        // review:request -- a directed RFC review ask. Pre-fix this fell into
-        // INFORMATIONAL because the verb was `review`, not `question`/`request`.
-        // Real incident: smugglr asked platform to review an RFC, watch woke
-        // platform, prompt said "silence is acknowledgment", platform no-opped.
+    fn build_wake_prompt_routes_by_verb_only() {
+        // #404: wake/reply decision is verb-only. Status is decoration.
+        // The pre-#404 fallback that treated `status=request` or `status=help`
+        // on any verb as reply-required was a workaround for the broken
+        // text-prefix wake gate. Senders who want a reply now use a
+        // wake-worthy verb directly: `--verb request`, `--verb help`,
+        // `--verb question`, `--verb blocker`.
         let signals = vec![
             (
-                "id-rev".to_string(),
+                "id-rev-req".to_string(),
                 "@platform review:request {doc: rfc.md} -- review please".to_string(),
                 "smugglr".to_string(),
             ),
             (
-                "id-help".to_string(),
-                "@legion request:help -- need a hand".to_string(),
+                "id-help-verb".to_string(),
+                "@platform help -- need a hand on the rfc".to_string(),
                 "kelex".to_string(),
             ),
             (
-                "id-ok".to_string(),
-                "@legion review:approved -- LGTM".to_string(),
+                "id-request-verb".to_string(),
+                "@platform request -- could you review this".to_string(),
+                "kelex".to_string(),
+            ),
+            (
+                "id-approved".to_string(),
+                "@platform review:approved -- LGTM".to_string(),
                 "smugglr".to_string(),
             ),
         ];
@@ -1587,22 +1628,67 @@ workdir = "/tmp"
         let prompt = build_wake_prompt("platform", &signals);
 
         assert!(prompt.contains("REQUIRES A REPLY"));
-        assert!(
-            prompt.contains("id-rev"),
-            "review:request must require reply"
-        );
-        assert!(
-            prompt.contains("id-help"),
-            "request:help must require reply"
-        );
-
-        // Approvals stay informational -- silence is acknowledgment.
         assert!(prompt.contains("INFORMATIONAL"));
         let reply_section = &prompt
             [prompt.find("REQUIRES A REPLY").unwrap()..prompt.find("INFORMATIONAL").unwrap()];
+
         assert!(
-            !reply_section.contains("id-ok"),
-            "review:approved must not require reply"
+            reply_section.contains("id-help-verb"),
+            "verb=help must require reply"
+        );
+        assert!(
+            reply_section.contains("id-request-verb"),
+            "verb=request must require reply"
+        );
+        assert!(
+            !reply_section.contains("id-rev-req"),
+            "verb=review with status=request is no longer wake-worthy (#404 verb-only gate)"
+        );
+        assert!(
+            !reply_section.contains("id-approved"),
+            "verb=review with status=approved must not require reply"
+        );
+    }
+
+    #[test]
+    fn is_wake_worthy_recognizes_designated_verbs() {
+        for verb in WAKE_WORTHY_VERBS {
+            let text = format!("@kessel {verb} -- something");
+            assert!(
+                is_wake_worthy(&text),
+                "verb `{verb}` should be wake-worthy: {text}"
+            );
+        }
+    }
+
+    #[test]
+    fn is_wake_worthy_rejects_informational_verbs() {
+        for verb in ["announce", "ack", "info", "answer", "review"] {
+            let text = format!("@kessel {verb} -- fyi");
+            assert!(
+                !is_wake_worthy(&text),
+                "verb `{verb}` must not be wake-worthy: {text}"
+            );
+        }
+    }
+
+    #[test]
+    fn is_wake_worthy_rejects_posts() {
+        // Posts don't start with @recipient -- never wake.
+        assert!(!is_wake_worthy("just a musing about something"));
+        assert!(!is_wake_worthy("checking in @kessel did you see #401"));
+    }
+
+    #[test]
+    fn is_wake_worthy_ignores_status_decoration() {
+        // Status no longer gates wake; only the verb does.
+        assert!(
+            !is_wake_worthy("@platform review:request {doc: rfc.md}"),
+            "verb=review with status=request must not wake under verb-only gate"
+        );
+        assert!(
+            is_wake_worthy("@platform request:help -- pls"),
+            "verb=request stays wake-worthy regardless of status"
         );
     }
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -4889,8 +4889,9 @@ fn mesh_stale_cutoff_env_override_is_respected() {
 fn pending_replies_emits_wake_prompt_for_request_signals() {
     let dir = tempfile::tempdir().unwrap();
 
-    // smugglr asks platform to review an RFC -- the exact signal shape that
-    // dropped on 2026-04-26.
+    // smugglr asks platform to review an RFC. Under #404 the wake/reply gate
+    // is verb-only, so the right shape is `--verb request` (not the pre-#404
+    // `--verb review --status request` workaround).
     let out = legion_cmd(dir.path())
         .args([
             "signal",
@@ -4899,11 +4900,9 @@ fn pending_replies_emits_wake_prompt_for_request_signals() {
             "--to",
             "platform",
             "--verb",
-            "review",
-            "--status",
             "request",
             "--note",
-            "RFC at vault-2026/projects/smuggler/fence/rfc.md",
+            "RFC review at vault-2026/projects/smuggler/fence/rfc.md",
         ])
         .output()
         .unwrap();
@@ -4938,11 +4937,11 @@ fn pending_replies_emits_wake_prompt_for_request_signals() {
     let stdout = String::from_utf8_lossy(&out.stdout);
     assert!(
         stdout.contains("REQUIRES A REPLY"),
-        "review:request must surface as reply-required, got: {stdout}"
+        "verb=request must surface as reply-required, got: {stdout}"
     );
     assert!(
-        stdout.contains("review:request"),
-        "expected the signal text in the prompt, got: {stdout}"
+        stdout.contains("RFC review"),
+        "expected the signal note in the prompt, got: {stdout}"
     );
     assert!(
         !stdout.contains("v0.9.5 shipped"),


### PR DESCRIPTION
Closes #404.

## What changes

The watch wake gate moves from text-prefix `is_signal()` to verb-set membership.

```rust
pub const WAKE_WORTHY_VERBS: &[&str] = &["question", "request", "help", "blocker"];
```

This is the subsection of `--verb` intents that warrant spawning an asleep recipient. Other verbs (`announce`, `ack`, `info`, `answer`, bare `review`) still deliver to live sessions via the channel push but do not page an asleep agent. Posts never wake -- post = broadcast.

`signal_requires_reply` now delegates to `is_wake_worthy` so the wake decision and the REQUIRES A REPLY routing in `build_wake_prompt` use one verb cut. The pre-#404 status fallback (`review:request` / `help:request` as reply-required on any verb) was a workaround for the broken text-prefix gate and is dropped; senders who want a reply use a wake-worthy verb directly.

In `poll_cycle`, signals targeting a recipient with no wake-worthy verb are marked handled here so they do not re-poll forever. They remain visible via `legion bullpen` and were already delivered to live sessions by the channel push.

## Behavior matrix

| Sender | Recipient state | Result |
|---|---|---|
| `signal --to kessel --verb question` | asleep | wake fires, REQUIRES A REPLY |
| `signal --to kessel --verb question` | awake | channel push delivers; wake skipped via session lock |
| `signal --to kessel --verb announce` | asleep | no wake, marked handled, visible via `legion bullpen` |
| `signal --to kessel --verb announce` | awake | channel push delivers; no wake |
| `post --text "@kessel ..."` | any | no wake (post = broadcast); visible via `legion bullpen` |
| `signal --to kessel --verb review --status request` | any | no wake (verb-only gate; sender should use `--verb request`) |

## Tests

- `is_wake_worthy_recognizes_designated_verbs` -- every verb in `WAKE_WORTHY_VERBS` triggers wake.
- `is_wake_worthy_rejects_informational_verbs` -- `announce`, `ack`, `info`, `answer`, `review` do not.
- `is_wake_worthy_rejects_posts` -- text without `@recipient` never wakes.
- `is_wake_worthy_ignores_status_decoration` -- `verb=review status=request` no longer wakes; `verb=request status=anything` still does.
- `build_wake_prompt_routes_by_verb_only` -- replaces the prior status-fallback test with a verb-only assertion matrix.
- `pending_replies_emits_wake_prompt_for_request_signals` integration test updated to use `--verb request` instead of `--verb review --status request`.

## Out of scope

Spurious wakes against awake interactive Claude Code sessions are caused by the SessionStart-doesn't-write-session-lock gap (per snooze 019df0e2). With #404, watch correctly skips wake when the session lock is held, but interactive CC sessions don't write a lock so they can still get duplicate-spawned. Filed as a separate issue.

## Test plan
- [x] cargo test (116 passed)
- [x] cargo clippy --all-targets -- -D warnings (clean)
- [x] cargo fmt -- --check (clean)
- [x] pre-commit simplify gate (passed)