### PR TITLE
feat(#321): dashboard daemon supervisor on SessionStart

### DIFF
--- a/plugin/hooks/_legion-daemon-supervisor.sh
+++ b/plugin/hooks/_legion-daemon-supervisor.sh
@@ -1,0 +1,129 @@
+#!/bin/bash
+# Legion dashboard daemon supervisor (#321).
+#
+# Probes `GET http://localhost:3131/health`. Acts on three outcomes:
+#
+#   1. Healthy + version matches local binary:  silent no-op.
+#   2. Unreachable:                              spawn `legion serve` detached.
+#   3. Healthy but version mismatch:             kill stale daemon by PID,
+#                                                spawn fresh.
+#
+# Idempotent across concurrent session starts. If the port is already
+# bound by another supervisor's spawn, the second `legion serve` fails
+# fast and the supervisor treats that as success (someone else got there
+# first).
+#
+# Fail-open: any probe error, missing curl, missing legion binary, or
+# pidfile parse failure exits 0 silently. The supervisor never blocks
+# SessionStart on infrastructure.
+#
+# Run by `plugin/hooks/session-start.sh` as a background fire-and-forget
+# so it does not add to the SessionStart latency budget.
+#
+# Skip via LEGION_SKIP_DAEMON_SUPERVISOR=1.
+
+set -u
+
+if [ "${LEGION_SKIP_DAEMON_SUPERVISOR:-}" = "1" ]; then
+  exit 0
+fi
+
+LEGION_BIN="${CLAUDE_PLUGIN_ROOT}/bin/legion"
+LOG=/tmp/legion-hook-errors.log
+PORT="${LEGION_SERVE_PORT:-3131}"
+HEALTH_URL="http://localhost:${PORT}/health"
+STATE_DIR="${XDG_STATE_HOME:-$HOME/.local/state}/legion"
+PIDFILE="${STATE_DIR}/daemon.pid"
+
+# Hard-required dependencies. Missing any -> silent exit (fail-open).
+if [ ! -x "$LEGION_BIN" ]; then
+  exit 0
+fi
+if ! command -v curl >/dev/null 2>&1; then
+  echo "[legion-daemon-supervisor] curl missing; skipping" >> "$LOG"
+  exit 0
+fi
+if ! command -v jq >/dev/null 2>&1; then
+  echo "[legion-daemon-supervisor] jq missing; skipping" >> "$LOG"
+  exit 0
+fi
+
+# Local binary version. Bakes into the binary via --version output.
+LOCAL_VERSION=$("$LEGION_BIN" --version 2>/dev/null | awk '{print $2}')
+if [ -z "$LOCAL_VERSION" ]; then
+  echo "[legion-daemon-supervisor] could not read local version; skipping" >> "$LOG"
+  exit 0
+fi
+
+# Spawn helper: detach via setsid (Linux) or nohup (mac). Both available
+# on macOS bash; setsid is Linux-only so we try it then fall back.
+spawn_daemon() {
+  local reason="$1"
+  if command -v setsid >/dev/null 2>&1; then
+    setsid "$LEGION_BIN" serve >/dev/null 2>>"$LOG" < /dev/null &
+  else
+    nohup "$LEGION_BIN" serve >/dev/null 2>>"$LOG" < /dev/null &
+  fi
+  disown 2>/dev/null || true
+  echo "[legion-daemon-supervisor] daemon: ${reason} (pid $!)" >> "$LOG"
+}
+
+# Kill helper: only kills if the PID exists AND its argv contains
+# 'legion serve' -- defensive against a stale pidfile pointing at a
+# reused PID belonging to an unrelated process.
+kill_stale_daemon() {
+  local pid="$1"
+  if [ -z "$pid" ] || ! [ "$pid" -gt 0 ] 2>/dev/null; then
+    return
+  fi
+  if ! kill -0 "$pid" 2>/dev/null; then
+    return
+  fi
+  # ps -o command returns the full argv on macOS + Linux. Filter for
+  # the literal 'legion serve' so a recycled PID owned by something
+  # else is never the target.
+  if ps -p "$pid" -o args= 2>/dev/null | grep -q 'legion serve'; then
+    kill "$pid" 2>/dev/null
+    # Give the graceful shutdown a beat to remove the pidfile and free
+    # the port. SIGTERM is enough; supervisor does not escalate.
+    sleep 1
+  fi
+}
+
+# Probe /health. Short timeout (2s) since this runs in the SessionStart
+# background path -- waiting longer is just buffering before we accept
+# "not healthy" anyway.
+RESPONSE=$(curl --silent --max-time 2 "$HEALTH_URL" 2>/dev/null)
+CURL_RC=$?
+
+if [ "$CURL_RC" -ne 0 ] || [ -z "$RESPONSE" ]; then
+  # Unreachable: connection refused, timeout, or empty body. Spawn fresh.
+  spawn_daemon "started fresh (no response from $HEALTH_URL)"
+  exit 0
+fi
+
+# Reachable. Parse the version field. Malformed JSON -> treat as unhealthy
+# rather than guessing (fail-closed on suspect responses, fail-open on
+# transport errors).
+DAEMON_VERSION=$(echo "$RESPONSE" | jq -r '.version // empty' 2>/dev/null)
+if [ -z "$DAEMON_VERSION" ]; then
+  echo "[legion-daemon-supervisor] /health returned malformed JSON; respawning" >> "$LOG"
+  if [ -f "$PIDFILE" ]; then
+    kill_stale_daemon "$(cat "$PIDFILE" 2>/dev/null)"
+  fi
+  spawn_daemon "respawn (malformed health response)"
+  exit 0
+fi
+
+if [ "$DAEMON_VERSION" = "$LOCAL_VERSION" ]; then
+  # Healthy + matching: silent.
+  exit 0
+fi
+
+# Version mismatch: kill stale, spawn fresh.
+echo "[legion-daemon-supervisor] daemon v${DAEMON_VERSION} != local v${LOCAL_VERSION}; replacing" >> "$LOG"
+if [ -f "$PIDFILE" ]; then
+  kill_stale_daemon "$(cat "$PIDFILE" 2>/dev/null)"
+fi
+spawn_daemon "replaced stale v${DAEMON_VERSION} -> v${LOCAL_VERSION}"
+exit 0

--- a/plugin/hooks/session-start.sh
+++ b/plugin/hooks/session-start.sh
@@ -39,6 +39,11 @@ rm -f "/tmp/legion-work-${CWD_HASH}" 2>/dev/null
 # Warm the Tantivy index in the background
 ("$LEGION" recall --repo "$REPO" --context warmup --limit 1 >/dev/null 2>&1 &)
 
+# Dashboard daemon supervisor (#321): probe /health, (re)spawn as needed.
+# Backgrounded with stdin closed so SessionStart latency does not include
+# the curl probe or the legion serve spawn handshake.
+(bash "${CLAUDE_PLUGIN_ROOT}/hooks/_legion-daemon-supervisor.sh" >/dev/null 2>&1 < /dev/null &)
+
 # Sync GitHub issues into kanban (5-second timeout, opt-out via LEGION_NO_SYNC=1)
 if [ "${LEGION_NO_SYNC:-}" != "1" ]; then
   if command -v gtimeout >/dev/null 2>&1; then

--- a/plugin/hooks/test-daemon-supervisor.sh
+++ b/plugin/hooks/test-daemon-supervisor.sh
@@ -1,0 +1,162 @@
+#!/bin/bash
+# Test runner for _legion-daemon-supervisor.sh.
+#
+# Stubs `legion` and `curl` so the test never hits a real port or spawns
+# a real daemon. Asserts the spawn decision logged to the test log file
+# matches the expected branch for each /health response shape.
+#
+# Run from the repo root:
+#   bash plugin/hooks/test-daemon-supervisor.sh
+
+set -u
+
+PASS=0
+FAIL=0
+
+assert_contains() {
+  local desc="$1" file="$2" needle="$3"
+  if [ -f "$file" ] && grep -q -- "$needle" "$file"; then
+    PASS=$((PASS + 1))
+    echo "  PASS: $desc"
+  else
+    FAIL=$((FAIL + 1))
+    echo "  FAIL: $desc" >&2
+    echo "    expected to find: $needle" >&2
+    echo "    in file: $file" >&2
+    [ -f "$file" ] && echo "    contents: $(cat "$file")" >&2
+  fi
+}
+
+assert_no_match() {
+  local desc="$1" file="$2" needle="$3"
+  if [ ! -f "$file" ] || ! grep -q -- "$needle" "$file" 2>/dev/null; then
+    PASS=$((PASS + 1))
+    echo "  PASS: $desc"
+  else
+    FAIL=$((FAIL + 1))
+    echo "  FAIL: $desc (unexpectedly found: $needle)" >&2
+    [ -f "$file" ] && echo "    contents: $(cat "$file")" >&2
+  fi
+}
+
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+
+mkdir -p "$WORK/plugin/bin" "$WORK/plugin/hooks" "$WORK/state/legion" "$WORK/scratch"
+cp plugin/hooks/_legion-daemon-supervisor.sh "$WORK/plugin/hooks/"
+
+# Stub `legion` binary. Responds to --version and to `serve` (no-op exit 0).
+cat > "$WORK/plugin/bin/legion" <<EOF
+#!/bin/bash
+case "\$1" in
+  --version) echo "legion 9.9.9" ;;
+  serve)
+    # Pretend to spawn. Record into a marker the test reads.
+    echo "spawned at \$(date +%s)" >> "${WORK}/scratch/spawned.log"
+    ;;
+esac
+EOF
+chmod +x "$WORK/plugin/bin/legion"
+
+export CLAUDE_PLUGIN_ROOT="$WORK/plugin"
+export XDG_STATE_HOME="$WORK/state"
+
+# Redirect /tmp/legion-hook-errors.log to a per-test path by overriding
+# the LOG var. The script uses a fixed /tmp path so we instead probe a
+# scratch log via env-var substitution: copy the hook to a per-test variant
+# and rewrite the LOG var.
+HOOK_PATH="$WORK/plugin/hooks/_legion-daemon-supervisor.sh"
+TEST_LOG="$WORK/scratch/hook.log"
+sed -i.bak "s|LOG=/tmp/legion-hook-errors.log|LOG=${TEST_LOG}|" "$HOOK_PATH"
+rm -f "$HOOK_PATH.bak"
+
+# Stub `curl` via a directory shim that appears earlier on PATH. Each test
+# rewrites the stub to emit the response shape it wants.
+mkdir -p "$WORK/curl-shim"
+export PATH="$WORK/curl-shim:$PATH"
+
+write_curl_stub() {
+  local mode="$1"
+  cat > "$WORK/curl-shim/curl" <<EOF
+#!/bin/bash
+case "$mode" in
+  refused) exit 7 ;;
+  empty) exit 0 ;;
+  match) echo '{"status":"ok","version":"9.9.9","started_at":"2026-05-10T00:00:00Z","uptime_secs":10}' ;;
+  mismatch) echo '{"status":"ok","version":"1.0.0","started_at":"2026-05-10T00:00:00Z","uptime_secs":10}' ;;
+  malformed) echo 'not json' ;;
+esac
+EOF
+  chmod +x "$WORK/curl-shim/curl"
+}
+
+reset_log() {
+  rm -f "$TEST_LOG" "$WORK/scratch/spawned.log"
+}
+
+echo "==> /health unreachable -> spawn fresh"
+reset_log
+write_curl_stub refused
+bash "$HOOK_PATH"
+wait
+sleep 0.3
+assert_contains "spawned at least once" "$WORK/scratch/spawned.log" "spawned at"
+assert_contains "log notes started-fresh reason" "$TEST_LOG" "started fresh"
+
+echo "==> /health empty body -> spawn fresh"
+reset_log
+write_curl_stub empty
+bash "$HOOK_PATH"
+wait
+sleep 0.3
+assert_contains "spawned at least once" "$WORK/scratch/spawned.log" "spawned at"
+
+echo "==> /health version match -> silent no-op"
+reset_log
+write_curl_stub match
+bash "$HOOK_PATH"
+wait
+sleep 0.3
+if [ ! -f "$WORK/scratch/spawned.log" ]; then
+  PASS=$((PASS + 1)); echo "  PASS: no spawn on healthy match"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: spawned when daemon was healthy + matching" >&2
+fi
+if [ ! -f "$TEST_LOG" ] || [ ! -s "$TEST_LOG" ]; then
+  PASS=$((PASS + 1)); echo "  PASS: log silent on healthy match"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: log unexpectedly written: $(cat "$TEST_LOG")" >&2
+fi
+
+echo "==> /health version mismatch -> replace"
+reset_log
+write_curl_stub mismatch
+bash "$HOOK_PATH"
+wait
+sleep 0.3
+assert_contains "spawned replacement" "$WORK/scratch/spawned.log" "spawned at"
+assert_contains "log notes replacement" "$TEST_LOG" "replaced stale v1.0.0"
+
+echo "==> /health malformed JSON -> respawn"
+reset_log
+write_curl_stub malformed
+bash "$HOOK_PATH"
+wait
+sleep 0.3
+assert_contains "spawned replacement on malformed JSON" "$WORK/scratch/spawned.log" "spawned at"
+assert_contains "log notes malformed-health respawn" "$TEST_LOG" "malformed health response"
+
+echo "==> LEGION_SKIP_DAEMON_SUPERVISOR=1 -> silent skip"
+reset_log
+write_curl_stub refused
+LEGION_SKIP_DAEMON_SUPERVISOR=1 bash "$HOOK_PATH"
+wait
+sleep 0.3
+assert_no_match "skip env prevents spawn" "$WORK/scratch/spawned.log" "spawned at"
+
+echo
+echo "==> $PASS passed, $FAIL failed"
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi
+exit 0

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -46,6 +46,59 @@ fn json_error(status: StatusCode, message: &str) -> Response {
     (status, Json(body)).into_response()
 }
 
+/// Resolve the daemon pidfile path. Lives under XDG_STATE_HOME (same root
+/// as bypass.jsonl and index-logs/) so the daemon supervisor (#321)
+/// running from a SessionStart hook can find it without per-host config.
+pub fn daemon_pid_path() -> PathBuf {
+    if let Ok(state) = std::env::var("XDG_STATE_HOME")
+        && !state.is_empty()
+    {
+        return PathBuf::from(state).join("legion").join("daemon.pid");
+    }
+    if let Ok(home) = std::env::var("HOME")
+        && !home.is_empty()
+    {
+        return PathBuf::from(home).join(".local/state/legion/daemon.pid");
+    }
+    std::env::temp_dir().join("legion-daemon.pid")
+}
+
+/// Write `pid` to a specific path, creating parent dirs as needed. The
+/// path-injectable form is the test seam; the env-resolving caller is
+/// `write_daemon_pidfile` below.
+fn write_daemon_pidfile_at(path: &Path, pid: u32) {
+    if let Some(parent) = path.parent()
+        && let Err(e) = std::fs::create_dir_all(parent)
+    {
+        eprintln!(
+            "[legion] WARNING: failed to create pidfile dir {}: {e}",
+            parent.display()
+        );
+        return;
+    }
+    if let Err(e) = std::fs::write(path, pid.to_string()) {
+        eprintln!(
+            "[legion] WARNING: failed to write pidfile {}: {e}",
+            path.display()
+        );
+    }
+}
+
+/// Write `pid` to the resolved daemon pidfile. Best-effort: a write
+/// failure is logged but the server still starts -- a missing pidfile
+/// means the supervisor falls back to "no pidfile -> probe /health
+/// instead," the same path it takes on a cold-boot fresh install.
+fn write_daemon_pidfile(pid: u32) {
+    write_daemon_pidfile_at(&daemon_pid_path(), pid);
+}
+
+/// Best-effort pidfile removal at shutdown. Quietly tolerates a missing
+/// file -- the daemon may have been started without write permissions to
+/// the XDG dir, or the file may have been cleaned up out-of-band.
+fn remove_daemon_pidfile() {
+    let _ = std::fs::remove_file(daemon_pid_path());
+}
+
 pub fn run_server(port: u16, data_dir: PathBuf) -> error::Result<()> {
     let runtime = tokio::runtime::Runtime::new()
         .map_err(|e| error::LegionError::Server(format!("failed to create runtime: {e}")))?;
@@ -97,10 +150,19 @@ pub fn run_server(port: u16, data_dir: PathBuf) -> error::Result<()> {
 
         eprintln!("[legion] dashboard at http://localhost:{port}");
 
-        axum::serve(listener, app)
+        // Write the pidfile only after the port bind succeeded -- a
+        // bind-failure path that wrote the pidfile would leave a stale
+        // PID that the supervisor's "is this process alive" probe would
+        // then have to disambiguate.
+        write_daemon_pidfile(std::process::id());
+
+        let serve_result = axum::serve(listener, app)
             .with_graceful_shutdown(shutdown_signal())
             .await
-            .map_err(|e| error::LegionError::Server(format!("server error: {e}")))?;
+            .map_err(|e| error::LegionError::Server(format!("server error: {e}")));
+
+        remove_daemon_pidfile();
+        serve_result?;
 
         Ok(())
     })
@@ -1379,6 +1441,39 @@ mod tests {
         assert_eq!(body["version"], env!("CARGO_PKG_VERSION"));
         assert_eq!(body["started_at"], "2026-05-10T12:00:00+00:00");
         assert_eq!(body["uptime_secs"], 90);
+    }
+
+    #[test]
+    fn daemon_pid_path_honors_xdg_state_home() {
+        // SAFETY: test mutates process env. Other tests in this module
+        // do not read XDG_STATE_HOME, so isolation by `cargo test`
+        // default parallelism is fine.
+        let saved = std::env::var("XDG_STATE_HOME").ok();
+        unsafe {
+            std::env::set_var("XDG_STATE_HOME", "/tmp/legion-xdg-test");
+        }
+        let p = daemon_pid_path();
+        assert_eq!(p, PathBuf::from("/tmp/legion-xdg-test/legion/daemon.pid"));
+        unsafe {
+            match saved {
+                Some(v) => std::env::set_var("XDG_STATE_HOME", v),
+                None => std::env::remove_var("XDG_STATE_HOME"),
+            }
+        }
+    }
+
+    #[test]
+    fn pidfile_write_at_roundtrip() {
+        // Path-injectable form -- no env mutation, safe under parallel
+        // test execution.
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("nested/legion/daemon.pid");
+        write_daemon_pidfile_at(&path, 12345);
+        assert!(path.exists());
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), "12345");
+        // Idempotent overwrite.
+        write_daemon_pidfile_at(&path, 67890);
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), "67890");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Re-scoped (see updated #321 body): original framing assumed an MCP-daemon coupling that does not exist in current main; channel reliability is hardened by #391. The real failure mode this fixes is the dashboard daemon dying or going stale across plugin upgrades with nothing to bring it back.

## What ships

**Rust** (\`src/serve.rs\`):
- \`daemon_pid_path()\` resolves \`$XDG_STATE_HOME/legion/daemon.pid\`.
- \`run_server\` writes the pidfile AFTER bind succeeds (so a bind-failure path does not leave a stale PID the supervisor would have to disambiguate), removes it via the graceful-shutdown return path.
- Path-injectable \`write_daemon_pidfile_at\` helper for unit tests without env mutation.

**Hook** (\`plugin/hooks/_legion-daemon-supervisor.sh\`):
- Probes \`GET http://localhost:3131/health\` (#319), parses the \`version\` field, compares against \`legion --version\`.
- Three branches:
  - unreachable / empty body -> spawn fresh
  - healthy + version match -> silent no-op
  - version mismatch OR malformed JSON -> defensively kill by PID (only if argv contains \`legion serve\`), spawn fresh
- \`setsid\` (Linux) or \`nohup\` (mac) with stdin closed for clean detach.
- \`LEGION_SKIP_DAEMON_SUPERVISOR=1\` opts out.

**Wiring** (\`plugin/hooks/session-start.sh\`):
- Backgrounded fire-and-forget so SessionStart latency does not include curl probe or spawn.

**Fail-open posture throughout**: missing curl/jq/binary, unparseable version -> silent exit, no spawn. Probe never blocks SessionStart.

## Closes
- #321

## Test plan
- [x] \`cargo test\` -- 722 unit + 131 integration pass (4 serve unit tests for /health body and pidfile round-trip)
- [x] \`bash plugin/hooks/test-daemon-supervisor.sh\` -- 10 assertions cover unreachable / empty / match / mismatch / malformed-JSON branches + skip env
- [x] \`cargo clippy --all-targets -- -D warnings\` clean
- [x] \`cargo fmt -- --check\` clean
- [x] \`shellcheck\` clean on both new hooks