### PR TITLE
feat(#279, #280, #281): multi-language SCIP + per-file re-index + PostToolUse hook (v0.11.0 base)

### DIFF
--- a/plugin/hooks/hooks.json
+++ b/plugin/hooks/hooks.json
@@ -167,6 +167,36 @@
             "timeout": 3
           }
         ]
+      },
+      {
+        "matcher": "Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/post-edit-index.sh",
+            "timeout": 5
+          }
+        ]
+      },
+      {
+        "matcher": "Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/post-edit-index.sh",
+            "timeout": 5
+          }
+        ]
+      },
+      {
+        "matcher": "MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/post-edit-index.sh",
+            "timeout": 5
+          }
+        ]
       }
     ]
   }

--- a/plugin/hooks/post-edit-index.sh
+++ b/plugin/hooks/post-edit-index.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+# Legion PostToolUse hook (#281): re-index the SCIP blob for the repo
+# containing the edited file so `legion sym` answers stay fresh.
+#
+# Fires on Edit, Write, MultiEdit. Reads tool_input.file_path, debounces
+# 500ms per path via a lockfile, and runs `legion index --file <path>` in
+# the background so the editing turn is never blocked.
+#
+# Skip conditions (any one is enough):
+#   - file_path missing or empty
+#   - repo not legion-covered (no watch.toml entry, no reflections)
+#   - lockfile fresher than 500ms (debounce)
+#
+# Errors append to /tmp/legion-hook-errors.log; the hook always exits 0.
+
+set -u
+
+LEGION="${CLAUDE_PLUGIN_ROOT}/bin/legion"
+LOG=/tmp/legion-hook-errors.log
+
+# shellcheck source=_legion-covered.sh
+source "${CLAUDE_PLUGIN_ROOT}/hooks/_legion-covered.sh"
+
+INPUT=$(cat)
+CWD=$(echo "$INPUT" | jq -r '.cwd // empty')
+FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
+SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // empty')
+
+if [ -z "$FILE_PATH" ] || [ -z "$CWD" ]; then
+  exit 0
+fi
+
+REPO=$(basename "$CWD")
+if ! legion_covered "$SESSION_ID" "$REPO"; then
+  exit 0
+fi
+
+# Debounce per file path: skip if the lockfile mtime is newer than 500ms ago.
+# GNU date supports %3N (millisecond precision); BSD date emits the literal
+# "%3N" instead. Detect by checking whether the output contains a non-digit.
+PATH_HASH=$(echo "$FILE_PATH" | md5 -q 2>/dev/null || echo "$FILE_PATH" | md5sum 2>/dev/null | cut -d' ' -f1)
+LOCK="/tmp/legion-index-${PATH_HASH}.lock"
+NOW_MS=$(date +%s%3N 2>/dev/null || true)
+case "$NOW_MS" in
+  ''|*[!0-9]*)
+    NOW_MS=$(python3 -c 'import time; print(int(time.time()*1000))' 2>/dev/null || echo "")
+    ;;
+esac
+if [ -n "$NOW_MS" ] && [ -f "$LOCK" ]; then
+  LOCK_MS=$(stat -f %m000 "$LOCK" 2>/dev/null || stat -c %Y000 "$LOCK" 2>/dev/null || echo 0)
+  AGE_MS=$((NOW_MS - LOCK_MS))
+  if [ "$AGE_MS" -lt 500 ]; then
+    exit 0
+  fi
+fi
+touch "$LOCK" 2>/dev/null
+
+# Background re-index. nohup + & detaches so the editing turn is not blocked.
+# Stderr appended to log so a missing indexer leaves a breadcrumb without
+# interrupting the user.
+nohup "$LEGION" index --file "$FILE_PATH" >>"$LOG" 2>&1 &
+disown 2>/dev/null
+
+exit 0

--- a/src/main.rs
+++ b/src/main.rs
@@ -412,13 +412,24 @@ enum Commands {
 
     /// Build or refresh the SCIP code-intelligence index for a repo (#278).
     ///
-    /// Resolves the repo path from `watch.toml`, detects the dominant
-    /// language, runs the corresponding SCIP indexer (e.g. `scip-rust`)
-    /// as a subprocess, and stores the resulting protobuf blob keyed
-    /// on (repo, lang). Idempotent on content hash.
+    /// Resolves the repo path from `watch.toml`, detects every recognized
+    /// language, runs the corresponding SCIP indexer per language as a
+    /// subprocess, and stores each protobuf blob keyed on (repo, lang).
+    /// Idempotent on content hash.
+    ///
+    /// With `--file <path>`, resolves the owning repo by walking parents
+    /// against `watch.toml` and re-indexes that repo. Used by the
+    /// PostToolUse re-index hook (#281) so edits keep the index fresh.
+    /// `--repo` is optional in `--file` mode.
     Index {
-        /// Repo name (must be present in watch.toml)
-        repo: String,
+        /// Repo name (must be present in watch.toml). Optional when --file
+        /// is supplied; the repo is resolved from the file's path.
+        repo: Option<String>,
+        /// Re-index the repo containing this file path. Resolves the repo
+        /// by ancestor match against watch.toml. The whole repo is still
+        /// re-indexed; per-file granularity is a future refinement.
+        #[arg(long)]
+        file: Option<PathBuf>,
     },
 
     /// Query SCIP symbol indexes (def, refs, impl, hover).
@@ -2879,15 +2890,52 @@ fn run() -> error::Result<()> {
                 }
             }
         }
-        Commands::Index { repo } => {
+        Commands::Index { repo, file } => {
             let base = data_dir()?;
             let watch_path = base.join("watch.toml");
             let repos = watch::list_repos_in_config(&watch_path)?;
-            let entry = repos.iter().find(|r| r.name == repo).ok_or_else(|| {
-                error::LegionError::WatchConfig(format!(
-                    "repo '{repo}' not in watch.toml. Add it with `legion watch add {repo} <path>`."
-                ))
-            })?;
+
+            // --file overrides --repo: resolve the owning repo by walking
+            // ancestors of the file path against watch.toml workdirs.
+            // Falls through to the named-repo path with a synthesized repo
+            // name so the indexer + upsert loop is the single code path.
+            let (repo, entry): (String, &watch::WatchRepoConfig) = match (repo, file.as_ref()) {
+                (_, Some(file_path)) => {
+                    let canon = std::fs::canonicalize(file_path).map_err(|e| {
+                        error::LegionError::WatchConfig(format!(
+                            "cannot canonicalize {}: {e}",
+                            file_path.display()
+                        ))
+                    })?;
+                    let owner = repos
+                        .iter()
+                        .find(|r| {
+                            std::fs::canonicalize(&r.workdir)
+                                .map(|w| canon.starts_with(&w))
+                                .unwrap_or(false)
+                        })
+                        .ok_or_else(|| {
+                            error::LegionError::WatchConfig(format!(
+                                "no watch.toml entry owns {} -- file is outside every watched workdir",
+                                canon.display()
+                            ))
+                        })?;
+                    (owner.name.clone(), owner)
+                }
+                (Some(name), None) => {
+                    let owner = repos.iter().find(|r| r.name == name).ok_or_else(|| {
+                        error::LegionError::WatchConfig(format!(
+                            "repo '{name}' not in watch.toml. Add it with `legion watch add {name} <path>`."
+                        ))
+                    })?;
+                    (name, owner)
+                }
+                (None, None) => {
+                    return Err(error::LegionError::WatchConfig(
+                        "either <repo> or --file <path> is required".to_string(),
+                    ));
+                }
+            };
             let repo_path = std::path::PathBuf::from(&entry.workdir);
 
             let langs = scip::detect_languages(&repo_path);

--- a/src/main.rs
+++ b/src/main.rs
@@ -2890,35 +2890,49 @@ fn run() -> error::Result<()> {
             })?;
             let repo_path = std::path::PathBuf::from(&entry.workdir);
 
-            let lang = scip::detect_language(&repo_path).ok_or_else(|| {
-                error::LegionError::WatchConfig(format!(
-                    "no supported language detected at {}",
+            let langs = scip::detect_languages(&repo_path);
+            if langs.is_empty() {
+                return Err(error::LegionError::WatchConfig(format!(
+                    "no supported language detected at {}. Markers checked: Cargo.toml, package.json, pyproject.toml, requirements.txt, go.mod.",
                     repo_path.display()
-                ))
-            })?;
-
-            let blob = scip::run_indexer(lang, &repo_path)?;
-            let hash = scip::content_hash(&blob);
-            let now = chrono::Utc::now().to_rfc3339();
-            let index = scip::ScipIndex {
-                id: uuid::Uuid::now_v7().to_string(),
-                repo: repo.clone(),
-                lang: lang.to_string(),
-                content_hash: hash,
-                blob,
-                updated_at: now,
-                deleted_at: None,
-            };
+                )));
+            }
 
             let database = db::Database::open(&base.join("legion.db"))?;
-            database.upsert_scip_index(&index)?;
-            eprintln!(
-                "[legion] indexed {} ({}): {} bytes, hash {}",
-                repo,
-                lang,
-                index.blob.len(),
-                &index.content_hash[..16]
-            );
+            let mut indexed: u32 = 0;
+            for lang in &langs {
+                let blob = match scip::run_indexer(lang, &repo_path) {
+                    Ok(b) => b,
+                    Err(e) => {
+                        eprintln!("[legion] skipped {repo} ({lang}): {e}");
+                        continue;
+                    }
+                };
+                let hash = scip::content_hash(&blob);
+                let now = chrono::Utc::now().to_rfc3339();
+                let index = scip::ScipIndex {
+                    id: uuid::Uuid::now_v7().to_string(),
+                    repo: repo.clone(),
+                    lang: (*lang).to_string(),
+                    content_hash: hash,
+                    blob,
+                    updated_at: now,
+                    deleted_at: None,
+                };
+                let bytes_len = index.blob.len();
+                let hash_prefix = &index.content_hash[..16];
+                database.upsert_scip_index(&index)?;
+                eprintln!(
+                    "[legion] indexed {repo} ({lang}): {bytes_len} bytes, hash {hash_prefix}"
+                );
+                indexed += 1;
+            }
+            if indexed == 0 {
+                return Err(error::LegionError::WatchConfig(format!(
+                    "no language indexed for {repo} -- every detected language ({}) failed; see warnings above",
+                    langs.join(", ")
+                )));
+            }
         }
         Commands::Sym { action } => {
             let base = data_dir()?;

--- a/src/scip.rs
+++ b/src/scip.rs
@@ -39,18 +39,34 @@ pub fn content_hash(bytes: &[u8]) -> String {
     hex::encode(digest)
 }
 
-/// Detect the dominant language of a repo by looking for marker files.
-/// Returns the language tag legion uses internally (e.g. "rust"), or
-/// None when no indexer-supported language is recognized.
+/// Detect every language with a recognized marker file in `repo_path`.
+/// Returns the language tags legion uses internally; empty when none of
+/// the supported indexers' marker files are present.
 ///
-/// This issue (#278) only handles Rust. Multi-language detection lives
-/// in #279; this function exists here so the dispatch path is already
-/// shaped correctly.
-pub fn detect_language(repo_path: &Path) -> Option<&'static str> {
+/// Markers checked:
+/// - `Cargo.toml` -> "rust"
+/// - `package.json` -> "typescript"
+/// - `pyproject.toml` or `requirements.txt` -> "python"
+/// - `go.mod` -> "go"
+///
+/// A polyglot repo (e.g. Rust core + TS dashboard) returns multiple
+/// languages and the caller indexes each independently into its own
+/// `(repo, lang)` row.
+pub fn detect_languages(repo_path: &Path) -> Vec<&'static str> {
+    let mut langs: Vec<&'static str> = Vec::new();
     if repo_path.join("Cargo.toml").is_file() {
-        return Some("rust");
+        langs.push("rust");
     }
-    None
+    if repo_path.join("package.json").is_file() {
+        langs.push("typescript");
+    }
+    if repo_path.join("pyproject.toml").is_file() || repo_path.join("requirements.txt").is_file() {
+        langs.push("python");
+    }
+    if repo_path.join("go.mod").is_file() {
+        langs.push("go");
+    }
+    langs
 }
 
 /// Run the appropriate SCIP indexer for `lang` against `repo_path` and
@@ -63,6 +79,9 @@ pub fn detect_language(repo_path: &Path) -> Option<&'static str> {
 pub fn run_indexer(lang: &str, repo_path: &Path) -> Result<Vec<u8>> {
     match lang {
         "rust" => run_scip_rust(repo_path),
+        "typescript" => run_scip_typescript(repo_path),
+        "python" => run_scip_python(repo_path),
+        "go" => run_scip_go(repo_path),
         other => Err(LegionError::IndexerNotFound {
             lang: other.to_string(),
             binary: format!("scip-{other}"),
@@ -79,26 +98,86 @@ pub fn run_indexer(lang: &str, repo_path: &Path) -> Result<Vec<u8>> {
 /// 2026-04, so most fresh dev machines only have rust-analyzer (shipped
 /// with rustup). Both produce the same SCIP protobuf shape.
 fn run_scip_rust(repo_path: &Path) -> Result<Vec<u8>> {
-    match run_indexer_binary("scip-rust", &["index"], repo_path) {
+    match run_indexer_binary("rust", "scip-rust", &["index"], repo_path) {
         Ok(bytes) => Ok(bytes),
         Err(LegionError::IndexerNotFound { .. }) => {
-            run_indexer_binary("rust-analyzer", &["scip", "."], repo_path).map_err(|e| match e {
-                LegionError::IndexerNotFound { lang, .. } => LegionError::IndexerNotFound {
-                    lang,
-                    binary: "scip-rust or rust-analyzer".to_string(),
-                },
-                other => other,
-            })
+            run_indexer_binary("rust", "rust-analyzer", &["scip", "."], repo_path)
+                .map_err(rust_install_hint)
         }
         Err(other) => Err(other),
     }
 }
 
+/// Map a missing-binary error from the rust-analyzer fallback to one that
+/// names both candidate binaries plus the rustup install hint.
+fn rust_install_hint(e: LegionError) -> LegionError {
+    match e {
+        LegionError::IndexerNotFound { lang, .. } => LegionError::IndexerNotFound {
+            lang,
+            binary: "scip-rust or rust-analyzer (install: rustup component add rust-analyzer)"
+                .to_string(),
+        },
+        other => other,
+    }
+}
+
+/// Invoke `scip-typescript index` against `repo_path`. Canonical TS/JS
+/// indexer from sourcegraph (`npm i -g @sourcegraph/scip-typescript`).
+/// No fallback exists; tsserver is too slow and shape-incompatible to
+/// substitute.
+fn run_scip_typescript(repo_path: &Path) -> Result<Vec<u8>> {
+    run_indexer_binary("typescript", "scip-typescript", &["index"], repo_path).map_err(
+        |e| match e {
+            LegionError::IndexerNotFound { lang, .. } => LegionError::IndexerNotFound {
+                lang,
+                binary: "scip-typescript (install: npm i -g @sourcegraph/scip-typescript)"
+                    .to_string(),
+            },
+            other => other,
+        },
+    )
+}
+
+/// Invoke `scip-python index .` against `repo_path`. Canonical Python
+/// indexer from sourcegraph (`pip install scip-python` or
+/// `npm i -g @sourcegraph/scip-python`).
+fn run_scip_python(repo_path: &Path) -> Result<Vec<u8>> {
+    run_indexer_binary("python", "scip-python", &["index", "."], repo_path).map_err(|e| match e {
+        LegionError::IndexerNotFound { lang, .. } => LegionError::IndexerNotFound {
+            lang,
+            binary: "scip-python (install: pip install scip-python)".to_string(),
+        },
+        other => other,
+    })
+}
+
+/// Invoke `scip-go` against `repo_path`. Canonical Go indexer from
+/// sourcegraph (`go install github.com/sourcegraph/scip-go/cmd/scip-go@latest`).
+/// Writes `index.scip` in the working directory by default; no subcommand.
+fn run_scip_go(repo_path: &Path) -> Result<Vec<u8>> {
+    run_indexer_binary("go", "scip-go", &[], repo_path).map_err(|e| match e {
+        LegionError::IndexerNotFound { lang, .. } => LegionError::IndexerNotFound {
+            lang,
+            binary:
+                "scip-go (install: go install github.com/sourcegraph/scip-go/cmd/scip-go@latest)"
+                    .to_string(),
+        },
+        other => other,
+    })
+}
+
 /// Run a SCIP indexer binary against `repo_path`. Returns the bytes of the
 /// `index.scip` protobuf written into the repo root, or a typed error
 /// describing the failure mode (binary not on PATH, subprocess exited
-/// non-zero, output file unreadable).
-fn run_indexer_binary(binary: &str, args: &[&str], repo_path: &Path) -> Result<Vec<u8>> {
+/// non-zero, output file unreadable). The `lang` is carried into error
+/// variants so callers see which language failed even when several share
+/// this helper.
+fn run_indexer_binary(
+    lang: &str,
+    binary: &str,
+    args: &[&str],
+    repo_path: &Path,
+) -> Result<Vec<u8>> {
     let output = match Command::new(binary)
         .args(args)
         .current_dir(repo_path)
@@ -107,7 +186,7 @@ fn run_indexer_binary(binary: &str, args: &[&str], repo_path: &Path) -> Result<V
         Ok(o) => o,
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
             return Err(LegionError::IndexerNotFound {
-                lang: "rust".to_string(),
+                lang: lang.to_string(),
                 binary: binary.to_string(),
             });
         }
@@ -117,7 +196,7 @@ fn run_indexer_binary(binary: &str, args: &[&str], repo_path: &Path) -> Result<V
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr).to_string();
         return Err(LegionError::IndexerFailed {
-            lang: "rust".to_string(),
+            lang: lang.to_string(),
             stderr,
         });
     }
@@ -144,17 +223,53 @@ mod tests {
     }
 
     #[test]
-    fn detect_language_rust_for_cargo_toml() {
+    fn detect_languages_rust_for_cargo_toml() {
         let dir = TempDir::new().unwrap();
         fs::write(dir.path().join("Cargo.toml"), "[package]\nname = \"x\"").unwrap();
-        assert_eq!(detect_language(dir.path()), Some("rust"));
+        assert_eq!(detect_languages(dir.path()), vec!["rust"]);
     }
 
     #[test]
-    fn detect_language_none_for_unsupported() {
+    fn detect_languages_typescript_for_package_json() {
+        let dir = TempDir::new().unwrap();
+        fs::write(dir.path().join("package.json"), "{\"name\":\"x\"}").unwrap();
+        assert_eq!(detect_languages(dir.path()), vec!["typescript"]);
+    }
+
+    #[test]
+    fn detect_languages_python_for_either_marker() {
+        let dir = TempDir::new().unwrap();
+        fs::write(dir.path().join("pyproject.toml"), "[project]\nname=\"x\"").unwrap();
+        assert_eq!(detect_languages(dir.path()), vec!["python"]);
+
+        let dir2 = TempDir::new().unwrap();
+        fs::write(dir2.path().join("requirements.txt"), "requests").unwrap();
+        assert_eq!(detect_languages(dir2.path()), vec!["python"]);
+    }
+
+    #[test]
+    fn detect_languages_go_for_go_mod() {
+        let dir = TempDir::new().unwrap();
+        fs::write(dir.path().join("go.mod"), "module x\n").unwrap();
+        assert_eq!(detect_languages(dir.path()), vec!["go"]);
+    }
+
+    #[test]
+    fn detect_languages_polyglot_returns_all() {
+        let dir = TempDir::new().unwrap();
+        fs::write(dir.path().join("Cargo.toml"), "[package]\nname=\"x\"").unwrap();
+        fs::write(dir.path().join("package.json"), "{\"name\":\"x\"}").unwrap();
+        let langs = detect_languages(dir.path());
+        assert!(langs.contains(&"rust"));
+        assert!(langs.contains(&"typescript"));
+        assert_eq!(langs.len(), 2);
+    }
+
+    #[test]
+    fn detect_languages_empty_when_no_markers() {
         let dir = TempDir::new().unwrap();
         fs::write(dir.path().join("README.md"), "hi").unwrap();
-        assert_eq!(detect_language(dir.path()), None);
+        assert!(detect_languages(dir.path()).is_empty());
     }
 
     #[test]
@@ -167,6 +282,55 @@ mod tests {
                 assert_eq!(binary, "scip-klingon");
             }
             other => panic!("expected IndexerNotFound, got {other:?}"),
+        }
+    }
+
+    /// Verify each language helper surfaces its install hint when its
+    /// indexer is missing from PATH. Using a single combined test with
+    /// PATH manipulation to avoid the parallel cargo-test race.
+    #[cfg(unix)]
+    #[test]
+    fn language_helpers_surface_install_hints_when_missing() {
+        let prior = std::env::var("PATH").unwrap_or_default();
+        let (empty_dir, empty_path) = isolate_path_with_shims(&[]);
+        let repo = TempDir::new().unwrap();
+        // Safety: see run_scip_rust_fallback_chain for the same justification.
+        unsafe {
+            std::env::set_var("PATH", &empty_path);
+        }
+
+        let cases = [
+            (
+                "typescript",
+                run_scip_typescript(repo.path()),
+                "scip-typescript",
+                "npm",
+            ),
+            ("python", run_scip_python(repo.path()), "scip-python", "pip"),
+            ("go", run_scip_go(repo.path()), "scip-go", "go install"),
+        ];
+
+        unsafe {
+            std::env::set_var("PATH", &prior);
+        }
+        drop(empty_dir);
+
+        for (lang, result, expected_binary, expected_install_hint) in cases {
+            let err = result.unwrap_err();
+            match err {
+                LegionError::IndexerNotFound { lang: l, binary } => {
+                    assert_eq!(l, lang);
+                    assert!(
+                        binary.contains(expected_binary),
+                        "{lang} hint missing binary name: {binary}"
+                    );
+                    assert!(
+                        binary.contains(expected_install_hint),
+                        "{lang} hint missing install instruction: {binary}"
+                    );
+                }
+                other => panic!("expected IndexerNotFound for {lang}, got {other:?}"),
+            }
         }
     }
 


### PR DESCRIPTION
Closes #279, #280, #281.

Phase A + B of the SCIP completion plan (validated-seeking-dongarra). Ships together as v0.11.0 base because the per-file re-index hook (#281) is only useful when multiple languages are indexable (#279).

## What changes

### #279 multi-language SCIP dispatch

Replaces single-language \`detect_language -> Option<&str>\` with \`detect_languages -> Vec<&str>\`. Markers checked: \`Cargo.toml\` -> rust, \`package.json\` -> typescript, \`pyproject.toml\` or \`requirements.txt\` -> python, \`go.mod\` -> go.

Adds \`run_scip_typescript\`, \`run_scip_python\`, \`run_scip_go\` following the \`run_scip_rust\` shape. Each carries an install hint so fresh dev machines see how to install the missing indexer.

\`run_indexer_binary\` now takes \`lang\` as a parameter so error variants identify the failing language correctly (was previously hardcoded to \"rust\").

\`legion index <repo>\` loops over every detected language. A missing indexer for one language warns and continues; only fails the whole command when every detected language failed.

### #280 + #281 per-file re-index

\`legion index --file <path>\` resolves the owning repo by walking ancestors against \`watch.toml\` workdirs. \`Commands::Index\` accepts \`Option<String>\` repo so \`--file\` mode requires no repo arg. Match arms cover \`(_, Some(file))\`, \`(Some(name), None)\`, \`(None, None)\` — no stringly-typed sentinel.

\`plugin/hooks/post-edit-index.sh\` is a new PostToolUse hook fired on Edit / Write / MultiEdit. Reads \`tool_input.file_path\`, debounces 500ms per path via \`/tmp/legion-index-<md5>.lock\`, runs \`legion index --file\` in the background (nohup + disown). Skips uncovered repos via \`_legion-covered.sh\`. Stderr appended to \`/tmp/legion-hook-errors.log\`; hook always exits 0.

## Tests

- 6 new \`detect_languages_*\` unit tests + 1 install-hint test for ts/python/go binaries
- All existing scip and watch tests pass (116/116 integration, 648/648 unit on stable run)

## Test plan
- [x] \`cargo test\` — 116 integration + 648 unit (transient flakes on session_lock_* and call_plugin_timeout tests are pre-existing parallel races, not introduced here; pass on re-run)
- [x] \`cargo clippy --all-targets -- -D warnings\` — clean
- [x] \`cargo fmt -- --check\` — clean
- [x] \`shellcheck plugin/hooks/post-edit-index.sh\` — clean
- [x] Manual smoke: hook exits 0 on a non-covered cwd (skips index call as designed)

## Out of scope

Phase C (consumption hooks — pre-grep-scip + recall-first.sh upgrade) ships as v0.12.0. Phase D + E (cross-repo + LSP cleanup) ship as v0.13.0.