### PR TITLE
fix(#458): pre-bash-grep relevance gate -- block only on local-repo sym hits

### DIFF
--- a/plugin/hooks/_legion-prequery.sh
+++ b/plugin/hooks/_legion-prequery.sh
@@ -206,6 +206,32 @@ legion_prequery_sym_def() {
   echo "$out"
 }
 
+# legion_prequery_filter_hits_local HITS_JSON REPO -- filter a sym hits
+# JSON array down to entries where .repo matches REPO. Echoes filtered
+# JSON (possibly "[]") on stdout. Used by the block-tier decision so
+# common dictionary words like `name`, `data`, `value` that happen to be
+# symbol-shaped do not trigger blocks when the search target is unrelated
+# to those hits' actual repo (#458).
+#
+# Why: legion sym def --json searches every stored SCIP index across the
+# cluster. A grep on the operator's local TOML config will return a block
+# decision tripped by `name` happening to be a symbol in huttspawn's
+# TypeScript -- those hits are not relevant to the search target. The
+# relevance gate filters cluster-wide hits down to the SAME repo as the
+# search context before deciding to block.
+legion_prequery_filter_hits_local() {
+  local hits="$1" repo="$2"
+  if [ -z "$hits" ] || [ "$hits" = "[]" ] || [ "$hits" = "null" ]; then
+    echo "[]"
+    return 0
+  fi
+  if [ -z "$repo" ]; then
+    echo "[]"
+    return 0
+  fi
+  echo "$hits" | jq --arg r "$repo" '[.[] | select(.repo == $r)]' 2>/dev/null || echo "[]"
+}
+
 # legion_prequery_emit_allow CTX -- emit the PreToolUse JSON shape that
 # allows the call and injects CTX as additionalContext.
 legion_prequery_emit_allow() {

--- a/plugin/hooks/pre-bash-grep.sh
+++ b/plugin/hooks/pre-bash-grep.sh
@@ -100,21 +100,36 @@ fi
 # In an unindexed repo, the agent has no sym alternative, so we keep the
 # softer State 1 (inject + nudge) shape.
 if legion_indexed "$SESSION_ID" "$REPO"; then
-  REASON="Use \`legion sym def ${PATTERN}\` -- it answered this in bytes from the SCIP index. Bash ${BINARY} on \`${PATTERN}\` would scan files and bill cache_read.
+  # Relevance gate (#458): cluster-wide sym hits in unrelated repos are
+  # not a useful redirect for a grep targeting THIS repo. Common
+  # dictionary words like `name`, `data`, `value`, `type`, `id` are
+  # symbol-shaped and exist as identifiers in every codebase, but a
+  # grep on the operator's TOML config in legion's repo should not be
+  # blocked because huttspawn has a variable named `name`. Filter
+  # cluster-wide hits down to hits IN THIS REPO before deciding.
+  LOCAL_HITS=$(legion_prequery_filter_hits_local "$HITS" "$REPO")
+  if [ "$LOCAL_HITS" = "[]" ]; then
+    # No relevant hits in this repo's index. Fall through to inject
+    # below -- the cluster-wide hits may still be useful context but
+    # don't justify blocking.
+    :
+  else
+    REASON="Use \`legion sym def ${PATTERN} --repo ${REPO}\` -- it answered this in bytes from the SCIP index. Bash ${BINARY} on \`${PATTERN}\` would scan files and bill cache_read.
 
-\`legion sym def ${PATTERN}\` returned:
+\`legion sym def ${PATTERN} --repo ${REPO}\` returned:
 
 \`\`\`json
-${HITS}
+${LOCAL_HITS}
 \`\`\`
 
-If you genuinely need ${BINARY} (e.g. searching for a literal that is not a symbol, or comparing line numbers across files), retry with one of:
+If you genuinely need ${BINARY} (e.g. searching for a literal that is not a symbol in this repo, or comparing line numbers across files), retry with one of:
 - \`LEGION_BYPASS_GREP=1 ${COMMAND}\`
 - \`${COMMAND} # legion-bypass: <one-line reason>\`
 
 Either path allows and writes one row to bypass.jsonl so we can see where sym is under-serving."
-  legion_prequery_emit_block "$REASON"
-  exit 0
+    legion_prequery_emit_block "$REASON"
+    exit 0
+  fi
 fi
 
 # State 1 INJECT: not indexed but we did find something via the cluster

--- a/plugin/hooks/test-pre-bash-grep.sh
+++ b/plugin/hooks/test-pre-bash-grep.sh
@@ -81,7 +81,14 @@ case "$1" in
     if [ "$2" = "def" ] && [ "$3" = "--json" ]; then
       case "$4" in
         Symbol*|fn_main|main)
-          echo '[{"file":"src/main.rs","line":42,"symbol":"main"}]'
+          # Local-repo hit -- relevance gate (#458) keeps it.
+          echo '[{"file":"src/main.rs","line":42,"symbol":"main","repo":"legion","lang":"rust"}]'
+          ;;
+        commonword|dictword)
+          # Cluster-wide hit in an unrelated repo -- relevance gate
+          # filters this out so the block tier does NOT fire on a
+          # search in legion's own files.
+          echo '[{"file":"src/foo.ts","line":10,"symbol":"commonword","repo":"huttspawn","lang":"typescript"}]'
           ;;
         *)
           echo '[]'
@@ -160,13 +167,25 @@ echo "==> hook end-to-end: non-symbol pattern passes through"
 out=$(echo '{"cwd":"/tmp/legion","tool_name":"Bash","tool_input":{"command":"grep -r foo|bar src/"},"session_id":"t"}' | bash "$HOOK")
 assert_empty "regex pattern -> pass through" "$out"
 
-echo "==> hook end-to-end: indexed repo + symbol-shape pattern -> BLOCK"
+echo "==> hook end-to-end: indexed repo + symbol-shape pattern with LOCAL-REPO hit -> BLOCK"
 out=$(echo '{"cwd":"/tmp/legion","tool_name":"Bash","tool_input":{"command":"grep -r Symbol src/"},"session_id":"block-t"}' | bash "$HOOK")
 assert_contains "block decision present" "$out" '"decision": "block"'
 assert_contains "block reason mentions sym def" "$out" 'legion sym def'
 assert_contains "block reason names the pattern" "$out" 'Symbol'
 assert_contains "block reason offers env bypass" "$out" 'LEGION_BYPASS_GREP=1'
 assert_contains "block reason offers sentinel bypass" "$out" '# legion-bypass:'
+
+echo "==> #458 relevance gate: cluster-wide hit but NOT in this repo -> pass through (no block)"
+# Stub legion returns commonword hits in huttspawn, but the grep target is in /tmp/legion.
+# Pre-#458 behavior: would block on those cross-repo hits.
+# Post-#458 behavior: relevance gate filters to local hits (empty) and falls through.
+out=$(echo '{"cwd":"/tmp/legion","tool_name":"Bash","tool_input":{"command":"grep -r commonword src/"},"session_id":"relevance-t"}' | bash "$HOOK")
+if echo "$out" | grep -q '"decision": "block"'; then
+  FAIL=$((FAIL + 1)); echo "  FAIL: cross-repo-only hits should NOT trigger block in target repo"
+  echo "    output: $out" >&2
+else
+  PASS=$((PASS + 1)); echo "  PASS: cross-repo-only hits do not trigger block"
+fi
 
 echo "==> hook end-to-end: bypass via env -> allow + telemetry"
 export LEGION_TEST_MARKER="$WORK/state/bypass-marker.log"


### PR DESCRIPTION
## Summary
Pre-bash-grep hook (#438 in 0.13.1) blocked when ANY cluster-wide sym hit existed for a symbol-shaped pattern. Common dictionary words (\`name\`, \`data\`, \`value\`, \`type\`, \`id\`) are symbol-shaped AND exist as identifiers in every codebase. Result: hook author blocked by their own hook on 2026-05-10 while grepping watch.toml for \`name = "ledger"\`.

## Fix
New helper \`legion_prequery_filter_hits_local\` filters cluster-wide sym hits down to entries where \`.repo\` matches the target repo. Block-tier decision now uses LOCAL_HITS instead of cluster-wide HITS. Zero local hits -> fall through (no block, no inject; cluster-wide hits not justified as redirect).

Block reason updated to include \`--repo \$REPO\` in the suggested sym command so the agent's redirect targets the same repo.

## Closes
- #458

## Test plan
- [x] New assertion: cluster-wide hit but NOT in this repo -> pass through
- [x] Existing block test still passes (Symbol hit with repo=legion)
- [x] Stub legion sym output now carries \`repo\` field
- [x] 37 hook tests pass, 722 unit + 131 integration
- [x] shellcheck clean

## Follow-up worth noting
Same false-positive family may apply to pre-grep-scip.sh and pre-read-sym.sh inject paths (no block tier there today). Filter their inject context to local hits in a future PR.