### PR TITLE
feat(#357): legion uncertainty CLI surface (emit, witness, calibration, orphans)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -590,6 +590,12 @@ enum Commands {
         action: TelemetryAction,
     },
 
+    /// Pillar 2: emit / witness predictions, read calibration + orphan metrics
+    Uncertainty {
+        #[command(subcommand)]
+        action: UncertaintyAction,
+    },
+
     /// Show reflection statistics
     Stats {
         /// Repository name (omit for all repos)
@@ -1060,6 +1066,90 @@ enum TelemetryAction {
         /// Top N rows by count (default 20, 0 means all).
         #[arg(long, default_value_t = 20)]
         top: usize,
+        /// Emit JSON instead of human-readable text.
+        #[arg(long)]
+        json: bool,
+    },
+}
+
+#[derive(Subcommand)]
+enum UncertaintyAction {
+    /// Record a fresh prediction. Mirrors platform's
+    /// POST /api/uncertainty/predictions. Returns JSON `{id, orphan_after}`
+    /// on stdout. Non-blocking: failures log to stderr and exit 0 so a
+    /// downstream emit hook can never break the agent.
+    Emit {
+        /// Logical surface for the prediction (e.g. `legion.task`,
+        /// `legion.review`, `legion.scip-query`).
+        #[arg(long)]
+        surface: String,
+        /// Feature key from SCIP / task classifier
+        /// (e.g. `scip.high-connectivity-refactor`, `schema.new-table`).
+        #[arg(long)]
+        feature_key: String,
+        /// Stable hash of `(features + task description)`. Lets the
+        /// witness path look up the matching prediction without an id.
+        #[arg(long)]
+        input_fingerprint: String,
+        /// Model that produced the prediction (e.g. `claude-opus-4-7`).
+        #[arg(long)]
+        model: String,
+        /// Model version string. Free-form; calibration cohorts include it
+        /// to detect regressions across releases.
+        #[arg(long)]
+        model_version: String,
+        /// Claimed probability of shipping without iteration. [0.0, 1.0].
+        #[arg(long)]
+        claimed_confidence: f64,
+        /// Prediction payload (JSON). Free-form per-surface schema, e.g.
+        /// `{"predicted_tokens": 5000000, "predicted_wallclock_seconds": 7200}`.
+        #[arg(long)]
+        payload: String,
+        /// Days until the prediction transitions to orphan if not witnessed.
+        /// Default 30. Setting 0 disables the orphan sweep for this row.
+        #[arg(long, default_value_t = 30)]
+        orphan_ttl_days: u32,
+    },
+
+    /// Record an outcome for a prediction. Mirrors platform's
+    /// PUT /api/uncertainty/predictions/:id/witness. Idempotent failure:
+    /// re-witnessing an already-witnessed prediction is an error.
+    Witness {
+        /// Prediction id to witness against.
+        prediction_id: String,
+        /// Outcome category: `shipped`, `scoped-down`, `escalated`, `abandoned`.
+        #[arg(long)]
+        outcome_label: String,
+        /// Normalized correctness in [0.0, 1.0]. 1.0 = predicted exactly,
+        /// 0.0 = totally wrong. Calibration math uses this.
+        #[arg(long)]
+        outcome_correctness: f64,
+        /// Optional outcome payload (JSON) -- typically
+        /// `{"actual_tokens": ..., "actual_wallclock_seconds": ...}`.
+        #[arg(long)]
+        payload: Option<String>,
+    },
+
+    /// Read calibration snapshots for a cohort. Output is one row per
+    /// reliability bucket with claimed vs actual, counts, Brier score.
+    Calibration {
+        /// Filter to one surface.
+        #[arg(long)]
+        surface: Option<String>,
+        /// Filter to one model.
+        #[arg(long)]
+        model: Option<String>,
+        /// Emit JSON instead of human-readable text.
+        #[arg(long)]
+        json: bool,
+    },
+
+    /// Count predictions currently in the orphan state. Surface-grouped.
+    /// For the dashboard + nightly Slack digest in #360.
+    Orphans {
+        /// Filter to one surface.
+        #[arg(long)]
+        surface: Option<String>,
         /// Emit JSON instead of human-readable text.
         #[arg(long)]
         json: bool,
@@ -3191,6 +3281,156 @@ fn main() -> error::Result<()> {
     })
 }
 
+/// Dispatch `legion uncertainty ...`. Non-blocking emit posture: emit
+/// failures log to stderr and return Ok so an upstream hook can never
+/// abort the agent on a telemetry-shaped problem. Witness / calibration /
+/// orphans surface errors normally -- those are explicit user actions.
+fn run_uncertainty(action: UncertaintyAction) -> error::Result<()> {
+    use std::io::Write;
+    let base = data_dir()?;
+    let database = db::Database::open(&base.join("legion.db"))?;
+    let stdout = std::io::stdout();
+    let mut out = stdout.lock();
+
+    match action {
+        UncertaintyAction::Emit {
+            surface,
+            feature_key,
+            input_fingerprint,
+            model,
+            model_version,
+            claimed_confidence,
+            payload,
+            orphan_ttl_days,
+        } => {
+            let confidence = match uncertainty::types::Confidence::from_f64(claimed_confidence) {
+                Ok(c) => c,
+                Err(e) => {
+                    eprintln!("[legion uncertainty emit] {e}");
+                    return Ok(());
+                }
+            };
+            let payload_value: serde_json::Value = match serde_json::from_str(&payload) {
+                Ok(v) => v,
+                Err(e) => {
+                    eprintln!("[legion uncertainty emit] payload not valid JSON: {e}");
+                    return Ok(());
+                }
+            };
+            let input = uncertainty::types::PredictionInput {
+                surface,
+                feature_key,
+                input_fingerprint,
+                model,
+                model_version,
+                claimed_confidence: confidence,
+                prediction_payload: payload_value,
+                orphan_after: uncertainty::storage::orphan_after_from_ttl(orphan_ttl_days),
+            };
+            let prediction = uncertainty::types::Prediction::new(input);
+            if let Err(e) = database.insert_prediction(&prediction) {
+                eprintln!("[legion uncertainty emit] insert failed: {e}");
+                return Ok(());
+            }
+            let out_json = serde_json::json!({
+                "id": prediction.id,
+                "orphan_after": prediction.orphan_after,
+            });
+            writeln!(out, "{}", serde_json::to_string(&out_json)?)?;
+        }
+
+        UncertaintyAction::Witness {
+            prediction_id,
+            outcome_label,
+            outcome_correctness,
+            payload,
+        } => {
+            let label = uncertainty::types::OutcomeLabel::from_str(&outcome_label)
+                .map_err(|e| error::LegionError::WorkSource(format!("{e}")))?;
+            let correctness = uncertainty::types::Correctness::from_f64(outcome_correctness)
+                .map_err(|e| error::LegionError::WorkSource(format!("{e}")))?;
+            let payload_value: serde_json::Value = match payload {
+                Some(s) => serde_json::from_str(&s)
+                    .map_err(|e| error::LegionError::WorkSource(format!("payload JSON: {e}")))?,
+                None => serde_json::json!({}),
+            };
+            let mut prediction = database
+                .get_prediction(&prediction_id)
+                .map_err(|e| error::LegionError::WorkSource(format!("{e}")))?
+                .ok_or_else(|| {
+                    error::LegionError::WorkSource(format!("prediction not found: {prediction_id}"))
+                })?;
+            let now = chrono::Utc::now().to_rfc3339();
+            prediction
+                .witness(label, payload_value, correctness, &now)
+                .map_err(|e| error::LegionError::WorkSource(format!("{e}")))?;
+            database
+                .update_prediction(&prediction)
+                .map_err(|e| error::LegionError::WorkSource(format!("{e}")))?;
+            let out_json = serde_json::json!({
+                "id": prediction.id,
+                "state": prediction.state.as_str(),
+                "witnessed_at": prediction.witnessed_at,
+            });
+            writeln!(out, "{}", serde_json::to_string(&out_json)?)?;
+        }
+
+        UncertaintyAction::Calibration {
+            surface,
+            model,
+            json,
+        } => {
+            let snaps = database
+                .list_calibration_snapshots(surface.as_deref(), model.as_deref())
+                .map_err(|e| error::LegionError::WorkSource(format!("{e}")))?;
+            if json {
+                writeln!(out, "{}", serde_json::to_string(&snaps)?)?;
+            } else if snaps.is_empty() {
+                writeln!(
+                    out,
+                    "[legion uncertainty] no calibration snapshots in scope"
+                )?;
+            } else {
+                writeln!(
+                    out,
+                    "{:<48} {:<8} {:<8} {:<8} {:<8} {:<8} {:<8}",
+                    "cohort", "lower", "upper", "claimed", "actual", "n", "brier"
+                )?;
+                for s in &snaps {
+                    writeln!(
+                        out,
+                        "{:<48} {:<8.2} {:<8.2} {:<8.2} {:<8.2} {:<8} {:<8.4}",
+                        s.cohort_key,
+                        s.bucket_lower,
+                        s.bucket_upper,
+                        s.claimed_confidence,
+                        s.actual_correctness,
+                        s.prediction_count,
+                        s.brier_score,
+                    )?;
+                }
+            }
+        }
+
+        UncertaintyAction::Orphans { surface, json } => {
+            let rows = database
+                .count_orphans_by_surface(surface.as_deref())
+                .map_err(|e| error::LegionError::WorkSource(format!("{e}")))?;
+            if json {
+                writeln!(out, "{}", serde_json::to_string(&rows)?)?;
+            } else if rows.is_empty() {
+                writeln!(out, "[legion uncertainty] no orphans in scope")?;
+            } else {
+                writeln!(out, "{:<32} {:<8}", "surface", "count")?;
+                for r in &rows {
+                    writeln!(out, "{:<32} {:<8}", r.surface, r.count)?;
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
 fn run() -> error::Result<()> {
     raise_fd_limit();
     let cli = Cli::parse();
@@ -4333,6 +4573,9 @@ fn run() -> error::Result<()> {
                 }
             }
         },
+        Commands::Uncertainty { action } => {
+            run_uncertainty(action)?;
+        }
         Commands::Serve { port } => {
             let base = data_dir()?;
             let watch_path = base.join("watch.toml");

--- a/src/main.rs
+++ b/src/main.rs
@@ -3336,7 +3336,18 @@ fn run_uncertainty(action: UncertaintyAction) -> error::Result<()> {
                 "id": prediction.id,
                 "orphan_after": prediction.orphan_after,
             });
-            writeln!(out, "{}", serde_json::to_string(&out_json)?)?;
+            // Emit is non-blocking: a closed stdout pipe or serialize error
+            // must not propagate as a process error, otherwise an upstream
+            // hook could break the agent on a stdout-side problem unrelated
+            // to the prediction having landed in the DB.
+            match serde_json::to_string(&out_json) {
+                Ok(s) => {
+                    if let Err(e) = writeln!(out, "{s}") {
+                        eprintln!("[legion uncertainty emit] stdout write failed: {e}");
+                    }
+                }
+                Err(e) => eprintln!("[legion uncertainty emit] serialize failed: {e}"),
+            }
         }
 
         UncertaintyAction::Witness {

--- a/src/uncertainty/mod.rs
+++ b/src/uncertainty/mod.rs
@@ -5,21 +5,18 @@
 //! witnesses the outcome when work completes, and rolls reliability
 //! snapshots so vault's COS routing has live cost estimates.
 //!
-//! This module owns the domain types and lifecycle math. Database CRUD
-//! lands in `db.rs` alongside the rest of the storage layer; the hookable
-//! CLI surface (`legion uncertainty ...`) wires the two together in
-//! `main.rs` (see issue #357).
+//! This module owns the domain types, lifecycle math, and storage CRUD
+//! for predictions and calibration snapshots. The CLI surface
+//! (`legion uncertainty ...`) wires the pieces together in `main.rs`.
 //!
 //! Module layout:
 //!
 //! - [`types`] -- Prediction, CalibrationSnapshot, PredictionState,
-//!   OutcomeLabel, Confidence, PredictionInput, cohort_key helper.
+//!   OutcomeLabel, Confidence, Correctness, PredictionInput, cohort_key helper.
 //! - [`error`] -- UncertaintyError via thiserror.
+//! - [`storage`] -- impl Database for insert/get/update/list + the
+//!   `orphan_after_from_ttl` helper used at the CLI emit boundary.
 
 pub mod error;
+pub mod storage;
 pub mod types;
-
-// Re-exports land here once #357 (CLI) and #358 (hooks) start consuming
-// the types. Keeping them un-re-exported now keeps `cargo clippy -D warnings`
-// quiet without sprinkling per-item allow attributes that would have to be
-// reverted later.

--- a/src/uncertainty/storage.rs
+++ b/src/uncertainty/storage.rs
@@ -1,0 +1,395 @@
+//! Database CRUD for the uncertainty engine.
+//!
+//! Type-aware bridge between `db::Database` and the domain types in
+//! [`super::types`]. Reads route through the type constructors so the
+//! `[0, 1]` newtype guarantee survives storage round-trips; writes use
+//! plain rusqlite params, matching the rest of the data layer.
+
+use chrono::Utc;
+use rusqlite::params;
+
+use crate::db::Database;
+
+use super::error::{Result, UncertaintyError};
+use super::types::{
+    CalibrationSnapshot, Confidence, Correctness, OutcomeLabel, Prediction, PredictionState,
+};
+
+/// One row of the surface-grouped orphan summary.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct OrphanSummaryRow {
+    pub surface: String,
+    pub count: i64,
+}
+
+impl Database {
+    /// Insert a freshly-emitted prediction. Conflict on id is a hard error.
+    pub fn insert_prediction(&self, p: &Prediction) -> Result<()> {
+        let payload_json = serde_json::to_string(&p.prediction_payload)?;
+        self.conn.execute(
+            "INSERT INTO uncertainty_prediction \
+             (id, surface, feature_key, input_fingerprint, model, model_version, \
+              claimed_confidence, prediction_payload, state, cohort_key, \
+              created_at, updated_at, orphan_after) \
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)",
+            params![
+                p.id,
+                p.surface,
+                p.feature_key,
+                p.input_fingerprint,
+                p.model,
+                p.model_version,
+                p.claimed_confidence.value(),
+                payload_json,
+                p.state.as_str(),
+                p.cohort_key,
+                p.created_at,
+                p.updated_at,
+                p.orphan_after,
+            ],
+        )?;
+        Ok(())
+    }
+
+    /// Fetch one prediction by id. None if the row does not exist or is
+    /// soft-deleted.
+    pub fn get_prediction(&self, id: &str) -> Result<Option<Prediction>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT id, surface, feature_key, input_fingerprint, model, model_version, \
+             claimed_confidence, prediction_payload, state, outcome_label, outcome_payload, \
+             outcome_correctness, cohort_key, created_at, updated_at, witnessed_at, \
+             orphan_after \
+             FROM uncertainty_prediction \
+             WHERE id = ?1 AND deleted_at IS NULL",
+        )?;
+        let mut rows = stmt.query(params![id])?;
+        if let Some(row) = rows.next()? {
+            Ok(Some(map_prediction_row(row)?))
+        } else {
+            Ok(None)
+        }
+    }
+
+    /// Persist a prediction whose state has advanced (witness / calibrate /
+    /// orphan / retire). UPDATE keyed by id; updated_at is taken from the
+    /// in-memory row so callers control the timestamp.
+    pub fn update_prediction(&self, p: &Prediction) -> Result<()> {
+        let payload_json = serde_json::to_string(&p.prediction_payload)?;
+        let outcome_payload_json = match &p.outcome_payload {
+            Some(v) => Some(serde_json::to_string(v)?),
+            None => None,
+        };
+        let outcome_correctness_f64 = p.outcome_correctness.map(|c| c.value());
+        let outcome_label_str = p.outcome_label.map(|l| l.as_str());
+        let rows = self.conn.execute(
+            "UPDATE uncertainty_prediction SET \
+             prediction_payload = ?1, \
+             state = ?2, \
+             outcome_label = ?3, \
+             outcome_payload = ?4, \
+             outcome_correctness = ?5, \
+             witnessed_at = ?6, \
+             updated_at = ?7 \
+             WHERE id = ?8 AND deleted_at IS NULL",
+            params![
+                payload_json,
+                p.state.as_str(),
+                outcome_label_str,
+                outcome_payload_json,
+                outcome_correctness_f64,
+                p.witnessed_at,
+                p.updated_at,
+                p.id,
+            ],
+        )?;
+        if rows == 0 {
+            return Err(UncertaintyError::PredictionNotFound(p.id.clone()));
+        }
+        Ok(())
+    }
+
+    /// Read calibration snapshot rows, optionally filtered by surface +
+    /// model. Ordered by `bucket_lower` ASC so a reliability diagram can
+    /// render top-to-bottom.
+    ///
+    /// `surface` and `model` are matched as prefixes of the cohort_key
+    /// (`<surface>:<model>:<version>:<bucket>`), so a surface-only filter
+    /// returns rows for every model under that surface.
+    pub fn list_calibration_snapshots(
+        &self,
+        surface: Option<&str>,
+        model: Option<&str>,
+    ) -> Result<Vec<CalibrationSnapshot>> {
+        let mut clauses: Vec<String> = vec!["deleted_at IS NULL".to_string()];
+        let mut binds: Vec<String> = Vec::new();
+
+        if let Some(s) = surface {
+            clauses.push(format!("cohort_key LIKE ?{}", binds.len() + 1));
+            binds.push(format!("{}:%", s));
+        }
+        if let Some(m) = model {
+            clauses.push(format!("cohort_key LIKE ?{}", binds.len() + 1));
+            binds.push(format!("%:{}:%", m));
+        }
+
+        let sql = format!(
+            "SELECT id, cohort_key, bucket_lower, bucket_upper, claimed_confidence, \
+             actual_correctness, actual_correctness_raw, prediction_count, orphan_count, \
+             brier_score, computed_at, updated_at \
+             FROM uncertainty_calibration_snapshot WHERE {} ORDER BY bucket_lower ASC",
+            clauses.join(" AND ")
+        );
+
+        let mut stmt = self.conn.prepare(&sql)?;
+        let bind_refs: Vec<&dyn rusqlite::types::ToSql> = binds
+            .iter()
+            .map(|b| b as &dyn rusqlite::types::ToSql)
+            .collect();
+        let rows = stmt.query_map(bind_refs.as_slice(), |row| {
+            Ok(CalibrationSnapshot {
+                id: row.get(0)?,
+                cohort_key: row.get(1)?,
+                bucket_lower: row.get(2)?,
+                bucket_upper: row.get(3)?,
+                claimed_confidence: row.get(4)?,
+                actual_correctness: row.get(5)?,
+                actual_correctness_raw: row.get(6)?,
+                prediction_count: row.get(7)?,
+                orphan_count: row.get(8)?,
+                brier_score: row.get(9)?,
+                computed_at: row.get(10)?,
+                updated_at: row.get(11)?,
+            })
+        })?;
+        rows.collect::<std::result::Result<Vec<_>, _>>()
+            .map_err(UncertaintyError::Database)
+    }
+
+    /// Group orphan-state predictions by surface. Optionally filtered to a
+    /// single surface. Used by the dashboard + nightly digest.
+    pub fn count_orphans_by_surface(&self, surface: Option<&str>) -> Result<Vec<OrphanSummaryRow>> {
+        let (sql, bind): (&str, Vec<String>) = match surface {
+            Some(s) => (
+                "SELECT surface, COUNT(*) as c FROM uncertainty_prediction \
+                 WHERE state = 'orphaned' AND deleted_at IS NULL AND surface = ?1 \
+                 GROUP BY surface ORDER BY c DESC",
+                vec![s.to_string()],
+            ),
+            None => (
+                "SELECT surface, COUNT(*) as c FROM uncertainty_prediction \
+                 WHERE state = 'orphaned' AND deleted_at IS NULL \
+                 GROUP BY surface ORDER BY c DESC",
+                Vec::new(),
+            ),
+        };
+        let mut stmt = self.conn.prepare(sql)?;
+        let bind_refs: Vec<&dyn rusqlite::types::ToSql> = bind
+            .iter()
+            .map(|b| b as &dyn rusqlite::types::ToSql)
+            .collect();
+        let rows = stmt.query_map(bind_refs.as_slice(), |row| {
+            Ok(OrphanSummaryRow {
+                surface: row.get(0)?,
+                count: row.get(1)?,
+            })
+        })?;
+        rows.collect::<std::result::Result<Vec<_>, _>>()
+            .map_err(UncertaintyError::Database)
+    }
+}
+
+fn map_prediction_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<Prediction> {
+    let claimed_confidence_raw: f64 = row.get(6)?;
+    let payload_str: String = row.get(7)?;
+    let payload: serde_json::Value = serde_json::from_str(&payload_str).map_err(|e| {
+        rusqlite::Error::FromSqlConversionFailure(7, rusqlite::types::Type::Text, Box::new(e))
+    })?;
+    let state_str: String = row.get(8)?;
+    let state = PredictionState::from_str(&state_str).map_err(|e| {
+        rusqlite::Error::FromSqlConversionFailure(8, rusqlite::types::Type::Text, Box::new(e))
+    })?;
+    let outcome_label_opt: Option<String> = row.get(9)?;
+    let outcome_label = match outcome_label_opt {
+        Some(s) => Some(OutcomeLabel::from_str(&s).map_err(|e| {
+            rusqlite::Error::FromSqlConversionFailure(9, rusqlite::types::Type::Text, Box::new(e))
+        })?),
+        None => None,
+    };
+    let outcome_payload_str: Option<String> = row.get(10)?;
+    let outcome_payload = match outcome_payload_str {
+        Some(s) => Some(serde_json::from_str(&s).map_err(|e| {
+            rusqlite::Error::FromSqlConversionFailure(10, rusqlite::types::Type::Text, Box::new(e))
+        })?),
+        None => None,
+    };
+    let outcome_correctness_raw: Option<f64> = row.get(11)?;
+    let outcome_correctness = match outcome_correctness_raw {
+        Some(c) => Some(Correctness::from_f64(c).map_err(|e| {
+            rusqlite::Error::FromSqlConversionFailure(11, rusqlite::types::Type::Real, Box::new(e))
+        })?),
+        None => None,
+    };
+    let claimed_confidence = Confidence::from_f64(claimed_confidence_raw).map_err(|e| {
+        rusqlite::Error::FromSqlConversionFailure(6, rusqlite::types::Type::Real, Box::new(e))
+    })?;
+
+    Ok(Prediction {
+        id: row.get(0)?,
+        surface: row.get(1)?,
+        feature_key: row.get(2)?,
+        input_fingerprint: row.get(3)?,
+        model: row.get(4)?,
+        model_version: row.get(5)?,
+        claimed_confidence,
+        prediction_payload: payload,
+        state,
+        outcome_label,
+        outcome_payload,
+        outcome_correctness,
+        cohort_key: row.get(12)?,
+        created_at: row.get(13)?,
+        updated_at: row.get(14)?,
+        witnessed_at: row.get(15)?,
+        orphan_after: row.get(16)?,
+    })
+}
+
+/// Compute the ISO 8601 timestamp `days` days in the future. Used by the
+/// emit CLI to derive `orphan_after` from `--orphan-ttl-days`.
+pub fn orphan_after_from_ttl(days: u32) -> Option<String> {
+    if days == 0 {
+        return None;
+    }
+    let when = Utc::now() + chrono::Duration::days(days as i64);
+    Some(when.to_rfc3339())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::uncertainty::types::{Confidence, PredictionInput};
+
+    fn fresh_input() -> PredictionInput {
+        PredictionInput {
+            surface: "legion.task".into(),
+            feature_key: "scip.refactor".into(),
+            input_fingerprint: "fp-1".into(),
+            model: "claude-opus-4-7".into(),
+            model_version: "4.7".into(),
+            claimed_confidence: Confidence::from_f64(0.7).unwrap(),
+            prediction_payload: serde_json::json!({ "predicted_tokens": 1500 }),
+            orphan_after: Some("2026-06-12T00:00:00+00:00".into()),
+        }
+    }
+
+    fn test_db() -> Database {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("test.db");
+        // Leak the tempdir so the path remains valid for the test body.
+        std::mem::forget(dir);
+        Database::open(&path).unwrap()
+    }
+
+    #[test]
+    fn insert_and_get_prediction_round_trips() {
+        let db = test_db();
+        let p = Prediction::new(fresh_input());
+        db.insert_prediction(&p).unwrap();
+        let fetched = db.get_prediction(&p.id).unwrap().unwrap();
+        assert_eq!(fetched.id, p.id);
+        assert_eq!(fetched.surface, "legion.task");
+        assert_eq!(fetched.state, PredictionState::Emitted);
+        assert_eq!(fetched.claimed_confidence.value(), 0.7);
+        assert!(fetched.outcome_correctness.is_none());
+    }
+
+    #[test]
+    fn get_prediction_missing_returns_none() {
+        let db = test_db();
+        let none = db.get_prediction("nope").unwrap();
+        assert!(none.is_none());
+    }
+
+    #[test]
+    fn update_prediction_persists_state_transition() {
+        let db = test_db();
+        let mut p = Prediction::new(fresh_input());
+        db.insert_prediction(&p).unwrap();
+        p.witness(
+            OutcomeLabel::Shipped,
+            serde_json::json!({ "actual_tokens": 1400 }),
+            Correctness::from_f64(0.95).unwrap(),
+            "2026-05-12T10:00:00+00:00",
+        )
+        .unwrap();
+        db.update_prediction(&p).unwrap();
+        let fetched = db.get_prediction(&p.id).unwrap().unwrap();
+        assert_eq!(fetched.state, PredictionState::Witnessed);
+        assert_eq!(fetched.outcome_label, Some(OutcomeLabel::Shipped));
+        assert_eq!(fetched.outcome_correctness.map(|c| c.value()), Some(0.95));
+    }
+
+    #[test]
+    fn update_prediction_missing_returns_not_found() {
+        let db = test_db();
+        let p = Prediction::new(fresh_input());
+        let err = db.update_prediction(&p).unwrap_err();
+        assert!(matches!(err, UncertaintyError::PredictionNotFound(_)));
+    }
+
+    #[test]
+    fn insert_prediction_rejects_duplicate_id() {
+        let db = test_db();
+        let p = Prediction::new(fresh_input());
+        db.insert_prediction(&p).unwrap();
+        let err = db.insert_prediction(&p).unwrap_err();
+        assert!(matches!(err, UncertaintyError::Database(_)));
+    }
+
+    #[test]
+    fn count_orphans_groups_by_surface() {
+        let db = test_db();
+        for _ in 0..3 {
+            let mut p = Prediction::new(fresh_input());
+            p.orphan("2026-05-12T10:00:00+00:00").unwrap();
+            db.insert_prediction(&p).unwrap();
+            db.update_prediction(&p).unwrap();
+        }
+        let mut other = fresh_input();
+        other.surface = "legion.review".into();
+        let mut p = Prediction::new(other);
+        p.orphan("2026-05-12T10:00:00+00:00").unwrap();
+        db.insert_prediction(&p).unwrap();
+        db.update_prediction(&p).unwrap();
+
+        let all = db.count_orphans_by_surface(None).unwrap();
+        let task_row = all.iter().find(|r| r.surface == "legion.task").unwrap();
+        let review_row = all.iter().find(|r| r.surface == "legion.review").unwrap();
+        assert_eq!(task_row.count, 3);
+        assert_eq!(review_row.count, 1);
+
+        let filtered = db.count_orphans_by_surface(Some("legion.task")).unwrap();
+        assert_eq!(filtered.len(), 1);
+        assert_eq!(filtered[0].count, 3);
+    }
+
+    #[test]
+    fn orphan_after_zero_returns_none() {
+        assert!(orphan_after_from_ttl(0).is_none());
+    }
+
+    #[test]
+    fn orphan_after_nonzero_returns_some() {
+        let s = orphan_after_from_ttl(30).unwrap();
+        // Parse round-trips through chrono cleanly.
+        let parsed = chrono::DateTime::parse_from_rfc3339(&s).unwrap();
+        assert!(parsed > chrono::Utc::now());
+    }
+
+    #[test]
+    fn list_calibration_snapshots_empty_db_returns_empty() {
+        let db = test_db();
+        let snaps = db.list_calibration_snapshots(None, None).unwrap();
+        assert!(snaps.is_empty());
+    }
+}

--- a/src/uncertainty/storage.rs
+++ b/src/uncertainty/storage.rs
@@ -112,9 +112,12 @@ impl Database {
     /// model. Ordered by `bucket_lower` ASC so a reliability diagram can
     /// render top-to-bottom.
     ///
-    /// `surface` and `model` are matched as prefixes of the cohort_key
-    /// (`<surface>:<model>:<version>:<bucket>`), so a surface-only filter
-    /// returns rows for every model under that surface.
+    /// `surface` and `model` are matched as prefixes / interior segments of
+    /// the cohort_key (`<surface>:<model>:<version>:<bucket>`). The model
+    /// filter uses `%:<model>:%` which can over-match if a future surface
+    /// or version legitimately contains a colon-bounded substring equal to
+    /// a model name. Tighten by querying against normalized columns once
+    /// the calibration roller in #359 starts producing rows at scale.
     pub fn list_calibration_snapshots(
         &self,
         surface: Option<&str>,
@@ -282,17 +285,19 @@ mod tests {
         }
     }
 
-    fn test_db() -> Database {
+    /// Build a DB on a fresh tempdir. Returns both so the caller binds the
+    /// TempDir for the test body's lifetime -- letting the handle drop would
+    /// delete the directory before the DB is done with it.
+    fn test_db() -> (tempfile::TempDir, Database) {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("test.db");
-        // Leak the tempdir so the path remains valid for the test body.
-        std::mem::forget(dir);
-        Database::open(&path).unwrap()
+        let db = Database::open(&path).unwrap();
+        (dir, db)
     }
 
     #[test]
     fn insert_and_get_prediction_round_trips() {
-        let db = test_db();
+        let (_dir, db) = test_db();
         let p = Prediction::new(fresh_input());
         db.insert_prediction(&p).unwrap();
         let fetched = db.get_prediction(&p.id).unwrap().unwrap();
@@ -305,14 +310,14 @@ mod tests {
 
     #[test]
     fn get_prediction_missing_returns_none() {
-        let db = test_db();
+        let (_dir, db) = test_db();
         let none = db.get_prediction("nope").unwrap();
         assert!(none.is_none());
     }
 
     #[test]
     fn update_prediction_persists_state_transition() {
-        let db = test_db();
+        let (_dir, db) = test_db();
         let mut p = Prediction::new(fresh_input());
         db.insert_prediction(&p).unwrap();
         p.witness(
@@ -331,7 +336,7 @@ mod tests {
 
     #[test]
     fn update_prediction_missing_returns_not_found() {
-        let db = test_db();
+        let (_dir, db) = test_db();
         let p = Prediction::new(fresh_input());
         let err = db.update_prediction(&p).unwrap_err();
         assert!(matches!(err, UncertaintyError::PredictionNotFound(_)));
@@ -339,7 +344,7 @@ mod tests {
 
     #[test]
     fn insert_prediction_rejects_duplicate_id() {
-        let db = test_db();
+        let (_dir, db) = test_db();
         let p = Prediction::new(fresh_input());
         db.insert_prediction(&p).unwrap();
         let err = db.insert_prediction(&p).unwrap_err();
@@ -348,19 +353,19 @@ mod tests {
 
     #[test]
     fn count_orphans_groups_by_surface() {
-        let db = test_db();
+        let (_dir, db) = test_db();
+        // Each prediction is constructed Emitted, transitioned to Orphaned,
+        // then inserted: the row lands with state='orphaned' directly.
         for _ in 0..3 {
             let mut p = Prediction::new(fresh_input());
             p.orphan("2026-05-12T10:00:00+00:00").unwrap();
             db.insert_prediction(&p).unwrap();
-            db.update_prediction(&p).unwrap();
         }
         let mut other = fresh_input();
         other.surface = "legion.review".into();
         let mut p = Prediction::new(other);
         p.orphan("2026-05-12T10:00:00+00:00").unwrap();
         db.insert_prediction(&p).unwrap();
-        db.update_prediction(&p).unwrap();
 
         let all = db.count_orphans_by_surface(None).unwrap();
         let task_row = all.iter().find(|r| r.surface == "legion.task").unwrap();
@@ -388,7 +393,7 @@ mod tests {
 
     #[test]
     fn list_calibration_snapshots_empty_db_returns_empty() {
-        let db = test_db();
+        let (_dir, db) = test_db();
         let snaps = db.list_calibration_snapshots(None, None).unwrap();
         assert!(snaps.is_empty());
     }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -5566,3 +5566,218 @@ fn document_create_rejects_malformed_payload() {
         "expected JSON error message, got: {stderr}"
     );
 }
+
+#[test]
+fn uncertainty_emit_writes_prediction() {
+    // #357: emit happy path. CLI returns {id, orphan_after} JSON;
+    // a follow-up calibration query against the cohort is empty (no
+    // snapshots until #359 daemon runs) but does not error.
+    let dir = tempfile::tempdir().unwrap();
+    let out = legion_cmd(dir.path())
+        .args([
+            "uncertainty",
+            "emit",
+            "--surface",
+            "legion.task",
+            "--feature-key",
+            "scip.refactor",
+            "--input-fingerprint",
+            "fp-test-1",
+            "--model",
+            "claude-opus-4-7",
+            "--model-version",
+            "4.7",
+            "--claimed-confidence",
+            "0.7",
+            "--payload",
+            r#"{"predicted_tokens":1500}"#,
+            "--orphan-ttl-days",
+            "30",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "emit failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8(out.stdout).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(stdout.trim()).unwrap();
+    assert!(parsed["id"].is_string());
+    assert!(parsed["orphan_after"].is_string());
+}
+
+#[test]
+fn uncertainty_emit_zero_ttl_means_no_orphan_window() {
+    // --orphan-ttl-days 0 disables orphan sweep for that row.
+    let dir = tempfile::tempdir().unwrap();
+    let out = legion_cmd(dir.path())
+        .args([
+            "uncertainty",
+            "emit",
+            "--surface",
+            "legion.task",
+            "--feature-key",
+            "scip.refactor",
+            "--input-fingerprint",
+            "fp-test-2",
+            "--model",
+            "claude-opus-4-7",
+            "--model-version",
+            "4.7",
+            "--claimed-confidence",
+            "0.7",
+            "--payload",
+            r#"{}"#,
+            "--orphan-ttl-days",
+            "0",
+        ])
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+    let stdout = String::from_utf8(out.stdout).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(stdout.trim()).unwrap();
+    assert!(parsed["orphan_after"].is_null());
+}
+
+#[test]
+fn uncertainty_emit_invalid_confidence_is_nonblocking() {
+    // Emit is non-blocking by design: caller errors surface on stderr
+    // but exit 0 so an upstream hook can never break the agent.
+    let dir = tempfile::tempdir().unwrap();
+    let out = legion_cmd(dir.path())
+        .args([
+            "uncertainty",
+            "emit",
+            "--surface",
+            "legion.task",
+            "--feature-key",
+            "scip.refactor",
+            "--input-fingerprint",
+            "fp-test-3",
+            "--model",
+            "claude-opus-4-7",
+            "--model-version",
+            "4.7",
+            "--claimed-confidence",
+            "1.5",
+            "--payload",
+            r#"{}"#,
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "emit must exit 0 even on validation error"
+    );
+    let stderr = String::from_utf8(out.stderr).unwrap();
+    assert!(
+        stderr.contains("claimed_confidence"),
+        "expected error on stderr, got: {stderr}"
+    );
+}
+
+#[test]
+fn uncertainty_witness_advances_state() {
+    // Emit a prediction, witness it, then verify the row state advanced.
+    let dir = tempfile::tempdir().unwrap();
+    let emit = legion_cmd(dir.path())
+        .args([
+            "uncertainty",
+            "emit",
+            "--surface",
+            "legion.task",
+            "--feature-key",
+            "scip.refactor",
+            "--input-fingerprint",
+            "fp-w-1",
+            "--model",
+            "claude-opus-4-7",
+            "--model-version",
+            "4.7",
+            "--claimed-confidence",
+            "0.7",
+            "--payload",
+            r#"{"predicted_tokens":1000}"#,
+        ])
+        .output()
+        .unwrap();
+    let emit_out: serde_json::Value =
+        serde_json::from_str(String::from_utf8(emit.stdout).unwrap().trim()).unwrap();
+    let id = emit_out["id"].as_str().unwrap();
+
+    let witness = legion_cmd(dir.path())
+        .args([
+            "uncertainty",
+            "witness",
+            id,
+            "--outcome-label",
+            "shipped",
+            "--outcome-correctness",
+            "0.95",
+            "--payload",
+            r#"{"actual_tokens":950}"#,
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        witness.status.success(),
+        "witness failed: {}",
+        String::from_utf8_lossy(&witness.stderr)
+    );
+    let stdout = String::from_utf8(witness.stdout).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(stdout.trim()).unwrap();
+    assert_eq!(parsed["state"], "witnessed");
+    assert!(parsed["witnessed_at"].is_string());
+}
+
+#[test]
+fn uncertainty_witness_missing_id_fails() {
+    let dir = tempfile::tempdir().unwrap();
+    let out = legion_cmd(dir.path())
+        .args([
+            "uncertainty",
+            "witness",
+            "does-not-exist",
+            "--outcome-label",
+            "shipped",
+            "--outcome-correctness",
+            "0.9",
+        ])
+        .output()
+        .unwrap();
+    assert!(!out.status.success(), "missing id must error");
+    let stderr = String::from_utf8(out.stderr).unwrap();
+    assert!(
+        stderr.contains("prediction not found") || stderr.contains("does-not-exist"),
+        "expected not-found error, got: {stderr}"
+    );
+}
+
+#[test]
+fn uncertainty_orphans_empty_initially() {
+    let dir = tempfile::tempdir().unwrap();
+    let out = legion_cmd(dir.path())
+        .args(["uncertainty", "orphans", "--json"])
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+    let stdout = String::from_utf8(out.stdout).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(stdout.trim()).unwrap();
+    let arr = parsed.as_array().unwrap();
+    assert!(arr.is_empty());
+}
+
+#[test]
+fn uncertainty_calibration_empty_initially() {
+    let dir = tempfile::tempdir().unwrap();
+    let out = legion_cmd(dir.path())
+        .args(["uncertainty", "calibration", "--json"])
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+    let stdout = String::from_utf8(out.stdout).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(stdout.trim()).unwrap();
+    let arr = parsed.as_array().unwrap();
+    assert!(arr.is_empty());
+}


### PR DESCRIPTION
## Summary

Third child of #354 -- the four-verb CLI surface mirroring platform's uncertainty HTTP API. Stacks on PR #471 (schema) and PR #472 (types).

| Verb | Posture | Output |
|---|---|---|
| `emit` | **Non-blocking** -- validation, insert, serialize, and stdout failures all log to stderr but exit 0 so an upstream hook can never break the agent | `{id, orphan_after}` JSON on stdout |
| `witness` | Error-on-failure -- explicit user action | `{id, state, witnessed_at}` JSON on stdout |
| `calibration` | Error-on-failure -- explicit user action | Reliability buckets (text or `--json`) |
| `orphans` | Error-on-failure -- explicit user action | Surface-grouped counts (text or `--json`) |

### Storage layer

New `src/uncertainty/storage.rs` bridges `db::Database` to the domain types:
- `insert_prediction`, `get_prediction` (type-aware: `claimed_confidence` and `outcome_correctness` rehydrate through the newtype constructors so the [0, 1] guarantee survives storage round-trips)
- `update_prediction` (returns `PredictionNotFound` when the id is missing)
- `list_calibration_snapshots` (prefix-matches `cohort_key` for surface+model filters; doc-flagged as fuzzy until the #359 calibration roller produces enough data to need tightening)
- `count_orphans_by_surface`
- `orphan_after_from_ttl` helper used at the emit boundary

### Tests

- **9 storage unit tests**: CRUD round-trip happy path, missing-id None, missing-id UPDATE returns PredictionNotFound, duplicate insert errors, orphan grouping by surface (filtered + unfiltered), `orphan_after_from_ttl` 0 vs non-zero, empty calibration list.
- **7 CLI integration tests**: emit returns `{id, orphan_after}` JSON, `--orphan-ttl-days 0` nulls `orphan_after`, invalid `--claimed-confidence 1.5` is non-blocking (exit 0 + stderr message), witness advances state with `witnessed_at`, witness on missing id errors with not-found message, orphans + calibration return empty JSON arrays initially.

36 uncertainty tests total across the module.

### Acceptance criteria

- [x] All four subcommands functional, with `--json` flag where applicable
- [x] Non-blocking emit: writes failures log to stderr but exit 0
- [x] cargo test covers each subcommand happy + error paths
- [x] legion --help lists 'uncertainty' under top-level commands
- [x] cargo clippy --all-targets -- -D warnings clean
- [x] cargo fmt -- --check clean
- [x] No unwrap() in production code

Refs #354. Builds on #355 (PR #471) and #356 (PR #472). Unblocks #358 (auto-emit + auto-witness hooks).