### PR TITLE
feat(#285): legion consult --symbol -- cross-repo SCIP symbol lookup

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -205,15 +205,33 @@ enum Commands {
         json: bool,
     },
 
-    /// Search reflections across all repos for cross-agent consultation
+    /// Search across legion's cross-agent surfaces.
+    ///
+    /// Two query modes (mutually exclusive):
+    /// - `--context "<query>"` searches reflections across every repo.
+    /// - `--symbol <name>` searches SCIP indexes (#285) across every
+    ///   repo and reports `(repo, lang, def_location, refs_count)` for
+    ///   each match. Used by recall-first.sh's cheap chain to answer
+    ///   code-intelligence questions without spawning Explore.
     Consult {
-        /// Context describing the problem to search for
-        #[arg(long)]
-        context: String,
+        /// Context describing the problem to search for (reflection mode).
+        /// Mutually exclusive with --symbol.
+        #[arg(long, conflicts_with = "symbol")]
+        context: Option<String>,
 
-        /// Maximum number of reflections to return
+        /// Symbol name to look up across every indexed repo (SCIP mode).
+        /// Mutually exclusive with --context.
+        #[arg(long, conflicts_with = "context")]
+        symbol: Option<String>,
+
+        /// Maximum number of reflections to return (reflection mode only).
         #[arg(long, default_value = "3")]
         limit: usize,
+
+        /// Emit JSON for the symbol mode output (reflection mode is
+        /// always human-formatted today).
+        #[arg(long)]
+        json: bool,
     },
 
     /// Configure Claude Code hooks for legion
@@ -2246,6 +2264,81 @@ fn run_sym_action(database: &db::Database, action: SymAction) -> error::Result<(
 /// `ScipIndex` into a `Vec<SymbolLocation>`; this function handles the
 /// scoping (repo/lang filters), the rust-only gate for `impl`, the
 /// "no index found" exit, deterministic sort, and human/JSON output.
+/// One row in the cross-repo symbol consult output.
+#[derive(serde::Serialize)]
+struct ConsultSymbolHit {
+    repo: String,
+    lang: String,
+    file: String,
+    line: u32,
+    column: u32,
+    refs_count: usize,
+}
+
+/// Implementation of `legion consult --symbol <name>` (#285).
+///
+/// Walks every (repo, lang) pair in `scip_indexes`, finds matching
+/// definitions, counts references per match. Output is sorted by repo
+/// then lang then file. Empty result exits 0 silently in human mode and
+/// emits `[]` in JSON mode -- a thin response is data, not failure.
+fn run_consult_symbol(database: &db::Database, name: &str, json: bool) -> error::Result<()> {
+    use std::io::Write;
+    let indexes = database.list_scip_indexes_filtered(None, None)?;
+
+    let mut hits: Vec<ConsultSymbolHit> = Vec::new();
+    for idx in &indexes {
+        let defs = match sym::query_definitions(&idx.blob, name, &idx.repo, &idx.lang) {
+            Ok(d) => d,
+            Err(e) => {
+                eprintln!("[legion] skipped {}/{}: {e}", idx.repo, idx.lang);
+                continue;
+            }
+        };
+        if defs.is_empty() {
+            continue;
+        }
+        let refs_count = sym::query_references(&idx.blob, name, &idx.repo, &idx.lang)
+            .map(|r| r.len())
+            .unwrap_or(0);
+        for d in defs {
+            hits.push(ConsultSymbolHit {
+                repo: d.repo,
+                lang: d.lang,
+                file: d.file,
+                line: d.line,
+                column: d.column,
+                refs_count,
+            });
+        }
+    }
+
+    hits.sort_by(|a, b| {
+        a.repo
+            .cmp(&b.repo)
+            .then(a.lang.cmp(&b.lang))
+            .then(a.file.cmp(&b.file))
+            .then(a.line.cmp(&b.line))
+    });
+
+    let stdout = std::io::stdout();
+    let mut out = stdout.lock();
+    if json {
+        serde_json::to_writer(&mut out, &hits)?;
+        writeln!(out)?;
+    } else if hits.is_empty() {
+        info!("[legion] no SCIP index has a definition for `{}`", name);
+    } else {
+        for h in &hits {
+            writeln!(
+                out,
+                "{}/{}\t{}:{}:{}\t({} ref(s))",
+                h.repo, h.lang, h.file, h.line, h.column, h.refs_count
+            )?;
+        }
+    }
+    Ok(())
+}
+
 fn run_location_query<F>(
     database: &db::Database,
     repo: Option<String>,
@@ -2593,20 +2686,43 @@ fn run() -> error::Result<()> {
                 }
             }
         }
-        Commands::Consult { context, limit } => {
+        Commands::Consult {
+            context,
+            symbol,
+            limit,
+            json,
+        } => {
             let base = data_dir()?;
             let database = db::Database::open(&base.join("legion.db"))?;
-            let index = search::SearchIndex::open(&base.join("index"))?;
 
-            let result = match try_load_embed_model() {
-                Some(model) => recall::consult(&database, &index, &model, &context, limit)?,
-                None => recall::consult_bm25(&database, &index, &context, limit)?,
-            };
-            let output = recall::format_for_consult(&result);
-            if output.is_empty() {
-                info!("[legion] no reflections matched context: \"{}\"", context);
-            } else {
-                print!("{output}");
+            match (context, symbol) {
+                (Some(ctx), None) => {
+                    let index = search::SearchIndex::open(&base.join("index"))?;
+                    let result = match try_load_embed_model() {
+                        Some(model) => recall::consult(&database, &index, &model, &ctx, limit)?,
+                        None => recall::consult_bm25(&database, &index, &ctx, limit)?,
+                    };
+                    let output = recall::format_for_consult(&result);
+                    if output.is_empty() {
+                        info!("[legion] no reflections matched context: \"{}\"", ctx);
+                    } else {
+                        print!("{output}");
+                    }
+                }
+                (None, Some(name)) => {
+                    run_consult_symbol(&database, &name, json)?;
+                }
+                (None, None) => {
+                    return Err(error::LegionError::WatchConfig(
+                        "either --context <query> or --symbol <name> is required".to_string(),
+                    ));
+                }
+                (Some(_), Some(_)) => {
+                    // clap's conflicts_with should reject this before we get here.
+                    return Err(error::LegionError::WatchConfig(
+                        "--context and --symbol are mutually exclusive".to_string(),
+                    ));
+                }
             }
         }
         Commands::Post {

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1230,6 +1230,75 @@ fn consult_no_matches() {
 }
 
 #[test]
+fn consult_symbol_empty_db_human_mode() {
+    // #285: --symbol on a fresh DB with no SCIP indexes should exit 0
+    // and print "no SCIP index..." on stderr in human mode.
+    let dir = tempfile::tempdir().unwrap();
+    let output = legion_cmd(dir.path())
+        .args(["--verbose", "consult", "--symbol", "Database"])
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "consult --symbol should succeed on empty DB: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("no SCIP index has a definition for `Database`"),
+        "expected no-index message on stderr, got: {stderr}"
+    );
+}
+
+#[test]
+fn consult_symbol_empty_db_json_mode() {
+    // #285: --symbol --json on a fresh DB returns the empty array.
+    let dir = tempfile::tempdir().unwrap();
+    let output = legion_cmd(dir.path())
+        .args(["consult", "--symbol", "Database", "--json"])
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "consult --symbol --json should succeed on empty DB: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert_eq!(
+        stdout.trim(),
+        "[]",
+        "expected `[]` for empty result, got: {stdout}"
+    );
+}
+
+#[test]
+fn consult_requires_context_or_symbol() {
+    // #285: consult with neither --context nor --symbol must error.
+    let dir = tempfile::tempdir().unwrap();
+    let output = legion_cmd(dir.path()).args(["consult"]).output().unwrap();
+    assert!(!output.status.success(), "consult with no args should fail");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("--context") && stderr.contains("--symbol"),
+        "error message should mention both modes, got: {stderr}"
+    );
+}
+
+#[test]
+fn consult_context_and_symbol_mutually_exclusive() {
+    // #285: clap's conflicts_with should reject both flags at parse time.
+    let dir = tempfile::tempdir().unwrap();
+    let output = legion_cmd(dir.path())
+        .args(["consult", "--context", "x", "--symbol", "Y"])
+        .output()
+        .unwrap();
+    assert!(
+        !output.status.success(),
+        "consult with both --context and --symbol should fail at parse time"
+    );
+}
+
+#[test]
 fn reflect_with_metadata_flags() {
     let dir = tempfile::tempdir().unwrap();
 


### PR DESCRIPTION
Closes #285. Phase D (a) of the SCIP completion plan.

Adds a second mode to `legion consult`: alongside `--context <query>` (reflection search across repos), `--symbol <name>` walks every `(repo, lang)` pair in `scip_indexes`, finds matching definitions, and counts references per match.

## Output

```
$ legion consult --symbol Database
legion/rust    src/db.rs:42:1    (87 ref(s))

$ legion consult --symbol Database --json
[{"repo":"legion","lang":"rust","file":"src/db.rs","line":42,"column":1,"refs_count":87}]
```

`--context` and `--symbol` are mutually exclusive (clap conflicts_with); at least one is required at runtime.

## Why this matters now

`recall-first.sh`'s cheap-chain (#413, ships in v0.12.0) calls `legion consult --symbol` and silently absorbs the failure today because the flag does not exist yet. With #285 merged, that call returns real cross-repo data so the Explore-gate denial carries cross-repo SCIP context, not just same-repo recall + sym hits.

## Test plan
- [x] cargo test (120 integration / 653 unit pass on stable run)
- [x] cargo clippy -- -D warnings (clean)
- [x] cargo fmt -- --check (clean)
- [x] 4 new integration tests cover empty-DB human + json modes, missing-flag error, and clap conflicts_with

## Reuse

`run_consult_symbol` reuses `db::list_scip_indexes_filtered(None, None)` and `sym::query_definitions` / `sym::query_references` -- no new SCIP parsing code.