### PR TITLE
chore(release): 0.12.0 -- SCIP consumption hooks (cost-control payoff)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
     {
       "name": "legion",
       "description": "Agent memory layer with recall, reflect, consult, bullpen, and cross-agent coordination. Includes health monitoring and auto-wake. Hooks wire legion into every session automatically.",
-      "version": "0.11.0",
+      "version": "0.12.0",
       "author": {
         "name": "Sean Silvius",
         "email": "sean@silvius.me"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "legion"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2024"
 description = "Agent specialization through deliberate practice"
 

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "legion",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "Institutional memory for Claude Code agents with real-time team channel.",
   "author": {
     "name": "Sean Silvius",

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Legion Changelog
 
+## 0.12.0
+
+SCIP consumption hooks. Phase C of the SCIP completion plan -- the cost-control payoff. Both surfaces are token-cheap legion CLI calls that prevent expensive tool calls. Ships standalone so the cache_r reduction is measurable in isolation: the 1B+ cache_r token explosion that prompted the SCIP completion push is the metric this release should move.
+
+### New
+
+- **`pre-grep-scip.sh` PreToolUse hook** (#414, closes #283): sibling of `pre-grep-recall.sh`. Intercepts Grep + Glob; if the pattern looks like a bare symbol (CamelCase or snake_case identifier, length > 2, no regex metacharacters), runs `legion sym def --json` and `legion sym refs --json`, injects results as `additionalContext`. Never blocks the tool. Skips on regex-shaped patterns, short patterns, missing legion binary, empty SCIP results, uncovered repos. 11-test smoke suite at `plugin/hooks/test-pre-grep-scip.sh`.
+
+### Changed
+
+- **`recall-first.sh` Explore branch upgraded to the full cheap chain** (#414, closes #413): the Agent(Explore) branch previously ran only `legion recall` and on a threshold hit told the agent to use Grep instead -- perverse-incentive failure mode that shifted cost sideways (per reflection 019d84c7). New chain: `recall` -> `consult` -> `surface` -> `sym def` + `consult --symbol` (when prompt mentions an identifier-shaped token). Decision: deny when ANY source returns informative content. Denial message rewritten to "Read the specific files referenced in these results for detail. Do NOT switch to Grep -- it is not cheaper." Identifier extraction floors at 5 chars and excludes a short stopword set so common words don't trigger sym calls.
+
+### Pattern delivered
+
+**Cheap-paths-first interception.** Every expensive read tool (Grep, Glob, Agent(Explore), WebFetch, WebSearch) now has a PreToolUse hook that exhausts legion's local indexes (recall, consult, surface, sym, consult --symbol) before the expensive call fires. The cache_r savings come from the agent getting its answer from the injection and never running the original tool, OR from running it with prior context that bounds the scan.
+
 ## 0.11.0
 
 SCIP indexer breadth + freshness. Phase A + B of the SCIP completion plan. The indexer now covers every primary language the team writes (Rust, TypeScript, Python, Go) and edits trigger background re-indexing so `legion sym` answers stay current. Phase C (consumption hooks -- the cost-control payoff) ships next as 0.12.0 in isolation so the cache_r reduction is measurable.


### PR DESCRIPTION
Cuts v0.12.0 from main. Phase C of the SCIP completion plan (#414 already merged):

- pre-grep-scip.sh PreToolUse hook (#283)
- recall-first.sh Explore branch upgraded to full cheap chain (#413)

This is the cost-control phase. Every expensive read tool (Grep / Glob / Agent(Explore)) now has a PreToolUse hook that exhausts legion's local indexes first. Ships standalone so the cache_r reduction is measurable against the v0.11.0 baseline.

CHANGELOG entry written; pre-commit synced plugin.json + marketplace.json.

## Test plan
- [x] cargo test (116 + 648 passed locally)
- [x] shellcheck on new + modified hooks
- [x] pre-commit simplify gate clean

## After merge

```
git tag v0.12.0
git push origin v0.12.0
```

Then v0.13.0 (Phases D + E -- daemon background indexer + cross-repo consult --symbol + drop LSP from recommended setup) is the last SCIP release.