### PR TITLE
fix(#478): pre-whoami-rewrite hook

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,12 +57,13 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
-      # On Windows the runner image sometimes leaves rustup-init.exe in
-      # PATH ahead of cargo, so `cargo test` parses as `rustup-init test`
-      # and fails before the suite runs. Forcing the default toolchain
-      # ensures cargo resolves regardless of PATH order. Idempotent on
-      # ubuntu / macos.
-      - run: rustup default stable
+      # Windows runner image sometimes leaves rustup-init.exe in PATH
+      # ahead of cargo, so `cargo test` parses as `rustup-init test` and
+      # fails before the suite runs. Forcing the default toolchain on
+      # Windows only -- the dtolnay action may install rustc without
+      # rustup on macOS, where this step would fail with command-not-found.
+      - if: runner.os == 'Windows'
+        run: rustup default stable
         shell: bash
       - uses: Swatinem/rust-cache@v2
       - run: cargo test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,5 +57,12 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
+      # On Windows the runner image sometimes leaves rustup-init.exe in
+      # PATH ahead of cargo, so `cargo test` parses as `rustup-init test`
+      # and fails before the suite runs. Forcing the default toolchain
+      # ensures cargo resolves regardless of PATH order. Idempotent on
+      # ubuntu / macos.
+      - run: rustup default stable
+        shell: bash
       - uses: Swatinem/rust-cache@v2
       - run: cargo test

--- a/plugin/hooks/hooks.json
+++ b/plugin/hooks/hooks.json
@@ -128,6 +128,11 @@
             "type": "command",
             "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/pre-bash-grep.sh",
             "timeout": 6
+          },
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/pre-whoami-rewrite.sh",
+            "timeout": 5
           }
         ]
       },

--- a/plugin/hooks/pre-whoami-rewrite.sh
+++ b/plugin/hooks/pre-whoami-rewrite.sh
@@ -1,0 +1,105 @@
+#!/bin/bash
+# Legion PreToolUse Bash hook: guard against agents replacing their identity
+# reflection without deliberate intent.
+#
+# Agents have been treating `legion reflect --whoami` like a CLAUDE.md edit
+# -- stuffing architecture rules, file paths, and build commands into the
+# identity domain. That bloats the SessionStart banner past its 2K budget
+# and crowds out real identity (role, voice, doctrine).
+#
+# Two failure modes the hook fights:
+# 1. Rewriting the whole banner as one blob instead of chaining beats via
+#    --follows <prev-id> -- which preserves the history and lets the banner
+#    show the latest beat while older context stays recall-findable.
+# 2. Storing project knowledge (rules, paths, commands) as identity. That
+#    content belongs as a regular reflection -- recall + consult will
+#    surface it when relevant.
+#
+# When the agent runs `legion reflect --whoami` (or `--domain identity`)
+# AND an identity already exists for the repo AND the command does NOT
+# carry --force or --follows, the hook blocks with the current identity
+# inline so the agent re-reads who they are before replacing it.
+#
+# Bypass paths (the only legitimate continuations):
+# - --follows <prev-id>: chain a new identity beat onto the existing one.
+# - --force: explicit acknowledgment that this is a full rewrite.
+
+set -u
+
+INPUT=$(cat)
+
+if ! command -v jq >/dev/null 2>&1; then
+  exit 0
+fi
+
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
+if [ -z "$COMMAND" ]; then
+  exit 0
+fi
+
+# Trigger only on legion reflect calls that set the identity domain. Match
+# the basename pattern (catches /opt/homebrew/bin/legion too) so the same
+# bypass that hit no-gh cannot slip past here.
+TRIMMED="${COMMAND#"${COMMAND%%[![:space:]]*}"}"
+FIRST_TOKEN="${TRIMMED%%[[:space:]]*}"
+FIRST_BIN="${FIRST_TOKEN##*/}"
+if [ "$FIRST_BIN" != "legion" ]; then
+  exit 0
+fi
+
+case "$COMMAND" in
+  *"reflect"*"--whoami"*) ;;
+  *"reflect"*"--domain"*"identity"*) ;;
+  *) exit 0 ;;
+esac
+
+# Bypass: explicit --force or --follows is the right shape -- agent
+# already signaled intent.
+case "$COMMAND" in
+  *"--force"*|*"--follows"*) exit 0 ;;
+esac
+
+# Extract --repo argument so we can ask the right repo's identity.
+REPO=$(echo "$COMMAND" | sed -nE 's/.*--repo[= ]+([A-Za-z0-9_,.\/-]+).*/\1/p' | head -n1)
+if [ -z "$REPO" ]; then
+  exit 0
+fi
+# Compound repo (a,b,c) -- check the first one for an existing identity.
+REPO="${REPO%%,*}"
+
+LEGION_BIN="${LEGION_BIN:-legion}"
+if ! command -v "$LEGION_BIN" >/dev/null 2>&1; then
+  exit 0
+fi
+
+EXISTING=$("$LEGION_BIN" whoami --repo "$REPO" 2>/dev/null)
+if [ -z "$EXISTING" ]; then
+  exit 0
+fi
+# whoami output always carries the header. Count the body lines; if the
+# only content is the header, no identity exists yet and the rewrite is
+# the first-time setup -- allow it.
+BODY_LINES=$(echo "$EXISTING" | grep -cvE '^=== WHO YOU ARE|^\[Legion\] Identity|^$')
+if [ "$BODY_LINES" -lt 1 ]; then
+  exit 0
+fi
+
+REASON=$(printf '%s\n%s\n\n%s\n\n%s\n\n%s\n' \
+  "You're about to rewrite your identity reflection. Read who you are first:" \
+  "" \
+  "--- Current identity (would be replaced) ---" \
+  "$EXISTING" \
+  "--- End ---
+Have you grown out of this?
+
+- If yes -- you're genuinely evolving your role, voice, or doctrine -- pick the right shape:
+  - Preferred: chain a new beat with --follows <prev-id>. The banner shows the latest beat; older history stays recall-findable. Get the prev-id with: legion recall --repo $REPO --domain identity --limit 1
+  - Full rewrite: re-run with --force. Old identity becomes the previous link in the chain, banner replaced wholesale.
+- If your text is project knowledge (architecture rules, file paths, build commands, naming conventions): drop --whoami. Store as a regular reflection:
+    legion reflect --repo $REPO --text \"...\"
+  Recall + consult will surface it when relevant. The 2K SessionStart banner only fits role/voice/doctrine; project rules crowd it out.")
+
+jq -n --arg reason "$REASON" '{
+  "decision": "block",
+  "reason": $reason
+}'

--- a/plugin/hooks/test-pre-whoami-rewrite.sh
+++ b/plugin/hooks/test-pre-whoami-rewrite.sh
@@ -1,0 +1,122 @@
+#!/bin/bash
+# Test runner for the pre-whoami-rewrite PreToolUse hook.
+#
+# Stubs the legion binary to control whether an identity "exists" so we
+# can exercise the block + bypass paths. Run from the repo root:
+#
+#   bash plugin/hooks/test-pre-whoami-rewrite.sh
+
+set -u
+
+PASS=0
+FAIL=0
+
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+
+mkdir -p "$WORK/plugin/bin" "$WORK/plugin/hooks"
+cp plugin/hooks/pre-whoami-rewrite.sh "$WORK/plugin/hooks/"
+
+# Stub legion: switches behaviour on $LEGION_TEST_HAS_IDENTITY.
+cat > "$WORK/plugin/bin/legion" <<'EOF'
+#!/bin/bash
+if [ "$1" = "whoami" ]; then
+  if [ "${LEGION_TEST_HAS_IDENTITY:-0}" = "1" ]; then
+    echo "=== WHO YOU ARE -- READ THIS ==="
+    echo "[Legion] Identity for test:"
+    echo "- I am the test agent. I do test things."
+    echo ""
+    echo "DECISION ORDER: do the right thing."
+    exit 0
+  fi
+  echo "=== WHO YOU ARE -- READ THIS ==="
+  echo "[Legion] Identity for test:"
+  exit 0
+fi
+exit 0
+EOF
+chmod +x "$WORK/plugin/bin/legion"
+
+export PATH="$WORK/plugin/bin:$PATH"
+export CLAUDE_PLUGIN_ROOT="$WORK/plugin"
+export LEGION_BIN="$WORK/plugin/bin/legion"
+
+HOOK="$WORK/plugin/hooks/pre-whoami-rewrite.sh"
+
+run_hook() {
+  local cmd="$1"
+  printf '%s' "{\"tool_input\":{\"command\":${cmd}}}" | bash "$HOOK"
+}
+
+assert_blocked() {
+  local desc="$1" cmd="$2"
+  local out
+  out=$(LEGION_TEST_HAS_IDENTITY=1 run_hook "$cmd")
+  if echo "$out" | grep -q '"decision":[[:space:]]*"block"'; then
+    PASS=$((PASS + 1))
+    echo "  PASS: $desc"
+  else
+    FAIL=$((FAIL + 1))
+    echo "  FAIL: $desc" >&2
+    echo "    cmd: $cmd" >&2
+    echo "    out: $out" >&2
+  fi
+}
+
+assert_allowed() {
+  local desc="$1" cmd="$2" has_id="${3:-1}"
+  local out
+  out=$(LEGION_TEST_HAS_IDENTITY=$has_id run_hook "$cmd")
+  if echo "$out" | grep -q '"decision":[[:space:]]*"block"'; then
+    FAIL=$((FAIL + 1))
+    echo "  FAIL: $desc (expected allow, got block)" >&2
+    echo "    cmd: $cmd" >&2
+  else
+    PASS=$((PASS + 1))
+    echo "  PASS: $desc"
+  fi
+}
+
+echo "==> blocks whoami rewrite when identity already exists"
+assert_blocked "bare --whoami rewrite" \
+  '"legion reflect --whoami --repo test --text \"new id\""'
+assert_blocked "absolute-path legion" \
+  '"/opt/homebrew/bin/legion reflect --whoami --repo test --text \"new id\""'
+assert_blocked "--domain identity equivalent" \
+  '"legion reflect --domain identity --repo test --text \"new id\""'
+
+echo "==> allows when --force is set"
+assert_allowed "--force bypass" \
+  '"legion reflect --whoami --force --repo test --text \"new id\""'
+
+echo "==> allows when --follows is set"
+assert_allowed "--follows bypass" \
+  '"legion reflect --whoami --follows 019abc --repo test --text \"new beat\""'
+
+echo "==> allows first-time identity (no existing whoami)"
+assert_allowed "first-time setup" \
+  '"legion reflect --whoami --repo test --text \"initial id\""' \
+  "0"
+
+echo "==> ignores non-reflect legion commands"
+assert_allowed "recall is not reflect" \
+  '"legion recall --repo test --context foo"'
+assert_allowed "kanban is not reflect" \
+  '"legion kanban list --repo test"'
+
+echo "==> ignores reflect without identity domain"
+assert_allowed "regular reflect with no domain" \
+  '"legion reflect --repo test --text \"a project lesson\""'
+assert_allowed "reflect with non-identity domain" \
+  '"legion reflect --domain checkpoint --repo test --text \"x\""'
+
+echo "==> ignores commands not starting with legion"
+assert_allowed "git command" \
+  '"git status"'
+assert_allowed "echo mentions legion reflect --whoami" \
+  '"echo legion reflect --whoami --repo test"'
+
+echo
+echo "PASS: $PASS"
+echo "FAIL: $FAIL"
+[ "$FAIL" -eq 0 ] || exit 1


### PR DESCRIPTION
## Summary

Closes #478. New PreToolUse Bash hook intercepts \`legion reflect --whoami\` (and \`--domain identity\`). When the repo already has an identity AND the command lacks \`--force\` / \`--follows\`, blocks with the current identity inline. Forces the agent to read who they are before replacing it; redirects to the right shape (chain, full-rewrite with --force, or drop --whoami if it's project knowledge).

Same basename-match pattern as the no-gh fix in #477 -- absolute-path invocations cannot slip past.

## Bypass paths

- \`--follows <prev-id>\` -- chain a new beat (preferred)
- \`--force\` -- explicit wholesale replacement

## Test plan

- [x] 12-case test runner \`plugin/hooks/test-pre-whoami-rewrite.sh\` covers: bare invocation, absolute-path, --domain identity equivalent, --force bypass, --follows bypass, first-time setup, non-reflect commands, non-legion commands, echoed strings
- [x] shellcheck clean on hook + test runner
- [x] hooks.json validates as JSON