### PR TITLE
feat(#462): sub-issue worksource verbs + legion sub-issue CLI

### DIFF
--- a/plugin/worksources/github
+++ b/plugin/worksources/github
@@ -154,6 +154,91 @@ case "${1:-}" in
     jq -n --arg url "$URL" --argjson number "${NUMBER:-0}" '{"url":$url,"number":$number}'
     ;;
 
+  create-sub-issue)
+    # Create a sub-issue linked to a parent issue (#462). Uses GitHub's
+    # native sub-issue relationship via GraphQL: create the child issue
+    # the normal way, look up both node ids, then call addSubIssue.
+    #
+    # Env: LEGION_WS_REPO, LEGION_WS_PARENT_NUMBER, LEGION_WS_TITLE,
+    #      LEGION_WS_BODY (optional)
+    # Output: {"url": "...", "number": N}
+    TITLE="${LEGION_WS_TITLE:-}"
+    BODY="${LEGION_WS_BODY:-}"
+    PARENT="${LEGION_WS_PARENT_NUMBER:-}"
+    if [ -z "$REPO" ] || [ -z "$TITLE" ] || [ -z "$PARENT" ]; then
+      echo '{"error":"LEGION_WS_REPO, LEGION_WS_TITLE, and LEGION_WS_PARENT_NUMBER required"}' >&2
+      exit 1
+    fi
+    if ! command -v gh &>/dev/null; then
+      echo '{"error":"gh CLI not found"}' >&2
+      exit 1
+    fi
+    # Owner / name split for the graphql query.
+    OWNER="${REPO%/*}"
+    NAME="${REPO#*/}"
+    # Look up the parent issue's node id BEFORE creating the child, so
+    # a missing parent does not leave us with an orphan child.
+    PARENT_ID=$(gh api graphql -f query="query(\$o: String!, \$n: String!, \$num: Int!) { repository(owner: \$o, name: \$n) { issue(number: \$num) { id } } }" \
+      -F o="$OWNER" -F n="$NAME" -F num="$PARENT" --jq '.data.repository.issue.id' 2>/dev/null) \
+      || { echo "{\"error\":\"parent issue #$PARENT not found in $REPO\"}" >&2; exit 1; }
+    if [ -z "$PARENT_ID" ] || [ "$PARENT_ID" = "null" ]; then
+      echo "{\"error\":\"parent issue #$PARENT not found in $REPO\"}" >&2
+      exit 1
+    fi
+    # Create the child issue.
+    ARGS=(issue create --repo "$REPO" --title "$TITLE")
+    [ -n "$BODY" ] && ARGS+=(--body "$BODY")
+    URL=$(gh "${ARGS[@]}") || { echo '{"error":"gh issue create failed"}' >&2; exit 1; }
+    CHILD_NUMBER=$(echo "$URL" | grep -oE '[0-9]+$' || echo "0")
+    # Look up the child's node id.
+    CHILD_ID=$(gh api graphql -f query="query(\$o: String!, \$n: String!, \$num: Int!) { repository(owner: \$o, name: \$n) { issue(number: \$num) { id } } }" \
+      -F o="$OWNER" -F n="$NAME" -F num="$CHILD_NUMBER" --jq '.data.repository.issue.id' 2>/dev/null)
+    if [ -z "$CHILD_ID" ] || [ "$CHILD_ID" = "null" ]; then
+      echo "{\"error\":\"child issue #$CHILD_NUMBER created but node id lookup failed\"}" >&2
+      exit 1
+    fi
+    # Link as sub-issue. GraphQL addSubIssue mutation -- requires the
+    # sub-issues feature enabled on the repo. On failure we still return
+    # the child url+number so the caller has the issue reference; the
+    # missing link surfaces as a warning to stderr.
+    gh api graphql -f query="mutation(\$parent: ID!, \$child: ID!) { addSubIssue(input: { issueId: \$parent, subIssueId: \$child }) { issue { id } } }" \
+      -F parent="$PARENT_ID" -F child="$CHILD_ID" >/dev/null 2>&1 \
+      || echo "[github] WARNING: child issue #$CHILD_NUMBER created but addSubIssue mutation failed (sub-issues may not be enabled for $REPO)" >&2
+    jq -n --arg url "$URL" --argjson number "${CHILD_NUMBER:-0}" '{"url":$url,"number":$number}'
+    ;;
+
+  list-sub-issues)
+    # List sub-issues of a parent issue (#462).
+    #
+    # Env: LEGION_WS_REPO, LEGION_WS_PARENT_NUMBER, LEGION_WS_STATE
+    #      (open|closed|all, default: open)
+    # Output: JSON array of issues with {url, number, title, state}.
+    PARENT="${LEGION_WS_PARENT_NUMBER:-}"
+    STATE="${LEGION_WS_STATE:-open}"
+    if [ -z "$REPO" ] || [ -z "$PARENT" ]; then
+      echo "[]"
+      exit 0
+    fi
+    if ! command -v gh &>/dev/null; then
+      echo "[]"
+      exit 0
+    fi
+    OWNER="${REPO%/*}"
+    NAME="${REPO#*/}"
+    # GraphQL: fetch the parent's subIssues connection. Filter by state
+    # in jq since the GraphQL connection doesn't support state filter
+    # directly without invoking the issueFilters argument.
+    RESULT=$(gh api graphql -f query="query(\$o: String!, \$n: String!, \$num: Int!) { repository(owner: \$o, name: \$n) { issue(number: \$num) { subIssues(first: 100) { nodes { number url title state body } } } } }" \
+      -F o="$OWNER" -F n="$NAME" -F num="$PARENT" 2>/dev/null) || { echo "[]"; exit 0; }
+    if [ "$STATE" = "all" ]; then
+      echo "$RESULT" | jq '[.data.repository.issue.subIssues.nodes[]]'
+    else
+      # GitHub returns state in uppercase (OPEN / CLOSED); normalize for the filter.
+      UPPER=$(echo "$STATE" | tr '[:lower:]' '[:upper:]')
+      echo "$RESULT" | jq --arg s "$UPPER" '[.data.repository.issue.subIssues.nodes[] | select(.state == $s)]'
+    fi
+    ;;
+
   create-pr)
     TITLE="${LEGION_WS_TITLE:-}"
     BODY="${LEGION_WS_BODY:-}"

--- a/src/main.rs
+++ b/src/main.rs
@@ -539,6 +539,15 @@ enum Commands {
         action: DocumentAction,
     },
 
+    /// Sub-issue verbs over the work source plugin (#462). Operator-
+    /// facing surface for creating a child issue linked to a parent
+    /// via GitHub's native sub-issue relationship, and listing the
+    /// children of a parent.
+    SubIssue {
+        #[command(subcommand)]
+        action: SubIssueAction,
+    },
+
     /// Probe a fresh MCP subprocess for notifier health (#391). Spawns
     /// `legion mcp` over stdio, sends `initialize` + `legion/notifier_health`
     /// JSON-RPC requests, prints the health JSON. This spins up a NEW MCP
@@ -883,6 +892,43 @@ enum DocumentAction {
     },
     /// Mark a document archived.
     Archive { id: String },
+}
+
+#[derive(Subcommand)]
+enum SubIssueAction {
+    /// Create a child issue linked to a parent via GitHub's native
+    /// sub-issue relationship (#462). The plugin looks up the parent
+    /// node id first, errors if the parent does not exist, then
+    /// creates the child and links via the addSubIssue mutation.
+    Create {
+        /// Repo containing the parent issue (used to resolve the work
+        /// source plugin).
+        #[arg(long)]
+        repo: String,
+        /// Parent issue number.
+        #[arg(long)]
+        parent: u64,
+        /// Title of the new child issue.
+        #[arg(long)]
+        title: String,
+        /// Optional body for the child issue. Reads from stdin when
+        /// --body is omitted AND stdin is not a TTY.
+        #[arg(long)]
+        body: Option<String>,
+    },
+    /// List sub-issues of a parent (#462).
+    List {
+        #[arg(long)]
+        repo: String,
+        #[arg(long)]
+        parent: u64,
+        /// State filter: open (default) | closed | all.
+        #[arg(long, default_value = "open")]
+        state: String,
+        /// Emit as JSON.
+        #[arg(long)]
+        json: bool,
+    },
 }
 
 #[derive(Subcommand)]
@@ -4052,6 +4098,53 @@ fn run() -> error::Result<()> {
                 }
             }
         }
+        Commands::SubIssue { action } => match action {
+            SubIssueAction::Create {
+                repo,
+                parent,
+                title,
+                body,
+            } => {
+                let (plugin, github_repo, _) =
+                    worksource::resolve_config(&repo).ok_or_else(|| {
+                        error::LegionError::WorkSource(format!(
+                            "no work source configured for repo '{repo}'"
+                        ))
+                    })?;
+                let created = worksource::create_sub_issue(
+                    &plugin,
+                    &github_repo,
+                    parent,
+                    &title,
+                    body.as_deref(),
+                )?;
+                println!("{}", created.url);
+            }
+            SubIssueAction::List {
+                repo,
+                parent,
+                state,
+                json,
+            } => {
+                let (plugin, github_repo, _) =
+                    worksource::resolve_config(&repo).ok_or_else(|| {
+                        error::LegionError::WorkSource(format!(
+                            "no work source configured for repo '{repo}'"
+                        ))
+                    })?;
+                let issues =
+                    worksource::list_sub_issues(&plugin, &github_repo, parent, Some(&state))?;
+                if json {
+                    println!("{}", serde_json::to_string(&issues)?);
+                } else if issues.is_empty() {
+                    println!("[legion] no sub-issues of #{parent} in {github_repo}");
+                } else {
+                    for i in &issues {
+                        println!("#{}\t{}\t{}", i.number, i.state, i.title);
+                    }
+                }
+            }
+        },
         Commands::McpHealth { wait } => {
             // Spawn `legion mcp` as a subprocess. Send `initialize`, wait
             // for the notifier to tick at least once, then send

--- a/src/worksource.rs
+++ b/src/worksource.rs
@@ -455,6 +455,66 @@ pub struct CreatedIssue {
 }
 
 /// Create an issue via a work source plugin.
+/// Create a child issue linked to a parent issue as a native sub-issue
+/// via the GitHub GraphQL `addSubIssue` mutation (#462). Returns the
+/// child issue's `CreatedIssue` shape.
+///
+/// Plugin implementation looks up the parent's node id first, creates
+/// the child via `gh issue create`, looks up the child's node id, then
+/// calls the addSubIssue mutation. If the parent does not exist, the
+/// plugin errors out BEFORE creating the child so we don't leave an
+/// orphan. If addSubIssue fails (sub-issues disabled on the repo), the
+/// child issue still exists; the plugin warns to stderr but returns
+/// success so the caller has the issue reference.
+pub fn create_sub_issue(
+    plugin_name: &str,
+    github_repo: &str,
+    parent_number: u64,
+    title: &str,
+    body: Option<&str>,
+) -> Result<CreatedIssue> {
+    let plugin_path = find_plugin(plugin_name)
+        .ok_or_else(|| LegionError::WorkSource(format!("plugin not found: {plugin_name}")))?;
+    let parent_str = parent_number.to_string();
+    let mut env: Vec<(&str, &str)> = vec![
+        ("LEGION_WS_REPO", github_repo),
+        ("LEGION_WS_PARENT_NUMBER", &parent_str),
+        ("LEGION_WS_TITLE", title),
+    ];
+    if let Some(b) = body {
+        env.push(("LEGION_WS_BODY", b));
+    }
+    let output = call_plugin(&plugin_path, &["create-sub-issue"], &env)?;
+    let created: CreatedIssue =
+        serde_json::from_str(&output).map_err(|e| LegionError::WorkSource(e.to_string()))?;
+    Ok(created)
+}
+
+/// List sub-issues of a parent issue (#462). State filter is one of
+/// `open` / `closed` / `all`; defaults to `open` when None.
+pub fn list_sub_issues(
+    plugin_name: &str,
+    github_repo: &str,
+    parent_number: u64,
+    state: Option<&str>,
+) -> Result<Vec<ExternalIssue>> {
+    let plugin_path = match find_plugin(plugin_name) {
+        Some(p) => p,
+        None => return Ok(Vec::new()),
+    };
+    let parent_str = parent_number.to_string();
+    let state_str = state.unwrap_or("open");
+    let env: Vec<(&str, &str)> = vec![
+        ("LEGION_WS_REPO", github_repo),
+        ("LEGION_WS_PARENT_NUMBER", &parent_str),
+        ("LEGION_WS_STATE", state_str),
+    ];
+    let output = call_plugin(&plugin_path, &["list-sub-issues"], &env)?;
+    let issues: Vec<ExternalIssue> =
+        serde_json::from_str(&output).map_err(|e| LegionError::WorkSource(e.to_string()))?;
+    Ok(issues)
+}
+
 pub fn create_issue(
     plugin_name: &str,
     github_repo: &str,


### PR DESCRIPTION
## Summary
Native GitHub sub-issue support over the work source plugin layer. Child of completion-enforcement epic #460.

## What ships

**worksource Rust layer**:
- \`create_sub_issue(plugin, repo, parent_number, title, body)\`
- \`list_sub_issues(plugin, repo, parent_number, state)\`

**github plugin** (\`plugin/worksources/github\`):
- \`create-sub-issue\` subcommand: looks up parent's GraphQL node id FIRST (errors before creating child if parent missing -- no orphans), creates child via \`gh issue create\`, calls \`addSubIssue\` mutation. addSubIssue failure (sub-issues disabled on the repo) emits a warning but returns the child url+number anyway.
- \`list-sub-issues\` subcommand: GraphQL query on parent's \`subIssues\` connection with client-side state filtering.

**CLI**:
- \`legion sub-issue create --repo R --parent N --title T [--body B]\`
- \`legion sub-issue list --repo R --parent N [--state open|closed|all] [--json]\`

## Out of scope (deferred follow-ups)

- **PostToolUse auto-mirror**: hook that creates a sub-issue per TaskCreate event. Foundation ships here; the auto-mirror needs branch-name parsing to find the parent issue and is more brittle. File a separate issue once these verbs prove themselves manually.
- **GitLab plugin**: legion ships GH-first today.

## Why GraphQL not REST

\`addSubIssue\` is the only native API for the sub-issue relationship. REST returns \`parent-issue\` in response bodies but has no way to set the link. Two-step lookup-then-mutate is the cost of native.

## Closes
- #462 (child of #460)

## Test plan
- [x] \`cargo test\` -- 722 unit + 131 integration pass
- [x] \`cargo clippy --all-targets -- -D warnings\` clean
- [x] \`cargo fmt -- --check\` clean
- [x] \`shellcheck plugin/worksources/github\` clean
- [ ] Manual smoke test by operator on first use (CI can't auth to GH)