### PR TITLE
feat(#438): pre-bash-grep hook + three-state ladder for grep/find via Bash

### DIFF
--- a/plugin/hooks/_legion-prequery.sh
+++ b/plugin/hooks/_legion-prequery.sh
@@ -68,12 +68,14 @@ legion_prequery_extract_pattern() {
   head="${head%%;*}"
   head="${head%%&&*}"
 
-  # Tokenize naively on whitespace. Caveat: this does not honor quoted
-  # strings with embedded spaces -- a pattern like `grep "foo bar" .` will
-  # extract just `"foo` (and the symbol-shape filter will reject it, which
-  # is fine; the inject path tolerates a miss).
-  # shellcheck disable=SC2206
-  local toks=( $head )
+  # Tokenize on whitespace via `read -ra` so glob characters in the
+  # command (`grep -r foo *.rs`) do NOT expand against the hook's CWD.
+  # Caveat: quoted strings with embedded spaces are not honored -- a
+  # pattern like `grep "foo bar" .` extracts just `"foo` (and the
+  # symbol-shape filter rejects it, which is the right outcome; the
+  # inject path tolerates a miss).
+  local toks=()
+  IFS=' ' read -ra toks <<< "$head"
 
   # Skip the binary token itself.
   local i=1

--- a/plugin/hooks/_legion-prequery.sh
+++ b/plugin/hooks/_legion-prequery.sh
@@ -1,0 +1,229 @@
+#!/bin/bash
+# Shared helpers for the grep/Read enforcement hook ladder (#438/#439).
+#
+# All three pre-* hooks (pre-bash-grep, pre-grep-scip, pre-grep-recall)
+# source this file to share pattern detection, sym/recall probes,
+# bypass-reason extraction, telemetry write, and ladder decision logic.
+#
+# Three-state ladder (per repo):
+#
+#   State 1 INJECT  -- repo not indexed OR sym/recall returned no hits.
+#                       Hook emits allow + additionalContext containing
+#                       whatever sym/recall did find. Agent decides.
+#   State 2 BLOCK   -- repo indexed AND sym returned >= 1 def
+#                       (high-confidence answer is one byte-cheap CLI
+#                       call away). Hook emits decision: block with the
+#                       sym results inline as the reason.
+#   State 3 BYPASS  -- LEGION_BYPASS_GREP=1 env OR `# legion-bypass:`
+#                       sentinel substring in the Bash command. Hook
+#                       writes one telemetry row and emits allow.
+#
+# The bypass tier always wins: an explicit operator escape never blocks.
+# A bypass is logged regardless of whether sym/recall had hits -- the
+# value of telemetry is "what query was the index missing for an agent
+# that escaped" and that question only resolves with both signals.
+
+LEGION_PREQUERY_BIN="${CLAUDE_PLUGIN_ROOT}/bin/legion"
+LEGION_PREQUERY_LOG=/tmp/legion-hook-errors.log
+
+# Pull in the coverage + indexed-repo probes. Both files are siblings;
+# guard against double-source by checking whether the function is already
+# defined (callers may have sourced them too).
+if ! declare -F legion_covered >/dev/null 2>&1; then
+  # shellcheck source=_legion-covered.sh
+  source "${CLAUDE_PLUGIN_ROOT}/hooks/_legion-covered.sh"
+fi
+if ! declare -F legion_indexed >/dev/null 2>&1; then
+  # shellcheck source=_legion-indexed.sh
+  source "${CLAUDE_PLUGIN_ROOT}/hooks/_legion-indexed.sh"
+fi
+
+# legion_prequery_bash_binary CMD -- echo the leading search binary name
+# (grep|rg|ag|ack|find|fd) on match, empty on miss.
+legion_prequery_bash_binary() {
+  local cmd="$1"
+  local trimmed="${cmd#"${cmd%%[![:space:]]*}"}"
+  case "$trimmed" in
+    grep\ *|grep) echo grep ;;
+    rg\ *|rg)     echo rg ;;
+    ag\ *|ag)     echo ag ;;
+    ack\ *|ack)   echo ack ;;
+    find\ *|find) echo find ;;
+    fd\ *|fd)     echo fd ;;
+  esac
+}
+
+# legion_prequery_extract_pattern CMD BINARY -- echo the bare pattern
+# argument extracted from a Bash command. Skips flags (-x, --foo,
+# --bar=baz). Stops at the first pipe, redirect, or `;`. For find/fd,
+# returns the search term (the value of -name, or the first non-flag
+# positional). For grep/rg/ag/ack, returns the first non-flag arg.
+legion_prequery_extract_pattern() {
+  local cmd="$1" binary="$2"
+  # Truncate at pipe / redirect / chain operators so we only parse the
+  # leading invocation.
+  local head="${cmd%%|*}"
+  head="${head%%>*}"
+  head="${head%%<*}"
+  head="${head%%;*}"
+  head="${head%%&&*}"
+
+  # Tokenize naively on whitespace. Caveat: this does not honor quoted
+  # strings with embedded spaces -- a pattern like `grep "foo bar" .` will
+  # extract just `"foo` (and the symbol-shape filter will reject it, which
+  # is fine; the inject path tolerates a miss).
+  # shellcheck disable=SC2206
+  local toks=( $head )
+
+  # Skip the binary token itself.
+  local i=1
+  if [ "$binary" = "find" ] || [ "$binary" = "fd" ]; then
+    # find/fd: scan for -name VALUE or first non-flag arg that is not
+    # a path segment.
+    while [ $i -lt ${#toks[@]} ]; do
+      local t="${toks[$i]}"
+      case "$t" in
+        -name|--iname)
+          i=$((i + 1))
+          [ $i -lt ${#toks[@]} ] && echo "${toks[$i]//\"/}" && return 0
+          ;;
+        -*) i=$((i + 1)) ;;
+        *)
+          # Strip surrounding quotes if any.
+          local cleaned="${t//\"/}"
+          cleaned="${cleaned//\'/}"
+          # Skip path-shaped args like `.`, `./`, `src/`, leading `-`.
+          case "$cleaned" in
+            .|./*|/*) i=$((i + 1)) ;;
+            *) echo "$cleaned" && return 0 ;;
+          esac
+          ;;
+      esac
+    done
+    return 0
+  fi
+
+  # grep/rg/ag/ack: first non-flag positional, with -e PAT and --regexp=PAT
+  # as explicit pattern carriers.
+  while [ $i -lt ${#toks[@]} ]; do
+    local t="${toks[$i]}"
+    case "$t" in
+      -e|--regexp)
+        i=$((i + 1))
+        [ $i -lt ${#toks[@]} ] && echo "${toks[$i]//\"/}" && return 0
+        ;;
+      --regexp=*)
+        echo "${t#--regexp=}" | tr -d '"' | tr -d "'"
+        return 0
+        ;;
+      -*) i=$((i + 1)) ;;
+      *)
+        local cleaned="${t//\"/}"
+        cleaned="${cleaned//\'/}"
+        echo "$cleaned"
+        return 0
+        ;;
+    esac
+  done
+}
+
+# legion_prequery_is_symbol PATTERN -- exit 0 if pattern looks like a bare
+# symbol identifier (CamelCase or snake_case, length > 2, no regex
+# metachars). Exit 1 otherwise.
+legion_prequery_is_symbol() {
+  local p="$1"
+  # Strip leading/trailing word boundaries that some Grep callers add.
+  p=$(echo "$p" | sed -E 's/^\\b//; s/\\b$//')
+  if echo "$p" | grep -qE '^[A-Z][A-Za-z0-9_]{2,}$|^[a-z_][a-z_0-9]{2,}$'; then
+    return 0
+  fi
+  return 1
+}
+
+# legion_prequery_bypass_reason CMD -- echo the bypass reason if the
+# command (or env) signals an operator escape, empty otherwise.
+legion_prequery_bypass_reason() {
+  local cmd="$1"
+  if [ "${LEGION_BYPASS_GREP:-}" = "1" ]; then
+    echo "env:LEGION_BYPASS_GREP=1"
+    return 0
+  fi
+  # `# legion-bypass: <free-form reason>` substring. Anchor to the
+  # comment marker so a literal "legion-bypass" elsewhere in the
+  # command does not trigger.
+  local match
+  match=$(echo "$cmd" | grep -oE '# legion-bypass:[^|;&>]*' | head -1)
+  if [ -n "$match" ]; then
+    # Strip the prefix and trim.
+    local reason="${match#'# legion-bypass:'}"
+    # Trim leading whitespace.
+    reason="${reason#"${reason%%[![:space:]]*}"}"
+    echo "$reason"
+    return 0
+  fi
+}
+
+# legion_prequery_record_bypass REPO SESSION TOOL PATTERN REASON HAD_SYM HAD_RECALL
+# -- write one bypass row via the legion telemetry CLI. Best-effort; a
+# missing binary or write failure is logged + swallowed (telemetry must
+# never break the agent).
+legion_prequery_record_bypass() {
+  local repo="$1" session="$2" tool="$3" pattern="$4" reason="$5"
+  local had_sym="$6" had_recall="$7"
+  if [ ! -x "$LEGION_PREQUERY_BIN" ]; then
+    return 0
+  fi
+  local args=(
+    telemetry record-bypass
+    --repo "$repo"
+    --session-id "$session"
+    --tool "$tool"
+    --pattern "$pattern"
+    --bypass-reason "$reason"
+  )
+  if [ "$had_sym" = "true" ]; then args+=(--had-sym-hits); fi
+  if [ "$had_recall" = "true" ]; then args+=(--had-recall-hits); fi
+  "$LEGION_PREQUERY_BIN" "${args[@]}" 2>>"$LEGION_PREQUERY_LOG" >/dev/null || true
+}
+
+# legion_prequery_sym_def PATTERN -- run `legion sym def --json <pattern>`.
+# Echoes JSON array on hit, empty on miss / non-symbol / missing binary.
+legion_prequery_sym_def() {
+  local pattern="$1"
+  if ! legion_prequery_is_symbol "$pattern"; then
+    return 0
+  fi
+  if [ ! -x "$LEGION_PREQUERY_BIN" ]; then
+    return 0
+  fi
+  local out
+  out=$("$LEGION_PREQUERY_BIN" sym def --json "$pattern" 2>>"$LEGION_PREQUERY_LOG")
+  if [ -z "$out" ] || [ "$out" = "[]" ] || [ "$out" = "null" ]; then
+    return 0
+  fi
+  echo "$out"
+}
+
+# legion_prequery_emit_allow CTX -- emit the PreToolUse JSON shape that
+# allows the call and injects CTX as additionalContext.
+legion_prequery_emit_allow() {
+  local ctx="$1"
+  jq -n --arg ctx "$ctx" '{
+    "hookSpecificOutput": {
+      "hookEventName": "PreToolUse",
+      "permissionDecision": "allow",
+      "permissionDecisionReason": "legion sym/recall results injected",
+      "additionalContext": $ctx
+    }
+  }'
+}
+
+# legion_prequery_emit_block REASON -- emit the PreToolUse JSON shape
+# that blocks the call. The reason is the message the agent reads.
+legion_prequery_emit_block() {
+  local reason="$1"
+  jq -n --arg reason "$reason" '{
+    "decision": "block",
+    "reason": $reason
+  }'
+}

--- a/plugin/hooks/hooks.json
+++ b/plugin/hooks/hooks.json
@@ -123,6 +123,11 @@
             "type": "command",
             "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/no-direct-db.sh",
             "timeout": 5
+          },
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/pre-bash-grep.sh",
+            "timeout": 6
           }
         ]
       },

--- a/plugin/hooks/pre-bash-grep.sh
+++ b/plugin/hooks/pre-bash-grep.sh
@@ -1,0 +1,132 @@
+#!/bin/bash
+# Legion PreToolUse hook (#438): when a Bash command starts with a search
+# binary (grep|rg|ag|ack|find|fd), apply the three-state ladder:
+#
+#   1. INJECT  -- repo not indexed or no high-confidence sym hit.
+#                 Emit additionalContext with whatever sym found.
+#   2. BLOCK   -- repo indexed AND `legion sym def` returned >=1 result.
+#                 Block the Bash call; the agent should call sym instead.
+#   3. BYPASS  -- LEGION_BYPASS_GREP=1 env or `# legion-bypass:` sentinel
+#                 substring in the command. Always allows; logs telemetry.
+#
+# Sibling of pre-grep-scip.sh and pre-grep-recall.sh which cover the
+# Grep and Glob tools. This hook closes the Bash escape gap demonstrated
+# in #438: agents typing `grep -r ...` via Bash slipped past the existing
+# tool-matched hooks entirely.
+#
+# Skip discipline:
+# - LEGION_SKIP_PRE_BASH_GREP=1: skip this hook specifically.
+# - command does not start with a covered search binary: pass through.
+# - repo not legion-covered: pass through (universal hook gate).
+# - extracted pattern not symbol-shaped: pass through (regex/free text
+#   queries aren't sym lookups).
+# - missing legion binary: pass through.
+#
+# Error handling: every legion invocation appends stderr to
+# /tmp/legion-hook-errors.log; the hook always exits 0.
+
+if [ "${LEGION_SKIP_PRE_BASH_GREP:-}" = "1" ]; then
+  echo "[legion-pre-bash-grep] skipped (LEGION_SKIP_PRE_BASH_GREP=1)" >&2
+  exit 0
+fi
+
+INPUT=$(cat)
+if [ -z "$INPUT" ]; then
+  exit 0
+fi
+
+CWD=$(echo "$INPUT" | jq -r '.cwd // empty' 2>/dev/null)
+TOOL=$(echo "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null)
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
+SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // empty' 2>/dev/null)
+
+if [ -z "$CWD" ] || [ "$TOOL" != "Bash" ] || [ -z "$COMMAND" ]; then
+  exit 0
+fi
+
+REPO="${LEGION_REPO:-$(basename "$CWD")}"
+if [ -z "$REPO" ]; then
+  exit 0
+fi
+
+# Source the shared library. It sources _legion-covered.sh and
+# _legion-indexed.sh transitively.
+# shellcheck source=_legion-prequery.sh
+source "${CLAUDE_PLUGIN_ROOT}/hooks/_legion-prequery.sh"
+
+# Universal gate: skip uncovered repos.
+if ! legion_covered "$SESSION_ID" "$REPO"; then
+  exit 0
+fi
+
+# Detect leading search binary; pass through if none.
+BINARY=$(legion_prequery_bash_binary "$COMMAND")
+if [ -z "$BINARY" ]; then
+  exit 0
+fi
+
+# Extract the pattern. Empty extraction means we couldn't isolate one;
+# pass through rather than guessing.
+PATTERN=$(legion_prequery_extract_pattern "$COMMAND" "$BINARY")
+if [ -z "$PATTERN" ]; then
+  exit 0
+fi
+
+# Probe sym before any decision so the bypass row carries the
+# `had_sym_hits` signal that #440's summary will need.
+HITS=$(legion_prequery_sym_def "$PATTERN")
+HAD_SYM="false"
+if [ -n "$HITS" ]; then
+  HAD_SYM="true"
+fi
+
+# State 3: bypass wins. Record telemetry, allow.
+BYPASS_REASON=$(legion_prequery_bypass_reason "$COMMAND")
+if [ -n "$BYPASS_REASON" ]; then
+  legion_prequery_record_bypass \
+    "$REPO" "$SESSION_ID" "Bash" "$PATTERN" "$BYPASS_REASON" \
+    "$HAD_SYM" "false"
+  exit 0
+fi
+
+# No hits: state 1 INJECT path is empty -- nothing to inject. Pass through
+# silently rather than emit a content-free additionalContext block (which
+# would just bill cache_read for "no hits").
+if [ "$HAD_SYM" != "true" ]; then
+  exit 0
+fi
+
+# State 2 BLOCK: only when the repo actually has an index to redirect to.
+# In an unindexed repo, the agent has no sym alternative, so we keep the
+# softer State 1 (inject + nudge) shape.
+if legion_indexed "$SESSION_ID" "$REPO"; then
+  REASON="Use \`legion sym def ${PATTERN}\` -- it answered this in bytes from the SCIP index. Bash ${BINARY} on \`${PATTERN}\` would scan files and bill cache_read.
+
+\`legion sym def ${PATTERN}\` returned:
+
+\`\`\`json
+${HITS}
+\`\`\`
+
+If you genuinely need ${BINARY} (e.g. searching for a literal that is not a symbol, or comparing line numbers across files), retry with one of:
+- \`LEGION_BYPASS_GREP=1 ${COMMAND}\`
+- \`${COMMAND} # legion-bypass: <one-line reason>\`
+
+Either path allows and writes one row to bypass.jsonl so we can see where sym is under-serving."
+  legion_prequery_emit_block "$REASON"
+  exit 0
+fi
+
+# State 1 INJECT: not indexed but we did find something via the cluster
+# (sym pulls from every stored index, not just the current repo). Emit
+# the hits as additionalContext so the agent can decide.
+CTX="## Legion sym for \`${PATTERN}\` (Bash ${BINARY})
+
+\`legion sym def ${PATTERN}\` returned:
+
+\`\`\`json
+${HITS}
+\`\`\`
+
+This repo has no SCIP index, so the block tier is disabled. Consider \`legion sym def ${PATTERN}\` instead of ${BINARY} on this pattern."
+legion_prequery_emit_allow "$CTX"

--- a/plugin/hooks/test-pre-bash-grep.sh
+++ b/plugin/hooks/test-pre-bash-grep.sh
@@ -1,0 +1,211 @@
+#!/bin/bash
+# Test runner for pre-bash-grep.sh and the _legion-prequery.sh helpers.
+#
+# Builds a fake CLAUDE_PLUGIN_ROOT with a stub `legion` binary so the
+# tests don't depend on a real legion build, real watch.toml, or real
+# SCIP indexes. Each test feeds synthetic hook JSON over stdin and
+# asserts on stdout shape.
+#
+# Run from the repo root:
+#   bash plugin/hooks/test-pre-bash-grep.sh
+#
+# Exits 0 on success, 1 on any failed assertion.
+
+set -u
+
+PASS=0
+FAIL=0
+
+assert_contains() {
+  local desc="$1" haystack="$2" needle="$3"
+  if echo "$haystack" | grep -q -- "$needle"; then
+    PASS=$((PASS + 1))
+    echo "  PASS: $desc"
+  else
+    FAIL=$((FAIL + 1))
+    echo "  FAIL: $desc" >&2
+    echo "    expected to find: $needle" >&2
+    echo "    in: $haystack" >&2
+  fi
+}
+
+assert_empty() {
+  local desc="$1" actual="$2"
+  if [ -z "$actual" ]; then
+    PASS=$((PASS + 1))
+    echo "  PASS: $desc"
+  else
+    FAIL=$((FAIL + 1))
+    echo "  FAIL: $desc" >&2
+    echo "    expected empty, got: $actual" >&2
+  fi
+}
+
+assert_eq() {
+  local desc="$1" actual="$2" expected="$3"
+  if [ "$actual" = "$expected" ]; then
+    PASS=$((PASS + 1))
+    echo "  PASS: $desc"
+  else
+    FAIL=$((FAIL + 1))
+    echo "  FAIL: $desc (expected '$expected', got '$actual')" >&2
+  fi
+}
+
+# Set up a fake plugin root with stub binaries.
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+
+mkdir -p "$WORK/plugin/bin" "$WORK/plugin/hooks" "$WORK/cache" "$WORK/state"
+cp plugin/hooks/_legion-covered.sh "$WORK/plugin/hooks/"
+cp plugin/hooks/_legion-indexed.sh "$WORK/plugin/hooks/"
+cp plugin/hooks/_legion-prequery.sh "$WORK/plugin/hooks/"
+cp plugin/hooks/pre-bash-grep.sh "$WORK/plugin/hooks/"
+
+# Stub legion binary: dispatches on argv[1].
+cat > "$WORK/plugin/bin/legion" <<'EOF'
+#!/bin/bash
+case "$1" in
+  watch)
+    [ "$2" = "list" ] && echo "legion /tmp/legion"
+    ;;
+  stats)
+    echo "legion: 5 reflections"
+    ;;
+  index)
+    if [ "$2" = "--status" ] && [ "$3" = "--json" ]; then
+      echo '[{"repo":"legion","lang":"rust","size_bytes":100,"updated_at":"2026-01-01T00:00:00Z"}]'
+    fi
+    ;;
+  sym)
+    if [ "$2" = "def" ] && [ "$3" = "--json" ]; then
+      case "$4" in
+        Symbol*|fn_main|main)
+          echo '[{"file":"src/main.rs","line":42,"symbol":"main"}]'
+          ;;
+        *)
+          echo '[]'
+          ;;
+      esac
+    fi
+    ;;
+  telemetry)
+    # Append the args to a marker file so tests can verify.
+    shift
+    echo "$@" >> "${LEGION_TEST_MARKER:-/dev/null}"
+    ;;
+esac
+EOF
+chmod +x "$WORK/plugin/bin/legion"
+
+export CLAUDE_PLUGIN_ROOT="$WORK/plugin"
+export XDG_CACHE_HOME="$WORK/cache"
+
+HOOK="$WORK/plugin/hooks/pre-bash-grep.sh"
+
+# ---------- _legion-prequery.sh helper unit tests ----------
+
+# shellcheck source=plugin/hooks/_legion-prequery.sh
+source "$WORK/plugin/hooks/_legion-prequery.sh"
+
+echo "==> bash-binary detection"
+assert_eq "leading grep -> grep"  "$(legion_prequery_bash_binary 'grep -r foo .')"   "grep"
+assert_eq "leading rg -> rg"      "$(legion_prequery_bash_binary 'rg --no-heading x')" "rg"
+assert_eq "leading find -> find"  "$(legion_prequery_bash_binary 'find . -name foo')" "find"
+assert_eq "leading fd -> fd"      "$(legion_prequery_bash_binary 'fd Symbol src/')"   "fd"
+assert_eq "leading ls -> empty"   "$(legion_prequery_bash_binary 'ls -la')"           ""
+assert_eq "echo -> empty"         "$(legion_prequery_bash_binary 'echo grep is not running')" ""
+
+echo "==> pattern extraction"
+assert_eq "grep -r PAT ."            "$(legion_prequery_extract_pattern 'grep -r Symbol .' grep)" "Symbol"
+assert_eq "grep --no-heading PAT ."  "$(legion_prequery_extract_pattern 'grep --no-heading SymbolName src/' grep)" "SymbolName"
+assert_eq "grep -e PAT ."            "$(legion_prequery_extract_pattern 'grep -e MyFunc src/' grep)" "MyFunc"
+assert_eq "grep --regexp=PAT ."      "$(legion_prequery_extract_pattern 'grep --regexp=Foo src/' grep)" "Foo"
+assert_eq "rg PAT"                   "$(legion_prequery_extract_pattern 'rg fn_main src/' rg)" "fn_main"
+assert_eq "find . -name PAT"         "$(legion_prequery_extract_pattern 'find . -name Symbol' find)" "Symbol"
+assert_eq "find skips path arg"      "$(legion_prequery_extract_pattern 'find ./src -name Foo' find)" "Foo"
+
+echo "==> symbol-shape detection"
+legion_prequery_is_symbol "Symbol" && actual=0 || actual=1
+assert_eq "CamelCase symbol"  "$actual" "0"
+legion_prequery_is_symbol "fn_main" && actual=0 || actual=1
+assert_eq "snake_case symbol" "$actual" "0"
+legion_prequery_is_symbol "ab" && actual=0 || actual=1
+assert_eq "too-short rejected" "$actual" "1"
+legion_prequery_is_symbol "foo|bar" && actual=0 || actual=1
+assert_eq "regex alternation rejected" "$actual" "1"
+legion_prequery_is_symbol "two words" && actual=0 || actual=1
+assert_eq "whitespace rejected" "$actual" "1"
+legion_prequery_is_symbol "^anchored" && actual=0 || actual=1
+assert_eq "anchored rejected" "$actual" "1"
+
+echo "==> bypass reason detection"
+LEGION_BYPASS_GREP=1 reason=$(legion_prequery_bypass_reason 'grep foo .')
+assert_eq "env var triggers bypass" "$reason" "env:LEGION_BYPASS_GREP=1"
+unset LEGION_BYPASS_GREP
+
+reason=$(legion_prequery_bypass_reason 'grep foo . # legion-bypass: searching literal string')
+assert_eq "comment sentinel triggers bypass" "$reason" "searching literal string"
+
+reason=$(legion_prequery_bypass_reason 'grep foo .')
+assert_empty "no bypass reason on plain command" "$reason"
+
+# ---------- pre-bash-grep.sh end-to-end tests ----------
+
+echo "==> hook end-to-end: non-search command passes through"
+out=$(echo '{"cwd":"/tmp/legion","tool_name":"Bash","tool_input":{"command":"ls -la"},"session_id":"t"}' | bash "$HOOK")
+assert_empty "ls passes through silently" "$out"
+
+echo "==> hook end-to-end: non-symbol pattern passes through"
+out=$(echo '{"cwd":"/tmp/legion","tool_name":"Bash","tool_input":{"command":"grep -r foo|bar src/"},"session_id":"t"}' | bash "$HOOK")
+assert_empty "regex pattern -> pass through" "$out"
+
+echo "==> hook end-to-end: indexed repo + symbol-shape pattern -> BLOCK"
+out=$(echo '{"cwd":"/tmp/legion","tool_name":"Bash","tool_input":{"command":"grep -r Symbol src/"},"session_id":"block-t"}' | bash "$HOOK")
+assert_contains "block decision present" "$out" '"decision": "block"'
+assert_contains "block reason mentions sym def" "$out" 'legion sym def'
+assert_contains "block reason names the pattern" "$out" 'Symbol'
+assert_contains "block reason offers env bypass" "$out" 'LEGION_BYPASS_GREP=1'
+assert_contains "block reason offers sentinel bypass" "$out" '# legion-bypass:'
+
+echo "==> hook end-to-end: bypass via env -> allow + telemetry"
+export LEGION_TEST_MARKER="$WORK/state/bypass-marker.log"
+out=$(LEGION_BYPASS_GREP=1 echo '{"cwd":"/tmp/legion","tool_name":"Bash","tool_input":{"command":"grep -r Symbol src/"},"session_id":"bypass-env-t"}' | LEGION_BYPASS_GREP=1 bash "$HOOK")
+assert_empty "env bypass exits 0 with no decision JSON" "$out"
+if [ -f "$LEGION_TEST_MARKER" ] && grep -q "record-bypass" "$LEGION_TEST_MARKER"; then
+  PASS=$((PASS + 1)); echo "  PASS: env bypass writes telemetry row"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: env bypass did not write telemetry row" >&2
+fi
+unset LEGION_BYPASS_GREP
+
+echo "==> hook end-to-end: bypass via comment sentinel -> allow + telemetry"
+rm -f "$LEGION_TEST_MARKER"
+out=$(echo '{"cwd":"/tmp/legion","tool_name":"Bash","tool_input":{"command":"grep -r Symbol src/ # legion-bypass: testing"},"session_id":"bypass-sentinel-t"}' | bash "$HOOK")
+assert_empty "sentinel bypass exits 0 with no decision JSON" "$out"
+if [ -f "$LEGION_TEST_MARKER" ] && grep -q "record-bypass" "$LEGION_TEST_MARKER"; then
+  PASS=$((PASS + 1)); echo "  PASS: sentinel bypass writes telemetry row"
+  if grep -q "testing" "$LEGION_TEST_MARKER"; then
+    PASS=$((PASS + 1)); echo "  PASS: bypass reason captured"
+  else
+    FAIL=$((FAIL + 1)); echo "  FAIL: bypass reason not captured in telemetry args" >&2
+  fi
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: sentinel bypass did not write telemetry row" >&2
+fi
+
+echo "==> hook end-to-end: skip via LEGION_SKIP_PRE_BASH_GREP=1"
+out=$(LEGION_SKIP_PRE_BASH_GREP=1 echo '{"cwd":"/tmp/legion","tool_name":"Bash","tool_input":{"command":"grep -r Symbol src/"},"session_id":"skip-t"}' | LEGION_SKIP_PRE_BASH_GREP=1 bash "$HOOK")
+assert_empty "skip env exits 0" "$out"
+unset LEGION_SKIP_PRE_BASH_GREP
+
+echo "==> hook end-to-end: non-Bash tool passes through"
+out=$(echo '{"cwd":"/tmp/legion","tool_name":"Read","tool_input":{"command":"grep -r Symbol src/"},"session_id":"t"}' | bash "$HOOK")
+assert_empty "non-Bash tool ignored" "$out"
+
+echo
+echo "==> $PASS passed, $FAIL failed"
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary
- Closes the Bash escape gap. Existing pre-grep-scip + pre-grep-recall hooks cover the Grep/Glob tools; agents typing \`grep -r ...\` or \`rg ...\` via Bash slipped past entirely.
- Three-state ladder per (repo, command):
  - **INJECT** -- not indexed or no symbol-shape pattern. Pass through or surface sym hits as additionalContext.
  - **BLOCK** -- repo indexed AND \`legion sym def\` returned >=1 result. Block the call with sym hits inline; reason text directs the agent at sym + names both bypass mechanisms.
  - **BYPASS** -- \`LEGION_BYPASS_GREP=1\` env or \`# legion-bypass: <reason>\` comment substring. Always allows; writes one telemetry row via \`legion telemetry record-bypass\` (#437) so #440's summary will see escapes from day one.
- Shared helper file (\`_legion-prequery.sh\`) factors out Bash binary detection, pattern extraction (-e PAT, --regexp=PAT, find -name PAT, path-arg skipping), symbol-shape filter, bypass detection, telemetry write, sym probe, and the two PreToolUse JSON emitters. Future PR (#439 Read hook) will reuse and refactor pre-grep-scip + pre-grep-recall to share the same library.

## Closes
- #438

## Review fixes
- Pre-commit simplify caught a glob-expansion footgun in pattern tokenization (\`local toks=( \$head )\` expands globs against CWD). Fixed via \`read -ra\`.

## Test plan
- [x] 36 hook assertions in \`test-pre-bash-grep.sh\` cover binary detection, pattern extraction edge cases, symbol-shape filter, env+sentinel bypass paths, telemetry write, skip env, non-Bash tool pass-through
- [x] \`cargo test\` -- 698 unit + 129 integration pass (no Rust changes)
- [x] \`cargo clippy --all-targets -- -D warnings\` clean
- [x] \`shellcheck plugin/hooks/_legion-prequery.sh plugin/hooks/pre-bash-grep.sh plugin/hooks/test-pre-bash-grep.sh\` clean
- [x] Quality gate clean