### PR TITLE
feat(#461): stop hook blocks on incomplete TaskList items

### DIFF
--- a/plugin/hooks/hooks.json
+++ b/plugin/hooks/hooks.json
@@ -222,6 +222,26 @@
             "timeout": 5
           }
         ]
+      },
+      {
+        "matcher": "TaskCreate",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/post-task-state.sh",
+            "timeout": 3
+          }
+        ]
+      },
+      {
+        "matcher": "TaskUpdate",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/post-task-state.sh",
+            "timeout": 3
+          }
+        ]
       }
     ]
   }

--- a/plugin/hooks/post-task-state.sh
+++ b/plugin/hooks/post-task-state.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+# Legion PostToolUse hook (#461): mirror TaskCreate and TaskUpdate events
+# into a per-session task-state log so the Stop hook can refuse to let
+# the agent end with incomplete work.
+#
+# The harness owns the live TaskList state but doesn't expose it on a
+# stable on-disk path. Legion maintains its own append-only event log at
+# ${XDG_STATE_HOME}/legion/tasks-<session>.jsonl. The Stop hook reduces
+# over the log to determine current task statuses.
+#
+# Event shape (one JSON object per line):
+#   {"ts":"...","event":"create","task_id":"...","subject":"...","status":"pending"}
+#   {"ts":"...","event":"update","task_id":"...","status":"in_progress"}
+#   {"ts":"...","event":"update","task_id":"...","status":"completed"}
+#
+# Skip via LEGION_SKIP_TASK_STATE=1.
+#
+# Fail-open: missing jq, missing session_id, malformed input -- exit 0
+# silently. Failing this hook should never block the agent's actual
+# tool call.
+
+set -u
+
+if [ "${LEGION_SKIP_TASK_STATE:-}" = "1" ]; then
+  exit 0
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+  exit 0
+fi
+
+INPUT=$(cat)
+if [ -z "$INPUT" ]; then
+  exit 0
+fi
+
+TOOL=$(echo "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null)
+SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // empty' 2>/dev/null)
+
+if [ -z "$SESSION_ID" ]; then
+  exit 0
+fi
+
+case "$TOOL" in
+  TaskCreate|TaskUpdate) ;;
+  *) exit 0 ;;
+esac
+
+STATE_DIR="${XDG_STATE_HOME:-$HOME/.local/state}/legion"
+mkdir -p "$STATE_DIR" 2>/dev/null
+LOG="${STATE_DIR}/tasks-${SESSION_ID}.jsonl"
+
+TS=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+if [ "$TOOL" = "TaskCreate" ]; then
+  # TaskCreate returns an id in the tool result; the input carries the
+  # subject. The harness's TaskCreate response shape is {"id": "...",
+  # "subject": "...", "status": "pending"}. We pull both id and subject.
+  TASK_ID=$(echo "$INPUT" | jq -r '.tool_response.id // empty' 2>/dev/null)
+  SUBJECT=$(echo "$INPUT" | jq -r '.tool_input.subject // empty' 2>/dev/null)
+  if [ -z "$TASK_ID" ]; then
+    # Some harness versions report the id under a different field; skip
+    # silently rather than write a half-event.
+    exit 0
+  fi
+  jq -c -n --arg ts "$TS" --arg id "$TASK_ID" --arg subject "$SUBJECT" \
+    '{ts: $ts, event: "create", task_id: $id, subject: $subject, status: "pending"}' \
+    >> "$LOG" 2>/dev/null
+else
+  # TaskUpdate carries task_id + the status field that changed.
+  TASK_ID=$(echo "$INPUT" | jq -r '.tool_input.task_id // empty' 2>/dev/null)
+  STATUS=$(echo "$INPUT" | jq -r '.tool_input.status // empty' 2>/dev/null)
+  if [ -z "$TASK_ID" ] || [ -z "$STATUS" ]; then
+    exit 0
+  fi
+  jq -c -n --arg ts "$TS" --arg id "$TASK_ID" --arg status "$STATUS" \
+    '{ts: $ts, event: "update", task_id: $id, status: $status}' \
+    >> "$LOG" 2>/dev/null
+fi
+
+exit 0

--- a/plugin/hooks/stop.sh
+++ b/plugin/hooks/stop.sh
@@ -1,8 +1,23 @@
 #!/bin/bash
-# Legion Stop hook: one reflection if you learned something non-obvious.
-# Full wind-down belongs in /snooze, not here.
+# Legion Stop hook.
+#
+# Two-layer enforcement on every Stop event:
+#
+# 1. INCOMPLETE-WORK GATE (#461). If the harness has pending/in_progress
+#    TaskList items in this session, block the Stop with a directive that
+#    forces the agent to either complete, mark blocked, mark needs_input,
+#    or cancel each one. No silent abandonment of multi-step plans.
+#
+# 2. REFLECTION PROMPT. If work happened this session and the reflection
+#    hasn't fired yet, prompt for one. Skip when nothing was learned.
+#
+# Bypass: LEGION_SKIP_STOP_BLOCK=1 env skips both gates. Writes a
+# telemetry row via `legion telemetry record-bypass` so the escape is
+# visible to #440's summary.
+
 INPUT=$(cat)
 CWD=$(echo "$INPUT" | jq -r '.cwd // empty')
+SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // empty')
 
 if [ -z "$CWD" ]; then
   exit 0
@@ -11,6 +26,70 @@ fi
 REPO=$(basename "$CWD")
 CWD_HASH=$(echo "$CWD" | md5 -q 2>/dev/null || echo "$CWD" | md5sum 2>/dev/null | cut -d' ' -f1)
 
+LEGION_BIN="${CLAUDE_PLUGIN_ROOT}/bin/legion"
+
+# Bypass: skip both gates, log the escape if telemetry is available.
+if [ "${LEGION_SKIP_STOP_BLOCK:-}" = "1" ]; then
+  if [ -x "$LEGION_BIN" ] && [ -n "$SESSION_ID" ]; then
+    "$LEGION_BIN" telemetry record-bypass \
+      --repo "$REPO" \
+      --session-id "$SESSION_ID" \
+      --tool Stop \
+      --pattern "session-end" \
+      --bypass-reason "env:LEGION_SKIP_STOP_BLOCK=1" \
+      2>/dev/null || true
+  fi
+  exit 0
+fi
+
+# ---------- (1) Incomplete-work gate ----------
+#
+# Reduce over the session task-state log written by post-task-state.sh
+# (#461 PostToolUse hook). Last-status-wins per task_id; block if any
+# task ends in pending or in_progress.
+
+STATE_DIR="${XDG_STATE_HOME:-$HOME/.local/state}/legion"
+TASK_LOG="${STATE_DIR}/tasks-${SESSION_ID}.jsonl"
+
+if [ -n "$SESSION_ID" ] && [ -f "$TASK_LOG" ] && command -v jq >/dev/null 2>&1; then
+  # Walk the event log, folding each event into a per-task accumulator
+  # that preserves the original subject (from the create event) while
+  # tracking the latest status. Output lines for tasks still in pending
+  # or in_progress.
+  INCOMPLETE=$(jq -s -r '
+    reduce .[] as $e ({};
+      .[$e.task_id] = (
+        (.[$e.task_id] // {}) +
+        {status: $e.status, subject: ($e.subject // (.[$e.task_id].subject // ""))}
+      )
+    )
+    | to_entries
+    | map(select(.value.status == "pending" or .value.status == "in_progress"))
+    | map("- " + .key + " [" + .value.status + "]: " + (.value.subject // "<no subject>"))
+    | .[]
+  ' "$TASK_LOG" 2>/dev/null)
+
+  if [ -n "$INCOMPLETE" ]; then
+    REASON="You have incomplete tasks in this session and cannot stop yet. Open items:
+
+${INCOMPLETE}
+
+Each one needs an explicit terminal state before you stop:
+- complete the work and run TaskUpdate(status=completed)
+- mark deleted with a reason if it is no longer relevant
+- if you are stuck, EXPLICITLY say so -- either post a blocked-note to legion or open a kanban needs_input card so the human-side queue picks it up
+
+\"Should I keep going?\" is not a question to ask the operator after every step. The plan is the permission. Keep going.
+
+To bypass (rare, diagnostics or explicit operator session-end), set LEGION_SKIP_STOP_BLOCK=1. The bypass writes one row to bypass.jsonl."
+
+    jq -n --arg reason "$REASON" '{decision: "block", reason: $reason}'
+    exit 0
+  fi
+fi
+
+# ---------- (2) Reflection prompt ----------
+#
 # Prevent re-fires: one reflect prompt per session
 MARKER="/tmp/legion-reflected-${CWD_HASH}"
 if [ -f "$MARKER" ]; then

--- a/plugin/hooks/test-stop-task-block.sh
+++ b/plugin/hooks/test-stop-task-block.sh
@@ -1,0 +1,138 @@
+#!/bin/bash
+# Test runner for the stop-hook task-state block (#461).
+#
+# Builds a fake CLAUDE_PLUGIN_ROOT and exercises both:
+# - post-task-state.sh: writes one event row per TaskCreate/TaskUpdate.
+# - stop.sh: reads the event log, blocks when any task is incomplete.
+#
+# Run from the repo root:
+#   bash plugin/hooks/test-stop-task-block.sh
+
+set -u
+
+PASS=0
+FAIL=0
+
+assert_contains() {
+  local desc="$1" haystack="$2" needle="$3"
+  if echo "$haystack" | grep -q -- "$needle"; then
+    PASS=$((PASS + 1))
+    echo "  PASS: $desc"
+  else
+    FAIL=$((FAIL + 1))
+    echo "  FAIL: $desc" >&2
+    echo "    expected to find: $needle" >&2
+    echo "    in: $haystack" >&2
+  fi
+}
+
+assert_empty() {
+  local desc="$1" actual="$2"
+  if [ -z "$actual" ]; then
+    PASS=$((PASS + 1))
+    echo "  PASS: $desc"
+  else
+    FAIL=$((FAIL + 1))
+    echo "  FAIL: $desc" >&2
+    echo "    expected empty, got: $actual" >&2
+  fi
+}
+
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+
+mkdir -p "$WORK/plugin/bin" "$WORK/plugin/hooks" "$WORK/state/legion"
+cp plugin/hooks/post-task-state.sh "$WORK/plugin/hooks/"
+cp plugin/hooks/stop.sh "$WORK/plugin/hooks/"
+
+# Stub legion binary that no-ops on telemetry record-bypass.
+cat > "$WORK/plugin/bin/legion" <<'EOF'
+#!/bin/bash
+exit 0
+EOF
+chmod +x "$WORK/plugin/bin/legion"
+
+export CLAUDE_PLUGIN_ROOT="$WORK/plugin"
+export XDG_STATE_HOME="$WORK/state"
+
+POST_HOOK="$WORK/plugin/hooks/post-task-state.sh"
+STOP_HOOK="$WORK/plugin/hooks/stop.sh"
+
+SESSION="test-session-461"
+
+# Seed work marker so the reflection prompt would normally fire (we
+# want to verify the task-block path runs BEFORE the reflection path).
+CWD="/tmp/legion-test"
+CWD_HASH=$(echo "$CWD" | md5 -q 2>/dev/null || echo "$CWD" | md5sum | cut -d' ' -f1)
+touch "/tmp/legion-work-${CWD_HASH}"
+trap 'rm -rf "$WORK" /tmp/legion-work-'"${CWD_HASH}"' /tmp/legion-reflected-'"${CWD_HASH}" EXIT
+
+echo "==> post-task-state appends create event"
+echo "{\"session_id\":\"${SESSION}\",\"tool_name\":\"TaskCreate\",\"tool_input\":{\"subject\":\"Ship the thing\"},\"tool_response\":{\"id\":\"1\",\"status\":\"pending\"}}" | bash "$POST_HOOK"
+LOG="$WORK/state/legion/tasks-${SESSION}.jsonl"
+if [ -f "$LOG" ] && grep -q '"event":"create"' "$LOG" && grep -q '"task_id":"1"' "$LOG"; then
+  PASS=$((PASS + 1)); echo "  PASS: create event written"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: create event missing"
+  [ -f "$LOG" ] && cat "$LOG" >&2
+fi
+
+echo "==> post-task-state appends update event (in_progress)"
+echo "{\"session_id\":\"${SESSION}\",\"tool_name\":\"TaskUpdate\",\"tool_input\":{\"task_id\":\"1\",\"status\":\"in_progress\"}}" | bash "$POST_HOOK"
+if grep -q '"event":"update"' "$LOG" && grep -q '"status":"in_progress"' "$LOG"; then
+  PASS=$((PASS + 1)); echo "  PASS: update event written"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: update event missing"
+fi
+
+echo "==> stop hook BLOCKS with in_progress task"
+out=$(echo "{\"cwd\":\"${CWD}\",\"session_id\":\"${SESSION}\"}" | bash "$STOP_HOOK")
+assert_contains "block decision present" "$out" '"decision": "block"'
+assert_contains "lists incomplete task id" "$out" '- 1 \[in_progress\]'
+assert_contains "lists subject" "$out" 'Ship the thing'
+assert_contains "names bypass env" "$out" 'LEGION_SKIP_STOP_BLOCK=1'
+
+echo "==> mark complete, then stop passes through to reflection path"
+echo "{\"session_id\":\"${SESSION}\",\"tool_name\":\"TaskUpdate\",\"tool_input\":{\"task_id\":\"1\",\"status\":\"completed\"}}" | bash "$POST_HOOK"
+out=$(echo "{\"cwd\":\"${CWD}\",\"session_id\":\"${SESSION}\"}" | bash "$STOP_HOOK")
+# With completed tasks but unfired reflection marker, the reflection
+# prompt should fire (since /tmp/legion-work marker exists from the
+# trap setup).
+assert_contains "reflection prompt fires" "$out" 'What would you tell another agent'
+
+# Clean up reflection marker for next test
+rm -f "/tmp/legion-reflected-${CWD_HASH}"
+
+echo "==> bypass via LEGION_SKIP_STOP_BLOCK=1 exits 0"
+# Re-seed with an in_progress task.
+echo "{\"session_id\":\"${SESSION}\",\"tool_name\":\"TaskUpdate\",\"tool_input\":{\"task_id\":\"1\",\"status\":\"in_progress\"}}" | bash "$POST_HOOK"
+out=$(LEGION_SKIP_STOP_BLOCK=1 echo "{\"cwd\":\"${CWD}\",\"session_id\":\"${SESSION}\"}" | LEGION_SKIP_STOP_BLOCK=1 bash "$STOP_HOOK")
+assert_empty "bypass produces no output" "$out"
+
+echo "==> no session_id: hook passes through"
+out=$(echo "{\"cwd\":\"${CWD}\"}" | bash "$STOP_HOOK")
+# Should NOT block on task state since no session = no task log.
+# May still emit reflection prompt if work marker is present, but
+# task-block path is bypassed cleanly.
+if echo "$out" | grep -q 'decision.*block.*incomplete tasks'; then
+  FAIL=$((FAIL + 1)); echo "  FAIL: missing session_id should not trigger task block"
+else
+  PASS=$((PASS + 1)); echo "  PASS: missing session_id skips task block"
+fi
+
+# Clean up reflection marker before missing-log test
+rm -f "/tmp/legion-reflected-${CWD_HASH}"
+
+echo "==> no task log: hook passes through to reflection"
+SESSION2="no-tasks-session"
+out=$(echo "{\"cwd\":\"${CWD}\",\"session_id\":\"${SESSION2}\"}" | bash "$STOP_HOOK")
+# No task log for SESSION2 -> task-block path skipped -> reflection fires
+# (work marker present).
+assert_contains "no task log falls through to reflection" "$out" 'What would you tell another agent'
+
+echo
+echo "==> $PASS passed, $FAIL failed"
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary
CC's training disposition is "act once, check in" -- agents stop mid-plan to ask "should I keep going?" after each step. Demonstrated this session multiple times. The hook now forces completion mechanically.

## What ships

**\`post-task-state.sh\`** (new PostToolUse hook on TaskCreate/TaskUpdate)
- Appends one JSONL event per tool call to \`\${XDG_STATE_HOME}/legion/tasks-<session_id>.jsonl\`
- Legion maintains its own event log because the harness's TaskList state has no stable on-disk path

**\`stop.sh\`** (extended with task-state gate before the existing reflection prompt)
- Reads the event log, reduces to current status per task_id, blocks Stop with the list of incomplete tasks
- Block reason includes the open items + explicit terminal-state options (complete / mark deleted / post blocked) + the "plan is the permission" reminder + bypass env name
- Reflection prompt still fires after task gate passes -- two layers in order

**\`LEGION_SKIP_STOP_BLOCK=1\`** bypass writes a telemetry row via \`legion telemetry record-bypass\` (matches the grep enforcement chain's bypass pattern)

## Closes
- #461 (child of completion-enforcement epic #460)

## Test plan
- [x] 10 assertions in test-stop-task-block.sh: events written, block fires on in_progress, block reason has task id + subject + bypass env, completed-then-stop falls through to reflection, bypass exits 0, missing session passes through, missing log passes through
- [x] \`cargo test\` -- 722 unit + 131 integration pass (no Rust changes)
- [x] \`shellcheck\` clean on the three new/modified hooks