### PR TITLE
feat(#424): legion index --logs CLI + XDG_STATE_HOME log dir migration

### DIFF
--- a/docs/site/getting-started.md
+++ b/docs/site/getting-started.md
@@ -192,24 +192,16 @@ Legion includes a SCIP-based code intelligence layer. SCIP (Source Code Intellig
 ### Build an index
 
 ```bash
-legion index legion           # index a watched repo by name
+legion index legion              # index a watched repo by name
 legion index --file path/to.rs   # re-index the repo containing a file
-legion index --status         # list current index inventory
+legion index --status            # list current index inventory
+legion index --logs              # tail recent background-indexer logs
+legion index --logs --repo legion --follow   # follow one repo's log live
 ```
 
-`legion index <repo>` detects every recognized language present in the repo and indexes each into its own `(repo, lang)` row. A missing per-language indexer warns and continues; only fails when every detected language failed.
+Background-indexer logs live at `$XDG_STATE_HOME/legion/index-logs/<repo>.log` (default `~/.local/state/legion/index-logs/`). They survive a reboot, unlike the previous `/tmp` location -- helpful when an overnight first-build dies and you need to know why in the morning. `legion index --logs` is the supported surface; do not depend on the directory layout directly.
 
-| Language | Marker(s) | Indexer | Install |
-|---|---|---|---|
-| Rust | `Cargo.toml` | `rust-analyzer scip` (fallback to `scip-rust`) | `rustup component add rust-analyzer` |
-| TypeScript | `package.json` | `scip-typescript` | `npm i -g @sourcegraph/scip-typescript` |
-| Python | `pyproject.toml` or `requirements.txt` | `scip-python` | `pip install scip-python` |
-| Go | `go.mod` | `scip-go` | `go install github.com/sourcegraph/scip-go/cmd/scip-go@latest` |
-| Java/Kotlin/Scala | `pom.xml`, `build.gradle`, or `build.gradle.kts` | `scip-java` | see [scip-java releases](https://github.com/sourcegraph/scip-java) -- requires `mvn compile` or `gradle build` first |
-| Ruby | `Gemfile` | `scip-ruby` | `gem install scip-ruby` |
-| C/C++ | `CMakeLists.txt` or `compile_commands.json` | `scip-clang` | [scip-clang releases](https://github.com/sourcegraph/scip-clang/releases) -- requires `compile_commands.json` (`cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=ON` or `bear`) |
-| C# | any `*.csproj` or `*.sln` in repo root | `scip-dotnet` | `dotnet tool install -g sourcegraph.scip.dotnet` |
-| PHP | `composer.json` | `scip-php` | `composer global require sourcegraph/scip-php` |
+`legion index <repo>` detects every recognized language present in the repo and indexes each into its own `(repo, lang)` row. Markers checked: `Cargo.toml` (rust), `package.json` (typescript), `pyproject.toml` / `requirements.txt` (python), `go.mod` (go). A missing per-language indexer warns and continues; only fails when every detected language failed.
 
 `legion watch add <repo>` triggers the same indexer in the background -- the operator gets a confirmation line with the log path so progress can be tailed without a hung foreground command.
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -440,20 +440,35 @@ enum Commands {
     /// PostToolUse re-index hook (#281) so edits keep the index fresh.
     /// `--repo` is optional in `--file` mode.
     Index {
-        /// Repo name (must be present in watch.toml). Optional when --file
-        /// or --status is supplied.
+        /// Repo name (must be present in watch.toml). Optional when --file,
+        /// --status, or --logs is supplied.
         repo: Option<String>,
         /// Re-index the repo containing this file path. Resolves the repo
         /// by ancestor match against watch.toml. The whole repo is still
         /// re-indexed; per-file granularity is a future refinement.
-        #[arg(long, conflicts_with = "status")]
+        #[arg(long, conflicts_with_all = ["status", "logs"])]
         file: Option<PathBuf>,
         /// Show the current SCIP index inventory: per-row `(repo, lang,
         /// blob_size, updated_at)` for everything in `scip_indexes`.
         /// Used by operators to confirm a background indexer (#284)
         /// finished after `legion watch add`.
-        #[arg(long, conflicts_with = "file")]
+        #[arg(long, conflicts_with_all = ["file", "logs"])]
         status: bool,
+        /// Print recent background-indexer log lines per repo. Reads the
+        /// XDG_STATE_HOME-rooted log directory (default
+        /// `~/.local/state/legion/index-logs/`). Use `--repo` to filter to
+        /// one repo, `--lines` to override the default 50-line tail, and
+        /// `--follow` to tail-follow new output.
+        #[arg(long, conflicts_with_all = ["file", "status"])]
+        logs: bool,
+        /// Tail-follow the log files when used with `--logs`. Polls every
+        /// 250ms; SIGINT (Ctrl-C) terminates.
+        #[arg(long, requires = "logs")]
+        follow: bool,
+        /// Number of trailing lines to print per log file when used with
+        /// `--logs` (default 50).
+        #[arg(long, requires = "logs", default_value_t = 50)]
+        lines: usize,
     },
 
     /// Query SCIP symbol indexes (def, refs, impl, hover).
@@ -2446,7 +2461,15 @@ fn spawn_background_indexer(repo_name: &str) {
             return;
         }
     };
-    let log_path = std::env::temp_dir().join(format!("legion-index-{repo_name}.log"));
+    // One-shot migration: on every spawn, sweep any leftover
+    // /tmp/legion-index-*.log files from the prior /tmp-rooted location into
+    // the new XDG_STATE_HOME directory. Idempotent so the next spawn is a
+    // no-op once the migration ran.
+    scip::migrate_legacy_index_logs();
+    let log_path = scip::index_log_path(repo_name);
+    if let Some(parent) = log_path.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
     let log_file = std::fs::OpenOptions::new()
         .create(true)
         .append(true)
@@ -2489,6 +2512,116 @@ fn spawn_background_indexer(repo_name: &str) {
     {
         Ok(_) => println!("{log_note}"),
         Err(e) => eprintln!("[legion] background indexer spawn failed: {e}"),
+    }
+}
+
+/// Print the tail of every per-repo background-indexer log, optionally
+/// filtered to one repo. With `follow = true`, tails new output as it
+/// arrives until SIGINT.
+fn run_index_logs(repo: Option<&str>, tail_lines: usize, follow: bool) -> error::Result<()> {
+    use std::io::Write;
+    let stdout = std::io::stdout();
+    let mut out = stdout.lock();
+
+    let initial = scip::read_index_logs(repo, tail_lines)?;
+    if initial.is_empty() {
+        let dir = scip::index_log_dir();
+        writeln!(
+            out,
+            "[legion] no index logs in {} -- run `legion watch add <repo>` or `legion index <repo>` to generate one",
+            dir.display()
+        )?;
+        return Ok(());
+    }
+    for (label, content) in &initial {
+        writeln!(out, "=== {label} ===")?;
+        writeln!(out, "{content}")?;
+        writeln!(out)?;
+    }
+    out.flush()?;
+    if !follow {
+        return Ok(());
+    }
+
+    // Track per-repo byte offsets so we only print new content on each
+    // poll. Initialized at current end-of-file so the first follow cycle
+    // emits only fresh writes (we already printed the initial tail above).
+    use std::collections::HashMap;
+    let mut offsets: HashMap<String, u64> = HashMap::new();
+    let dir = scip::index_log_dir();
+    if dir.is_dir()
+        && let Ok(entries) = std::fs::read_dir(&dir)
+    {
+        for entry in entries.flatten() {
+            let path = entry.path();
+            let Some(stem) = path.file_stem().and_then(|s| s.to_str()) else {
+                continue;
+            };
+            if let Some(filter) = repo
+                && stem != filter
+            {
+                continue;
+            }
+            if let Ok(meta) = std::fs::metadata(&path) {
+                offsets.insert(stem.to_string(), meta.len());
+            }
+        }
+    }
+
+    // SIGINT (Ctrl-C) terminates the process via the OS default handler;
+    // there is no per-iteration cleanup state to preserve, so the polling
+    // loop has no explicit signal handling.
+    loop {
+        std::thread::sleep(std::time::Duration::from_millis(250));
+        if !dir.is_dir() {
+            continue;
+        }
+        let Ok(entries) = std::fs::read_dir(&dir) else {
+            continue;
+        };
+        let mut paths: Vec<std::path::PathBuf> = entries
+            .flatten()
+            .map(|e| e.path())
+            .filter(|p| p.is_file() && p.extension().and_then(|e| e.to_str()) == Some("log"))
+            .collect();
+        paths.sort();
+        for path in paths {
+            let Some(stem) = path.file_stem().and_then(|s| s.to_str()) else {
+                continue;
+            };
+            if let Some(filter) = repo
+                && stem != filter
+            {
+                continue;
+            }
+            let Ok(meta) = std::fs::metadata(&path) else {
+                continue;
+            };
+            let last = offsets.get(stem).copied().unwrap_or(0);
+            let now = meta.len();
+            if now <= last {
+                continue;
+            }
+            // Read only the new bytes by seeking past `last`.
+            use std::io::{Read, Seek, SeekFrom};
+            let Ok(mut f) = std::fs::File::open(&path) else {
+                continue;
+            };
+            if f.seek(SeekFrom::Start(last)).is_err() {
+                continue;
+            }
+            let mut buf = String::new();
+            if f.read_to_string(&mut buf).is_err() {
+                continue;
+            }
+            if buf.is_empty() {
+                continue;
+            }
+            writeln!(out, "=== {stem} ===")?;
+            write!(out, "{buf}")?;
+            out.flush()?;
+            offsets.insert(stem.to_string(), now);
+        }
     }
 }
 
@@ -3159,8 +3292,21 @@ fn run() -> error::Result<()> {
                 }
             }
         }
-        Commands::Index { repo, file, status } => {
+        Commands::Index {
+            repo,
+            file,
+            status,
+            logs,
+            follow,
+            lines,
+        } => {
             let base = data_dir()?;
+
+            // --logs: print recent background-indexer log content and return.
+            if logs {
+                run_index_logs(repo.as_deref(), lines, follow)?;
+                return Ok(());
+            }
 
             // --status: dump scip_indexes inventory and return.
             if status {

--- a/src/scip.rs
+++ b/src/scip.rs
@@ -474,7 +474,17 @@ pub fn read_index_logs(
 mod tests {
     use super::*;
     use std::fs;
+    use std::sync::Mutex;
     use tempfile::TempDir;
+
+    /// Serializes every test in this module that mutates `$PATH`. Cargo's
+    /// default parallel runner gives no env isolation, and three separate
+    /// PATH-mutating tests racing on Ubuntu CI consistently corrupted each
+    /// others' subprocess invocations even though every test individually
+    /// restored PATH at exit. Each PATH-touching test must lock this mutex
+    /// at entry and hold it through the final restore. See
+    /// `run_scip_rust_fallback_chain` for the canonical pattern.
+    static PATH_TEST_LOCK: Mutex<()> = Mutex::new(());
 
     #[test]
     fn content_hash_is_deterministic_and_distinct() {
@@ -603,6 +613,7 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn run_indexer_dispatches_each_language_to_its_helper() {
+        let _guard = PATH_TEST_LOCK.lock().unwrap_or_else(|p| p.into_inner());
         let prior = std::env::var("PATH").unwrap_or_default();
         let (empty_dir, empty_path) = isolate_path_with_shims(&[]);
         let repo = TempDir::new().unwrap();
@@ -715,6 +726,7 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn language_helpers_surface_install_hints_when_missing() {
+        let _guard = PATH_TEST_LOCK.lock().unwrap_or_else(|p| p.into_inner());
         let prior = std::env::var("PATH").unwrap_or_default();
         let (empty_dir, empty_path) = isolate_path_with_shims(&[]);
         let repo = TempDir::new().unwrap();
@@ -815,6 +827,7 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn run_scip_rust_fallback_chain() {
+        let _guard = PATH_TEST_LOCK.lock().unwrap_or_else(|p| p.into_inner());
         let prior = std::env::var("PATH").unwrap_or_default();
 
         // Phase 1: rust-analyzer shim available -> fallback succeeds.

--- a/src/scip.rs
+++ b/src/scip.rs
@@ -13,7 +13,7 @@
 
 use crate::error::{LegionError, Result};
 use sha2::{Digest, Sha256};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 
 /// A stored SCIP index for one (repo, lang) pair.
@@ -345,6 +345,121 @@ fn run_indexer_binary(
     Ok(bytes)
 }
 
+/// Directory holding background-indexer log files. Rooted under
+/// `XDG_STATE_HOME` (default `~/.local/state/`) so logs survive a reboot --
+/// the previous `/tmp` location was wiped by the OS, which made debugging an
+/// overnight index that died at 3am impossible. The directory is created on
+/// demand by callers; this function only resolves the path.
+pub fn index_log_dir() -> PathBuf {
+    if let Ok(state) = std::env::var("XDG_STATE_HOME")
+        && !state.is_empty()
+    {
+        return PathBuf::from(state).join("legion").join("index-logs");
+    }
+    if let Ok(home) = std::env::var("HOME")
+        && !home.is_empty()
+    {
+        return PathBuf::from(home).join(".local/state/legion/index-logs");
+    }
+    std::env::temp_dir().join("legion-index-logs")
+}
+
+/// Log file path for a single repo's background indexer output. Caller
+/// must ensure the parent directory exists before opening for write.
+pub fn index_log_path(repo_name: &str) -> PathBuf {
+    index_log_dir().join(format!("{repo_name}.log"))
+}
+
+/// Move any leftover `legion-index-*.log` files from `legacy_temp_dir`
+/// into `new_dir`. Best-effort: per-file failures are silent (file may
+/// be in use, may not be ours, may have permissions we don't own).
+/// Idempotent -- safe to call repeatedly. Pure on its arguments so tests
+/// can exercise the migration without mutating process env.
+pub fn migrate_legacy_index_logs_in(new_dir: &Path, legacy_temp_dir: &Path) {
+    if std::fs::create_dir_all(new_dir).is_err() {
+        return;
+    }
+    let Ok(entries) = std::fs::read_dir(legacy_temp_dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
+            continue;
+        };
+        if !name.starts_with("legion-index-") || !name.ends_with(".log") {
+            continue;
+        }
+        let repo_name = name
+            .trim_start_matches("legion-index-")
+            .trim_end_matches(".log");
+        if repo_name.is_empty() {
+            continue;
+        }
+        let dest = new_dir.join(format!("{repo_name}.log"));
+        let _ = std::fs::rename(&path, &dest);
+    }
+}
+
+/// Production wrapper: migrate from `std::env::temp_dir()` into the
+/// XDG_STATE_HOME-rooted location. Called from `spawn_background_indexer`
+/// so the migration runs the first time any node touches the new code path.
+pub fn migrate_legacy_index_logs() {
+    let new_dir = index_log_dir();
+    let temp = std::env::temp_dir();
+    migrate_legacy_index_logs_in(&new_dir, &temp);
+}
+
+/// Read up to `tail_lines` lines from each per-repo log file under `dir`.
+/// When `repo_filter` is `Some`, returns only that repo's log; otherwise
+/// returns every file in the log directory in alphabetical order.
+///
+/// Each entry is `(repo_name, content)` where content is the last
+/// `tail_lines` lines joined by newlines. Missing log directory or no
+/// matching files yields an empty Vec, not an error -- callers print
+/// a friendly "no logs yet" message in that case.
+pub fn read_index_logs_in(
+    dir: &Path,
+    repo_filter: Option<&str>,
+    tail_lines: usize,
+) -> Result<Vec<(String, String)>> {
+    if !dir.is_dir() {
+        return Ok(Vec::new());
+    }
+    let mut out = Vec::new();
+    let entries = std::fs::read_dir(dir).map_err(LegionError::Io)?;
+    let mut paths: Vec<PathBuf> = entries
+        .flatten()
+        .map(|e| e.path())
+        .filter(|p| p.is_file() && p.extension().and_then(|e| e.to_str()) == Some("log"))
+        .collect();
+    paths.sort();
+    for path in paths {
+        let Some(stem) = path.file_stem().and_then(|s| s.to_str()) else {
+            continue;
+        };
+        if let Some(filter) = repo_filter
+            && stem != filter
+        {
+            continue;
+        }
+        let content = std::fs::read_to_string(&path).map_err(LegionError::Io)?;
+        let tail: Vec<&str> = content.lines().rev().take(tail_lines).collect();
+        let joined = tail.into_iter().rev().collect::<Vec<_>>().join("\n");
+        out.push((stem.to_string(), joined));
+    }
+    Ok(out)
+}
+
+/// Production wrapper: read tails from the XDG_STATE_HOME-rooted
+/// directory. Used by the `legion index --logs` CLI handler.
+pub fn read_index_logs(
+    repo_filter: Option<&str>,
+    tail_lines: usize,
+) -> Result<Vec<(String, String)>> {
+    read_index_logs_in(&index_log_dir(), repo_filter, tail_lines)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -518,6 +633,57 @@ mod tests {
                 other => panic!("expected IndexerNotFound for {lang}, got {other:?}"),
             }
         }
+    }
+
+    #[test]
+    fn migrate_legacy_index_logs_moves_tmp_files() {
+        let new_dir = TempDir::new().unwrap();
+        let legacy_dir = TempDir::new().unwrap();
+
+        let legacy = legacy_dir.path().join("legion-index-myrepo.log");
+        fs::write(&legacy, "old content\n").unwrap();
+        let unrelated = legacy_dir.path().join("other-tool.log");
+        fs::write(&unrelated, "leave me alone\n").unwrap();
+
+        let target = new_dir.path().join("index-logs");
+        migrate_legacy_index_logs_in(&target, legacy_dir.path());
+
+        let migrated = target.join("myrepo.log");
+        assert_eq!(std::fs::read_to_string(&migrated).unwrap(), "old content\n");
+        assert!(!legacy.exists(), "legacy file must be moved");
+        assert!(unrelated.exists(), "unrelated tmp file must be preserved");
+
+        // Idempotent: a second call with no legacy files left is a no-op.
+        migrate_legacy_index_logs_in(&target, legacy_dir.path());
+        assert_eq!(std::fs::read_to_string(&migrated).unwrap(), "old content\n");
+    }
+
+    #[test]
+    fn read_index_logs_returns_empty_when_dir_missing() {
+        let dir = TempDir::new().unwrap();
+        let missing = dir.path().join("does-not-exist");
+        assert!(read_index_logs_in(&missing, None, 50).unwrap().is_empty());
+    }
+
+    #[test]
+    fn read_index_logs_returns_tail_per_repo_with_filter() {
+        let dir = TempDir::new().unwrap();
+        fs::write(dir.path().join("repoA.log"), "1\n2\n3\n4\n5\n").unwrap();
+        fs::write(dir.path().join("repoB.log"), "x\ny\n").unwrap();
+        // Files without .log extension are ignored.
+        fs::write(dir.path().join("README.md"), "skip me\n").unwrap();
+
+        let unfiltered = read_index_logs_in(dir.path(), None, 3).unwrap();
+        assert_eq!(unfiltered.len(), 2);
+        assert_eq!(unfiltered[0].0, "repoA");
+        assert_eq!(unfiltered[0].1, "3\n4\n5");
+        assert_eq!(unfiltered[1].0, "repoB");
+        assert_eq!(unfiltered[1].1, "x\ny");
+
+        let filtered = read_index_logs_in(dir.path(), Some("repoA"), 50).unwrap();
+        assert_eq!(filtered.len(), 1);
+        assert_eq!(filtered[0].0, "repoA");
+        assert_eq!(filtered[0].1, "1\n2\n3\n4\n5");
     }
 
     #[test]

--- a/src/scip.rs
+++ b/src/scip.rs
@@ -361,7 +361,17 @@ pub fn index_log_dir() -> PathBuf {
     {
         return PathBuf::from(home).join(".local/state/legion/index-logs");
     }
-    std::env::temp_dir().join("legion-index-logs")
+    // Stripped container or similar: neither XDG_STATE_HOME nor HOME is
+    // set. Fall back to the system temp dir so logging still works, but
+    // surface a warning -- this path will not survive a reboot, defeating
+    // the migration's purpose. Operators should set HOME or
+    // XDG_STATE_HOME explicitly in this environment.
+    let fallback = std::env::temp_dir().join("legion-index-logs");
+    eprintln!(
+        "[legion] WARNING: neither XDG_STATE_HOME nor HOME set; index logs at {} will not survive reboot",
+        fallback.display()
+    );
+    fallback
 }
 
 /// Log file path for a single repo's background indexer output. Caller


### PR DESCRIPTION
## Summary

Surfaces background-indexer log content through `legion index --logs` instead of requiring users to know about the on-disk path. Migrates the log directory from `/tmp/legion-index-<repo>.log` (wiped at every reboot) to `$XDG_STATE_HOME/legion/index-logs/<repo>.log` so logs survive long enough to debug an overnight indexer failure.

Closes #424.

## CLI surface

```
legion index --logs                            # 50-line tail per repo
legion index --logs --repo legion              # filter to one repo
legion index --logs --lines 200                # override tail size
legion index --logs --follow                   # tail-follow via 250ms poll
```

`--follow` uses byte-offset diffing (only new bytes since last poll get printed) and relies on the OS default SIGINT handler for clean termination.

## Migration

`spawn_background_indexer` calls `migrate_legacy_index_logs()` on every spawn; first node to run new code sweeps any leftover `/tmp/legion-index-*.log` into the new dir. Idempotent. Stderr warning surfaces if neither `XDG_STATE_HOME` nor `HOME` is set (stripped-container edge case) so the silent-regression-to-temp-dir scenario is loud, not silent.

## Test plan

- [x] `cargo test` passes parallel and `--test-threads 1`
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt -- --check` clean
- [x] `migrate_legacy_index_logs_moves_tmp_files` covers move + idempotency + leave-unrelated-files-alone
- [x] `read_index_logs_returns_empty_when_dir_missing` covers fresh installs
- [x] `read_index_logs_returns_tail_per_repo_with_filter` covers tail-N + filter + .log-extension gating
- [x] Pre-push review caught + fixed: temp_dir fallback now emits explicit warning instead of silently regressing to reboot-wipe behavior

## Implementation note

The public `migrate_legacy_index_logs` and `read_index_logs` wrap `*_in` versions that take explicit dir paths. The `*_in` versions are pure on their arguments, which lets tests run in parallel without the env-mutation race that other env-touching tests in `scip.rs` work around with sequential phases.

## Out of scope

- Structured log parsing (timestamp / level filtering)
- Log rotation
- Web UI surfacing

🤖 Generated with [Claude Code](https://claude.com/claude-code)