### PR TITLE
fix(#459): watch.toml duplicate-agent disambiguation

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -5675,6 +5675,31 @@ fn run() -> error::Result<()> {
                     if repos.is_empty() {
                         println!("no repos in watch.toml");
                     } else {
+                        // Surface pre-existing recipient collisions (#459).
+                        // The `add` path rejects new duplicates, but a
+                        // manually edited watch.toml can still contain
+                        // collisions. Warn loud so the operator sees them.
+                        let mut recipient_counts: std::collections::HashMap<&str, Vec<&str>> =
+                            std::collections::HashMap::new();
+                        for r in &repos {
+                            recipient_counts
+                                .entry(r.recipient())
+                                .or_default()
+                                .push(&r.name);
+                        }
+                        for (recipient, names) in &recipient_counts {
+                            if names.len() > 1 {
+                                eprintln!(
+                                    "[WARNING] recipient '{}' shared by {} repos: {}. \
+                                     Directed @{} signals wake all of them silently. \
+                                     Fix by editing watch.toml to give each repo a unique agent.",
+                                    recipient,
+                                    names.len(),
+                                    names.join(", "),
+                                    recipient
+                                );
+                            }
+                        }
                         for repo in &repos {
                             let agent_note = repo
                                 .agent

--- a/src/watch.rs
+++ b/src/watch.rs
@@ -379,6 +379,35 @@ pub fn add_repo_to_config(
         )));
     }
 
+    // Recipient (signal-routing identity) collision check (#459). Two repos
+    // sharing one recipient creates silent multi-wake on directed signals --
+    // an @platform signal fires both /Volumes/.../platform and any other
+    // repo with agent=platform. The receiving agents have to flag mis-route
+    // every time, burning wake budget. Refuse the add up front; operator
+    // either picks a different agent or removes the conflicting entry.
+    //
+    // `recipient()` returns `agent` if set, else `name`. The proposed new
+    // recipient is `normalized_agent.as_deref().unwrap_or(name)`. Comparing
+    // both via recipient() handles all four cases:
+    //   1. new agent='X', existing name='X' (no agent override) -> conflict
+    //   2. new agent='X', existing agent='X' -> conflict
+    //   3. new name='X' (no agent), existing agent='X' -> conflict
+    //   4. new name='X' (no agent), existing name='X' -> earlier name-conflict path
+    let proposed_recipient = normalized_agent.as_deref().unwrap_or(name);
+    if let Some(existing) = config
+        .repos
+        .iter()
+        .find(|r| r.recipient() == proposed_recipient)
+    {
+        return Err(LegionError::WatchConfig(format!(
+            "recipient '{}' already in use by repo '{}' at {}. \
+             Each watched repo needs a unique signal-routing identity \
+             (its `agent` field, or its name when `agent` is unset). \
+             Pick a different agent for this repo or remove the existing entry.",
+            proposed_recipient, existing.name, existing.workdir
+        )));
+    }
+
     config.repos.push(WatchRepoConfig {
         name: name.to_string(),
         workdir: canonical_str,
@@ -2164,6 +2193,86 @@ workdir = "/nonexistent/path/that/does/not/exist"
             "expected 'already in use' error, got: {}",
             err
         );
+    }
+
+    #[test]
+    fn add_repo_errors_on_agent_collision_with_existing_agent() {
+        // #459: two repos with the same `agent` value create silent
+        // multi-wake on directed signals. The add path refuses up front.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let config_path = dir.path().join("watch.toml");
+        let workdir_a = dir.path().join("a");
+        let workdir_b = dir.path().join("b");
+        std::fs::create_dir_all(&workdir_a).expect("create a");
+        std::fs::create_dir_all(&workdir_b).expect("create b");
+
+        add_repo_to_config(&config_path, "alpha", &workdir_a, Some("platform"))
+            .expect("add a with agent");
+        let err =
+            add_repo_to_config(&config_path, "beta", &workdir_b, Some("platform")).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("recipient 'platform' already in use"),
+            "expected recipient-conflict error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn add_repo_errors_when_new_agent_collides_with_existing_name() {
+        // Case 1 from the recipient-conflict matrix: new agent='X' collides
+        // with existing name='X' (which has no agent override). Existing
+        // repo's recipient() returns its name, so the conflict is real.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let config_path = dir.path().join("watch.toml");
+        let workdir_a = dir.path().join("a");
+        let workdir_b = dir.path().join("b");
+        std::fs::create_dir_all(&workdir_a).expect("create a");
+        std::fs::create_dir_all(&workdir_b).expect("create b");
+
+        add_repo_to_config(&config_path, "platform", &workdir_a, None).expect("add platform");
+        let err =
+            add_repo_to_config(&config_path, "ledger", &workdir_b, Some("platform")).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("recipient 'platform' already in use"),
+            "expected recipient-conflict error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn add_repo_errors_when_new_name_collides_with_existing_agent_override() {
+        // Case 3: new name='X' (no agent) collides with existing agent='X'.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let config_path = dir.path().join("watch.toml");
+        let workdir_a = dir.path().join("a");
+        let workdir_b = dir.path().join("b");
+        std::fs::create_dir_all(&workdir_a).expect("create a");
+        std::fs::create_dir_all(&workdir_b).expect("create b");
+
+        add_repo_to_config(&config_path, "ledger", &workdir_a, Some("platform"))
+            .expect("add ledger with platform agent");
+        let err = add_repo_to_config(&config_path, "platform", &workdir_b, None).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("recipient 'platform' already in use"),
+            "expected recipient-conflict error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn add_repo_allows_distinct_agents() {
+        // Two repos with different agents add cleanly.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let config_path = dir.path().join("watch.toml");
+        let workdir_a = dir.path().join("a");
+        let workdir_b = dir.path().join("b");
+        std::fs::create_dir_all(&workdir_a).expect("create a");
+        std::fs::create_dir_all(&workdir_b).expect("create b");
+
+        add_repo_to_config(&config_path, "alpha", &workdir_a, Some("agent-a")).expect("a");
+        add_repo_to_config(&config_path, "beta", &workdir_b, Some("agent-b")).expect("b");
+        let repos = list_repos_in_config(&config_path).expect("list");
+        assert_eq!(repos.len(), 2);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Two repos sharing one recipient (agent field, or name when agent unset) create silent multi-wake on directed signals. ledger had agent=platform; @platform signals woke both the platform CWD and the ledger CWD. Six mis-route flags on a single bullpen thread before operator manually removed.

## Fix
Two layers, matching the issue's A+C recommendation:

**(A) Add-time gate**: \`legion watch add\` computes proposed_recipient (\`normalized_agent.as_deref().unwrap_or(name)\`) and checks against every existing repo's \`recipient()\`. Conflict -> clear error naming both repos.

**(C) List-time warning**: \`legion watch list\` walks repos, groups by \`recipient()\`, emits \`[WARNING]\` to stderr for any recipient shared by N>1 repos. Catches manually-edited duplicates the add gate can't prevent retroactively.

## Closes
- #459

## Test plan
- [x] 4 new unit tests in src/watch.rs cover the four conflict cases (agent-agent, agent-vs-name, name-vs-agent, distinct-agents-allowed)
- [x] \`cargo test\` -- 726 unit + 131 integration pass
- [x] \`cargo clippy --all-targets -- -D warnings\` clean
- [x] \`cargo fmt -- --check\` clean

## Sibling
\#226 (resolve client_repo from workdir) -- different layer. This is identity-layer; #226 is workdir-resolution-layer.