### PR TITLE
chore(release): 0.13.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
     {
       "name": "legion",
       "description": "Agent memory layer with recall, reflect, consult, bullpen, and cross-agent coordination. Includes health monitoring and auto-wake. Hooks wire legion into every session automatically.",
-      "version": "0.12.0",
+      "version": "0.13.0",
       "author": {
         "name": "Sean Silvius",
         "email": "sean@silvius.me"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1444,7 +1444,7 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "legion"
-version = "0.11.0"
+version = "0.13.0"
 dependencies = [
  "async-stream",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "legion"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2024"
 description = "Agent specialization through deliberate practice"
 

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "legion",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "Institutional memory for Claude Code agents with real-time team channel.",
   "author": {
     "name": "Sean Silvius",

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Legion Changelog
 
+## 0.13.0
+
+SCIP precision and reach. Phase D of the SCIP completion plan -- the v0.10-0.12 chain shipped storage, dispatch, hooks, and consumption; this release sharpens the query layer and extends indexer coverage to every canonical sourcegraph language. Reviewer agents also gain an impact-radius signal sourced from the SCIP refs graph.
+
+### New
+
+- **Descriptor-aware symbol matching** (#431, closes #421): `legion sym def | refs | impl | hover` no longer falls through to substring match for queries with explicit SCIP descriptor suffixes. `Foo#` matches Type Foo anywhere in the descriptor path; `Foo#bar().` requires both descriptors in order; `mod/Foo#` anchors the namespace. Bare-name queries gain exact-name match against any descriptor (precision win over substring -- `Foo` no longer matches `MyFoo#` or `FooBar#`). Substring fallback only fires when the symbol string itself fails to parse (defensive path for unusual indexer output). Empty queries and whitespace queries short-circuit to false instead of leaking through `.contains("")` returning true.
+
+- **Five new ecosystem indexers** (#432, closes #426/#427/#428/#429/#430): `scip-java` (markers `pom.xml` / `build.gradle` / `build.gradle.kts`), `scip-ruby` (`Gemfile`), `scip-clang` for C/C++ (`CMakeLists.txt` or `compile_commands.json`), `scip-dotnet` for C# (any `*.csproj` / `*.sln` -- first language whose marker requires a glob scan, new `has_dotnet_project` helper), and `scip-php` (`composer.json`). Each helper mirrors the existing TypeScript/Python/Go shape: missing-binary errors carry an install hint, subprocess non-zero surfaces stderr, output validated against `index.scip` in the repo root. Ships `legion` with eight working indexers (counting Rust); zero runtime cost in repos that don't have the markers, warn-and-skip when the binary isn't installed.
+
+- **`legion sym impact --repo <R> --diff <path-or-stdin>`** (#435, closes #423): for every symbol whose definition the diff touches, reports the SCIP reference count across the repo's index. Sorted descending so wide-blast-radius diffs surface first. `--json` emits a stable shape for agent consumption. The `LEGION_IMPACT_HIGH_THRESHOLD` env var (default 50) controls the `HIGH` tag in text output. Reviewer agents (vault, smugglr) can call this against a PR diff to flag changes that touch heavily-referenced symbols. Diff parser handles git's `+++ b/path`, plain `diff -u`'s `+++ path<TAB>mtime`, `/dev/null` deletes, single-line hunks omitting `,count`, and per-blob plus cross-blob symbol dedup so polyglot repos never double-emit.
+
+- **`legion index --logs`** (#433, closes #424): surfaces background-indexer log content through the CLI instead of requiring users to know about the on-disk path. Filters: `--repo <name>` to scope to one repo, `--lines N` to override the default 50-line tail, `--follow` to tail-follow new output via 250ms polling. Migrates the log directory from `/tmp/legion-index-<repo>.log` (wiped on reboot) to `$XDG_STATE_HOME/legion/index-logs/<repo>.log` so logs survive long enough to debug an overnight indexer failure. `spawn_background_indexer` calls `migrate_legacy_index_logs()` on every spawn for one-shot idempotent migration. Stderr warning fires if neither `XDG_STATE_HOME` nor `HOME` is set (stripped-container edge case) so the silent regression to reboot-wipe behavior is loud.
+
+- **`legion index --status --banner` SessionStart injection** (#434, closes #425): renders a per-repo SCIP health line so agents see whether `legion sym` will succeed before they call it. Single-line confirmation when every detected language has a fresh index (`[Legion] Index status for legion: rust: fresh (2h ago)`); multi-line block when anything is stale (>7 days) or missing, naming each language and the command to refresh. Banner mode never errors -- a banner-mode failure prints `[Legion] Index status: unavailable` and returns Ok so SessionStart can never block on it. `plugin/hooks/session-start.sh` injects the banner between the snooze block and the kanban block.
+
+### Changed
+
+- PATH-mutating tests in `src/scip.rs` (`run_indexer_dispatches_each_language_to_its_helper`, `language_helpers_surface_install_hints_when_missing`, `run_scip_rust_fallback_chain`) now serialize via a static `Mutex<()>` in the test module. cargo's parallel runner gives no env isolation, and three concurrent PATH-mutating tests on Ubuntu CI consistently corrupted each others' subprocess invocations even though each restored PATH at exit. Linux scheduling exposed the race that macOS hid. Non-PATH tests still parallelize.
+
+### Pattern delivered
+
+**Precision over coverage.** v0.10-v0.12 prioritized "answer the question fast" with substring match and four-language coverage. v0.13.0 says: when the question is precise, the answer should be too. Descriptor-aware matching (`Foo#` no longer collides with `MyFoo`) plus impact-radius (`Foo` is fresh = nothing; `Foo` with refs=147 = HIGH) plus eight-language coverage means the SCIP layer answers correctly more often, which closes the loop on the cache_r reduction thesis from v0.12.
+
 ## 0.12.0
 
 SCIP consumption hooks. Phase C of the SCIP completion plan -- the cost-control payoff. Both surfaces are token-cheap legion CLI calls that prevent expensive tool calls. Ships standalone so the cache_r reduction is measurable in isolation: the 1B+ cache_r token explosion that prompted the SCIP completion push is the metric this release should move.


### PR DESCRIPTION
## Summary

Cuts the v0.13.0 release. Bumps Cargo.toml, Cargo.lock, marketplace.json, plugin.json all to 0.13.0; adds CHANGELOG entry covering the five feature PRs and the test-serialization fix.

Closes the v0.10-v0.13 SCIP completion arc tracked by master plan reflection 019daeb5.

## Shipped in 0.13.0

- #431 (#421) descriptor-aware symbol matching
- #432 (#426/#427/#428/#429/#430) five new ecosystem indexers: java, ruby, clang, dotnet, php
- #435 (#423) `legion sym impact` diff impact radius
- #433 (#424) `legion index --logs` + XDG_STATE_HOME migration
- #434 (#425) `legion index --status --banner` + SessionStart injection
- PATH-mutating test serialization in `src/scip.rs` (Mutex<()>)

## Test plan

- [x] `cargo test` (688 + 122 pass)
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt -- --check` clean
- [x] `cargo build --release` succeeds
- [x] Versions consistent across all four manifests (verified by sync-version pre-commit hook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)