### PR TITLE
feat(#423): legion sym impact -- diff impact radius from SCIP refs_count

### DIFF
--- a/docs/site/getting-started.md
+++ b/docs/site/getting-started.md
@@ -204,12 +204,15 @@ legion index --status         # list current index inventory
 ### Query the index
 
 ```bash
-legion sym def Database         # definitions in this repo
-legion sym refs find_pending    # references (sorted by file/line)
-legion sym impl Iterator        # implementors of a trait (Rust only)
-legion sym hover Database       # signature + docstring
-legion consult --symbol Database  # cross-repo lookup
+legion sym def Database              # definitions in this repo
+legion sym refs find_pending         # references (sorted by file/line)
+legion sym impl Iterator             # implementors of a trait (Rust only)
+legion sym hover Database            # signature + docstring
+legion sym impact --repo legion --diff /path/to.diff   # impact radius from a diff
+legion consult --symbol Database     # cross-repo lookup
 ```
+
+`legion sym impact` parses a unified diff (file path or `-` for stdin), finds every symbol whose definition lives in a changed line range, and reports the SCIP reference count for each. Sorted by refs descending so wide-blast-radius diffs surface first. Pass `--json` for agent consumption. The `LEGION_IMPACT_HIGH_THRESHOLD` env var (default 50) controls the `HIGH` tag in text output. Reviewer agents (vault, smugglr) can call this against a PR diff to flag changes that touch heavily-referenced symbols.
 
 `legion consult --symbol` walks every `(repo, lang)` pair and reports `(repo, lang, def_location, refs_count)` per match. Used by the recall-first hook (#413) to inject cross-repo code intelligence before an agent spawns Explore on a question SCIP can already answer.
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -784,6 +784,21 @@ enum SymAction {
         #[arg(long)]
         json: bool,
     },
+
+    /// Impact radius: for every symbol whose definition the given diff
+    /// touches, report the SCIP reference count across the repo's index.
+    /// Used by smugglr to flag wide-blast-radius PRs at review time.
+    Impact {
+        /// Repo whose SCIP index to query
+        #[arg(long)]
+        repo: String,
+        /// Path to a unified diff file, or "-" to read from stdin
+        #[arg(long)]
+        diff: String,
+        /// Emit results as JSON instead of human-readable text
+        #[arg(long)]
+        json: bool,
+    },
 }
 
 #[derive(Subcommand)]
@@ -2262,7 +2277,73 @@ fn run_sym_action(database: &db::Database, action: SymAction) -> error::Result<(
             lang,
             json,
         } => run_hover_query(database, &name, repo, lang, json),
+        SymAction::Impact { repo, diff, json } => run_sym_impact(database, &repo, &diff, json),
     }
+}
+
+/// Read the diff source -- file path or "-" for stdin -- and run impact
+/// radius analysis against the repo's SCIP index. Prints sorted output
+/// (highest refs_count first) as either text or JSON.
+fn run_sym_impact(
+    database: &db::Database,
+    repo: &str,
+    diff_arg: &str,
+    json: bool,
+) -> error::Result<()> {
+    use std::io::{Read, Write};
+
+    let diff_text = if diff_arg == "-" {
+        let mut buf = String::new();
+        std::io::stdin()
+            .read_to_string(&mut buf)
+            .map_err(error::LegionError::Io)?;
+        buf
+    } else {
+        std::fs::read_to_string(diff_arg).map_err(error::LegionError::Io)?
+    };
+
+    let indexes = database.list_scip_indexes_filtered(Some(repo), None)?;
+    if indexes.is_empty() {
+        eprintln!("[legion] no SCIP index for repo '{repo}' -- run `legion index {repo}` first");
+        return Ok(());
+    }
+
+    let mut all_hits: Vec<sym::ImpactRadius> = Vec::new();
+    for idx in &indexes {
+        let hits = sym::diff_impact_radius(&idx.blob, &diff_text)?;
+        all_hits.extend(hits);
+    }
+    all_hits.sort_by_key(|h| std::cmp::Reverse(h.refs_count));
+
+    let stdout = std::io::stdout();
+    let mut out = stdout.lock();
+    if json {
+        let body = serde_json::to_string(&all_hits)
+            .map_err(|e| error::LegionError::Search(format!("impact json: {e}")))?;
+        writeln!(out, "{body}")?;
+        return Ok(());
+    }
+    if all_hits.is_empty() {
+        writeln!(out, "[legion] no symbol definitions touched by this diff")?;
+        return Ok(());
+    }
+    let high_threshold: u32 = std::env::var("LEGION_IMPACT_HIGH_THRESHOLD")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(50);
+    for hit in &all_hits {
+        let high = if hit.refs_count >= high_threshold {
+            "  HIGH"
+        } else {
+            ""
+        };
+        let loc = match &hit.def_location {
+            Some(loc) => format!("{}:{}", loc.file, loc.line),
+            None => "(no def location)".to_string(),
+        };
+        writeln!(out, "{loc}\t{}\trefs:{}{high}", hit.symbol, hit.refs_count)?;
+    }
+    Ok(())
 }
 
 /// One row in the cross-repo symbol consult output.

--- a/src/main.rs
+++ b/src/main.rs
@@ -2308,10 +2308,19 @@ fn run_sym_impact(
         return Ok(());
     }
 
+    // Cross-index dedup: a polyglot repo can have the same logical symbol
+    // appear in two language indexes. `diff_impact_radius` dedupes within
+    // one blob; this loop dedupes across blobs so the CLI never prints
+    // the same symbol twice.
+    let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
     let mut all_hits: Vec<sym::ImpactRadius> = Vec::new();
     for idx in &indexes {
         let hits = sym::diff_impact_radius(&idx.blob, &diff_text)?;
-        all_hits.extend(hits);
+        for hit in hits {
+            if seen.insert(hit.symbol.clone()) {
+                all_hits.push(hit);
+            }
+        }
     }
     all_hits.sort_by_key(|h| std::cmp::Reverse(h.refs_count));
 

--- a/src/sym.rs
+++ b/src/sym.rs
@@ -21,6 +21,15 @@ pub struct SymbolLocation {
     pub lang: String,
 }
 
+/// One impact-radius row: a symbol whose definition was touched by the
+/// diff, plus the SCIP reference count across the indexed repo.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ImpactRadius {
+    pub symbol: String,
+    pub refs_count: u32,
+    pub def_location: Option<SymbolLocation>,
+}
+
 /// Hover information: signature + docstring extracted from a SCIP document.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct HoverInfo {
@@ -252,6 +261,130 @@ pub fn query_implementors(
     Ok(out)
 }
 
+/// One file's worth of changed line ranges from a unified diff. Stores
+/// `(start_line, end_line_inclusive)` on the new (post-diff) side. We
+/// extract from `@@ -old +new @@` hunk headers; per-line + / - markers
+/// inside the hunk are not needed for impact-radius -- the hunk new
+/// range is the "touched area" and any def whose start line falls in
+/// that range counts as touched.
+type LineRange = (u32, u32);
+
+/// Map relative_path -> Vec<LineRange> on the new side.
+type DiffRanges = std::collections::HashMap<String, Vec<LineRange>>;
+
+/// Parse a unified diff (the output of `git diff` or similar) into the
+/// minimal per-file new-side line ranges that `diff_impact_radius`
+/// needs. Lines that the diff format does not understand (binary diffs,
+/// rename-only entries with no `@@` hunk) are silently skipped.
+pub fn parse_unified_diff(diff_text: &str) -> DiffRanges {
+    let mut out: DiffRanges = std::collections::HashMap::new();
+    let mut current_path: Option<String> = None;
+    for line in diff_text.lines() {
+        if let Some(rest) = line.strip_prefix("+++ ") {
+            // `+++ b/path/to/file.rs` -- strip the "b/" git convention.
+            // `/dev/null` (file deleted) leaves current_path None so the
+            // following hunks land nowhere.
+            let path = rest.trim();
+            if path == "/dev/null" {
+                current_path = None;
+                continue;
+            }
+            let stripped = path.strip_prefix("b/").unwrap_or(path);
+            current_path = Some(stripped.to_string());
+            continue;
+        }
+        if let Some(rest) = line.strip_prefix("@@ ") {
+            // "@@ -10,5 +12,7 @@ optional context"
+            // We want the +start,count token.
+            if let Some(plus_token) = rest.split_whitespace().find(|t| t.starts_with('+')) {
+                let plus = plus_token.trim_start_matches('+');
+                let (start_str, count_str) = match plus.split_once(',') {
+                    Some((s, c)) => (s, c),
+                    None => (plus, "1"),
+                };
+                let start: u32 = match start_str.parse() {
+                    Ok(n) => n,
+                    Err(_) => continue,
+                };
+                let count: u32 = count_str.parse().unwrap_or(1);
+                if let Some(path) = &current_path {
+                    let end = start.saturating_add(count.saturating_sub(1)).max(start);
+                    out.entry(path.clone()).or_default().push((start, end));
+                }
+            }
+        }
+    }
+    out
+}
+
+/// Given a SCIP index blob and a unified diff, return one ImpactRadius
+/// row for every symbol whose definition occurrence falls inside any
+/// changed line range. `refs_count` is the total non-definition
+/// occurrences for that symbol across the entire index. Result is
+/// unsorted; the CLI handler sorts descending by refs_count.
+///
+/// An empty index or a diff that touches no SCIP-indexed file returns
+/// an empty Vec, not an error -- callers route that to a friendly
+/// "nothing to report" message.
+pub fn diff_impact_radius(blob: &[u8], diff_text: &str) -> Result<Vec<ImpactRadius>> {
+    if blob.is_empty() {
+        return Ok(Vec::new());
+    }
+    let ranges = parse_unified_diff(diff_text);
+    if ranges.is_empty() {
+        return Ok(Vec::new());
+    }
+    let index = parse_blob(blob)?;
+
+    // First pass: collect (symbol -> refs_count) across the entire index.
+    let mut refs_count: std::collections::HashMap<String, u32> = std::collections::HashMap::new();
+    for doc in &index.documents {
+        for occ in &doc.occurrences {
+            if !is_definition(occ.symbol_roles) {
+                *refs_count.entry(occ.symbol.clone()).or_insert(0) += 1;
+            }
+        }
+    }
+
+    // Second pass: pick definitions whose range falls inside a hunk on
+    // the file's diff entry. Dedup on symbol so a symbol with multiple
+    // definitions (rare but legal) only contributes one row.
+    let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
+    let mut hits = Vec::new();
+    for doc in &index.documents {
+        let Some(file_ranges) = ranges.get(&doc.relative_path) else {
+            continue;
+        };
+        for occ in &doc.occurrences {
+            if !is_definition(occ.symbol_roles) {
+                continue;
+            }
+            let Some((line, column)) = range_start_1indexed(&occ.range) else {
+                continue;
+            };
+            if !file_ranges.iter().any(|(s, e)| line >= *s && line <= *e) {
+                continue;
+            }
+            if !seen.insert(occ.symbol.clone()) {
+                continue;
+            }
+            let count = refs_count.get(&occ.symbol).copied().unwrap_or(0);
+            hits.push(ImpactRadius {
+                symbol: occ.symbol.clone(),
+                refs_count: count,
+                def_location: Some(SymbolLocation {
+                    file: doc.relative_path.clone(),
+                    line,
+                    column,
+                    repo: String::new(),
+                    lang: String::new(),
+                }),
+            });
+        }
+    }
+    Ok(hits)
+}
+
 pub fn query_hover(
     blob: &[u8],
     symbol_name: &str,
@@ -318,85 +451,119 @@ mod tests {
     }
 
     #[test]
-    fn descriptor_query_with_type_suffix_matches_only_types() {
-        let scip_type = "rust-analyzer cargo legion 0.9.10 src/sym.rs/Foo#";
-        let scip_term = "rust-analyzer cargo legion 0.9.10 src/sym.rs/Foo.";
-        assert!(symbol_matches(scip_type, "Foo#"));
-        assert!(!symbol_matches(scip_term, "Foo#"));
+    fn parse_unified_diff_extracts_per_file_new_ranges() {
+        let diff = "\
+diff --git a/src/foo.rs b/src/foo.rs
+--- a/src/foo.rs
++++ b/src/foo.rs
+@@ -10,3 +12,5 @@ fn ctx
+ a
+-b
++c
++d
++e
+@@ -50,1 +60,2 @@
++x
++y
+diff --git a/src/bar.rs b/src/bar.rs
+--- a/src/bar.rs
++++ b/src/bar.rs
+@@ -1,2 +1,3 @@
+ keep
++new
++also new
+";
+        let ranges = parse_unified_diff(diff);
+        assert_eq!(ranges.get("src/foo.rs").unwrap(), &vec![(12, 16), (60, 61)]);
+        assert_eq!(ranges.get("src/bar.rs").unwrap(), &vec![(1, 3)]);
     }
 
     #[test]
-    fn descriptor_query_with_method_suffix_matches_only_methods() {
-        let scip_method = "rust-analyzer cargo legion 0.9.10 src/sym.rs/Foo#new().";
-        let scip_type = "rust-analyzer cargo legion 0.9.10 src/sym.rs/Foo#";
-        assert!(symbol_matches(scip_method, "new()."));
-        assert!(!symbol_matches(scip_type, "new()."));
+    fn parse_unified_diff_skips_dev_null_for_deleted_files() {
+        let diff = "\
+diff --git a/old.rs b/old.rs
+--- a/old.rs
++++ /dev/null
+@@ -1,3 +0,0 @@
+-removed
+";
+        let ranges = parse_unified_diff(diff);
+        assert!(ranges.is_empty());
     }
 
     #[test]
-    fn descriptor_path_query_anchors_to_type_then_method() {
-        let scip_method = "rust-analyzer cargo legion 0.9.10 src/sym.rs/Foo#bar().";
-        let scip_other = "rust-analyzer cargo legion 0.9.10 src/sym.rs/Bar#bar().";
-        assert!(symbol_matches(scip_method, "Foo#bar()."));
-        assert!(!symbol_matches(scip_other, "Foo#bar()."));
+    fn parse_unified_diff_handles_single_line_hunks_without_count() {
+        let diff = "\
++++ b/src/lib.rs
+@@ -42 +42 @@
+-old
++new
+";
+        let ranges = parse_unified_diff(diff);
+        assert_eq!(ranges.get("src/lib.rs").unwrap(), &vec![(42, 42)]);
     }
 
     #[test]
-    fn descriptor_query_with_namespace_prefix_filters_by_module() {
-        let scip_in_mod = "rust-analyzer cargo legion 0.9.10 mod/Foo#";
-        let scip_other_mod = "rust-analyzer cargo legion 0.9.10 other/Foo#";
-        assert!(symbol_matches(scip_in_mod, "mod/Foo#"));
-        assert!(!symbol_matches(scip_other_mod, "mod/Foo#"));
+    fn diff_impact_radius_returns_definitions_in_changed_ranges_with_ref_counts() {
+        let blob = build_index(vec![doc(
+            "src/foo.rs",
+            vec![
+                occ("hot()", vec![19, 0, 19, 3], true),
+                occ("cold()", vec![100, 0, 100, 3], true),
+                occ("hot()", vec![5, 0, 5, 3], false),
+                occ("hot()", vec![6, 0, 6, 3], false),
+                occ("cold()", vec![200, 0, 200, 3], false),
+            ],
+        )]);
+        let diff = "\
++++ b/src/foo.rs
+@@ -18,3 +18,5 @@
+ ctx
++changed
++changed
+";
+        let hits = diff_impact_radius(&blob, diff).unwrap();
+        assert_eq!(hits.len(), 1, "only `hot` is in the changed range");
+        assert_eq!(hits[0].symbol, "hot()");
+        assert_eq!(hits[0].refs_count, 2);
+        let loc = hits[0].def_location.as_ref().unwrap();
+        assert_eq!(loc.file, "src/foo.rs");
+        assert_eq!(loc.line, 20);
     }
 
     #[test]
-    fn bare_name_uses_exact_descriptor_name_match_not_substring() {
-        let scip_foo = "rust-analyzer cargo legion 0.9.10 src/sym.rs/Foo#";
-        let scip_my_foo = "rust-analyzer cargo legion 0.9.10 src/sym.rs/MyFoo#";
-        assert!(symbol_matches(scip_foo, "Foo"));
-        // Substring fallback would have matched MyFoo; precise name match does not.
-        assert!(!symbol_matches(scip_my_foo, "Foo"));
+    fn diff_impact_radius_empty_when_diff_touches_no_indexed_file() {
+        let blob = build_index(vec![doc(
+            "src/foo.rs",
+            vec![occ("Foo#", vec![5, 0, 5, 3], true)],
+        )]);
+        let diff = "\
++++ b/src/unrelated.rs
+@@ -1,1 +1,1 @@
+ line
+";
+        let hits = diff_impact_radius(&blob, diff).unwrap();
+        assert!(hits.is_empty());
     }
 
     #[test]
-    fn bare_name_falls_back_to_substring_when_symbol_unparseable() {
-        // No leading scheme: scip parser rejects; we fall through to substring.
-        let unparseable = "totally not a scip symbol but contains FooBar somewhere";
-        assert!(symbol_matches(unparseable, "FooBar"));
-    }
-
-    #[test]
-    fn descriptor_query_with_unparseable_symbol_falls_back_to_substring() {
-        // Symbol fails scip parse; explicit-suffix query falls back to substring of
-        // the raw query string, which still contains the descriptor characters.
-        let unparseable = "garbage Foo# more garbage";
-        assert!(symbol_matches(unparseable, "Foo#"));
-    }
-
-    #[test]
-    fn empty_query_does_not_match_real_symbol() {
-        let scip = "rust-analyzer cargo legion 0.9.10 src/sym.rs/Foo#";
-        assert!(!symbol_matches(scip, ""));
-    }
-
-    #[test]
-    fn empty_query_does_not_match_unparseable_symbol() {
-        // Locks down the contract: empty query never matches, even via the
-        // substring fallback path which would otherwise return true (every
-        // string contains the empty string).
-        let unparseable = "garbage symbol string";
-        assert!(!symbol_matches(unparseable, ""));
-    }
-
-    #[test]
-    fn query_with_whitespace_rejects_descriptor_path_and_uses_substring() {
-        // Whitespace queries cannot be valid SCIP descriptors; the synthetic
-        // prefix would otherwise parse them in unexpected ways. We short-circuit
-        // descriptor parsing and route them through name/substring tiers.
-        let scip = "rust-analyzer cargo legion 0.9.10 src/sym.rs/Foo#";
-        assert!(!symbol_matches(scip, "Foo Bar"));
-        assert!(!symbol_matches(scip, " Foo"));
-        assert!(!symbol_matches(scip, "Foo "));
+    fn diff_impact_radius_dedupes_repeated_definitions() {
+        let blob = build_index(vec![
+            doc("src/a.rs", vec![occ("Foo#", vec![9, 0, 9, 3], true)]),
+            doc("src/b.rs", vec![occ("Foo#", vec![19, 0, 19, 3], true)]),
+        ]);
+        let diff = "\
++++ b/src/a.rs
+@@ -8,3 +8,3 @@
+ line
++changed
++++ b/src/b.rs
+@@ -18,3 +18,3 @@
+ line
++changed
+";
+        let hits = diff_impact_radius(&blob, diff).unwrap();
+        assert_eq!(hits.len(), 1);
     }
 
     #[test]

--- a/src/sym.rs
+++ b/src/sym.rs
@@ -282,10 +282,12 @@ pub fn parse_unified_diff(diff_text: &str) -> DiffRanges {
     for line in diff_text.lines() {
         if let Some(rest) = line.strip_prefix("+++ ") {
             // `+++ b/path/to/file.rs` -- strip the "b/" git convention.
-            // `/dev/null` (file deleted) leaves current_path None so the
-            // following hunks land nowhere.
-            let path = rest.trim();
-            if path == "/dev/null" {
+            // Plain `diff -u` appends a tab + mtime after the path, so
+            // split on the first whitespace before treating the rest as
+            // the filename. `/dev/null` (file deleted) leaves
+            // current_path None so the following hunks land nowhere.
+            let path = rest.split_whitespace().next().unwrap_or("").trim();
+            if path.is_empty() || path == "/dev/null" {
                 current_path = None;
                 continue;
             }
@@ -451,6 +453,78 @@ mod tests {
     }
 
     #[test]
+    fn descriptor_query_with_type_suffix_matches_only_types() {
+        let scip_type = "rust-analyzer cargo legion 0.9.10 src/sym.rs/Foo#";
+        let scip_term = "rust-analyzer cargo legion 0.9.10 src/sym.rs/Foo.";
+        assert!(symbol_matches(scip_type, "Foo#"));
+        assert!(!symbol_matches(scip_term, "Foo#"));
+    }
+
+    #[test]
+    fn descriptor_query_with_method_suffix_matches_only_methods() {
+        let scip_method = "rust-analyzer cargo legion 0.9.10 src/sym.rs/Foo#new().";
+        let scip_type = "rust-analyzer cargo legion 0.9.10 src/sym.rs/Foo#";
+        assert!(symbol_matches(scip_method, "new()."));
+        assert!(!symbol_matches(scip_type, "new()."));
+    }
+
+    #[test]
+    fn descriptor_path_query_anchors_to_type_then_method() {
+        let scip_method = "rust-analyzer cargo legion 0.9.10 src/sym.rs/Foo#bar().";
+        let scip_other = "rust-analyzer cargo legion 0.9.10 src/sym.rs/Bar#bar().";
+        assert!(symbol_matches(scip_method, "Foo#bar()."));
+        assert!(!symbol_matches(scip_other, "Foo#bar()."));
+    }
+
+    #[test]
+    fn descriptor_query_with_namespace_prefix_filters_by_module() {
+        let scip_in_mod = "rust-analyzer cargo legion 0.9.10 mod/Foo#";
+        let scip_other_mod = "rust-analyzer cargo legion 0.9.10 other/Foo#";
+        assert!(symbol_matches(scip_in_mod, "mod/Foo#"));
+        assert!(!symbol_matches(scip_other_mod, "mod/Foo#"));
+    }
+
+    #[test]
+    fn bare_name_uses_exact_descriptor_name_match_not_substring() {
+        let scip_foo = "rust-analyzer cargo legion 0.9.10 src/sym.rs/Foo#";
+        let scip_my_foo = "rust-analyzer cargo legion 0.9.10 src/sym.rs/MyFoo#";
+        assert!(symbol_matches(scip_foo, "Foo"));
+        assert!(!symbol_matches(scip_my_foo, "Foo"));
+    }
+
+    #[test]
+    fn bare_name_falls_back_to_substring_when_symbol_unparseable() {
+        let unparseable = "totally not a scip symbol but contains FooBar somewhere";
+        assert!(symbol_matches(unparseable, "FooBar"));
+    }
+
+    #[test]
+    fn descriptor_query_with_unparseable_symbol_falls_back_to_substring() {
+        let unparseable = "garbage Foo# more garbage";
+        assert!(symbol_matches(unparseable, "Foo#"));
+    }
+
+    #[test]
+    fn empty_query_does_not_match_real_symbol() {
+        let scip = "rust-analyzer cargo legion 0.9.10 src/sym.rs/Foo#";
+        assert!(!symbol_matches(scip, ""));
+    }
+
+    #[test]
+    fn empty_query_does_not_match_unparseable_symbol() {
+        let unparseable = "garbage symbol string";
+        assert!(!symbol_matches(unparseable, ""));
+    }
+
+    #[test]
+    fn query_with_whitespace_rejects_descriptor_path_and_uses_substring() {
+        let scip = "rust-analyzer cargo legion 0.9.10 src/sym.rs/Foo#";
+        assert!(!symbol_matches(scip, "Foo Bar"));
+        assert!(!symbol_matches(scip, " Foo"));
+        assert!(!symbol_matches(scip, "Foo "));
+    }
+
+    #[test]
     fn parse_unified_diff_extracts_per_file_new_ranges() {
         let diff = "\
 diff --git a/src/foo.rs b/src/foo.rs
@@ -489,6 +563,23 @@ diff --git a/old.rs b/old.rs
 ";
         let ranges = parse_unified_diff(diff);
         assert!(ranges.is_empty());
+    }
+
+    #[test]
+    fn parse_unified_diff_strips_diff_u_timestamp_after_path() {
+        // Plain `diff -u` (not git) emits "+++ path\t<mtime>" rather than
+        // "+++ b/path". The path-extraction must not include the trailing
+        // tab + timestamp or it never matches a SCIP relative_path.
+        let diff = "\
+--- old/lib.rs\t2026-05-01 12:00:00.000000000 +0000
++++ new/lib.rs\t2026-05-07 09:00:00.000000000 +0000
+@@ -1,1 +1,1 @@
+-old
++new
+";
+        let ranges = parse_unified_diff(diff);
+        // `b/` strip is a no-op here; key is `new/lib.rs` not the timestamp.
+        assert_eq!(ranges.get("new/lib.rs").unwrap(), &vec![(1, 1)]);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Adds `legion sym impact --repo <R> --diff <path-or-stdin> [--json]` so reviewer agents can flag wide-blast-radius diffs at PR review time.

The CLI parses a unified diff, finds every symbol whose definition lives in a changed line range, and reports the SCIP reference count across the indexed repo. Sorted descending so wide-impact changes surface first. The `LEGION_IMPACT_HIGH_THRESHOLD` env var (default 50) controls the `HIGH` tag in text output.

Closes #423.

## Example

```
$ legion sym impact --repo legion --diff /tmp/pr.diff
src/db.rs:142   `db/Database#open()`         refs:147  HIGH
src/db.rs:198   `db/Database#close().`       refs:62   HIGH
src/sym.rs:88   `sym/format_loc().`          refs:3
```

`--json` emits a stable shape for agent consumption.

## Implementation

- `parse_unified_diff(text) -> Map<path, Vec<LineRange>>` extracts per-file new-side ranges from `+++` + `@@ -... +N,M @@` pairs. Handles git's `+++ b/path`, plain `diff -u`'s `+++ path\t<mtime>`, `/dev/null` deletes, and single-line hunks omitting `,count`.
- `diff_impact_radius(blob, diff_text) -> Vec<ImpactRadius>` does two passes per index: first builds (symbol -> non-def-occurrence-count), then walks docs whose path matches a diff entry and emits one row per definition whose start line falls in any changed range. Per-blob dedup on symbol.
- CLI handler reads diff from path or stdin, queries every (repo, lang) index for the named repo, dedupes across blobs (polyglot repos), sorts by refs_count descending.

## Test plan

- [x] `cargo test` (664 + 124 pass)
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt -- --check` clean
- [x] 6 new tests in `src/sym.rs` cover: multi-hunk extraction, `/dev/null`, single-line hunks without count, plain `diff -u` timestamp tail, definitions-in-changed-ranges with refs_count, unrelated-file empty result, repeated-definition dedup
- [x] Pre-push review caught + fixed: plain `diff -u` timestamp handling; cross-index dedup gap

## Smugglr agent prompt integration

NOT in this PR. The smugglr reviewer is an external agent (smugglr crate's own agent configuration); `.claude/agents/smugglr.md` does not exist in this repo. The CLI surface is documented in `docs/site/getting-started.md` so any reviewer agent (smugglr, vault, claude-code review-pr) can call it. Wiring the smugglr agent prompt to invoke `legion sym impact` is a follow-up that lives outside legion.

## Stack

This PR is independent of #421 / #432 / #433 / #434 -- shares no files except `Cargo.lock`. Land in any order.

## Out of scope

- Cross-repo impact (touching a TS package imported from another TS package)
- Cross-index dedup tests for the CLI handler (gap noted by reviewer; left as follow-up since the dedup is mechanical and behavior-equivalent to the per-blob dedup that is tested)
- Smugglr agent prompt update (lives in smugglr repo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)