### PR TITLE
feat(#456): documents table -- coordination substrate foundation

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -35,7 +35,7 @@ pub enum CardTimestamp {
 
 /// Persistent storage for reflections backed by SQLite.
 pub struct Database {
-    conn: Connection,
+    pub(crate) conn: Connection,
 }
 
 /// A single stored reflection tied to a repository.
@@ -857,6 +857,45 @@ impl Database {
             );
             CREATE INDEX IF NOT EXISTS idx_agent_session_log_recipient_exit \
                 ON agent_session_log(recipient, exit_at);",
+        )?;
+
+        // Migration 21: Documents table for the coordination substrate
+        // (#456, child of #455).
+        //
+        // Stores spec / NFR / blueprint / persona / journey / etc as rows
+        // with structured meta columns hoisted from a JSON payload. Hot
+        // pool by default; archived_at populates when work referencing
+        // the doc completes (kanban-spec linkage in a later child issue).
+        //
+        // The payload column holds the validated JSON for the document
+        // type. Type-specific schema validation at INSERT happens in a
+        // sibling child issue under #455 once vault's schemas land. For
+        // #456 the foundation ships; validator is a stub that accepts
+        // any JSON.
+        conn.execute_batch(
+            "CREATE TABLE IF NOT EXISTS documents (
+                id TEXT PRIMARY KEY,
+                type TEXT NOT NULL,
+                surface TEXT,
+                status TEXT NOT NULL DEFAULT 'draft',
+                priority TEXT,
+                owner TEXT NOT NULL,
+                payload TEXT NOT NULL,
+                archived_at TEXT,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL,
+                deleted_at TEXT
+            );
+            CREATE INDEX IF NOT EXISTS idx_documents_type
+                ON documents(type) WHERE archived_at IS NULL AND deleted_at IS NULL;
+            CREATE INDEX IF NOT EXISTS idx_documents_surface
+                ON documents(surface) WHERE archived_at IS NULL AND deleted_at IS NULL;
+            CREATE INDEX IF NOT EXISTS idx_documents_owner
+                ON documents(owner) WHERE archived_at IS NULL AND deleted_at IS NULL;
+            CREATE INDEX IF NOT EXISTS idx_documents_status
+                ON documents(status) WHERE archived_at IS NULL AND deleted_at IS NULL;
+            CREATE INDEX IF NOT EXISTS idx_documents_archived
+                ON documents(archived_at, type) WHERE archived_at IS NOT NULL AND deleted_at IS NULL;",
         )?;
 
         Ok(())

--- a/src/documents.rs
+++ b/src/documents.rs
@@ -1,0 +1,395 @@
+//! Documents table -- the coordination substrate (#456, child of #455).
+//!
+//! Stores spec / NFR / blueprint / persona / journey / etc as rows with
+//! a JSON payload + indexed meta columns hoisted from the payload's
+//! `meta` block. Hot pool by default; `archived_at` populates when work
+//! referencing the doc completes.
+//!
+//! The substrate is type-agnostic at the storage layer: any document
+//! type whose payload carries the canonical `meta` shape lands here.
+//! Type-specific schema validation belongs in a sibling issue once
+//! vault ships the schemas.
+
+use chrono::Utc;
+use rusqlite::params;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::db::Database;
+use crate::error::{LegionError, Result};
+
+/// A document row. The `payload` field is the raw validated JSON; the
+/// indexed columns are hoisted from `payload.meta` at insert time so
+/// SQL queries can filter without parsing JSON.
+///
+/// `id` is sourced from `payload.meta.id` when present (typed ids like
+/// `FR-EMAIL-003`), or generated as a UUIDv7 otherwise. Caller-supplied
+/// ids must be globally unique across the table; collision is a hard
+/// error.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct Document {
+    pub id: String,
+    pub doc_type: String,
+    pub surface: Option<String>,
+    pub status: String,
+    pub priority: Option<String>,
+    pub owner: String,
+    /// Raw payload JSON. Callers parse as needed for the specific type.
+    pub payload: String,
+    pub archived_at: Option<String>,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+/// Fields hoisted from `payload.meta` at insert time. Provided by the
+/// caller; the storage layer does not parse the payload itself, keeping
+/// this module type-agnostic. Schema validation lives in a sibling
+/// child issue under #455.
+#[derive(Debug, Clone)]
+pub struct DocumentMeta<'a> {
+    /// Optional caller-supplied id. When None, a UUIDv7 is generated.
+    pub id: Option<&'a str>,
+    pub doc_type: &'a str,
+    pub surface: Option<&'a str>,
+    /// Initial lifecycle status. Defaults to "draft" when None.
+    pub status: Option<&'a str>,
+    pub priority: Option<&'a str>,
+    pub owner: &'a str,
+}
+
+/// Filter for `list_documents`. None on every field returns all rows.
+/// Empty struct (all None) is the default broad query.
+#[derive(Debug, Clone, Default)]
+pub struct DocumentFilter<'a> {
+    pub doc_type: Option<&'a str>,
+    pub surface: Option<&'a str>,
+    pub status: Option<&'a str>,
+    pub owner: Option<&'a str>,
+    /// When None, returns hot rows only. Some(true) returns archived only.
+    /// Some(false) returns hot only (explicit).
+    pub archived: Option<bool>,
+}
+
+impl Database {
+    /// Insert a new document. Returns the inserted Document.
+    ///
+    /// `id` is taken from `meta.id` when supplied, else generated as
+    /// UUIDv7. Conflict on id is a hard error.
+    pub fn insert_document(&self, meta: &DocumentMeta<'_>, payload: &str) -> Result<Document> {
+        let now = Utc::now().to_rfc3339();
+        let id = match meta.id {
+            Some(s) if !s.is_empty() => s.to_string(),
+            _ => Uuid::now_v7().to_string(),
+        };
+        let status = meta.status.unwrap_or("draft");
+
+        self.conn.execute(
+            "INSERT INTO documents (id, type, surface, status, priority, owner, payload, created_at, updated_at) \
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?8)",
+            params![
+                &id,
+                meta.doc_type,
+                meta.surface,
+                status,
+                meta.priority,
+                meta.owner,
+                payload,
+                &now,
+            ],
+        ).map_err(|e| match e {
+            rusqlite::Error::SqliteFailure(ref err, _)
+                if err.code == rusqlite::ErrorCode::ConstraintViolation =>
+            {
+                LegionError::WorkSource(format!("document id '{id}' already exists"))
+            }
+            other => LegionError::Database(other),
+        })?;
+
+        Ok(Document {
+            id,
+            doc_type: meta.doc_type.to_string(),
+            surface: meta.surface.map(str::to_string),
+            status: status.to_string(),
+            priority: meta.priority.map(str::to_string),
+            owner: meta.owner.to_string(),
+            payload: payload.to_string(),
+            archived_at: None,
+            created_at: now.clone(),
+            updated_at: now,
+        })
+    }
+
+    /// Read a document by id. Returns None if the row is soft-deleted
+    /// or does not exist. Does NOT filter archived rows -- caller can
+    /// check `archived_at` on the returned Document.
+    pub fn get_document(&self, id: &str) -> Result<Option<Document>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT id, type, surface, status, priority, owner, payload, archived_at, created_at, updated_at \
+             FROM documents WHERE id = ?1 AND deleted_at IS NULL",
+        )?;
+        let mut rows = stmt.query(params![id])?;
+        if let Some(row) = rows.next()? {
+            Ok(Some(map_document_row(row)?))
+        } else {
+            Ok(None)
+        }
+    }
+
+    /// List documents matching the filter. Returns rows ordered by
+    /// updated_at DESC (most recently touched first).
+    pub fn list_documents(&self, filter: &DocumentFilter<'_>) -> Result<Vec<Document>> {
+        // Build the WHERE clause dynamically. Each filter clause adds a
+        // bind parameter; archived clause is fixed SQL.
+        let mut clauses: Vec<String> = vec!["deleted_at IS NULL".to_string()];
+        let mut binds: Vec<String> = Vec::new();
+
+        match filter.archived {
+            None | Some(false) => clauses.push("archived_at IS NULL".to_string()),
+            Some(true) => clauses.push("archived_at IS NOT NULL".to_string()),
+        }
+
+        if let Some(t) = filter.doc_type {
+            clauses.push(format!("type = ?{}", binds.len() + 1));
+            binds.push(t.to_string());
+        }
+        if let Some(s) = filter.surface {
+            clauses.push(format!("surface = ?{}", binds.len() + 1));
+            binds.push(s.to_string());
+        }
+        if let Some(st) = filter.status {
+            clauses.push(format!("status = ?{}", binds.len() + 1));
+            binds.push(st.to_string());
+        }
+        if let Some(o) = filter.owner {
+            clauses.push(format!("owner = ?{}", binds.len() + 1));
+            binds.push(o.to_string());
+        }
+
+        let sql = format!(
+            "SELECT id, type, surface, status, priority, owner, payload, archived_at, created_at, updated_at \
+             FROM documents WHERE {} ORDER BY updated_at DESC",
+            clauses.join(" AND ")
+        );
+
+        let mut stmt = self.conn.prepare(&sql)?;
+        let bind_refs: Vec<&dyn rusqlite::ToSql> =
+            binds.iter().map(|s| s as &dyn rusqlite::ToSql).collect();
+        let rows = stmt.query_map(bind_refs.as_slice(), map_document_row)?;
+        let mut out = Vec::new();
+        for r in rows {
+            out.push(r?);
+        }
+        Ok(out)
+    }
+
+    /// Mark a document archived. Sets `archived_at = now`, updates
+    /// `updated_at`. Idempotent: archiving an already-archived doc is
+    /// a no-op success. Returns the updated Document.
+    pub fn archive_document(&self, id: &str) -> Result<Document> {
+        let now = Utc::now().to_rfc3339();
+        let rows = self.conn.execute(
+            "UPDATE documents \
+             SET archived_at = COALESCE(archived_at, ?1), updated_at = ?1 \
+             WHERE id = ?2 AND deleted_at IS NULL",
+            params![&now, id],
+        )?;
+        if rows == 0 {
+            return Err(LegionError::WorkSource(format!(
+                "document '{id}' not found"
+            )));
+        }
+        self.get_document(id)?.ok_or_else(|| {
+            LegionError::WorkSource(format!("document '{id}' vanished after archive"))
+        })
+    }
+}
+
+fn map_document_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<Document> {
+    Ok(Document {
+        id: row.get(0)?,
+        doc_type: row.get(1)?,
+        surface: row.get(2)?,
+        status: row.get(3)?,
+        priority: row.get(4)?,
+        owner: row.get(5)?,
+        payload: row.get(6)?,
+        archived_at: row.get(7)?,
+        created_at: row.get(8)?,
+        updated_at: row.get(9)?,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn open_test_db() -> Database {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("test.db");
+        // Leak the tempdir so the path stays valid for the test's lifetime.
+        // Tests run in isolated processes; the OS reclaims at exit.
+        std::mem::forget(dir);
+        Database::open(&path).expect("open")
+    }
+
+    fn sample_meta<'a>(doc_type: &'a str, owner: &'a str) -> DocumentMeta<'a> {
+        DocumentMeta {
+            id: None,
+            doc_type,
+            surface: None,
+            status: None,
+            priority: None,
+            owner,
+        }
+    }
+
+    #[test]
+    fn insert_and_get_document_round_trips() {
+        let db = open_test_db();
+        let meta = DocumentMeta {
+            id: Some("FR-EMAIL-003"),
+            doc_type: "requirement",
+            surface: Some("email"),
+            status: Some("specified"),
+            priority: Some("SHALL"),
+            owner: "mail",
+        };
+        let payload = r#"{"meta":{"id":"FR-EMAIL-003"},"title":"Thread detail"}"#;
+        let inserted = db.insert_document(&meta, payload).expect("insert");
+        assert_eq!(inserted.id, "FR-EMAIL-003");
+        assert_eq!(inserted.doc_type, "requirement");
+        assert_eq!(inserted.surface.as_deref(), Some("email"));
+        assert_eq!(inserted.status, "specified");
+        assert_eq!(inserted.priority.as_deref(), Some("SHALL"));
+        assert_eq!(inserted.owner, "mail");
+        assert_eq!(inserted.payload, payload);
+        assert!(inserted.archived_at.is_none());
+
+        let fetched = db.get_document("FR-EMAIL-003").expect("get").expect("some");
+        assert_eq!(fetched.id, "FR-EMAIL-003");
+        assert_eq!(fetched.payload, payload);
+    }
+
+    #[test]
+    fn insert_without_id_generates_uuidv7() {
+        let db = open_test_db();
+        let inserted = db
+            .insert_document(&sample_meta("persona", "vault"), "{}")
+            .expect("insert");
+        // UUIDv7 string is 36 chars (8-4-4-4-12 with dashes).
+        assert_eq!(inserted.id.len(), 36);
+        assert!(inserted.id.contains('-'));
+    }
+
+    #[test]
+    fn insert_with_duplicate_id_errors() {
+        let db = open_test_db();
+        let mut meta = sample_meta("requirement", "mail");
+        meta.id = Some("FR-TEST-001");
+        db.insert_document(&meta, "{}").expect("first");
+        let err = db.insert_document(&meta, "{}").unwrap_err();
+        assert!(
+            err.to_string().contains("already exists"),
+            "expected conflict error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn get_nonexistent_returns_none() {
+        let db = open_test_db();
+        assert!(db.get_document("FR-NOPE-999").expect("get").is_none());
+    }
+
+    #[test]
+    fn list_documents_filters_by_type() {
+        let db = open_test_db();
+        db.insert_document(&sample_meta("requirement", "mail"), "{}")
+            .unwrap();
+        db.insert_document(&sample_meta("persona", "vault"), "{}")
+            .unwrap();
+        db.insert_document(&sample_meta("requirement", "platform"), "{}")
+            .unwrap();
+
+        let filter = DocumentFilter {
+            doc_type: Some("requirement"),
+            ..Default::default()
+        };
+        let rows = db.list_documents(&filter).expect("list");
+        assert_eq!(rows.len(), 2);
+        assert!(rows.iter().all(|r| r.doc_type == "requirement"));
+    }
+
+    #[test]
+    fn list_documents_filters_by_surface_owner_status() {
+        let db = open_test_db();
+        let mut a = sample_meta("requirement", "mail");
+        a.surface = Some("email");
+        a.status = Some("specified");
+        db.insert_document(&a, "{}").unwrap();
+
+        let mut b = sample_meta("requirement", "platform");
+        b.surface = Some("auth");
+        b.status = Some("draft");
+        db.insert_document(&b, "{}").unwrap();
+
+        let filter = DocumentFilter {
+            doc_type: Some("requirement"),
+            surface: Some("email"),
+            status: Some("specified"),
+            owner: Some("mail"),
+            ..Default::default()
+        };
+        let rows = db.list_documents(&filter).expect("list");
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].surface.as_deref(), Some("email"));
+    }
+
+    #[test]
+    fn list_documents_excludes_archived_by_default() {
+        let db = open_test_db();
+        let mut m = sample_meta("requirement", "mail");
+        m.id = Some("FR-A");
+        db.insert_document(&m, "{}").unwrap();
+        m.id = Some("FR-B");
+        db.insert_document(&m, "{}").unwrap();
+
+        db.archive_document("FR-A").expect("archive");
+
+        let hot = db.list_documents(&DocumentFilter::default()).expect("list");
+        assert_eq!(hot.len(), 1);
+        assert_eq!(hot[0].id, "FR-B");
+
+        let cold = db
+            .list_documents(&DocumentFilter {
+                archived: Some(true),
+                ..Default::default()
+            })
+            .expect("list");
+        assert_eq!(cold.len(), 1);
+        assert_eq!(cold[0].id, "FR-A");
+    }
+
+    #[test]
+    fn archive_document_is_idempotent() {
+        let db = open_test_db();
+        let mut m = sample_meta("requirement", "mail");
+        m.id = Some("FR-IDEM");
+        db.insert_document(&m, "{}").unwrap();
+
+        let first = db.archive_document("FR-IDEM").expect("first");
+        assert!(first.archived_at.is_some());
+        let first_ts = first.archived_at.clone();
+
+        // Second archive does not change archived_at (COALESCE preserves
+        // the original timestamp).
+        let second = db.archive_document("FR-IDEM").expect("second");
+        assert_eq!(second.archived_at, first_ts);
+    }
+
+    #[test]
+    fn archive_nonexistent_returns_error() {
+        let db = open_test_db();
+        let err = db.archive_document("FR-NOPE").unwrap_err();
+        assert!(err.to_string().contains("not found"));
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ mod channel;
 mod cluster;
 mod daemon;
 mod db;
+mod documents;
 mod embed;
 mod error;
 mod health;
@@ -517,6 +518,14 @@ enum Commands {
     /// Compute embeddings for all reflections that are missing them
     Backfill,
 
+    /// Coordination substrate documents (#455/#456): specs, NFRs,
+    /// blueprints, personas, journeys, etc. Type-agnostic at the storage
+    /// layer; payload is a validated JSON blob.
+    Document {
+        #[command(subcommand)]
+        action: DocumentAction,
+    },
+
     /// Probe a fresh MCP subprocess for notifier health (#391). Spawns
     /// `legion mcp` over stdio, sends `initialize` + `legion/notifier_health`
     /// JSON-RPC requests, prints the health JSON. This spins up a NEW MCP
@@ -802,6 +811,65 @@ enum Commands {
         #[arg(long)]
         json: bool,
     },
+}
+
+#[derive(Subcommand)]
+enum DocumentAction {
+    /// Insert a new document. Payload is read from --from (file path)
+    /// or stdin when --from is omitted. Meta fields are passed
+    /// explicitly to keep the storage layer type-agnostic; the schema
+    /// registry (sibling child of #455) will validate payloads against
+    /// the meta.type's schema once it ships.
+    Create {
+        /// Document type (e.g. "requirement", "nfr", "persona").
+        #[arg(long, value_name = "TYPE")]
+        doc_type: String,
+        /// Owner agent id.
+        #[arg(long)]
+        owner: String,
+        /// Optional explicit id. Defaults to a UUIDv7 when omitted; for
+        /// canonical typed ids like FR-EMAIL-003, pass them here.
+        #[arg(long)]
+        id: Option<String>,
+        /// Functional surface (omit for cross-cutting / type=blueprint).
+        #[arg(long)]
+        surface: Option<String>,
+        /// Initial lifecycle status (default: "draft").
+        #[arg(long)]
+        status: Option<String>,
+        /// RFC 2119 conformance level (requirement only): SHALL|SHOULD|MAY.
+        #[arg(long)]
+        priority: Option<String>,
+        /// Read payload from this file. When omitted, reads from stdin.
+        #[arg(long)]
+        from: Option<PathBuf>,
+    },
+    /// View a document by id.
+    View {
+        id: String,
+        /// Emit full row as JSON (default: human-friendly summary).
+        #[arg(long)]
+        json: bool,
+    },
+    /// List documents, optionally filtered.
+    List {
+        #[arg(long, value_name = "TYPE")]
+        doc_type: Option<String>,
+        #[arg(long)]
+        surface: Option<String>,
+        #[arg(long)]
+        status: Option<String>,
+        #[arg(long)]
+        owner: Option<String>,
+        /// Include archived documents (default: hot only).
+        #[arg(long)]
+        archived: bool,
+        /// Emit full result as JSON.
+        #[arg(long)]
+        json: bool,
+    },
+    /// Mark a document archived.
+    Archive { id: String },
 }
 
 #[derive(Subcommand)]
@@ -3828,6 +3896,124 @@ fn run() -> error::Result<()> {
             let model = embed::EmbedModel::load()?;
             let count = backfill_embeddings(&database, &model)?;
             info!("[legion] embedded {} reflections", count);
+        }
+        Commands::Document { action } => {
+            let base = data_dir()?;
+            let database = db::Database::open(&base.join("legion.db"))?;
+            match action {
+                DocumentAction::Create {
+                    doc_type,
+                    owner,
+                    id,
+                    surface,
+                    status,
+                    priority,
+                    from,
+                } => {
+                    // Payload from --from <path> or stdin.
+                    let payload = match from {
+                        Some(p) => std::fs::read_to_string(&p)?,
+                        None => {
+                            use std::io::Read;
+                            let mut buf = String::new();
+                            std::io::stdin().read_to_string(&mut buf)?;
+                            buf
+                        }
+                    };
+                    // Sanity-validate JSON shape so a typo doesn't land
+                    // in the table as a string blob. Schema-level
+                    // validation per type lives in a sibling child issue.
+                    serde_json::from_str::<serde_json::Value>(&payload).map_err(|e| {
+                        error::LegionError::WorkSource(format!("payload is not valid JSON: {e}"))
+                    })?;
+                    let meta = documents::DocumentMeta {
+                        id: id.as_deref(),
+                        doc_type: &doc_type,
+                        surface: surface.as_deref(),
+                        status: status.as_deref(),
+                        priority: priority.as_deref(),
+                        owner: &owner,
+                    };
+                    let doc = database.insert_document(&meta, &payload)?;
+                    println!("{}", doc.id);
+                }
+                DocumentAction::View { id, json } => {
+                    let doc = database.get_document(&id)?.ok_or_else(|| {
+                        error::LegionError::WorkSource(format!("document '{id}' not found"))
+                    })?;
+                    if json {
+                        println!("{}", serde_json::to_string(&doc)?);
+                    } else {
+                        println!("id:       {}", doc.id);
+                        println!("type:     {}", doc.doc_type);
+                        if let Some(s) = &doc.surface {
+                            println!("surface:  {s}");
+                        }
+                        println!("status:   {}", doc.status);
+                        if let Some(p) = &doc.priority {
+                            println!("priority: {p}");
+                        }
+                        println!("owner:    {}", doc.owner);
+                        if let Some(a) = &doc.archived_at {
+                            println!("archived: {a}");
+                        }
+                        println!("created:  {}", doc.created_at);
+                        println!("updated:  {}", doc.updated_at);
+                        println!("--- payload ---");
+                        println!("{}", doc.payload);
+                    }
+                }
+                DocumentAction::List {
+                    doc_type,
+                    surface,
+                    status,
+                    owner,
+                    archived,
+                    json,
+                } => {
+                    let filter = documents::DocumentFilter {
+                        doc_type: doc_type.as_deref(),
+                        surface: surface.as_deref(),
+                        status: status.as_deref(),
+                        owner: owner.as_deref(),
+                        archived: if archived { Some(true) } else { None },
+                    };
+                    let docs = database.list_documents(&filter)?;
+                    if json {
+                        println!("{}", serde_json::to_string(&docs)?);
+                    } else if docs.is_empty() {
+                        println!("[legion] no documents match filter");
+                    } else {
+                        use std::io::Write;
+                        let stdout = std::io::stdout();
+                        let mut out = stdout.lock();
+                        writeln!(
+                            out,
+                            "{:<24} {:<14} {:<14} {:<14} {:<10}",
+                            "id", "type", "surface", "owner", "status"
+                        )?;
+                        for d in &docs {
+                            writeln!(
+                                out,
+                                "{:<24} {:<14} {:<14} {:<14} {:<10}",
+                                d.id,
+                                d.doc_type,
+                                d.surface.as_deref().unwrap_or("-"),
+                                d.owner,
+                                d.status,
+                            )?;
+                        }
+                    }
+                }
+                DocumentAction::Archive { id } => {
+                    let doc = database.archive_document(&id)?;
+                    println!(
+                        "archived {} at {}",
+                        doc.id,
+                        doc.archived_at.as_deref().unwrap_or("?")
+                    );
+                }
+            }
         }
         Commands::McpHealth { wait } => {
             // Spawn `legion mcp` as a subprocess. Send `initialize`, wait

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -5384,3 +5384,147 @@ fn telemetry_list_filters_by_repo_and_since() {
         assert_eq!(row["repo"], "legion");
     }
 }
+
+#[test]
+fn document_create_view_list_archive_roundtrip() {
+    // #456: full lifecycle through the CLI. Verify a structured payload
+    // round-trips through insert -> view -> list -> archive, with
+    // archived rows excluded from default list and included with --archived.
+    let dir = tempfile::tempdir().unwrap();
+
+    // Create a typed-id requirement document with full meta + JSON payload.
+    let payload = r#"{"meta":{"id":"FR-TEST-001","type":"requirement"},"title":"Integration test target","description":"Round-trip through the documents table CLI."}"#;
+    let mut create_cmd = legion_cmd(dir.path());
+    create_cmd
+        .args([
+            "document",
+            "create",
+            "--doc-type",
+            "requirement",
+            "--owner",
+            "mail",
+            "--id",
+            "FR-TEST-001",
+            "--surface",
+            "email",
+            "--status",
+            "specified",
+            "--priority",
+            "SHALL",
+        ])
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped());
+    let mut child = create_cmd.spawn().expect("spawn");
+    use std::io::Write;
+    child
+        .stdin
+        .as_mut()
+        .unwrap()
+        .write_all(payload.as_bytes())
+        .expect("write stdin");
+    drop(child.stdin.take());
+    let create_out = child.wait_with_output().expect("wait");
+    assert!(
+        create_out.status.success(),
+        "document create failed: {}",
+        String::from_utf8_lossy(&create_out.stderr)
+    );
+    let stdout = String::from_utf8(create_out.stdout).unwrap();
+    assert!(
+        stdout.trim() == "FR-TEST-001",
+        "expected stdout to be the id, got: {stdout}"
+    );
+
+    // View as JSON; assert shape.
+    let view = legion_cmd(dir.path())
+        .args(["document", "view", "FR-TEST-001", "--json"])
+        .output()
+        .unwrap();
+    assert!(view.status.success());
+    let view_json: serde_json::Value =
+        serde_json::from_str(String::from_utf8(view.stdout).unwrap().trim()).unwrap();
+    assert_eq!(view_json["id"], "FR-TEST-001");
+    assert_eq!(view_json["doc_type"], "requirement");
+    assert_eq!(view_json["surface"], "email");
+    assert_eq!(view_json["status"], "specified");
+    assert_eq!(view_json["priority"], "SHALL");
+    assert_eq!(view_json["owner"], "mail");
+
+    // List filters by type.
+    let list = legion_cmd(dir.path())
+        .args(["document", "list", "--doc-type", "requirement", "--json"])
+        .output()
+        .unwrap();
+    assert!(list.status.success());
+    let docs: serde_json::Value =
+        serde_json::from_str(String::from_utf8(list.stdout).unwrap().trim()).unwrap();
+    let arr = docs.as_array().unwrap();
+    assert_eq!(arr.len(), 1);
+    assert_eq!(arr[0]["id"], "FR-TEST-001");
+
+    // Archive the row.
+    let archive = legion_cmd(dir.path())
+        .args(["document", "archive", "FR-TEST-001"])
+        .output()
+        .unwrap();
+    assert!(archive.status.success());
+
+    // Default list excludes archived.
+    let list_hot = legion_cmd(dir.path())
+        .args(["document", "list", "--json"])
+        .output()
+        .unwrap();
+    let hot_docs: serde_json::Value =
+        serde_json::from_str(String::from_utf8(list_hot.stdout).unwrap().trim()).unwrap();
+    assert!(hot_docs.as_array().unwrap().is_empty());
+
+    // --archived returns the archived row.
+    let list_cold = legion_cmd(dir.path())
+        .args(["document", "list", "--archived", "--json"])
+        .output()
+        .unwrap();
+    let cold_docs: serde_json::Value =
+        serde_json::from_str(String::from_utf8(list_cold.stdout).unwrap().trim()).unwrap();
+    let cold_arr = cold_docs.as_array().unwrap();
+    assert_eq!(cold_arr.len(), 1);
+    assert_eq!(cold_arr[0]["id"], "FR-TEST-001");
+    assert!(cold_arr[0]["archived_at"].is_string());
+}
+
+#[test]
+fn document_create_rejects_malformed_payload() {
+    // #456: payload must be valid JSON. Garbage payload should produce
+    // a clear error, not land in the table.
+    let dir = tempfile::tempdir().unwrap();
+    let mut cmd = legion_cmd(dir.path());
+    cmd.args([
+        "document",
+        "create",
+        "--doc-type",
+        "requirement",
+        "--owner",
+        "mail",
+        "--id",
+        "FR-BAD-001",
+    ])
+    .stdin(std::process::Stdio::piped())
+    .stdout(std::process::Stdio::piped())
+    .stderr(std::process::Stdio::piped());
+    let mut child = cmd.spawn().expect("spawn");
+    use std::io::Write;
+    child
+        .stdin
+        .as_mut()
+        .unwrap()
+        .write_all(b"this is not json")
+        .expect("write");
+    drop(child.stdin.take());
+    let out = child.wait_with_output().expect("wait");
+    assert!(!out.status.success(), "malformed payload should fail");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("not valid JSON"),
+        "expected JSON error message, got: {stderr}"
+    );
+}


### PR DESCRIPTION
## Summary
First piece of the v0.14 coordination substrate (#455 epic). Type-agnostic documents table -- specs, NFRs, blueprints, personas, journeys all land here, type-discriminated via the \`type\` column, with payload as validated JSON. Schema-level validation per type lives in a sibling child once vault ships the schemas.

## What ships
- **Migration 21**: documents table with id/type/surface/status/priority/owner/payload/archived_at/created_at/updated_at/deleted_at. Partial indexes on type/surface/owner/status for the hot pool, separate index for archived rows.
- **src/documents.rs**: Document/DocumentMeta/DocumentFilter types + impl Database with insert_document / get_document / list_documents / archive_document.
- **CLI**: \`legion document {create,view,list,archive}\`. Create reads payload from \`--from <path>\` or stdin; validates JSON shape before INSERT.
- **Idempotent archive**: COALESCE on archived_at preserves original timestamp on re-archive.

## Closes
- #456 (child of #455)

## DB visibility note
Bumped \`Database::conn\` to \`pub(crate)\` so the documents module can \`impl Database\` from outside src/db.rs. Alternative was moving every documents method into db.rs (~200 LOC of file motion); visibility bump was the smaller move.

## Test plan
- [x] 9 unit tests in src/documents.rs cover insert/get/list/archive + filter combos + duplicate-id conflict + idempotent archive + nonexistent archive error
- [x] 2 integration tests: full CLI roundtrip (create -> view -> list -> archive -> default-list-excludes -> --archived-includes), malformed-payload rejection
- [x] \`cargo test\` -- 731 unit + 133 integration pass
- [x] \`cargo clippy --all-targets -- -D warnings\` clean
- [x] \`cargo fmt -- --check\` clean