### PR TITLE
fix(#441): detect pnpm/yarn workspaces for scip-typescript

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
     {
       "name": "legion",
       "description": "Agent memory layer with recall, reflect, consult, bullpen, and cross-agent coordination. Includes health monitoring and auto-wake. Hooks wire legion into every session automatically.",
-      "version": "0.15.0",
+      "version": "0.15.1",
       "author": {
         "name": "Sean Silvius",
         "email": "sean@silvius.me"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1444,7 +1444,7 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "legion"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "async-stream",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "legion"
-version = "0.15.0"
+version = "0.15.1"
 edition = "2024"
 description = "Agent specialization through deliberate practice"
 

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "legion",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "description": "Institutional memory for Claude Code agents with real-time team channel.",
   "author": {
     "name": "Sean Silvius",

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Legion Changelog
 
+## 0.15.1
+
+Patch release. Closes a long-standing silent failure in the TypeScript SCIP indexer that returned `[]` for any symbol defined in a pnpm/yarn workspace package, masking real symbols as nonexistent and degrading every `legion sym def/refs` query on monorepos.
+
+### Fixed
+
+- **scip-typescript skips workspace packages on monorepos** (PR #483, closes #441 / #482): `run_scip_typescript` invoked `scip-typescript index` without `--pnpm-workspaces` / `--yarn-workspaces`, so the indexer honored only the root tsconfig's `include` set. On a typical monorepo with a narrow root tsconfig that produced an effectively empty index -- rafters' root had `include: ["test/**/*"]` and got a 51KB blob with zero symbols in `packages/*`; the same repo with the flag indexed 18MB across 13 workspaces. `legion sym def TokenRegistry` and friends silently returned `[]`, and agents concluded the symbol did not exist rather than recognizing an indexer gap. Fix: new `detect_ts_workspace_flavor` inspects `repo_path` for a workspace marker -- `pnpm-workspace.yaml` -> `--pnpm-workspaces`, `package.json` with a `workspaces` field (array or object) -> `--yarn-workspaces`, otherwise no extra flag. pnpm wins precedence when both files exist, matching pnpm's own resolution; malformed `package.json` falls through to the no-flag path so the indexer still runs. Argv selection is split into `scip_typescript_args` and pinned by a unit test so a silent rename of the scip-typescript CLI flag would not reproduce the same gap with no test failure. 8 new unit tests cover every detection branch.
+
 ## 0.15.0
 
 Pillar 2 ships -- the uncertainty engine. v0.14.0 made agents coordinate around work-genesis (documents, plans, sub-issues); v0.15.0 makes them predict cost and learn from outcomes. Every task the agent takes on emits a calibrated prediction; the witness path closes the loop when work completes. Vault-COS routing gains live cost estimates instead of static lookups. Two enforcement-hardening fixes ride along.

--- a/src/scip.rs
+++ b/src/scip.rs
@@ -214,16 +214,25 @@ fn detect_ts_workspace_flavor(repo_path: &Path) -> TsWorkspaceFlavor {
     TsWorkspaceFlavor::None
 }
 
+/// Map a workspace flavor to the scip-typescript argv. Split out so a unit
+/// test can pin the flag names: a silent rename in scip-typescript (or a
+/// typo introduced here) would otherwise only surface as another empty
+/// index in production. The flags are part of scip-typescript's public CLI
+/// contract (`scip-typescript index --help`).
+fn scip_typescript_args(flavor: TsWorkspaceFlavor) -> &'static [&'static str] {
+    match flavor {
+        TsWorkspaceFlavor::Pnpm => &["index", "--pnpm-workspaces"],
+        TsWorkspaceFlavor::Yarn => &["index", "--yarn-workspaces"],
+        TsWorkspaceFlavor::None => &["index"],
+    }
+}
+
 /// Invoke `scip-typescript index` against `repo_path`. Canonical TS/JS
 /// indexer from sourcegraph (`npm i -g @sourcegraph/scip-typescript`).
 /// No fallback exists; tsserver is too slow and shape-incompatible to
 /// substitute.
 fn run_scip_typescript(repo_path: &Path) -> Result<Vec<u8>> {
-    let args: &[&str] = match detect_ts_workspace_flavor(repo_path) {
-        TsWorkspaceFlavor::Pnpm => &["index", "--pnpm-workspaces"],
-        TsWorkspaceFlavor::Yarn => &["index", "--yarn-workspaces"],
-        TsWorkspaceFlavor::None => &["index"],
-    };
+    let args = scip_typescript_args(detect_ts_workspace_flavor(repo_path));
     run_indexer_binary("typescript", "scip-typescript", args, repo_path).map_err(|e| match e {
         LegionError::IndexerNotFound { lang, .. } => LegionError::IndexerNotFound {
             lang,
@@ -747,6 +756,24 @@ mod tests {
             detect_ts_workspace_flavor(dir.path()),
             TsWorkspaceFlavor::None
         );
+    }
+
+    /// Pin the scip-typescript flag names. The fix for #441 is one strcmp
+    /// away from silently regressing if a future refactor renames one of
+    /// these flags or drops the `--` prefix -- the production symptom is
+    /// the same empty-index gap we're closing here, with no test failure
+    /// to catch it. Lock the contract in one place.
+    #[test]
+    fn scip_typescript_args_pins_flag_names_per_flavor() {
+        assert_eq!(
+            scip_typescript_args(TsWorkspaceFlavor::Pnpm),
+            ["index", "--pnpm-workspaces"]
+        );
+        assert_eq!(
+            scip_typescript_args(TsWorkspaceFlavor::Yarn),
+            ["index", "--yarn-workspaces"]
+        );
+        assert_eq!(scip_typescript_args(TsWorkspaceFlavor::None), ["index"]);
     }
 
     /// Pin the dispatch table: each supported lang tag must route to a helper

--- a/src/scip.rs
+++ b/src/scip.rs
@@ -173,21 +173,64 @@ fn rust_install_hint(e: LegionError) -> LegionError {
     }
 }
 
+/// TypeScript workspace flavor detected at the repo root. Drives the
+/// `--pnpm-workspaces` / `--yarn-workspaces` flag that scip-typescript
+/// needs to walk a monorepo instead of honoring only the root tsconfig's
+/// narrow `include`.
+#[derive(Debug, PartialEq, Eq)]
+enum TsWorkspaceFlavor {
+    Pnpm,
+    Yarn,
+    None,
+}
+
+/// Inspect `repo_path` root for a workspace marker.
+///
+/// Precedence:
+/// - `pnpm-workspace.yaml` present -> Pnpm (matches pnpm's own resolution
+///   order: if the file exists, pnpm treats the repo as a pnpm workspace
+///   regardless of what `package.json` says)
+/// - `package.json` parses and contains a `workspaces` field (array or
+///   object form, both yarn and npm shape) -> Yarn
+/// - otherwise -> None
+///
+/// Without one of the workspace flags, scip-typescript honors only the
+/// root tsconfig's `include` set. On a typical monorepo with a narrow
+/// root tsconfig that produces an effectively empty index (rafters root
+/// `include: ["test/**/*"]` -> 51KB blob with no `packages/*` symbols;
+/// `scip-typescript index --pnpm-workspaces` from the same root -> 18MB
+/// covering 13 workspaces). See #441.
+fn detect_ts_workspace_flavor(repo_path: &Path) -> TsWorkspaceFlavor {
+    if repo_path.join("pnpm-workspace.yaml").is_file() {
+        return TsWorkspaceFlavor::Pnpm;
+    }
+    let pkg_json = repo_path.join("package.json");
+    if let Ok(bytes) = std::fs::read(&pkg_json)
+        && let Ok(value) = serde_json::from_slice::<serde_json::Value>(&bytes)
+        && value.get("workspaces").is_some()
+    {
+        return TsWorkspaceFlavor::Yarn;
+    }
+    TsWorkspaceFlavor::None
+}
+
 /// Invoke `scip-typescript index` against `repo_path`. Canonical TS/JS
 /// indexer from sourcegraph (`npm i -g @sourcegraph/scip-typescript`).
 /// No fallback exists; tsserver is too slow and shape-incompatible to
 /// substitute.
 fn run_scip_typescript(repo_path: &Path) -> Result<Vec<u8>> {
-    run_indexer_binary("typescript", "scip-typescript", &["index"], repo_path).map_err(
-        |e| match e {
-            LegionError::IndexerNotFound { lang, .. } => LegionError::IndexerNotFound {
-                lang,
-                binary: "scip-typescript (install: npm i -g @sourcegraph/scip-typescript)"
-                    .to_string(),
-            },
-            other => other,
+    let args: &[&str] = match detect_ts_workspace_flavor(repo_path) {
+        TsWorkspaceFlavor::Pnpm => &["index", "--pnpm-workspaces"],
+        TsWorkspaceFlavor::Yarn => &["index", "--yarn-workspaces"],
+        TsWorkspaceFlavor::None => &["index"],
+    };
+    run_indexer_binary("typescript", "scip-typescript", args, repo_path).map_err(|e| match e {
+        LegionError::IndexerNotFound { lang, .. } => LegionError::IndexerNotFound {
+            lang,
+            binary: "scip-typescript (install: npm i -g @sourcegraph/scip-typescript)".to_string(),
         },
-    )
+        other => other,
+    })
 }
 
 /// Invoke `scip-python index .` against `repo_path`. Canonical Python
@@ -604,6 +647,106 @@ mod tests {
         let dir = TempDir::new().unwrap();
         fs::write(dir.path().join("README.md"), "hi").unwrap();
         assert!(detect_languages(dir.path()).is_empty());
+    }
+
+    #[test]
+    fn detect_ts_workspace_flavor_pnpm_for_yaml_marker() {
+        let dir = TempDir::new().unwrap();
+        fs::write(
+            dir.path().join("pnpm-workspace.yaml"),
+            "packages:\n  - 'packages/*'\n",
+        )
+        .unwrap();
+        assert_eq!(
+            detect_ts_workspace_flavor(dir.path()),
+            TsWorkspaceFlavor::Pnpm
+        );
+    }
+
+    #[test]
+    fn detect_ts_workspace_flavor_yarn_for_workspaces_array() {
+        let dir = TempDir::new().unwrap();
+        fs::write(
+            dir.path().join("package.json"),
+            r#"{"name":"x","workspaces":["packages/*","apps/*"]}"#,
+        )
+        .unwrap();
+        assert_eq!(
+            detect_ts_workspace_flavor(dir.path()),
+            TsWorkspaceFlavor::Yarn
+        );
+    }
+
+    #[test]
+    fn detect_ts_workspace_flavor_yarn_for_workspaces_object() {
+        let dir = TempDir::new().unwrap();
+        fs::write(
+            dir.path().join("package.json"),
+            r#"{"name":"x","workspaces":{"packages":["packages/*"],"nohoist":["**/react-native"]}}"#,
+        )
+        .unwrap();
+        assert_eq!(
+            detect_ts_workspace_flavor(dir.path()),
+            TsWorkspaceFlavor::Yarn
+        );
+    }
+
+    #[test]
+    fn detect_ts_workspace_flavor_none_for_package_json_without_workspaces() {
+        let dir = TempDir::new().unwrap();
+        fs::write(
+            dir.path().join("package.json"),
+            r#"{"name":"x","version":"1.0.0"}"#,
+        )
+        .unwrap();
+        assert_eq!(
+            detect_ts_workspace_flavor(dir.path()),
+            TsWorkspaceFlavor::None
+        );
+    }
+
+    #[test]
+    fn detect_ts_workspace_flavor_none_when_no_markers() {
+        let dir = TempDir::new().unwrap();
+        assert_eq!(
+            detect_ts_workspace_flavor(dir.path()),
+            TsWorkspaceFlavor::None
+        );
+    }
+
+    /// Pnpm marker wins when both files exist. Matches pnpm's own resolution:
+    /// `pnpm-workspace.yaml` makes the repo a pnpm workspace regardless of
+    /// what package.json declares.
+    #[test]
+    fn detect_ts_workspace_flavor_pnpm_wins_over_package_json_workspaces() {
+        let dir = TempDir::new().unwrap();
+        fs::write(
+            dir.path().join("pnpm-workspace.yaml"),
+            "packages:\n  - 'packages/*'\n",
+        )
+        .unwrap();
+        fs::write(
+            dir.path().join("package.json"),
+            r#"{"name":"x","workspaces":["packages/*"]}"#,
+        )
+        .unwrap();
+        assert_eq!(
+            detect_ts_workspace_flavor(dir.path()),
+            TsWorkspaceFlavor::Pnpm
+        );
+    }
+
+    /// Malformed package.json must not panic or fail indexing -- fall through
+    /// to None so scip-typescript still runs (it'll surface its own JSON
+    /// parse error if the file is actually broken for tsc too).
+    #[test]
+    fn detect_ts_workspace_flavor_none_for_malformed_package_json() {
+        let dir = TempDir::new().unwrap();
+        fs::write(dir.path().join("package.json"), "not json at all {{{").unwrap();
+        assert_eq!(
+            detect_ts_workspace_flavor(dir.path()),
+            TsWorkspaceFlavor::None
+        );
     }
 
     /// Pin the dispatch table: each supported lang tag must route to a helper


### PR DESCRIPTION
Closes #441 (and #482, refiled today as a duplicate).

## Problem

`scip-typescript index` without `--pnpm-workspaces` / `--yarn-workspaces` honors only the root `tsconfig.json`'s `include` set. On a typical monorepo with a narrow root tsconfig that produces an effectively empty index. `legion sym def X` then silently returns `[]` for any symbol defined in `packages/*` / `apps/*`, and agents conclude the symbol doesn't exist rather than recognizing an indexer gap.

Measured on rafters (root `include: ["test/**/*"]`):
- before: 51KB blob, 0 symbols in `packages/*`
- after (`scip-typescript index --pnpm-workspaces`): 18MB across 13 workspaces

## Fix

`run_scip_typescript` now inspects `repo_path` for a workspace marker:

- `pnpm-workspace.yaml` present -> `--pnpm-workspaces`
- `package.json` parses with a `workspaces` field (array or object) -> `--yarn-workspaces`
- otherwise -> no extra flag (single-package repo, current behavior)

pnpm wins precedence when both files exist, matching pnpm's own resolution order. Malformed `package.json` falls through to the no-flag path so the indexer still runs (scip-typescript surfaces the parse error itself if tsc can't read it either).

Argv selection is split out into `scip_typescript_args` so a small table test pins each flavor -> exact flag string. A silent rename of the scip-typescript CLI flag would otherwise reproduce the same empty-index gap with no test failure.

## Tests

Seven new unit tests in `scip.rs::tests`:

- `detect_ts_workspace_flavor_pnpm_for_yaml_marker`
- `detect_ts_workspace_flavor_yarn_for_workspaces_array`
- `detect_ts_workspace_flavor_yarn_for_workspaces_object`
- `detect_ts_workspace_flavor_none_for_package_json_without_workspaces`
- `detect_ts_workspace_flavor_none_when_no_markers`
- `detect_ts_workspace_flavor_pnpm_wins_over_package_json_workspaces`
- `detect_ts_workspace_flavor_none_for_malformed_package_json`
- `scip_typescript_args_pins_flag_names_per_flavor`

cargo test (752 + 143), cargo clippy -- -D warnings, cargo fmt --check all green. legion-simplify clean on both commits.

## Test plan

- [x] cargo test
- [x] cargo clippy -- -D warnings
- [x] cargo fmt -- --check
- [x] legion-simplify gate clean
- [ ] Verify on rafters: \`legion index rafters && legion sym def TokenRegistry --repo rafters\` returns non-empty