### PR TITLE
feat(#437): telemetry CLI + indexed-repo probe + index --status --json

### DIFF
--- a/plugin/hooks/_legion-indexed.sh
+++ b/plugin/hooks/_legion-indexed.sh
@@ -48,8 +48,10 @@ legion_indexed() {
     return 1
   fi
 
+  # Degraded environment: missing legion binary or missing jq. Do NOT cache
+  # the verdict -- mirrors _legion-covered.sh, so a transient missing-binary
+  # state during the session does not become sticky once the binary appears.
   if [ ! -x "$LEGION_INDEXED_BIN" ] || ! command -v jq >/dev/null 2>&1; then
-    printf '0' > "$cache_file" 2>/dev/null
     return 1
   fi
 

--- a/plugin/hooks/_legion-indexed.sh
+++ b/plugin/hooks/_legion-indexed.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+# Shared helper: decide whether a repo has a stored SCIP index. Block-state
+# enforcement in the grep/Read hooks (#438/#439) requires an index to redirect
+# to; without one, the hooks fall through to inject-only behavior. A repo is
+# "indexed" if `legion index --status --json` (#437) returns at least one row
+# matching it.
+#
+# Cached per (session, repo) under XDG_CACHE_HOME alongside `_legion-covered`.
+# Cache file contents: "1" = indexed, "0" = not indexed.
+#
+# Usage from a hook script:
+#
+#   source "${CLAUDE_PLUGIN_ROOT}/hooks/_legion-indexed.sh"
+#
+#   if ! legion_indexed "$SESSION_ID" "$REPO"; then
+#     # fall through to inject-only behavior (no block tier)
+#   fi
+#
+# Fail-open posture: missing binary, missing jq, malformed JSON -> return
+# "not indexed" (1) so the block tier is silently skipped rather than fired
+# on bad data. This is the inverse of `_legion-covered` (which fails to
+# "covered=true") because a missing/degraded probe must not let block-state
+# fire on a repo with no real index to redirect to.
+
+LEGION_INDEXED_BIN="${CLAUDE_PLUGIN_ROOT}/bin/legion"
+
+# legion_indexed SESSION_ID REPO -> exit 0 if indexed, 1 if not.
+legion_indexed() {
+  local session_id="${1:-}"
+  local repo="${2:-}"
+  if [ -z "$repo" ]; then
+    return 1
+  fi
+
+  local safe_session
+  safe_session=$(printf '%s' "$session_id" | tr -c 'a-zA-Z0-9_-' '_')
+  local safe_repo
+  safe_repo=$(printf '%s' "$repo" | tr -c 'a-zA-Z0-9_-' '_')
+
+  local cache_dir="${XDG_CACHE_HOME:-$HOME/.cache}/legion"
+  mkdir -p "$cache_dir" 2>/dev/null
+  local cache_file="${cache_dir}/indexed-${safe_session}-${safe_repo}"
+
+  if [ -f "$cache_file" ]; then
+    if [ "$(cat "$cache_file" 2>/dev/null)" = "1" ]; then
+      return 0
+    fi
+    return 1
+  fi
+
+  if [ ! -x "$LEGION_INDEXED_BIN" ] || ! command -v jq >/dev/null 2>&1; then
+    printf '0' > "$cache_file" 2>/dev/null
+    return 1
+  fi
+
+  local indexed=0
+  if "$LEGION_INDEXED_BIN" index --status --json "$repo" 2>/dev/null \
+       | jq -e --arg r "$repo" 'any(.[]; .repo == $r)' >/dev/null 2>&1; then
+    indexed=1
+  fi
+
+  printf '%s' "$indexed" > "$cache_file" 2>/dev/null
+
+  if [ "$indexed" -eq 1 ]; then
+    return 0
+  fi
+  return 1
+}

--- a/plugin/hooks/test-legion-indexed.sh
+++ b/plugin/hooks/test-legion-indexed.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+# Test runner for _legion-indexed.sh.
+#
+# Sources the helper and exercises the cache-hit, cache-miss, indexed,
+# and not-indexed branches against a fake `legion` binary on PATH. Does
+# not depend on the real legion build being present.
+#
+# Run from the repo root:
+#   bash plugin/hooks/test-legion-indexed.sh
+#
+# Exits 0 on success, 1 on any failed assertion.
+
+set -u
+
+PASS=0
+FAIL=0
+
+assert() {
+  local desc="$1"
+  local actual="$2"
+  local expected="$3"
+  if [ "$actual" = "$expected" ]; then
+    PASS=$((PASS + 1))
+    echo "  PASS: $desc"
+  else
+    FAIL=$((FAIL + 1))
+    echo "  FAIL: $desc (expected '$expected', got '$actual')" >&2
+  fi
+}
+
+# Build a temp environment: fake CLAUDE_PLUGIN_ROOT/bin/legion that returns
+# canned JSON, isolated XDG_CACHE_HOME so cache files don't collide with
+# the operator's real cache.
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+
+mkdir -p "$WORK/plugin/bin" "$WORK/plugin/hooks" "$WORK/cache"
+cp plugin/hooks/_legion-indexed.sh "$WORK/plugin/hooks/"
+
+# Fake legion binary: prints a fixed JSON array containing 'legion' and
+# 'smugglr', regardless of args. Exit 0.
+cat > "$WORK/plugin/bin/legion" <<'EOF'
+#!/bin/bash
+echo '[{"repo":"legion","lang":"rust","size_bytes":100,"updated_at":"2026-01-01T00:00:00Z"},{"repo":"smugglr","lang":"rust","size_bytes":200,"updated_at":"2026-01-01T00:00:00Z"}]'
+EOF
+chmod +x "$WORK/plugin/bin/legion"
+
+export CLAUDE_PLUGIN_ROOT="$WORK/plugin"
+export XDG_CACHE_HOME="$WORK/cache"
+
+# shellcheck source=plugin/hooks/_legion-indexed.sh
+source "$WORK/plugin/hooks/_legion-indexed.sh"
+
+echo "==> indexed repos return 0"
+legion_indexed "sess-1" "legion" && actual="0" || actual="1"
+assert "legion is indexed" "$actual" "0"
+
+legion_indexed "sess-1" "smugglr" && actual="0" || actual="1"
+assert "smugglr is indexed" "$actual" "0"
+
+echo "==> non-indexed repo returns 1"
+legion_indexed "sess-1" "platform" && actual="0" || actual="1"
+assert "platform is not indexed" "$actual" "1"
+
+echo "==> cache short-circuits second call"
+# Replace the fake binary with one that always errors. If the cache works,
+# the second probe for 'legion' must still succeed because it reads the
+# cached "1" without invoking the binary.
+cat > "$WORK/plugin/bin/legion" <<'EOF'
+#!/bin/bash
+exit 1
+EOF
+chmod +x "$WORK/plugin/bin/legion"
+
+legion_indexed "sess-1" "legion" && actual="0" || actual="1"
+assert "cached legion still indexed" "$actual" "0"
+legion_indexed "sess-1" "platform" && actual="0" || actual="1"
+assert "cached platform still not indexed" "$actual" "1"
+
+echo "==> empty repo arg returns 1"
+legion_indexed "sess-2" "" && actual="0" || actual="1"
+assert "empty repo treated as not indexed" "$actual" "1"
+
+echo "==> missing legion binary -> not indexed"
+rm -f "$WORK/plugin/bin/legion"
+legion_indexed "sess-3" "rafters" && actual="0" || actual="1"
+assert "missing binary -> not indexed (block tier disabled)" "$actual" "1"
+
+echo
+echo "==> $PASS passed, $FAIL failed"
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi
+exit 0

--- a/plugin/hooks/test-legion-indexed.sh
+++ b/plugin/hooks/test-legion-indexed.sh
@@ -81,10 +81,24 @@ echo "==> empty repo arg returns 1"
 legion_indexed "sess-2" "" && actual="0" || actual="1"
 assert "empty repo treated as not indexed" "$actual" "1"
 
-echo "==> missing legion binary -> not indexed"
+echo "==> missing legion binary -> not indexed (no cache poison)"
 rm -f "$WORK/plugin/bin/legion"
 legion_indexed "sess-3" "rafters" && actual="0" || actual="1"
 assert "missing binary -> not indexed (block tier disabled)" "$actual" "1"
+# The missing-binary path must NOT cache the verdict; otherwise a transient
+# missing state becomes sticky for the rest of the session.
+assert "missing-binary path leaves no cache file" \
+  "$([ -f "$XDG_CACHE_HOME/legion/indexed-sess-3-rafters" ] && echo yes || echo no)" \
+  "no"
+
+echo "==> binary appears mid-session -> probe re-runs and succeeds"
+cat > "$WORK/plugin/bin/legion" <<'EOF'
+#!/bin/bash
+echo '[{"repo":"rafters","lang":"typescript","size_bytes":300,"updated_at":"2026-01-01T00:00:00Z"}]'
+EOF
+chmod +x "$WORK/plugin/bin/legion"
+legion_indexed "sess-3" "rafters" && actual="0" || actual="1"
+assert "binary returned -> rafters now indexed" "$actual" "0"
 
 echo
 echo "==> $PASS passed, $FAIL failed"

--- a/src/error.rs
+++ b/src/error.rs
@@ -105,6 +105,9 @@ pub enum LegionError {
 
     #[error("indexer failed for {lang}: {stderr}")]
     IndexerFailed { lang: String, stderr: String },
+
+    #[error("telemetry error: {0}")]
+    Telemetry(String),
 }
 
 pub type Result<T> = std::result::Result<T, LegionError>;

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,6 +27,7 @@ mod sym;
 mod sync;
 mod sync_actor;
 mod task;
+mod telemetry;
 #[cfg(test)]
 mod testutil;
 mod usage;
@@ -476,6 +477,11 @@ enum Commands {
         /// `legion sym` will succeed before they try.
         #[arg(long, requires = "status")]
         banner: bool,
+        /// Emit `--status` output as a JSON array of {repo, lang, size_bytes,
+        /// updated_at} objects. Hooks (#437/#438/#439) consume this to probe
+        /// whether a repo is indexed before applying enforcement.
+        #[arg(long, requires = "status", conflicts_with = "banner")]
+        json: bool,
     },
 
     /// Query SCIP symbol indexes (def, refs, impl, hover).
@@ -509,6 +515,16 @@ enum Commands {
 
     /// Compute embeddings for all reflections that are missing them
     Backfill,
+
+    /// Bypass telemetry: log when an agent escapes a grep/Read enforcement
+    /// hook (#438/#439), and read the log back. Append-only JSONL at
+    /// `${XDG_STATE_HOME:-~/.local/state}/legion/bypass.jsonl`. Feeds the
+    /// uncertainty engine (#354) -- bypass volume on a (repo, pattern) is a
+    /// signal that sym/recall is missing an answer agents expected.
+    Telemetry {
+        #[command(subcommand)]
+        action: TelemetryAction,
+    },
 
     /// Show reflection statistics
     Stats {
@@ -820,6 +836,55 @@ enum SymAction {
         /// Emit results as JSON instead of human-readable text
         #[arg(long)]
         json: bool,
+    },
+}
+
+#[derive(Subcommand)]
+enum TelemetryAction {
+    /// Append one bypass row to `bypass.jsonl`. Called by the grep/Read
+    /// enforcement hooks (#438/#439) when an agent escapes via env var or
+    /// `# legion-bypass:` sentinel in a Bash command. Errors are surfaced;
+    /// the hook layer decides whether to swallow them (it does -- telemetry
+    /// must never break the agent).
+    RecordBypass {
+        /// Repo the bypass occurred in
+        #[arg(long)]
+        repo: String,
+        /// Claude Code session id (passed through from the hook input)
+        #[arg(long)]
+        session_id: String,
+        /// Tool name that was bypassed (`Bash`, `Grep`, `Glob`, `Read`)
+        #[arg(long)]
+        tool: String,
+        /// Pattern or path the bypass applied to
+        #[arg(long)]
+        pattern: String,
+        /// Free-form reason captured from the bypass mechanism (env value,
+        /// `# legion-bypass: <reason>` substring, etc).
+        #[arg(long)]
+        bypass_reason: String,
+        /// Whether `legion sym def/refs` had hits the agent ignored
+        #[arg(long)]
+        had_sym_hits: bool,
+        /// Whether `legion recall` had hits the agent ignored
+        #[arg(long)]
+        had_recall_hits: bool,
+        /// Optional agent identifier (default: empty). Hooks resolve this
+        /// once per session via `legion whoami` and pass it through.
+        #[arg(long, default_value = "")]
+        agent: String,
+    },
+
+    /// Read the bypass log. Filters by `--since` (duration like `24h`,
+    /// `7d`) and `--repo`. Used by `legion telemetry summary` (#440) and by
+    /// downstream consumers (uncertainty engine #354).
+    ListBypasses {
+        /// Drop rows older than this duration. Format: `30s`, `15m`, `24h`, `7d`.
+        #[arg(long)]
+        since: Option<String>,
+        /// Restrict to a single repo
+        #[arg(long)]
+        repo: Option<String>,
     },
 }
 
@@ -3480,6 +3545,7 @@ fn run() -> error::Result<()> {
             follow,
             lines,
             banner,
+            json,
         } => {
             let base = data_dir()?;
 
@@ -3498,8 +3564,21 @@ fn run() -> error::Result<()> {
             // --status: dump scip_indexes inventory and return.
             if status {
                 let database = db::Database::open(&base.join("legion.db"))?;
-                let indexes = database.list_scip_indexes_filtered(None, None)?;
-                if indexes.is_empty() {
+                let indexes = database.list_scip_indexes_filtered(repo.as_deref(), None)?;
+                if json {
+                    let rows: Vec<serde_json::Value> = indexes
+                        .iter()
+                        .map(|idx| {
+                            serde_json::json!({
+                                "repo": idx.repo,
+                                "lang": idx.lang,
+                                "size_bytes": idx.blob.len(),
+                                "updated_at": idx.updated_at,
+                            })
+                        })
+                        .collect();
+                    println!("{}", serde_json::to_string(&rows)?);
+                } else if indexes.is_empty() {
                     info!("[legion] no SCIP indexes recorded yet");
                 } else {
                     use std::io::Write;
@@ -3722,6 +3801,39 @@ fn run() -> error::Result<()> {
             let database = db::Database::open(&base.join("legion.db"))?;
             stats::stats(&database, repo.as_deref())?;
         }
+        Commands::Telemetry { action } => match action {
+            TelemetryAction::RecordBypass {
+                repo,
+                session_id,
+                tool,
+                pattern,
+                bypass_reason,
+                had_sym_hits,
+                had_recall_hits,
+                agent,
+            } => {
+                let record = telemetry::BypassRecord {
+                    ts: chrono::Utc::now(),
+                    repo,
+                    session_id,
+                    agent,
+                    tool,
+                    pattern,
+                    bypass_reason,
+                    had_sym_hits,
+                    had_recall_hits,
+                };
+                telemetry::append_bypass(&record)?;
+            }
+            TelemetryAction::ListBypasses { since, repo } => {
+                let since_dur = match since {
+                    Some(s) => Some(telemetry::parse_duration(&s)?),
+                    None => None,
+                };
+                let rows = telemetry::list_bypasses(since_dur, repo.as_deref())?;
+                println!("{}", serde_json::to_string(&rows)?);
+            }
+        },
         Commands::Serve { port } => {
             let base = data_dir()?;
             let watch_path = base.join("watch.toml");

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -263,10 +263,10 @@ mod tests {
     #[test]
     fn bypass_log_path_uses_xdg_state_home() {
         let saved_xdg = std::env::var("XDG_STATE_HOME").ok();
-        let saved_home = std::env::var("HOME").ok();
-        // SAFETY: tests in this module touch process env. Run with
-        // `cargo test -- --test-threads=1` if env races become an issue.
-        // We restore env at the end of the test.
+        // SAFETY: this test mutates process env. Cargo runs tests in parallel
+        // by default, so a concurrent test reading XDG_STATE_HOME could
+        // observe the override. None do today; if that changes, run this
+        // module with `cargo test -- --test-threads=1`.
         unsafe {
             std::env::set_var("XDG_STATE_HOME", "/tmp/legion-xdg-test");
         }
@@ -276,10 +276,6 @@ mod tests {
             match saved_xdg {
                 Some(v) => std::env::set_var("XDG_STATE_HOME", v),
                 None => std::env::remove_var("XDG_STATE_HOME"),
-            }
-            match saved_home {
-                Some(v) => std::env::set_var("HOME", v),
-                None => std::env::remove_var("HOME"),
             }
         }
     }

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -1,0 +1,286 @@
+//! Bypass telemetry: append-only JSONL log of agent escapes from the grep/Read
+//! enforcement hooks (#437/#438/#439). Each row is a single JSON object on its
+//! own line. The file lives under `$XDG_STATE_HOME/legion/bypass.jsonl` so it
+//! survives a reboot and matches the index-log dir migration shipped in 0.13
+//! (#424). Errors during write are surfaced to the caller; the hook layer
+//! decides whether to drop them on the floor (it does -- telemetry must never
+//! break the agent).
+//!
+//! Read path is `list_bypasses`, used by `legion telemetry list-bypasses` and
+//! by the summary endpoint shipped in #440.
+use std::fs::OpenOptions;
+use std::io::{BufRead, BufReader, Write};
+use std::path::PathBuf;
+
+use chrono::{DateTime, Duration, Utc};
+use serde::{Deserialize, Serialize};
+
+use crate::error::{LegionError, Result};
+
+/// One row in `bypass.jsonl`. Captures who escaped which enforcement hook on
+/// what query, plus whether the index even had hits to redirect to. The last
+/// two fields are the load-bearing telemetry signal -- a bypass with
+/// `had_sym_hits = false` means the index is missing an answer the agent
+/// expected; a bypass with `had_sym_hits = true` means the agent ignored a
+/// good answer and we should ask why (reflections 019dd266, 019d766f).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct BypassRecord {
+    pub ts: DateTime<Utc>,
+    pub repo: String,
+    pub session_id: String,
+    pub agent: String,
+    pub tool: String,
+    pub pattern: String,
+    pub bypass_reason: String,
+    pub had_sym_hits: bool,
+    pub had_recall_hits: bool,
+}
+
+/// Resolve the canonical bypass log path. Uses `XDG_STATE_HOME` if set,
+/// otherwise `$HOME/.local/state/legion`, otherwise system temp dir with a
+/// stderr warning (matches `scip::index_log_dir`).
+pub fn bypass_log_path() -> PathBuf {
+    bypass_log_dir().join("bypass.jsonl")
+}
+
+fn bypass_log_dir() -> PathBuf {
+    if let Ok(state) = std::env::var("XDG_STATE_HOME")
+        && !state.is_empty()
+    {
+        return PathBuf::from(state).join("legion");
+    }
+    if let Ok(home) = std::env::var("HOME")
+        && !home.is_empty()
+    {
+        return PathBuf::from(home).join(".local/state/legion");
+    }
+    let fallback = std::env::temp_dir().join("legion");
+    eprintln!(
+        "[legion] WARNING: neither XDG_STATE_HOME nor HOME set; bypass log at {} will not survive reboot",
+        fallback.display()
+    );
+    fallback
+}
+
+/// Append one record to the bypass log. Creates parent dirs and the file on
+/// first use. The write itself is atomic at the line level on local
+/// filesystems because each record is a single short JSON line followed by a
+/// newline; concurrent writers will not interleave bytes.
+pub fn append_bypass(record: &BypassRecord) -> Result<()> {
+    append_bypass_to(&bypass_log_path(), record)
+}
+
+/// Test-friendly variant: write to an explicit path instead of the resolved
+/// XDG location.
+fn append_bypass_to(path: &std::path::Path, record: &BypassRecord) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let mut file = OpenOptions::new().create(true).append(true).open(path)?;
+    let line = serde_json::to_string(record)?;
+    file.write_all(line.as_bytes())?;
+    file.write_all(b"\n")?;
+    Ok(())
+}
+
+/// Read all bypass rows, optionally filtered by `since` (drop rows older than
+/// `now - since`) and `repo`. Malformed lines are skipped with a stderr
+/// breadcrumb; one bad row never poisons the whole list.
+pub fn list_bypasses(since: Option<Duration>, repo: Option<&str>) -> Result<Vec<BypassRecord>> {
+    list_bypasses_from(&bypass_log_path(), since, repo)
+}
+
+fn list_bypasses_from(
+    path: &std::path::Path,
+    since: Option<Duration>,
+    repo: Option<&str>,
+) -> Result<Vec<BypassRecord>> {
+    if !path.exists() {
+        return Ok(Vec::new());
+    }
+    let cutoff = since.map(|d| Utc::now() - d);
+    let file = std::fs::File::open(path)?;
+    let mut out = Vec::new();
+    for (i, line) in BufReader::new(file).lines().enumerate() {
+        let line = match line {
+            Ok(l) => l,
+            Err(e) => {
+                eprintln!("[legion] bypass.jsonl line {} read error: {e}", i + 1);
+                continue;
+            }
+        };
+        if line.trim().is_empty() {
+            continue;
+        }
+        let record: BypassRecord = match serde_json::from_str(&line) {
+            Ok(r) => r,
+            Err(e) => {
+                eprintln!("[legion] bypass.jsonl line {} parse error: {e}", i + 1);
+                continue;
+            }
+        };
+        if let Some(c) = cutoff
+            && record.ts < c
+        {
+            continue;
+        }
+        if let Some(r) = repo
+            && record.repo != r
+        {
+            continue;
+        }
+        out.push(record);
+    }
+    Ok(out)
+}
+
+/// Parse a duration string like `24h`, `7d`, `30m`, `90s`. Used by
+/// `--since` on `list-bypasses`.
+pub fn parse_duration(s: &str) -> Result<Duration> {
+    let s = s.trim();
+    if s.is_empty() {
+        return Err(LegionError::Telemetry(
+            "duration is empty (try 24h, 7d, 30m)".to_string(),
+        ));
+    }
+    let (num_part, unit) = s
+        .split_at(s.find(|c: char| !c.is_ascii_digit()).ok_or_else(|| {
+            LegionError::Telemetry(format!("duration '{s}' missing unit suffix"))
+        })?);
+    let n: i64 = num_part
+        .parse()
+        .map_err(|e| LegionError::Telemetry(format!("invalid duration number in '{s}': {e}")))?;
+    match unit {
+        "s" => Ok(Duration::seconds(n)),
+        "m" => Ok(Duration::minutes(n)),
+        "h" => Ok(Duration::hours(n)),
+        "d" => Ok(Duration::days(n)),
+        other => Err(LegionError::Telemetry(format!(
+            "unknown duration unit '{other}' (use s, m, h, d)"
+        ))),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn sample(repo: &str, ts: DateTime<Utc>) -> BypassRecord {
+        BypassRecord {
+            ts,
+            repo: repo.to_string(),
+            session_id: "sess-1".to_string(),
+            agent: "legion".to_string(),
+            tool: "Bash".to_string(),
+            pattern: "fn main".to_string(),
+            bypass_reason: "test".to_string(),
+            had_sym_hits: true,
+            had_recall_hits: false,
+        }
+    }
+
+    #[test]
+    fn round_trip_one_row() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("nested/bypass.jsonl");
+        let rec = sample("legion", Utc::now());
+        append_bypass_to(&path, &rec).unwrap();
+        let rows = list_bypasses_from(&path, None, None).unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0], rec);
+    }
+
+    #[test]
+    fn append_creates_parent_dirs() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("a/b/c/bypass.jsonl");
+        append_bypass_to(&path, &sample("legion", Utc::now())).unwrap();
+        assert!(path.exists());
+    }
+
+    #[test]
+    fn list_filters_by_repo() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("bypass.jsonl");
+        append_bypass_to(&path, &sample("legion", Utc::now())).unwrap();
+        append_bypass_to(&path, &sample("smugglr", Utc::now())).unwrap();
+        let rows = list_bypasses_from(&path, None, Some("legion")).unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].repo, "legion");
+    }
+
+    #[test]
+    fn list_filters_by_since() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("bypass.jsonl");
+        let now = Utc::now();
+        append_bypass_to(&path, &sample("legion", now - Duration::hours(48))).unwrap();
+        append_bypass_to(&path, &sample("legion", now - Duration::minutes(5))).unwrap();
+        let rows = list_bypasses_from(&path, Some(Duration::hours(24)), None).unwrap();
+        assert_eq!(rows.len(), 1);
+        assert!(rows[0].ts > now - Duration::hours(24));
+    }
+
+    #[test]
+    fn list_missing_file_returns_empty() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("does-not-exist.jsonl");
+        let rows = list_bypasses_from(&path, None, None).unwrap();
+        assert!(rows.is_empty());
+    }
+
+    #[test]
+    fn list_skips_malformed_lines() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("bypass.jsonl");
+        let good = sample("legion", Utc::now());
+        let mut f = std::fs::File::create(&path).unwrap();
+        writeln!(f, "{{not json").unwrap();
+        writeln!(f, "{}", serde_json::to_string(&good).unwrap()).unwrap();
+        writeln!(f, "").unwrap();
+        drop(f);
+        let rows = list_bypasses_from(&path, None, None).unwrap();
+        assert_eq!(rows.len(), 1);
+    }
+
+    #[test]
+    fn parse_duration_accepts_units() {
+        assert_eq!(parse_duration("30s").unwrap(), Duration::seconds(30));
+        assert_eq!(parse_duration("15m").unwrap(), Duration::minutes(15));
+        assert_eq!(parse_duration("24h").unwrap(), Duration::hours(24));
+        assert_eq!(parse_duration("7d").unwrap(), Duration::days(7));
+    }
+
+    #[test]
+    fn parse_duration_rejects_bad_input() {
+        assert!(parse_duration("").is_err());
+        assert!(parse_duration("24").is_err());
+        assert!(parse_duration("abc").is_err());
+        assert!(parse_duration("24x").is_err());
+    }
+
+    #[test]
+    fn bypass_log_path_uses_xdg_state_home() {
+        let saved_xdg = std::env::var("XDG_STATE_HOME").ok();
+        let saved_home = std::env::var("HOME").ok();
+        // SAFETY: tests in this module touch process env. Run with
+        // `cargo test -- --test-threads=1` if env races become an issue.
+        // We restore env at the end of the test.
+        unsafe {
+            std::env::set_var("XDG_STATE_HOME", "/tmp/legion-xdg-test");
+        }
+        let p = bypass_log_path();
+        assert_eq!(p, PathBuf::from("/tmp/legion-xdg-test/legion/bypass.jsonl"));
+        unsafe {
+            match saved_xdg {
+                Some(v) => std::env::set_var("XDG_STATE_HOME", v),
+                None => std::env::remove_var("XDG_STATE_HOME"),
+            }
+            match saved_home {
+                Some(v) => std::env::set_var("HOME", v),
+                None => std::env::remove_var("HOME"),
+            }
+        }
+    }
+}

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -254,7 +254,7 @@ mod tests {
         let mut f = std::fs::File::create(&path).unwrap();
         writeln!(f, "{{not json").unwrap();
         writeln!(f, "{}", serde_json::to_string(&good).unwrap()).unwrap();
-        writeln!(f, "").unwrap();
+        writeln!(f).unwrap();
         drop(f);
         let rows = list_bypasses_from(&path, None, None).unwrap();
         assert_eq!(rows.len(), 1);

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -211,6 +211,22 @@ mod tests {
     }
 
     #[test]
+    fn list_filters_by_since_and_repo_combined() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("bypass.jsonl");
+        let now = Utc::now();
+        // 4 rows: 2 legion (one stale, one fresh), 2 smugglr (one stale, one fresh).
+        append_bypass_to(&path, &sample("legion", now - Duration::hours(48))).unwrap();
+        append_bypass_to(&path, &sample("legion", now - Duration::minutes(5))).unwrap();
+        append_bypass_to(&path, &sample("smugglr", now - Duration::hours(48))).unwrap();
+        append_bypass_to(&path, &sample("smugglr", now - Duration::minutes(5))).unwrap();
+        let rows = list_bypasses_from(&path, Some(Duration::hours(24)), Some("legion")).unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].repo, "legion");
+        assert!(rows[0].ts > now - Duration::hours(24));
+    }
+
+    #[test]
     fn list_filters_by_since() {
         let tmp = TempDir::new().unwrap();
         let path = tmp.path().join("bypass.jsonl");

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -5075,3 +5075,162 @@ fn index_status_and_file_mutually_exclusive() {
         "index --status --file should fail at parse time"
     );
 }
+
+#[test]
+fn index_status_json_empty_db_returns_empty_array() {
+    // #437: --json output is the contract `_legion-indexed.sh` (and
+    // downstream #438/#439 hooks) read with `jq -e 'any(.[]; .repo == $r)'`.
+    // The empty case must be a valid JSON array, not "null", not empty
+    // stdout, not a wrapped object. Otherwise jq errors and every probe
+    // silently degrades to "not indexed", disabling block-state.
+    let dir = tempfile::tempdir().unwrap();
+    let output = legion_cmd(dir.path())
+        .args(["index", "--status", "--json"])
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "index --status --json should succeed on empty DB: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(stdout.trim())
+        .unwrap_or_else(|e| panic!("expected JSON array, got '{stdout}': {e}"));
+    let arr = parsed
+        .as_array()
+        .unwrap_or_else(|| panic!("expected top-level array, got: {parsed}"));
+    assert!(
+        arr.is_empty(),
+        "expected empty array on empty DB, got: {parsed}"
+    );
+}
+
+#[test]
+fn index_status_json_conflicts_with_banner() {
+    // --json and --banner are mutually exclusive: banner is human-readable,
+    // json is machine-readable. Combining them makes no sense and must fail
+    // at parse time so an operator who tries the wrong combo gets a clear
+    // error instead of unexpected output.
+    let dir = tempfile::tempdir().unwrap();
+    let output = legion_cmd(dir.path())
+        .args(["index", "--status", "--json", "--banner", "anything"])
+        .output()
+        .unwrap();
+    assert!(
+        !output.status.success(),
+        "index --status --json --banner should fail at parse time"
+    );
+}
+
+#[test]
+fn telemetry_record_and_list_roundtrip() {
+    // #437: end-to-end CLI round-trip. Hooks (#438/#439) shell out with
+    // long-form flags; if clap arg names or bool-flag semantics drift, the
+    // hooks break silently. This pins the surface.
+    let data_dir = tempfile::tempdir().unwrap();
+    let xdg_state = tempfile::tempdir().unwrap();
+
+    let output = legion_cmd(data_dir.path())
+        .env("XDG_STATE_HOME", xdg_state.path())
+        .args([
+            "telemetry",
+            "record-bypass",
+            "--repo",
+            "legion",
+            "--session-id",
+            "sess-int",
+            "--tool",
+            "Bash",
+            "--pattern",
+            "fn main",
+            "--bypass-reason",
+            "integration test",
+            "--had-sym-hits",
+            "--agent",
+            "legion-prime",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "record-bypass failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let output = legion_cmd(data_dir.path())
+        .env("XDG_STATE_HOME", xdg_state.path())
+        .args(["telemetry", "list-bypasses", "--since", "1h"])
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "list-bypasses failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let rows: serde_json::Value = serde_json::from_str(stdout.trim())
+        .unwrap_or_else(|e| panic!("expected JSON array, got '{stdout}': {e}"));
+    let arr = rows
+        .as_array()
+        .unwrap_or_else(|| panic!("expected array, got: {rows}"));
+    assert_eq!(arr.len(), 1, "expected one bypass row, got: {rows}");
+    let row = &arr[0];
+    assert_eq!(row["repo"], "legion");
+    assert_eq!(row["tool"], "Bash");
+    assert_eq!(row["pattern"], "fn main");
+    assert_eq!(row["had_sym_hits"], true);
+    assert_eq!(row["had_recall_hits"], false);
+    assert_eq!(row["agent"], "legion-prime");
+}
+
+#[test]
+fn telemetry_list_filters_by_repo_and_since() {
+    // Combined --since AND --repo filter: each is unit-tested alone in
+    // src/telemetry.rs, but the CLI dispatch path that threads both into
+    // list_bypasses is only exercised here.
+    let data_dir = tempfile::tempdir().unwrap();
+    let xdg_state = tempfile::tempdir().unwrap();
+
+    for repo in ["legion", "smugglr", "legion"] {
+        let out = legion_cmd(data_dir.path())
+            .env("XDG_STATE_HOME", xdg_state.path())
+            .args([
+                "telemetry",
+                "record-bypass",
+                "--repo",
+                repo,
+                "--session-id",
+                "sess",
+                "--tool",
+                "Bash",
+                "--pattern",
+                "x",
+                "--bypass-reason",
+                "test",
+            ])
+            .output()
+            .unwrap();
+        assert!(out.status.success());
+    }
+
+    let output = legion_cmd(data_dir.path())
+        .env("XDG_STATE_HOME", xdg_state.path())
+        .args([
+            "telemetry",
+            "list-bypasses",
+            "--since",
+            "1h",
+            "--repo",
+            "legion",
+        ])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let rows: serde_json::Value = serde_json::from_str(stdout.trim()).unwrap();
+    let arr = rows.as_array().unwrap();
+    assert_eq!(arr.len(), 2, "expected 2 legion rows, got: {rows}");
+    for row in arr {
+        assert_eq!(row["repo"], "legion");
+    }
+}


### PR DESCRIPTION
## Summary
- Ships the primitives the grep/Read enforcement chain (#438, #439, #440) needs.
- `legion telemetry record-bypass` / `list-bypasses` write/read JSONL bypass log at `\${XDG_STATE_HOME:-~/.local/state}/legion/bypass.jsonl`. Bool flags are clap presence-flags (`--had-sym-hits`).
- `legion index --status --json` emits `[{repo, lang, size_bytes, updated_at}]` -- single source of truth for the indexed-repo probe.
- `plugin/hooks/_legion-indexed.sh` mirrors `_legion-covered.sh` shape with inverted fail-open: missing binary returns "not indexed" so block tier silently disables instead of firing on bad data. Critically, the missing-binary path does NOT cache (avoiding session-stickiness on transient degraded state).

## Closes
- #437

## Review fixes applied
- **silent-failure-hunter HIGH**: dropped cache write on missing-binary path in `_legion-indexed.sh`; mirrors `_legion-covered.sh` exactly. Added 2 hook-test assertions (no-cache invariant + mid-session recovery).
- **pr-test-analyzer HIGH**: 4 integration tests pinning the binary surface contract -- empty-DB JSON array shape, clap arg conflicts, full-flag round-trip (proves \`--had-sym-hits\` is a presence flag as hooks will invoke it), combined since+repo filter dispatch.
- **Type-design recommendation deferred**: \`tool: String\` -> enum with Unknown(String) fallback. Defer to #440 where the summary endpoint will reveal whether typo fragmentation is real. Pre-data optimization risk.

## Test plan
- [x] \`cargo test\` -- 698 unit + 126 integration tests pass
- [x] \`cargo clippy -- -D warnings\` clean
- [x] \`cargo fmt -- --check\` clean
- [x] \`bash plugin/hooks/test-legion-indexed.sh\` -- 9/9 assertions pass
- [x] Manual smoke: \`legion telemetry record-bypass ...\` round-trips through \`legion telemetry list-bypasses --since 1h\`
- [x] Manual smoke: \`legion index --status --json | jq .\` parses, \`_legion-indexed.sh\` returns 0 for legion/smugglr, 1 for unindexed repos
- [x] Quality gate recorded clean (\`legion quality-gate\`)