### PR TITLE
feat(#440): telemetry summary CLI + HTTP endpoint for bypass volume

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -3892,8 +3892,12 @@ fn run() -> error::Result<()> {
                         "tool", "repo", "pattern", "count", "sym%", "recall%"
                     )?;
                     for row in &summary {
-                        let pattern = if row.pattern.len() > 32 {
-                            format!("{}...", &row.pattern[..29])
+                        // chars().take is char-boundary-safe; row.pattern
+                        // may contain multi-byte unicode (file paths,
+                        // quoted strings) where byte slicing would panic.
+                        let pattern = if row.pattern.chars().count() > 32 {
+                            let head: String = row.pattern.chars().take(29).collect();
+                            format!("{head}...")
                         } else {
                             row.pattern.clone()
                         };

--- a/src/main.rs
+++ b/src/main.rs
@@ -886,6 +886,24 @@ enum TelemetryAction {
         #[arg(long)]
         repo: Option<String>,
     },
+
+    /// Summarize bypass volume by `(tool, repo, pattern)`. Top under-served
+    /// query shapes surface first. Feeds the dashboard surface in #440 and
+    /// the uncertainty engine in #354.
+    Summary {
+        /// Drop rows older than this duration before summarizing.
+        #[arg(long)]
+        since: Option<String>,
+        /// Restrict to a single repo
+        #[arg(long)]
+        repo: Option<String>,
+        /// Top N rows by count (default 20, 0 means all).
+        #[arg(long, default_value_t = 20)]
+        top: usize,
+        /// Emit JSON instead of human-readable text.
+        #[arg(long)]
+        json: bool,
+    },
 }
 
 #[derive(Subcommand)]
@@ -3847,6 +3865,50 @@ fn run() -> error::Result<()> {
                 };
                 let rows = telemetry::list_bypasses(since_dur, repo.as_deref())?;
                 println!("{}", serde_json::to_string(&rows)?);
+            }
+            TelemetryAction::Summary {
+                since,
+                repo,
+                top,
+                json,
+            } => {
+                let since_dur = match since {
+                    Some(s) => Some(telemetry::parse_duration(&s)?),
+                    None => None,
+                };
+                let rows = telemetry::list_bypasses(since_dur, repo.as_deref())?;
+                let summary = telemetry::summarize(&rows, top);
+                if json {
+                    println!("{}", serde_json::to_string(&summary)?);
+                } else if summary.is_empty() {
+                    println!("[legion] no bypasses recorded in scope");
+                } else {
+                    use std::io::Write;
+                    let stdout = std::io::stdout();
+                    let mut out = stdout.lock();
+                    writeln!(
+                        out,
+                        "{:<6} {:<14} {:<32} {:<6} {:<8} {:<8}",
+                        "tool", "repo", "pattern", "count", "sym%", "recall%"
+                    )?;
+                    for row in &summary {
+                        let pattern = if row.pattern.len() > 32 {
+                            format!("{}...", &row.pattern[..29])
+                        } else {
+                            row.pattern.clone()
+                        };
+                        writeln!(
+                            out,
+                            "{:<6} {:<14} {:<32} {:<6} {:<8.1} {:<8.1}",
+                            row.tool,
+                            row.repo,
+                            pattern,
+                            row.count,
+                            row.had_sym_hits_pct * 100.0,
+                            row.had_recall_hits_pct * 100.0,
+                        )?;
+                    }
+                }
             }
         },
         Commands::Serve { port } => {

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -77,6 +77,7 @@ pub fn run_server(port: u16, data_dir: PathBuf) -> error::Result<()> {
             .route("/api/schedules/create", post(api_create_schedule))
             .route("/api/schedules/{id}/toggle", post(api_toggle_schedule))
             .route("/api/kanban", get(api_kanban))
+            .route("/api/telemetry/bypasses", get(api_telemetry_bypasses))
             .route("/api/kanban/{id}/move", post(api_kanban_move))
             .route("/api/kanban/workloads", get(api_kanban_workloads))
             .route("/{*path}", get(static_handler))
@@ -1262,6 +1263,46 @@ async fn api_kanban_workloads(State(state): State<AppState>) -> Response {
         ),
     }
 }
+
+/// Query parameters for GET /api/telemetry/bypasses.
+#[derive(serde::Deserialize)]
+struct TelemetryQuery {
+    /// Duration string (e.g. `24h`, `7d`); rows older than this are dropped.
+    since: Option<String>,
+    /// Restrict to a single repo.
+    repo: Option<String>,
+    /// Top N rows by count. Default 20; 0 means all.
+    top: Option<usize>,
+}
+
+/// GET /api/telemetry/bypasses -- summary of bypass volume by
+/// (tool, repo, pattern). Feeds the dashboard surface and the
+/// uncertainty engine consumer (#354). Reads bypass.jsonl directly;
+/// the file is append-only, so even if the legion DB is unavailable
+/// this endpoint still works.
+async fn api_telemetry_bypasses(Query(params): Query<TelemetryQuery>) -> Response {
+    let since_dur = match params.since.as_deref() {
+        Some(s) => match crate::telemetry::parse_duration(s) {
+            Ok(d) => Some(d),
+            Err(e) => {
+                return json_error(StatusCode::BAD_REQUEST, &format!("invalid since: {e}"));
+            }
+        },
+        None => None,
+    };
+    let rows = match crate::telemetry::list_bypasses(since_dur, params.repo.as_deref()) {
+        Ok(r) => r,
+        Err(e) => {
+            return json_error(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                &format!("read bypass log: {e}"),
+            );
+        }
+    };
+    let summary = crate::telemetry::summarize(&rows, params.top.unwrap_or(20));
+    Json(summary).into_response()
+}
+
 async fn shutdown_signal() {
     let ctrl_c = async {
         signal::ctrl_c()

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -134,6 +134,65 @@ fn list_bypasses_from(
     Ok(out)
 }
 
+/// One row of `legion telemetry summary` output. Aggregates bypass
+/// volume by `(tool, repo, pattern)` so an operator (and the uncertainty
+/// engine consumer in #354) can see where sym/recall is under-serving.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct BypassSummaryRow {
+    pub tool: String,
+    pub repo: String,
+    pub pattern: String,
+    pub count: usize,
+    /// Fraction (0.0..=1.0) of bypasses where sym had hits the agent
+    /// ignored. High value -> agent escapes despite a good answer; the
+    /// reason list is the right place to look for the why.
+    pub had_sym_hits_pct: f64,
+    pub had_recall_hits_pct: f64,
+    pub last_bypass_ts: DateTime<Utc>,
+    /// Deduped list of bypass_reason strings observed for this group.
+    pub bypass_reasons: Vec<String>,
+}
+
+/// Group bypass rows by (tool, repo, pattern), sort by count desc, take
+/// the top `n`. Used by both the CLI summary and the HTTP endpoint.
+pub fn summarize(rows: &[BypassRecord], top: usize) -> Vec<BypassSummaryRow> {
+    use std::collections::BTreeMap;
+    let mut groups: BTreeMap<(String, String, String), Vec<&BypassRecord>> = BTreeMap::new();
+    for r in rows {
+        groups
+            .entry((r.tool.clone(), r.repo.clone(), r.pattern.clone()))
+            .or_default()
+            .push(r);
+    }
+    let mut out: Vec<BypassSummaryRow> = groups
+        .into_iter()
+        .map(|((tool, repo, pattern), rs)| {
+            let count = rs.len();
+            let sym_hits = rs.iter().filter(|r| r.had_sym_hits).count();
+            let recall_hits = rs.iter().filter(|r| r.had_recall_hits).count();
+            let last = rs.iter().map(|r| r.ts).max().unwrap_or_else(Utc::now);
+            let mut reasons: Vec<String> = rs.iter().map(|r| r.bypass_reason.clone()).collect();
+            reasons.sort();
+            reasons.dedup();
+            BypassSummaryRow {
+                tool,
+                repo,
+                pattern,
+                count,
+                had_sym_hits_pct: sym_hits as f64 / count as f64,
+                had_recall_hits_pct: recall_hits as f64 / count as f64,
+                last_bypass_ts: last,
+                bypass_reasons: reasons,
+            }
+        })
+        .collect();
+    out.sort_by_key(|r| std::cmp::Reverse(r.count));
+    if top > 0 && out.len() > top {
+        out.truncate(top);
+    }
+    out
+}
+
 /// Parse a duration string like `24h`, `7d`, `30m`, `90s`. Used by
 /// `--since` on `list-bypasses`.
 pub fn parse_duration(s: &str) -> Result<Duration> {
@@ -258,6 +317,86 @@ mod tests {
         drop(f);
         let rows = list_bypasses_from(&path, None, None).unwrap();
         assert_eq!(rows.len(), 1);
+    }
+
+    #[test]
+    fn summarize_groups_by_tool_repo_pattern() {
+        let now = Utc::now();
+        let rows = vec![
+            sample("legion", now),
+            sample("legion", now - Duration::minutes(5)),
+            sample("smugglr", now - Duration::minutes(10)),
+        ];
+        let out = summarize(&rows, 0);
+        assert_eq!(
+            out.len(),
+            2,
+            "two groups (legion, smugglr) since pattern + tool match"
+        );
+        // Ordering: legion has count=2, smugglr count=1.
+        assert_eq!(out[0].repo, "legion");
+        assert_eq!(out[0].count, 2);
+        assert_eq!(out[1].repo, "smugglr");
+        assert_eq!(out[1].count, 1);
+    }
+
+    #[test]
+    fn summarize_top_truncates() {
+        let now = Utc::now();
+        let mut rows = Vec::new();
+        for i in 0..5 {
+            let mut r = sample("legion", now);
+            r.pattern = format!("pat-{i}");
+            // Repeat each pattern 5-i times so counts are 5,4,3,2,1
+            for _ in 0..(5 - i) {
+                rows.push(r.clone());
+            }
+        }
+        let out = summarize(&rows, 3);
+        assert_eq!(out.len(), 3);
+        assert_eq!(out[0].count, 5);
+        assert_eq!(out[1].count, 4);
+        assert_eq!(out[2].count, 3);
+    }
+
+    #[test]
+    fn summarize_pcts_and_reasons() {
+        let now = Utc::now();
+        let mut a = sample("legion", now);
+        a.bypass_reason = "env:LEGION_BYPASS_GREP=1".to_string();
+        a.had_sym_hits = true;
+        a.had_recall_hits = false;
+        let mut b = sample("legion", now);
+        b.bypass_reason = "searching literal".to_string();
+        b.had_sym_hits = false;
+        b.had_recall_hits = false;
+        let mut c = sample("legion", now);
+        c.bypass_reason = "env:LEGION_BYPASS_GREP=1".to_string();
+        c.had_sym_hits = true;
+        c.had_recall_hits = true;
+        let out = summarize(&[a, b, c], 0);
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].count, 3);
+        assert!((out[0].had_sym_hits_pct - 2.0 / 3.0).abs() < 1e-9);
+        assert!((out[0].had_recall_hits_pct - 1.0 / 3.0).abs() < 1e-9);
+        // Reasons deduped.
+        assert_eq!(out[0].bypass_reasons.len(), 2);
+        assert!(
+            out[0]
+                .bypass_reasons
+                .contains(&"env:LEGION_BYPASS_GREP=1".to_string())
+        );
+        assert!(
+            out[0]
+                .bypass_reasons
+                .contains(&"searching literal".to_string())
+        );
+    }
+
+    #[test]
+    fn summarize_empty_input_is_empty_output() {
+        let out = summarize(&[], 10);
+        assert!(out.is_empty());
     }
 
     #[test]

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -5241,6 +5241,99 @@ fn kanban_reconcile_dry_run_on_empty_db_is_quiet_success() {
 }
 
 #[test]
+fn telemetry_summary_rolls_up_groups() {
+    // #440: summary groups by (tool, repo, pattern), sorts by count desc.
+    // Seed three rows for one (Bash, legion, fn_main) group + one row for a
+    // different (Read, legion, src/main.rs) group; assert top row is the
+    // first group with count=3.
+    let data_dir = tempfile::tempdir().unwrap();
+    let xdg_state = tempfile::tempdir().unwrap();
+
+    for _ in 0..3 {
+        let out = legion_cmd(data_dir.path())
+            .env("XDG_STATE_HOME", xdg_state.path())
+            .args([
+                "telemetry",
+                "record-bypass",
+                "--repo",
+                "legion",
+                "--session-id",
+                "s",
+                "--tool",
+                "Bash",
+                "--pattern",
+                "fn_main",
+                "--bypass-reason",
+                "test",
+                "--had-sym-hits",
+            ])
+            .output()
+            .unwrap();
+        assert!(out.status.success());
+    }
+    let out = legion_cmd(data_dir.path())
+        .env("XDG_STATE_HOME", xdg_state.path())
+        .args([
+            "telemetry",
+            "record-bypass",
+            "--repo",
+            "legion",
+            "--session-id",
+            "s",
+            "--tool",
+            "Read",
+            "--pattern",
+            "src/main.rs",
+            "--bypass-reason",
+            "test",
+        ])
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+
+    let out = legion_cmd(data_dir.path())
+        .env("XDG_STATE_HOME", xdg_state.path())
+        .args(["telemetry", "summary", "--since", "1h", "--json"])
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "summary failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8(out.stdout).unwrap();
+    let rows: serde_json::Value = serde_json::from_str(stdout.trim()).unwrap();
+    let arr = rows.as_array().unwrap();
+    assert_eq!(arr.len(), 2, "two groups expected, got: {rows}");
+    assert_eq!(arr[0]["tool"], "Bash");
+    assert_eq!(arr[0]["count"], 3);
+    assert!((arr[0]["had_sym_hits_pct"].as_f64().unwrap() - 1.0).abs() < 1e-9);
+    assert_eq!(arr[1]["tool"], "Read");
+    assert_eq!(arr[1]["count"], 1);
+}
+
+#[test]
+fn telemetry_summary_empty_input_prints_no_bypasses_line() {
+    // Human-readable output on empty bypass log emits a clear no-data
+    // line so an operator running this on a fresh node sees the empty
+    // state rather than nothing.
+    let data_dir = tempfile::tempdir().unwrap();
+    let xdg_state = tempfile::tempdir().unwrap();
+
+    let out = legion_cmd(data_dir.path())
+        .env("XDG_STATE_HOME", xdg_state.path())
+        .args(["telemetry", "summary"])
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+    let stdout = String::from_utf8(out.stdout).unwrap();
+    assert!(
+        stdout.contains("no bypasses recorded"),
+        "expected no-bypasses line on empty log, got: {stdout}"
+    );
+}
+
+#[test]
 fn telemetry_list_filters_by_repo_and_since() {
     // Combined --since AND --repo filter: each is unit-tested alone in
     // src/telemetry.rs, but the CLI dispatch path that threads both into


### PR DESCRIPTION
## Summary
- \`legion telemetry summary [--since DURATION] [--repo R] [--top N] [--json]\` aggregates bypass.jsonl by (tool, repo, pattern), sorts by count desc, surfaces top under-served queries.
- \`GET /api/telemetry/bypasses?since=24h&repo=legion&top=20\` returns the same data as JSON via the dashboard HTTP server.
- Per-group fields: count, had_sym_hits_pct, had_recall_hits_pct, last_bypass_ts, deduped bypass_reasons.
- Empty input emits a clear no-data line in human format; JSON returns \`[]\`.
- Closes the grep enforcement chain at the consumer side. Feeds the dashboard surface and the uncertainty engine consumer (#354).

## Closes
- #440

## Review fixes
- Pre-commit simplify caught a UTF-8 boundary panic risk in the summary table's pattern truncation (\`&pattern[..29]\` panics on multi-byte codepoints). Fixed via \`chars().take(29).collect()\`.

## Test plan
- [x] 4 new unit tests in src/telemetry.rs (grouping, top truncation, pcts+reasons, empty input)
- [x] 2 new integration tests (full CLI record->summary roundtrip with JSON assertion, empty-state human line)
- [x] \`cargo test\` -- 702 unit + 131 integration pass
- [x] \`cargo clippy --all-targets -- -D warnings\` clean
- [x] \`cargo fmt -- --check\` clean
- [x] Manual smoke: \`legion telemetry summary\` and \`--json | jq\` round-trip