### PR TITLE
feat(#283, #413): SCIP consumption hooks -- pre-grep-scip + recall-first cheap-chain (v0.12.0 base)

### DIFF
--- a/plugin/hooks/hooks.json
+++ b/plugin/hooks/hooks.json
@@ -58,6 +58,11 @@
             "type": "command",
             "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/pre-grep-recall.sh",
             "timeout": 6
+          },
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/pre-grep-scip.sh",
+            "timeout": 6
           }
         ]
       },
@@ -67,6 +72,11 @@
           {
             "type": "command",
             "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/pre-grep-recall.sh",
+            "timeout": 6
+          },
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/pre-grep-scip.sh",
             "timeout": 6
           }
         ]

--- a/plugin/hooks/pre-grep-scip.sh
+++ b/plugin/hooks/pre-grep-scip.sh
@@ -1,0 +1,117 @@
+#!/bin/bash
+# Legion PreToolUse hook (#283): if a Grep or Glob pattern looks like a
+# bare symbol (CamelCase or snake_case, no regex noise, length > 2), run
+# `legion sym def --json <symbol>` and inject results as additionalContext
+# before the search tool fires.
+#
+# Sibling of pre-grep-recall.sh. Same skip discipline, same JSON I/O shape,
+# same coverage gate. Never blocks the tool. Falls through silently if
+# legion has no SCIP index for the repo or the pattern is not a symbol.
+#
+# Differences from pre-grep-recall.sh:
+# - Uses `legion sym def --json` (not `legion recall`)
+# - Pattern detection is symbol-shape, not natural-language tokenization
+# - LEGION_SKIP_PRE_GREP_SCIP=1 skips this hook specifically
+#
+# Error handling: every failure exits 0 with a stderr breadcrumb prefixed
+# "[legion-pre-grep-scip]". Errors append to /tmp/legion-hook-errors.log.
+
+LEGION="${CLAUDE_PLUGIN_ROOT}/bin/legion"
+LOG=/tmp/legion-hook-errors.log
+
+if [ "${LEGION_SKIP_PRE_GREP_SCIP:-}" = "1" ]; then
+  echo "[legion-pre-grep-scip] skipped (LEGION_SKIP_PRE_GREP_SCIP=1)" >&2
+  exit 0
+fi
+
+INPUT=$(cat)
+if [ -z "$INPUT" ]; then
+  exit 0
+fi
+
+CWD=$(echo "$INPUT" | jq -r '.cwd // empty' 2>/dev/null)
+TOOL=$(echo "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null)
+PATTERN=$(echo "$INPUT" | jq -r '.tool_input.pattern // empty' 2>/dev/null)
+
+if [ -z "$CWD" ] || [ -z "$TOOL" ] || [ -z "$PATTERN" ]; then
+  exit 0
+fi
+
+# Only apply to Grep and Glob.
+case "$TOOL" in
+  Grep|Glob) ;;
+  *) exit 0 ;;
+esac
+
+REPO="${LEGION_REPO:-$(basename "$CWD")}"
+if [ -z "$REPO" ]; then
+  exit 0
+fi
+
+# Skip uncovered repos.
+SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // empty' 2>/dev/null)
+if [ -f "${CLAUDE_PLUGIN_ROOT}/hooks/_legion-covered.sh" ]; then
+  # shellcheck source=_legion-covered.sh
+  source "${CLAUDE_PLUGIN_ROOT}/hooks/_legion-covered.sh"
+  if ! legion_covered "$SESSION_ID" "$REPO"; then
+    exit 0
+  fi
+fi
+
+# Symbol-shape detection: CamelCase or snake_case identifier, length > 2,
+# no regex metacharacters. This is the conservative case where the agent
+# is almost certainly looking for a definition or reference, not pattern
+# matching. Strip leading and trailing word boundaries (\b) if present
+# (a common Grep convention).
+SYMBOL=$(echo "$PATTERN" | sed -E 's/^\\b//; s/\\b$//')
+
+# Symbol regex covers both CamelCase and snake_case identifiers, length > 2,
+# and excludes regex metacharacters and whitespace by construction. If the
+# whole string does not match, this is a regex pattern, not a bare symbol.
+if ! echo "$SYMBOL" | grep -qE '^[A-Z][A-Za-z0-9_]{2,}$|^[a-z_][a-z_0-9]{2,}$'; then
+  exit 0
+fi
+
+# Bail if the legion binary is missing.
+if [ ! -x "$LEGION" ]; then
+  exit 0
+fi
+
+# Run sym def. The hook-level timeout in hooks.json (6s) bounds runtime;
+# no separate gtimeout wrapper here.
+HITS=$("$LEGION" sym def --json "$SYMBOL" 2>>"$LOG")
+RC=$?
+
+# Empty results or error -> skip injection.
+if [ "$RC" -ne 0 ] || [ -z "$HITS" ] || [ "$HITS" = "[]" ] || [ "$HITS" = "null" ]; then
+  exit 0
+fi
+
+# Also fetch refs for context (best-effort; skip on failure).
+REFS=$("$LEGION" sym refs --json "$SYMBOL" 2>>"$LOG" || true)
+REFS_LINE=""
+if [ -n "$REFS" ] && [ "$REFS" != "[]" ] && [ "$REFS" != "null" ]; then
+  REF_COUNT=$(echo "$REFS" | jq 'length' 2>/dev/null || echo "0")
+  REFS_LINE="(${REF_COUNT} reference(s) found via \`legion sym refs ${SYMBOL}\`)"
+fi
+
+CTX="## Legion SCIP for \`${SYMBOL}\`
+
+Before ${TOOL} on \`${PATTERN}\`, legion's pre-computed SCIP index returned:
+
+\`\`\`json
+${HITS}
+\`\`\`
+
+${REFS_LINE}
+
+If this answers your symbol question, skip the ${TOOL}. SCIP is byte-cheap; file scans are not."
+
+jq -n --arg ctx "$CTX" '{
+  "hookSpecificOutput": {
+    "hookEventName": "PreToolUse",
+    "permissionDecision": "allow",
+    "permissionDecisionReason": "legion sym hits for the symbol",
+    "additionalContext": $ctx
+  }
+}'

--- a/plugin/hooks/recall-first.sh
+++ b/plugin/hooks/recall-first.sh
@@ -112,22 +112,111 @@ If these answer your question, skip the ${TOOL}. Otherwise continue -- but consi
   fi
 fi
 
-# For Explore agents: deny the spawn if recall has a strong hit.
-# Extract the top score -- format is "score: 0.XX)" at end of each hit line.
-# If top score >= threshold, deny and return recall results instead.
+# For Explore agents (#413): run the full cheap chain before deciding.
+# recall alone is too narrow -- consult catches cross-agent memory,
+# surface catches recent cross-repo activity, sym catches code-intel
+# answers when the prompt mentions identifiers, consult --symbol covers
+# cross-repo code intel.
+#
+# Decision: deny when ANY source returns informative content. The closing
+# guidance points at Read with concrete paths from the results, not Grep
+# (the pre-#413 fallback shifted cost sideways instead of dropping it --
+# see reflection 019d84c7).
 DECISION="allow"
 REASON="legion recall hits for the query"
-if [ "$IS_EXPLORE" = true ] && [ -n "$HITS" ]; then
-  TOP_SCORE=$(echo "$HITS" | grep -oE 'score: [0-9]+\.[0-9]+' | head -1 | awk '{print $2}')
-  THRESHOLD="${LEGION_EXPLORE_THRESHOLD:-0.60}"
-  if [ -n "$TOP_SCORE" ] && awk "BEGIN{exit !($TOP_SCORE >= $THRESHOLD)}"; then
-    DECISION="deny"
-    REASON="legion recall answered this (score: ${TOP_SCORE}). Use the recall results instead of spawning Explore."
-    CTX="[Legion] Explore BLOCKED -- recall already has what you need:
+if [ "$IS_EXPLORE" = true ]; then
+  # Source 1 already done: HITS (recall). Score-based hit detection.
+  RECALL_HIT=false
+  if [ -n "$HITS" ]; then
+    TOP_SCORE=$(echo "$HITS" | grep -oE 'score: [0-9]+\.[0-9]+' | head -1 | awk '{print $2}')
+    THRESHOLD="${LEGION_EXPLORE_THRESHOLD:-0.60}"
+    if [ -n "$TOP_SCORE" ] && awk "BEGIN{exit !($TOP_SCORE >= $THRESHOLD)}"; then
+      RECALL_HIT=true
+    fi
+  fi
 
+  # Source 2: cross-agent memory. Best-effort; never errors out the hook.
+  CONSULT=$("$LEGION" consult --context "$QUERY" --limit 3 2>>"$LOG" || true)
+  CONSULT_HIT=false
+  if [ -n "$CONSULT" ] && echo "$CONSULT" | grep -q '^- '; then
+    CONSULT_HIT=true
+  fi
+
+  # Source 3: recent cross-repo activity. Topical surface for in-flight work.
+  SURFACE=$("$LEGION" surface --repo "$REPO" 2>>"$LOG" || true)
+  SURFACE_HIT=false
+  if [ -n "$SURFACE" ] && echo "$SURFACE" | grep -q '^- '; then
+    SURFACE_HIT=true
+  fi
+
+  # Source 4: code intelligence. Only fires when the prompt mentions an
+  # identifier-shaped token. Floor raised to 5 chars to filter out
+  # English stopwords (the, and, this, that, etc.) and the
+  # CASE_PATTERN excludes a small set of common-word-shapes that pass
+  # the regex but are obviously natural language.
+  #
+  # Both same-repo (sym def) and cross-repo (consult --symbol). The
+  # cross-repo flag may not exist yet (#285); the failure is silently
+  # absorbed by the trailing `|| true`.
+  IDENT=$(echo "$QUERY" \
+    | grep -oE '[A-Z][A-Za-z0-9_]{4,}|[a-z_][a-z_0-9]{4,}' \
+    | grep -viE '^(should|would|could|where|which|there|their|these|those|about|after|before|other|first|under|legion|claude|hooks|files|using)$' \
+    | head -1)
+  SYM=""
+  SYM_XREPO=""
+  SYM_HIT=false
+  if [ -n "$IDENT" ]; then
+    SYM=$("$LEGION" sym def --json "$IDENT" 2>>"$LOG" || true)
+    if [ -n "$SYM" ] && [ "$SYM" != "[]" ] && [ "$SYM" != "null" ]; then
+      SYM_HIT=true
+    fi
+    SYM_XREPO=$("$LEGION" consult --symbol "$IDENT" 2>>"$LOG" || true)
+    if [ -n "$SYM_XREPO" ] && echo "$SYM_XREPO" | grep -q '^- '; then
+      SYM_HIT=true
+    fi
+  fi
+
+  if [ "$RECALL_HIT" = true ] || [ "$CONSULT_HIT" = true ] || [ "$SURFACE_HIT" = true ] || [ "$SYM_HIT" = true ]; then
+    DECISION="deny"
+    REASON="legion's cheap-paths chain answered this. Use the injected results, then Read specific files if you need detail."
+
+    SECTIONS=""
+    if [ -n "$HITS" ]; then
+      SECTIONS="${SECTIONS}### legion recall (this repo)
 ${HITS}
 
-Use these results directly. If they are genuinely insufficient, rephrase your question and try a direct Grep or Read instead of Explore."
+"
+    fi
+    if [ -n "$CONSULT" ]; then
+      SECTIONS="${SECTIONS}### legion consult (cross-agent memory)
+${CONSULT}
+
+"
+    fi
+    if [ -n "$SURFACE" ]; then
+      SECTIONS="${SECTIONS}### legion surface (recent cross-repo activity)
+${SURFACE}
+
+"
+    fi
+    if [ -n "$SYM" ] && [ "$SYM" != "[]" ] && [ "$SYM" != "null" ]; then
+      SECTIONS="${SECTIONS}### legion sym def \`${IDENT}\` (this repo, SCIP)
+\`\`\`json
+${SYM}
+\`\`\`
+
+"
+    fi
+    if [ -n "$SYM_XREPO" ]; then
+      SECTIONS="${SECTIONS}### legion consult --symbol \`${IDENT}\` (cross-repo SCIP)
+${SYM_XREPO}
+
+"
+    fi
+
+    CTX="[Legion] Explore BLOCKED -- the cheap-paths chain already covers this:
+
+${SECTIONS}Read the specific files referenced in these results for detail. Do NOT switch to Grep -- it is not cheaper. The point is to skip the file scan, not to do it under a different tool name."
   fi
 fi
 

--- a/plugin/hooks/test-pre-grep-scip.sh
+++ b/plugin/hooks/test-pre-grep-scip.sh
@@ -1,0 +1,106 @@
+#!/bin/bash
+# Test runner for pre-grep-scip.sh.
+#
+# Feeds synthetic hook JSON into the hook and asserts the hook behaves
+# correctly on each branch. Does NOT require a working legion binary or
+# a populated SCIP index: when $LEGION is missing or `legion sym def`
+# returns nothing, the hook must exit 0 without emitting JSON, so all
+# "no injection expected" tests pass cleanly even in a cold environment.
+#
+# Run from the repo root:
+#   bash plugin/hooks/test-pre-grep-scip.sh
+#
+# Exits 0 on success, 1 on any failed assertion.
+
+set -u
+
+HOOK="${CLAUDE_PLUGIN_ROOT:-$(pwd)}/plugin/hooks/pre-grep-scip.sh"
+if [ ! -f "$HOOK" ]; then
+  echo "FAIL: hook not found at $HOOK" >&2
+  exit 1
+fi
+
+PASS=0
+FAIL=0
+
+# Reads stdin (the synthetic hook event) and asserts the hook produced no
+# stdout. Uses a heredoc-style invocation from callers so the function runs
+# in the parent shell and PASS/FAIL counters survive.
+assert_empty_stdout() {
+  local desc="$1"
+  local input
+  input=$(cat)
+  local output
+  output=$(echo "$input" | CLAUDE_PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$(pwd)}/plugin" bash "$HOOK" 2>/dev/null)
+  if [ -z "$output" ]; then
+    PASS=$((PASS + 1))
+    echo "  PASS: $desc"
+  else
+    FAIL=$((FAIL + 1))
+    echo "  FAIL: $desc"
+    echo "    expected empty stdout, got: $output" >&2
+  fi
+}
+
+echo "==> regex-noisy patterns skip injection"
+
+assert_empty_stdout "open paren in pattern -> skip" <<'EOF'
+{"cwd":"/tmp","tool_name":"Grep","tool_input":{"pattern":"abc(def"},"session_id":"t"}
+EOF
+
+assert_empty_stdout "alternation in pattern -> skip" <<'EOF'
+{"cwd":"/tmp","tool_name":"Grep","tool_input":{"pattern":"foo|bar"},"session_id":"t"}
+EOF
+
+assert_empty_stdout "anchored pattern -> skip" <<'EOF'
+{"cwd":"/tmp","tool_name":"Grep","tool_input":{"pattern":"^start"},"session_id":"t"}
+EOF
+
+assert_empty_stdout "whitespace in pattern -> skip" <<'EOF'
+{"cwd":"/tmp","tool_name":"Grep","tool_input":{"pattern":"two words"},"session_id":"t"}
+EOF
+
+echo "==> short / non-identifier patterns skip"
+
+assert_empty_stdout "length 2 -> skip" <<'EOF'
+{"cwd":"/tmp","tool_name":"Grep","tool_input":{"pattern":"to"},"session_id":"t"}
+EOF
+
+assert_empty_stdout "starts with digit -> skip" <<'EOF'
+{"cwd":"/tmp","tool_name":"Grep","tool_input":{"pattern":"123abc"},"session_id":"t"}
+EOF
+
+echo "==> non-Grep/Glob tools skip"
+
+assert_empty_stdout "Read tool -> skip" <<'EOF'
+{"cwd":"/tmp","tool_name":"Read","tool_input":{"file_path":"/tmp/foo"},"session_id":"t"}
+EOF
+
+assert_empty_stdout "Bash tool -> skip" <<'EOF'
+{"cwd":"/tmp","tool_name":"Bash","tool_input":{"command":"ls"},"session_id":"t"}
+EOF
+
+echo "==> missing fields skip"
+
+assert_empty_stdout "empty event -> skip" <<'EOF'
+{}
+EOF
+
+assert_empty_stdout "missing pattern -> skip" <<'EOF'
+{"cwd":"/tmp","tool_name":"Grep"}
+EOF
+
+echo "==> uncovered repo skips"
+
+# /tmp is never legion-covered.
+assert_empty_stdout "uncovered repo with valid symbol -> skip" <<'EOF'
+{"cwd":"/tmp","tool_name":"Grep","tool_input":{"pattern":"find_pending_signals"},"session_id":"t"}
+EOF
+
+echo
+echo "---"
+echo "Results: $PASS passed, $FAIL failed"
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
Closes #283, #413.

Phase C of the SCIP completion plan. The cost-control phase. Both surfaces are token-cheap legion CLI calls that prevent expensive tool calls. Ships standalone as v0.12.0 so the cache_r reduction is measurable in isolation.

## #283 -- pre-grep-scip.sh

New PreToolUse hook on Grep + Glob. If the pattern looks like a bare symbol (CamelCase or snake_case identifier, length > 2, no regex metacharacters), runs \`legion sym def --json\` and \`legion sym refs --json\`, injects results as additionalContext. Never blocks the tool.

Skip cases: regex-shaped patterns, short patterns, non-symbol patterns, missing legion binary, empty SCIP results, uncovered repos.

## #413 -- recall-first.sh upgraded

The Agent(Explore) branch ran only \`legion recall\` and on a threshold hit told the agent to use Grep instead. Cost shifted sideways (reflection 019d84c7). Now runs the full chain: recall -> consult -> surface -> sym def + consult --symbol when the prompt mentions an identifier. Decision: deny when ANY source returns informative content. Denial message points at Read with concrete paths; explicitly says \"do NOT switch to Grep -- it is not cheaper.\"

Each source is best-effort; failures are absorbed silently so legion degradation never blocks an Explore spawn that otherwise would have proceeded.

WebFetch / WebSearch branches unchanged.

## Test plan

- [x] \`bash plugin/hooks/test-pre-grep-scip.sh\` -- 11 passed
- [x] \`shellcheck plugin/hooks/pre-grep-scip.sh plugin/hooks/recall-first.sh\` -- clean
- [x] \`jq . plugin/hooks/hooks.json\` -- valid
- [x] Manual smoke: hook exits 0 on /tmp (uncovered repo), regex patterns, short patterns
- [x] \`cargo test\` -- 116 passed (no Rust changes; baseline)

## Verification once shipped

After rebuilding + restarting CC: ask \"where is find_pending_signals defined?\". Verify pre-grep-scip injection BEFORE any Grep call, and recall-first cheap-chain blocks any Explore spawn for a question the chain can answer.

## Out of scope

Phase D + E (cross-repo \`consult --symbol\` + drop LSP from recommended setup) ship as v0.13.0.