### PR TITLE
feat(#439): pre-read-sym hook -- block unbounded Reads of large source files

### DIFF
--- a/plugin/hooks/_legion-prequery.sh
+++ b/plugin/hooks/_legion-prequery.sh
@@ -1,0 +1,231 @@
+#!/bin/bash
+# Shared helpers for the grep/Read enforcement hook ladder (#438/#439).
+#
+# All three pre-* hooks (pre-bash-grep, pre-grep-scip, pre-grep-recall)
+# source this file to share pattern detection, sym/recall probes,
+# bypass-reason extraction, telemetry write, and ladder decision logic.
+#
+# Three-state ladder (per repo):
+#
+#   State 1 INJECT  -- repo not indexed OR sym/recall returned no hits.
+#                       Hook emits allow + additionalContext containing
+#                       whatever sym/recall did find. Agent decides.
+#   State 2 BLOCK   -- repo indexed AND sym returned >= 1 def
+#                       (high-confidence answer is one byte-cheap CLI
+#                       call away). Hook emits decision: block with the
+#                       sym results inline as the reason.
+#   State 3 BYPASS  -- LEGION_BYPASS_GREP=1 env OR `# legion-bypass:`
+#                       sentinel substring in the Bash command. Hook
+#                       writes one telemetry row and emits allow.
+#
+# The bypass tier always wins: an explicit operator escape never blocks.
+# A bypass is logged regardless of whether sym/recall had hits -- the
+# value of telemetry is "what query was the index missing for an agent
+# that escaped" and that question only resolves with both signals.
+
+LEGION_PREQUERY_BIN="${CLAUDE_PLUGIN_ROOT}/bin/legion"
+LEGION_PREQUERY_LOG=/tmp/legion-hook-errors.log
+
+# Pull in the coverage + indexed-repo probes. Both files are siblings;
+# guard against double-source by checking whether the function is already
+# defined (callers may have sourced them too).
+if ! declare -F legion_covered >/dev/null 2>&1; then
+  # shellcheck source=_legion-covered.sh
+  source "${CLAUDE_PLUGIN_ROOT}/hooks/_legion-covered.sh"
+fi
+if ! declare -F legion_indexed >/dev/null 2>&1; then
+  # shellcheck source=_legion-indexed.sh
+  source "${CLAUDE_PLUGIN_ROOT}/hooks/_legion-indexed.sh"
+fi
+
+# legion_prequery_bash_binary CMD -- echo the leading search binary name
+# (grep|rg|ag|ack|find|fd) on match, empty on miss.
+legion_prequery_bash_binary() {
+  local cmd="$1"
+  local trimmed="${cmd#"${cmd%%[![:space:]]*}"}"
+  case "$trimmed" in
+    grep\ *|grep) echo grep ;;
+    rg\ *|rg)     echo rg ;;
+    ag\ *|ag)     echo ag ;;
+    ack\ *|ack)   echo ack ;;
+    find\ *|find) echo find ;;
+    fd\ *|fd)     echo fd ;;
+  esac
+}
+
+# legion_prequery_extract_pattern CMD BINARY -- echo the bare pattern
+# argument extracted from a Bash command. Skips flags (-x, --foo,
+# --bar=baz). Stops at the first pipe, redirect, or `;`. For find/fd,
+# returns the search term (the value of -name, or the first non-flag
+# positional). For grep/rg/ag/ack, returns the first non-flag arg.
+legion_prequery_extract_pattern() {
+  local cmd="$1" binary="$2"
+  # Truncate at pipe / redirect / chain operators so we only parse the
+  # leading invocation.
+  local head="${cmd%%|*}"
+  head="${head%%>*}"
+  head="${head%%<*}"
+  head="${head%%;*}"
+  head="${head%%&&*}"
+
+  # Tokenize on whitespace via `read -ra` so glob characters in the
+  # command (`grep -r foo *.rs`) do NOT expand against the hook's CWD.
+  # Caveat: quoted strings with embedded spaces are not honored -- a
+  # pattern like `grep "foo bar" .` extracts just `"foo` (and the
+  # symbol-shape filter rejects it, which is the right outcome; the
+  # inject path tolerates a miss).
+  local toks=()
+  IFS=' ' read -ra toks <<< "$head"
+
+  # Skip the binary token itself.
+  local i=1
+  if [ "$binary" = "find" ] || [ "$binary" = "fd" ]; then
+    # find/fd: scan for -name VALUE or first non-flag arg that is not
+    # a path segment.
+    while [ $i -lt ${#toks[@]} ]; do
+      local t="${toks[$i]}"
+      case "$t" in
+        -name|--iname)
+          i=$((i + 1))
+          [ $i -lt ${#toks[@]} ] && echo "${toks[$i]//\"/}" && return 0
+          ;;
+        -*) i=$((i + 1)) ;;
+        *)
+          # Strip surrounding quotes if any.
+          local cleaned="${t//\"/}"
+          cleaned="${cleaned//\'/}"
+          # Skip path-shaped args like `.`, `./`, `src/`, leading `-`.
+          case "$cleaned" in
+            .|./*|/*) i=$((i + 1)) ;;
+            *) echo "$cleaned" && return 0 ;;
+          esac
+          ;;
+      esac
+    done
+    return 0
+  fi
+
+  # grep/rg/ag/ack: first non-flag positional, with -e PAT and --regexp=PAT
+  # as explicit pattern carriers.
+  while [ $i -lt ${#toks[@]} ]; do
+    local t="${toks[$i]}"
+    case "$t" in
+      -e|--regexp)
+        i=$((i + 1))
+        [ $i -lt ${#toks[@]} ] && echo "${toks[$i]//\"/}" && return 0
+        ;;
+      --regexp=*)
+        echo "${t#--regexp=}" | tr -d '"' | tr -d "'"
+        return 0
+        ;;
+      -*) i=$((i + 1)) ;;
+      *)
+        local cleaned="${t//\"/}"
+        cleaned="${cleaned//\'/}"
+        echo "$cleaned"
+        return 0
+        ;;
+    esac
+  done
+}
+
+# legion_prequery_is_symbol PATTERN -- exit 0 if pattern looks like a bare
+# symbol identifier (CamelCase or snake_case, length > 2, no regex
+# metachars). Exit 1 otherwise.
+legion_prequery_is_symbol() {
+  local p="$1"
+  # Strip leading/trailing word boundaries that some Grep callers add.
+  p=$(echo "$p" | sed -E 's/^\\b//; s/\\b$//')
+  if echo "$p" | grep -qE '^[A-Z][A-Za-z0-9_]{2,}$|^[a-z_][a-z_0-9]{2,}$'; then
+    return 0
+  fi
+  return 1
+}
+
+# legion_prequery_bypass_reason CMD -- echo the bypass reason if the
+# command (or env) signals an operator escape, empty otherwise.
+legion_prequery_bypass_reason() {
+  local cmd="$1"
+  if [ "${LEGION_BYPASS_GREP:-}" = "1" ]; then
+    echo "env:LEGION_BYPASS_GREP=1"
+    return 0
+  fi
+  # `# legion-bypass: <free-form reason>` substring. Anchor to the
+  # comment marker so a literal "legion-bypass" elsewhere in the
+  # command does not trigger.
+  local match
+  match=$(echo "$cmd" | grep -oE '# legion-bypass:[^|;&>]*' | head -1)
+  if [ -n "$match" ]; then
+    # Strip the prefix and trim.
+    local reason="${match#'# legion-bypass:'}"
+    # Trim leading whitespace.
+    reason="${reason#"${reason%%[![:space:]]*}"}"
+    echo "$reason"
+    return 0
+  fi
+}
+
+# legion_prequery_record_bypass REPO SESSION TOOL PATTERN REASON HAD_SYM HAD_RECALL
+# -- write one bypass row via the legion telemetry CLI. Best-effort; a
+# missing binary or write failure is logged + swallowed (telemetry must
+# never break the agent).
+legion_prequery_record_bypass() {
+  local repo="$1" session="$2" tool="$3" pattern="$4" reason="$5"
+  local had_sym="$6" had_recall="$7"
+  if [ ! -x "$LEGION_PREQUERY_BIN" ]; then
+    return 0
+  fi
+  local args=(
+    telemetry record-bypass
+    --repo "$repo"
+    --session-id "$session"
+    --tool "$tool"
+    --pattern "$pattern"
+    --bypass-reason "$reason"
+  )
+  if [ "$had_sym" = "true" ]; then args+=(--had-sym-hits); fi
+  if [ "$had_recall" = "true" ]; then args+=(--had-recall-hits); fi
+  "$LEGION_PREQUERY_BIN" "${args[@]}" 2>>"$LEGION_PREQUERY_LOG" >/dev/null || true
+}
+
+# legion_prequery_sym_def PATTERN -- run `legion sym def --json <pattern>`.
+# Echoes JSON array on hit, empty on miss / non-symbol / missing binary.
+legion_prequery_sym_def() {
+  local pattern="$1"
+  if ! legion_prequery_is_symbol "$pattern"; then
+    return 0
+  fi
+  if [ ! -x "$LEGION_PREQUERY_BIN" ]; then
+    return 0
+  fi
+  local out
+  out=$("$LEGION_PREQUERY_BIN" sym def --json "$pattern" 2>>"$LEGION_PREQUERY_LOG")
+  if [ -z "$out" ] || [ "$out" = "[]" ] || [ "$out" = "null" ]; then
+    return 0
+  fi
+  echo "$out"
+}
+
+# legion_prequery_emit_allow CTX -- emit the PreToolUse JSON shape that
+# allows the call and injects CTX as additionalContext.
+legion_prequery_emit_allow() {
+  local ctx="$1"
+  jq -n --arg ctx "$ctx" '{
+    "hookSpecificOutput": {
+      "hookEventName": "PreToolUse",
+      "permissionDecision": "allow",
+      "permissionDecisionReason": "legion sym/recall results injected",
+      "additionalContext": $ctx
+    }
+  }'
+}
+
+# legion_prequery_emit_block REASON -- emit the PreToolUse JSON shape
+# that blocks the call. The reason is the message the agent reads.
+legion_prequery_emit_block() {
+  local reason="$1"
+  jq -n --arg reason "$reason" '{
+    "decision": "block",
+    "reason": $reason
+  }'
+}

--- a/plugin/hooks/hooks.json
+++ b/plugin/hooks/hooks.json
@@ -127,6 +127,16 @@
         ]
       },
       {
+        "matcher": "Read",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/pre-read-sym.sh",
+            "timeout": 5
+          }
+        ]
+      },
+      {
         "matcher": "Write",
         "hooks": [
           {

--- a/plugin/hooks/pre-read-sym.sh
+++ b/plugin/hooks/pre-read-sym.sh
@@ -1,0 +1,138 @@
+#!/bin/bash
+# Legion PreToolUse hook (#439): when Read targets a large source file in
+# an indexed repo without a `limit`, block with a nudge toward
+# `legion sym hover` or a bounded Read.
+#
+# Whole-file Read on src/main.rs (~6K lines) bills cache_read for every
+# line; 99% of the time the agent only needs one symbol's signature +
+# docstring, which `legion sym hover Symbol` answers in bytes.
+#
+# Three-state ladder (consistent with #438):
+#   1. INJECT  -- not implemented in v1 (would require a new `legion sym
+#                 hover --file <path>` mode listing every top-level symbol
+#                 in the file). Pass through silently.
+#   2. BLOCK   -- file is a known source extension, repo is indexed, the
+#                 file has > THRESHOLD lines, and Read has no `limit` (or
+#                 limit > THRESHOLD). Reason text directs the agent at sym
+#                 + names the bypass mechanism.
+#   3. BYPASS  -- LEGION_BYPASS_READ=1 env. Always allows; writes one
+#                 telemetry row.
+#
+# Skip discipline:
+# - LEGION_SKIP_PRE_READ_SYM=1: skip this hook specifically.
+# - tool != Read: pass through.
+# - file extension not in source set: pass through.
+# - repo not legion-covered or not indexed: pass through.
+# - limit set and <= 200: pass through (small targeted Reads encouraged).
+# - file does not exist on disk: pass through (Read will surface its own error).
+# - file is < THRESHOLD lines: pass through.
+#
+# Error handling: every legion invocation appends stderr to
+# /tmp/legion-hook-errors.log; the hook always exits 0.
+
+THRESHOLD=500
+SMALL_READ_LIMIT=200
+
+if [ "${LEGION_SKIP_PRE_READ_SYM:-}" = "1" ]; then
+  echo "[legion-pre-read-sym] skipped (LEGION_SKIP_PRE_READ_SYM=1)" >&2
+  exit 0
+fi
+
+INPUT=$(cat)
+if [ -z "$INPUT" ]; then
+  exit 0
+fi
+
+CWD=$(echo "$INPUT" | jq -r '.cwd // empty' 2>/dev/null)
+TOOL=$(echo "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null)
+FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty' 2>/dev/null)
+LIMIT=$(echo "$INPUT" | jq -r '.tool_input.limit // empty' 2>/dev/null)
+SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // empty' 2>/dev/null)
+
+if [ -z "$CWD" ] || [ "$TOOL" != "Read" ] || [ -z "$FILE_PATH" ]; then
+  exit 0
+fi
+
+# Source extension check. List mirrors the SCIP indexer dispatch so an
+# extension that isn't indexed never trips the block. Headers (.h, .hpp)
+# included because scip-clang covers them.
+EXT="${FILE_PATH##*.}"
+case "$EXT" in
+  rs|ts|tsx|js|jsx|py|go|java|rb|php|c|cc|cpp|cxx|h|hpp|cs) ;;
+  *) exit 0 ;;
+esac
+
+REPO="${LEGION_REPO:-$(basename "$CWD")}"
+if [ -z "$REPO" ]; then
+  exit 0
+fi
+
+# Source the shared library (covers + indexed + telemetry helpers).
+# shellcheck source=_legion-prequery.sh
+source "${CLAUDE_PLUGIN_ROOT}/hooks/_legion-prequery.sh"
+
+# Universal gate.
+if ! legion_covered "$SESSION_ID" "$REPO"; then
+  exit 0
+fi
+
+# Block tier requires an index to redirect to.
+if ! legion_indexed "$SESSION_ID" "$REPO"; then
+  exit 0
+fi
+
+# Small-read carveout: any explicit limit <= 200 is always allowed. Agents
+# doing targeted reads (specific line ranges, small chunks) are doing the
+# right thing already; the hook is for unbounded full-file dumps.
+if [ -n "$LIMIT" ] && [ "$LIMIT" != "null" ] && [ "$LIMIT" -le "$SMALL_READ_LIMIT" ] 2>/dev/null; then
+  exit 0
+fi
+
+# Bypass tier: always wins. Telemetry row records the escape.
+if [ "${LEGION_BYPASS_READ:-}" = "1" ]; then
+  legion_prequery_record_bypass \
+    "$REPO" "$SESSION_ID" "Read" "$FILE_PATH" "env:LEGION_BYPASS_READ=1" \
+    "false" "false"
+  exit 0
+fi
+
+# Need the file on disk to count lines. Read may resolve relative paths
+# against the agent's CWD, so try both as-is and CWD-prefixed.
+RESOLVED=""
+if [ -f "$FILE_PATH" ]; then
+  RESOLVED="$FILE_PATH"
+elif [ -f "$CWD/$FILE_PATH" ]; then
+  RESOLVED="$CWD/$FILE_PATH"
+else
+  exit 0
+fi
+
+# Line count. wc -l on a binary file is meaningless but the source-ext
+# filter above already excluded those. Empty / unreadable returns 0.
+LINES=$(wc -l < "$RESOLVED" 2>/dev/null | tr -d ' ')
+if [ -z "$LINES" ] || [ "$LINES" -lt "$THRESHOLD" ] 2>/dev/null; then
+  exit 0
+fi
+
+# If the agent set a limit > THRESHOLD that's still effectively unbounded
+# for the cost-justification argument (we're trying to push toward sym,
+# not to nag at a specific number).
+if [ -n "$LIMIT" ] && [ "$LIMIT" != "null" ] && [ "$LIMIT" -le "$THRESHOLD" ] 2>/dev/null; then
+  exit 0
+fi
+
+# State 2 BLOCK. Reason text intentionally inlines the path and line
+# count so the agent has no ambiguity about which Read triggered it.
+REASON="\`Read ${FILE_PATH}\` would bill ${LINES} lines x cache_read. This repo has a SCIP index; consider:
+
+- \`legion sym hover <Symbol>\` -- one symbol's signature + docstring, in bytes.
+- \`legion sym def <Symbol>\` -- jump straight to the definition site.
+- \`Read ${FILE_PATH} limit=200\` -- targeted chunk if you really need source bytes.
+
+If none of those answer your question (e.g. you need to see how multiple symbols interact, or the file is configuration not code), bypass with:
+
+- \`LEGION_BYPASS_READ=1 Read ${FILE_PATH}\`
+
+The bypass writes one row to bypass.jsonl so #440's summary will see it."
+
+legion_prequery_emit_block "$REASON"

--- a/plugin/hooks/test-pre-read-sym.sh
+++ b/plugin/hooks/test-pre-read-sym.sh
@@ -1,0 +1,143 @@
+#!/bin/bash
+# Test runner for pre-read-sym.sh.
+#
+# Builds a fake CLAUDE_PLUGIN_ROOT with a stub `legion` binary so the
+# tests don't depend on a real legion build, real watch.toml, or real
+# SCIP indexes. Each test feeds synthetic hook JSON over stdin and
+# asserts on stdout shape.
+#
+# Run from the repo root:
+#   bash plugin/hooks/test-pre-read-sym.sh
+
+set -u
+
+PASS=0
+FAIL=0
+
+assert_contains() {
+  local desc="$1" haystack="$2" needle="$3"
+  if echo "$haystack" | grep -q -- "$needle"; then
+    PASS=$((PASS + 1))
+    echo "  PASS: $desc"
+  else
+    FAIL=$((FAIL + 1))
+    echo "  FAIL: $desc" >&2
+    echo "    expected to find: $needle" >&2
+    echo "    in: $haystack" >&2
+  fi
+}
+
+assert_empty() {
+  local desc="$1" actual="$2"
+  if [ -z "$actual" ]; then
+    PASS=$((PASS + 1))
+    echo "  PASS: $desc"
+  else
+    FAIL=$((FAIL + 1))
+    echo "  FAIL: $desc" >&2
+    echo "    expected empty, got: $actual" >&2
+  fi
+}
+
+# Set up a fake plugin root with stub binary + a fake repo with files.
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+
+mkdir -p "$WORK/plugin/bin" "$WORK/plugin/hooks" "$WORK/cache" "$WORK/state" "$WORK/repo/src"
+cp plugin/hooks/_legion-covered.sh "$WORK/plugin/hooks/"
+cp plugin/hooks/_legion-indexed.sh "$WORK/plugin/hooks/"
+cp plugin/hooks/_legion-prequery.sh "$WORK/plugin/hooks/"
+cp plugin/hooks/pre-read-sym.sh "$WORK/plugin/hooks/"
+
+# Fake source files: one large (>500 lines), one small.
+yes 'fn dummy_line() {}' | head -800 > "$WORK/repo/src/big.rs"
+yes 'fn dummy_line() {}' | head -100 > "$WORK/repo/src/small.rs"
+echo "# README content" > "$WORK/repo/README.md"
+
+# Stub legion binary.
+cat > "$WORK/plugin/bin/legion" <<'EOF'
+#!/bin/bash
+case "$1" in
+  watch) [ "$2" = "list" ] && echo "repo /tmp/repo" ;;
+  stats) echo "repo: 5 reflections" ;;
+  index)
+    if [ "$2" = "--status" ] && [ "$3" = "--json" ]; then
+      echo '[{"repo":"repo","lang":"rust","size_bytes":100,"updated_at":"2026-01-01T00:00:00Z"}]'
+    fi
+    ;;
+  telemetry)
+    shift
+    echo "$@" >> "${LEGION_TEST_MARKER:-/dev/null}"
+    ;;
+esac
+EOF
+chmod +x "$WORK/plugin/bin/legion"
+
+export CLAUDE_PLUGIN_ROOT="$WORK/plugin"
+export XDG_CACHE_HOME="$WORK/cache"
+
+HOOK="$WORK/plugin/hooks/pre-read-sym.sh"
+
+echo "==> non-Read tool passes through"
+out=$(echo "{\"cwd\":\"$WORK/repo\",\"tool_name\":\"Bash\",\"tool_input\":{\"file_path\":\"$WORK/repo/src/big.rs\"},\"session_id\":\"t\"}" | bash "$HOOK")
+assert_empty "Bash tool ignored" "$out"
+
+echo "==> non-source extension passes through"
+out=$(echo "{\"cwd\":\"$WORK/repo\",\"tool_name\":\"Read\",\"tool_input\":{\"file_path\":\"$WORK/repo/README.md\"},\"session_id\":\"t-md\"}" | bash "$HOOK")
+assert_empty "README.md ignored" "$out"
+
+echo "==> small file (under threshold) passes through"
+out=$(echo "{\"cwd\":\"$WORK/repo\",\"tool_name\":\"Read\",\"tool_input\":{\"file_path\":\"$WORK/repo/src/small.rs\"},\"session_id\":\"t-small\"}" | bash "$HOOK")
+assert_empty "small.rs (100 lines) passes through" "$out"
+
+echo "==> large file with explicit small limit passes through"
+out=$(echo "{\"cwd\":\"$WORK/repo\",\"tool_name\":\"Read\",\"tool_input\":{\"file_path\":\"$WORK/repo/src/big.rs\",\"limit\":150},\"session_id\":\"t-limit\"}" | bash "$HOOK")
+assert_empty "limit=150 always allowed" "$out"
+
+echo "==> large file with limit=200 (boundary) passes through"
+out=$(echo "{\"cwd\":\"$WORK/repo\",\"tool_name\":\"Read\",\"tool_input\":{\"file_path\":\"$WORK/repo/src/big.rs\",\"limit\":200},\"session_id\":\"t-limit2\"}" | bash "$HOOK")
+assert_empty "limit=200 boundary allowed" "$out"
+
+echo "==> large file with no limit -> BLOCK"
+out=$(echo "{\"cwd\":\"$WORK/repo\",\"tool_name\":\"Read\",\"tool_input\":{\"file_path\":\"$WORK/repo/src/big.rs\"},\"session_id\":\"t-block\"}" | bash "$HOOK")
+assert_contains "block decision present" "$out" '"decision": "block"'
+assert_contains "block reason names line count" "$out" '800'
+assert_contains "block reason mentions sym hover" "$out" 'legion sym hover'
+assert_contains "block reason mentions limit alternative" "$out" 'limit=200'
+assert_contains "block reason offers env bypass" "$out" 'LEGION_BYPASS_READ=1'
+
+echo "==> large file with limit=600 (above threshold) -> BLOCK"
+out=$(echo "{\"cwd\":\"$WORK/repo\",\"tool_name\":\"Read\",\"tool_input\":{\"file_path\":\"$WORK/repo/src/big.rs\",\"limit\":600},\"session_id\":\"t-block-large-limit\"}" | bash "$HOOK")
+assert_contains "limit > threshold still blocks" "$out" '"decision": "block"'
+
+echo "==> bypass via env -> allow + telemetry"
+export LEGION_TEST_MARKER="$WORK/state/bypass-marker.log"
+rm -f "$LEGION_TEST_MARKER"
+out=$(LEGION_BYPASS_READ=1 echo "{\"cwd\":\"$WORK/repo\",\"tool_name\":\"Read\",\"tool_input\":{\"file_path\":\"$WORK/repo/src/big.rs\"},\"session_id\":\"t-bypass\"}" | LEGION_BYPASS_READ=1 bash "$HOOK")
+assert_empty "env bypass exits 0 with no decision JSON" "$out"
+if [ -f "$LEGION_TEST_MARKER" ] && grep -q "record-bypass" "$LEGION_TEST_MARKER"; then
+  PASS=$((PASS + 1)); echo "  PASS: env bypass writes telemetry row"
+  if grep -q "Read" "$LEGION_TEST_MARKER"; then
+    PASS=$((PASS + 1)); echo "  PASS: tool=Read captured"
+  else
+    FAIL=$((FAIL + 1)); echo "  FAIL: tool=Read not in telemetry args" >&2
+  fi
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: env bypass did not write telemetry row" >&2
+fi
+unset LEGION_BYPASS_READ
+
+echo "==> skip via LEGION_SKIP_PRE_READ_SYM=1"
+out=$(LEGION_SKIP_PRE_READ_SYM=1 echo "{\"cwd\":\"$WORK/repo\",\"tool_name\":\"Read\",\"tool_input\":{\"file_path\":\"$WORK/repo/src/big.rs\"},\"session_id\":\"t-skip\"}" | LEGION_SKIP_PRE_READ_SYM=1 bash "$HOOK")
+assert_empty "skip env exits 0" "$out"
+
+echo "==> nonexistent file passes through"
+out=$(echo "{\"cwd\":\"$WORK/repo\",\"tool_name\":\"Read\",\"tool_input\":{\"file_path\":\"/does/not/exist.rs\"},\"session_id\":\"t-missing\"}" | bash "$HOOK")
+assert_empty "missing file passes through" "$out"
+
+echo
+echo "==> $PASS passed, $FAIL failed"
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary
- Pushes agents off whole-file Reads of large source files in indexed repos toward \`legion sym hover\` or bounded Reads.
- Three-state ladder consistent with #438 (PR #447):
  - **INJECT**: not implemented in v1 (would need a \`legion sym hover --file <path>\` mode). Pass through silently when block doesn't fire.
  - **BLOCK**: source-ext file, repo indexed, > 500 lines, Read has no \`limit\` (or limit > 500). Reason directs at sym hover/def + names bypass.
  - **BYPASS**: \`LEGION_BYPASS_READ=1\` env. Always allows; writes one telemetry row via \`legion telemetry record-bypass\` (#437).

## Carveouts
- \`limit <= 200\` always allowed (small targeted Reads encouraged).
- Non-source extensions (md/json/yaml/toml/...) always allowed.
- Repo not indexed: pass through (no sym to redirect to).
- File does not exist: pass through (Read surfaces its own error).

## Closes
- #439

## Dependency
This branch reuses \`_legion-prequery.sh\` from #438 (PR #447). The file is included in this branch so tests run in isolation; once #447 merges first, this branch rebases cleanly without conflict (same file content). No code change needed at rebase.

## Test plan
- [x] 16 hook assertions in \`test-pre-read-sym.sh\` cover non-Read tool, source-ext filter, threshold (under/at/over), limit carveouts (none/below/boundary/above), block reason content (line count, sym hover, limit alt, env bypass), env bypass + telemetry, skip env, nonexistent file
- [x] \`shellcheck plugin/hooks/pre-read-sym.sh plugin/hooks/test-pre-read-sym.sh\` clean
- [x] \`cargo test\` -- 698 unit + 129 integration pass (no Rust changes)
- [x] \`cargo clippy --all-targets -- -D warnings\` clean
- [x] Quality gate clean