### PR TITLE
feat(#410): SessionStart sunphase + weekday block, legion now CLI

### DIFF
--- a/plugin/hooks/session-start.sh
+++ b/plugin/hooks/session-start.sh
@@ -72,7 +72,17 @@ append_block() {
   fi
 }
 
-# 1. Identity -- who am I. Front and center, banner-wrapped by the binary.
+# 0. Now -- weekday + local time + sunphase. One line, lands first so an
+# agent reads "today is Sunday afternoon" before identity primes voice.
+# claude-code's own systemPrompt ships `currentDate` but no weekday and
+# no hour, so agents pattern-match on conversation density and start
+# saying "tonight" or "wind down" when the operator has the rest of the
+# workday ahead. See #410.
+NOW=$("$LEGION" now --banner 2>>"$LOG")
+legion_check $? "now"
+append_block "$NOW"
+
+# 1. Identity -- who am I. Banner-wrapped by the binary.
 IDENTITY=$("$LEGION" whoami --repo "$REPO" --limit 5 2>>"$LOG")
 legion_check $? "whoami"
 append_block "$IDENTITY"

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,7 @@ mod init;
 mod kanban;
 mod mcp;
 mod mesh;
+mod now;
 mod pr_view;
 mod recall;
 mod reflect;
@@ -515,6 +516,23 @@ enum Commands {
 
     /// Compute embeddings for all reflections that are missing them
     Backfill,
+
+    /// Print the current local time, weekday, and sunphase (#410).
+    ///
+    /// Used by SessionStart to inject a one-line framing block so agents
+    /// stop pattern-matching "tonight" / "wind down" when the operator
+    /// has the rest of the workday ahead. Day-of-week is included
+    /// because date alone does not tell an agent it's Sunday vs Monday.
+    Now {
+        /// Emit the SessionStart-friendly one-line banner. Default
+        /// without --json or --banner is the human-readable banner;
+        /// --json emits a structured snapshot for other consumers.
+        #[arg(long)]
+        banner: bool,
+        /// Emit a JSON snapshot {date, weekday, time, timezone, sunphase}.
+        #[arg(long, conflicts_with = "banner")]
+        json: bool,
+    },
 
     /// Bypass telemetry: log when an agent escapes a grep/Read enforcement
     /// hook (#438/#439), and read the log back. Append-only JSONL at
@@ -3778,6 +3796,17 @@ fn run() -> error::Result<()> {
             let model = embed::EmbedModel::load()?;
             let count = backfill_embeddings(&database, &model)?;
             info!("[legion] embedded {} reflections", count);
+        }
+        Commands::Now { banner: _, json } => {
+            // The default and `--banner` output are the same one-line
+            // string; `banner` is accepted for explicitness in scripts
+            // (matches `legion index --status --banner`'s convention).
+            let snap = now::NowSnapshot::from_local(chrono::Local::now());
+            if json {
+                println!("{}", serde_json::to_string(&snap)?);
+            } else {
+                println!("{}", snap.banner());
+            }
         }
         Commands::Init { force } => {
             init::init(force)?;

--- a/src/now.rs
+++ b/src/now.rs
@@ -74,7 +74,7 @@ impl NowSnapshot {
     }
 
     /// One-line banner suitable for SessionStart additionalContext.
-    /// Format: `[Legion] Now: Sunday 2026-05-10, 14:32 PT (afternoon)`.
+    /// Format: `[Legion] Now: Sun 2026-05-10, 14:32 PT (afternoon)`.
     /// Timezone is omitted when chrono returns an empty `%Z` (some systems
     /// where `%Z` resolves to nothing rather than a name) so the line stays
     /// well-formed.

--- a/src/now.rs
+++ b/src/now.rs
@@ -1,0 +1,165 @@
+//! Time-of-day awareness for SessionStart (#410). Agents pattern-match on
+//! conversation density and start saying "tonight" / "wind down" when the
+//! operator has the rest of the workday ahead. Injecting a time + sunphase
+//! line into SessionStart shifts the framing to the actual hour.
+//!
+//! Day-of-week matters too: this session demonstrated planning a "Mon-Thu"
+//! sprint on a Sunday because the date was visible but the weekday wasn't.
+//!
+//! Output is intentionally one short line so it never crowds identity.
+
+use chrono::{DateTime, Datelike, Local, Timelike};
+use serde::Serialize;
+
+/// Coarse time-of-day bucket. Drives framing register (morning -> kicking
+/// off, afternoon -> mid-stride, evening -> wrap-up) more reliably than
+/// raw hour numerals do.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum Sunphase {
+    LateNight,
+    PreDawn,
+    Morning,
+    Midday,
+    Afternoon,
+    Evening,
+    Night,
+}
+
+impl Sunphase {
+    pub fn from_local_hour(hour: u32) -> Self {
+        match hour {
+            0..=4 => Self::LateNight,
+            5..=6 => Self::PreDawn,
+            7..=10 => Self::Morning,
+            11..=13 => Self::Midday,
+            14..=17 => Self::Afternoon,
+            18..=20 => Self::Evening,
+            _ => Self::Night,
+        }
+    }
+
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::LateNight => "late-night",
+            Self::PreDawn => "pre-dawn",
+            Self::Morning => "morning",
+            Self::Midday => "midday",
+            Self::Afternoon => "afternoon",
+            Self::Evening => "evening",
+            Self::Night => "night",
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+pub struct NowSnapshot {
+    pub date: String,
+    pub weekday: String,
+    pub time: String,
+    pub timezone: String,
+    pub sunphase: &'static str,
+}
+
+impl NowSnapshot {
+    pub fn from_local(now: DateTime<Local>) -> Self {
+        let phase = Sunphase::from_local_hour(now.hour());
+        Self {
+            date: now.format("%Y-%m-%d").to_string(),
+            weekday: now.weekday().to_string(),
+            time: now.format("%H:%M").to_string(),
+            timezone: now.format("%Z").to_string(),
+            sunphase: phase.as_str(),
+        }
+    }
+
+    /// One-line banner suitable for SessionStart additionalContext.
+    /// Format: `[Legion] Now: Sunday 2026-05-10, 14:32 PT (afternoon)`.
+    /// Timezone is omitted when chrono returns an empty `%Z` (some systems
+    /// where `%Z` resolves to nothing rather than a name) so the line stays
+    /// well-formed.
+    pub fn banner(&self) -> String {
+        let tz = if self.timezone.is_empty() {
+            String::new()
+        } else {
+            format!(" {}", self.timezone)
+        };
+        format!(
+            "[Legion] Now: {} {}, {}{} ({})",
+            self.weekday, self.date, self.time, tz, self.sunphase
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+
+    #[test]
+    fn sunphase_covers_all_24_hours() {
+        for h in 0..24 {
+            // Should never panic; every hour maps to exactly one phase.
+            let _ = Sunphase::from_local_hour(h);
+        }
+    }
+
+    #[test]
+    fn sunphase_boundaries() {
+        assert_eq!(Sunphase::from_local_hour(0), Sunphase::LateNight);
+        assert_eq!(Sunphase::from_local_hour(4), Sunphase::LateNight);
+        assert_eq!(Sunphase::from_local_hour(5), Sunphase::PreDawn);
+        assert_eq!(Sunphase::from_local_hour(6), Sunphase::PreDawn);
+        assert_eq!(Sunphase::from_local_hour(7), Sunphase::Morning);
+        assert_eq!(Sunphase::from_local_hour(10), Sunphase::Morning);
+        assert_eq!(Sunphase::from_local_hour(11), Sunphase::Midday);
+        assert_eq!(Sunphase::from_local_hour(13), Sunphase::Midday);
+        assert_eq!(Sunphase::from_local_hour(14), Sunphase::Afternoon);
+        assert_eq!(Sunphase::from_local_hour(17), Sunphase::Afternoon);
+        assert_eq!(Sunphase::from_local_hour(18), Sunphase::Evening);
+        assert_eq!(Sunphase::from_local_hour(20), Sunphase::Evening);
+        assert_eq!(Sunphase::from_local_hour(21), Sunphase::Night);
+        assert_eq!(Sunphase::from_local_hour(23), Sunphase::Night);
+    }
+
+    #[test]
+    fn snapshot_from_known_local() {
+        let dt = Local
+            .with_ymd_and_hms(2026, 5, 10, 14, 32, 0)
+            .single()
+            .unwrap();
+        let snap = NowSnapshot::from_local(dt);
+        assert_eq!(snap.date, "2026-05-10");
+        assert_eq!(snap.weekday, "Sun");
+        assert_eq!(snap.time, "14:32");
+        assert_eq!(snap.sunphase, "afternoon");
+    }
+
+    #[test]
+    fn banner_includes_weekday_date_time_phase() {
+        let dt = Local
+            .with_ymd_and_hms(2026, 5, 10, 14, 32, 0)
+            .single()
+            .unwrap();
+        let banner = NowSnapshot::from_local(dt).banner();
+        assert!(banner.starts_with("[Legion] Now: Sun 2026-05-10"));
+        assert!(banner.contains("14:32"));
+        assert!(banner.contains("(afternoon)"));
+    }
+
+    #[test]
+    fn banner_omits_empty_timezone() {
+        let dt = Local
+            .with_ymd_and_hms(2026, 5, 10, 14, 32, 0)
+            .single()
+            .unwrap();
+        let mut snap = NowSnapshot::from_local(dt);
+        snap.timezone = String::new();
+        let banner = snap.banner();
+        assert!(
+            !banner.contains("  "),
+            "double space when timezone is empty: {banner}"
+        );
+        assert!(banner.ends_with("(afternoon)"));
+    }
+}


### PR DESCRIPTION
## Summary
- Adds \`legion now [--banner|--json]\` CLI. Banner is the SessionStart-friendly one-liner: \`[Legion] Now: Sun 2026-05-10, 11:01 PT (midday)\`.
- New module \`src/now.rs\`: Sunphase enum (LateNight..Night) with fixed-hour mapping per #410 spec, NowSnapshot, banner formatter that handles empty \`%Z\` gracefully (some hosts return \`-07:00\` instead of \`PT\`).
- \`plugin/hooks/session-start.sh\`: emits the now block as block 0, before identity. claude-code ships \`currentDate\` but no weekday and no hour, so agents pattern-match on density and start saying "tonight" / "wind down" when it's actually 11am midday.
- Demonstrated this session: I planned a Mon-Thu sprint on a Sunday because the date was visible but the weekday wasn't. Sean called the slip out -- this issue is the fix.

## Closes
- #410

## Test plan
- [x] 5 unit tests in src/now.rs cover hour boundaries (0-4 late-night, 5-6 pre-dawn, ..., 21-23 night), snapshot from known local time, banner format, empty-timezone edge case
- [x] \`cargo test\` -- 703 unit + 129 integration pass
- [x] \`cargo clippy --all-targets -- -D warnings\` clean
- [x] \`cargo fmt -- --check\` clean
- [x] Manual smoke: \`legion now --banner\` and \`legion now --json | jq\` round-trip
- [x] Quality gate clean