### PR TITLE
feat(#484): watch panic-stop on subscription-quota exhaustion

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -98,6 +98,26 @@ fn map_reflection_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<Reflection> {
     })
 }
 
+/// Map a database row to a RateLimitSample struct. Shared by every query
+/// that selects the canonical column order
+/// (id, hostname, session_id, sampled_at, five_hour_pct, five_hour_resets_at,
+///  seven_day_pct, seven_day_resets_at, model).
+fn map_rate_limit_sample_row(
+    row: &rusqlite::Row<'_>,
+) -> rusqlite::Result<crate::statusline::RateLimitSample> {
+    Ok(crate::statusline::RateLimitSample {
+        id: row.get(0)?,
+        hostname: row.get(1)?,
+        session_id: row.get(2)?,
+        sampled_at: row.get(3)?,
+        five_hour_pct: row.get(4)?,
+        five_hour_resets_at: row.get(5)?,
+        seven_day_pct: row.get(6)?,
+        seven_day_resets_at: row.get(7)?,
+        model: row.get(8)?,
+    })
+}
+
 /// Map a database row to a Schedule struct.
 fn map_schedule_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<Schedule> {
     let enabled_int: i32 = row.get(5)?;
@@ -3305,17 +3325,27 @@ impl Database {
         )?;
         let mut rows = stmt.query([])?;
         match rows.next().map_err(LegionError::Database)? {
-            Some(row) => Ok(Some(crate::statusline::RateLimitSample {
-                id: row.get(0)?,
-                hostname: row.get(1)?,
-                session_id: row.get(2)?,
-                sampled_at: row.get(3)?,
-                five_hour_pct: row.get(4)?,
-                five_hour_resets_at: row.get(5)?,
-                seven_day_pct: row.get(6)?,
-                seven_day_resets_at: row.get(7)?,
-                model: row.get(8)?,
-            })),
+            Some(row) => Ok(Some(map_rate_limit_sample_row(row)?)),
+            None => Ok(None),
+        }
+    }
+
+    /// Most recent rate-limit sample for a single host. Used by the watch
+    /// quota-panic gate, which only cares about THIS node's headroom --
+    /// a peer node hitting its cap should not gate this node's spawns.
+    pub fn latest_rate_limit_sample_for_host(
+        &self,
+        hostname: &str,
+    ) -> Result<Option<crate::statusline::RateLimitSample>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT id, hostname, session_id, sampled_at, five_hour_pct, \
+             five_hour_resets_at, seven_day_pct, seven_day_resets_at, model \
+             FROM rate_limit_samples WHERE deleted_at IS NULL AND hostname = ?1 \
+             ORDER BY sampled_at DESC LIMIT 1",
+        )?;
+        let mut rows = stmt.query(rusqlite::params![hostname])?;
+        match rows.next().map_err(LegionError::Database)? {
+            Some(row) => Ok(Some(map_rate_limit_sample_row(row)?)),
             None => Ok(None),
         }
     }
@@ -3354,19 +3384,7 @@ impl Database {
              WHERE rn = 1 \
              ORDER BY hostname",
         )?;
-        let rows = stmt.query_map([], |row| {
-            Ok(crate::statusline::RateLimitSample {
-                id: row.get(0)?,
-                hostname: row.get(1)?,
-                session_id: row.get(2)?,
-                sampled_at: row.get(3)?,
-                five_hour_pct: row.get(4)?,
-                five_hour_resets_at: row.get(5)?,
-                seven_day_pct: row.get(6)?,
-                seven_day_resets_at: row.get(7)?,
-                model: row.get(8)?,
-            })
-        })?;
+        let rows = stmt.query_map([], map_rate_limit_sample_row)?;
         let mut out = Vec::new();
         for row in rows {
             out.push(row?);

--- a/src/watch.rs
+++ b/src/watch.rs
@@ -200,6 +200,16 @@ pub struct WatchConfig {
     #[serde(default = "default_persona_lease_ttl_secs")]
     pub persona_lease_ttl_secs: u64,
 
+    /// Subscription-quota threshold (0-100). When this host's most recent
+    /// rate-limit sample shows either the 5-hour or 7-day window at or above
+    /// this percentage, watch enters panic mode: poll cycles are skipped and
+    /// a single bullpen post announces the halt. A second post announces
+    /// recovery once the sample drops back below the threshold. Default
+    /// 99.0 -- aggressive but leaves a single-percent buffer for the sample
+    /// race so we do not burn the last sliver of quota on auto-wake spawns.
+    #[serde(default = "default_quota_panic_threshold_pct")]
+    pub quota_panic_threshold_pct: f64,
+
     /// Whether this node serves the web dashboard.
     /// Only one node per network should have this set to true.
     #[serde(default)]
@@ -250,6 +260,10 @@ fn default_persona_lease_ttl_secs() -> u64 {
     600
 }
 
+fn default_quota_panic_threshold_pct() -> f64 {
+    99.0
+}
+
 impl Default for WatchConfig {
     fn default() -> Self {
         Self {
@@ -264,6 +278,7 @@ impl Default for WatchConfig {
             retention_days: default_retention_days(),
             session_lock_ttl_secs: default_session_lock_ttl_secs(),
             persona_lease_ttl_secs: default_persona_lease_ttl_secs(),
+            quota_panic_threshold_pct: default_quota_panic_threshold_pct(),
             serve: false,
             cluster: None,
             repos: Vec::new(),
@@ -1212,6 +1227,96 @@ pub fn poll_cycle(
     Ok(spawned)
 }
 
+/// Pure predicate: does this sample cross the panic threshold? Missing
+/// pct values are treated as below-threshold so a partially-populated
+/// sample (e.g. one window not yet known) cannot fire panic on its own.
+fn sample_crosses_threshold(
+    sample: &crate::statusline::RateLimitSample,
+    threshold_pct: f64,
+) -> bool {
+    sample.five_hour_pct.is_some_and(|p| p >= threshold_pct)
+        || sample.seven_day_pct.is_some_and(|p| p >= threshold_pct)
+}
+
+/// Gate for subscription-quota panic-stop. When the most recent rate-limit
+/// sample for this host shows either the 5-hour or 7-day window at or above
+/// the configured threshold, watch enters panic mode and skips spawn
+/// cycles. A single bullpen post fires on the healthy -> panic edge; a
+/// matching post fires on the panic -> healthy edge.
+///
+/// Per-host (not cluster-wide): a peer node burning its cap should not
+/// gate this node's spawns. Each watch instance reads its own samples.
+///
+/// DB read failures return `false` (do not halt watch). A transient query
+/// error is not a reason to enter panic, and a stuck panic state would
+/// itself be a denial-of-service against the operator's mesh.
+pub struct QuotaPanicGate {
+    threshold_pct: f64,
+    host: String,
+    post_repo: String,
+    in_panic: bool,
+}
+
+impl QuotaPanicGate {
+    pub fn new(threshold_pct: f64, host: String, post_repo: String) -> Self {
+        Self {
+            threshold_pct,
+            host,
+            post_repo,
+            in_panic: false,
+        }
+    }
+
+    /// True when the most recent sample for this host crosses the
+    /// threshold. DB errors and absent samples both return `false`.
+    pub fn quota_panic_active(&self, db: &Database) -> bool {
+        match db.latest_rate_limit_sample_for_host(&self.host) {
+            Ok(Some(sample)) => sample_crosses_threshold(&sample, self.threshold_pct),
+            Ok(None) => false,
+            Err(e) => {
+                eprintln!(
+                    "[legion watch] quota panic check error: {} -- treating as healthy",
+                    e
+                );
+                false
+            }
+        }
+    }
+
+    /// Evaluate the gate, emit a single bullpen post on each state edge,
+    /// and return the current panic state. Callers skip the spawn cycle
+    /// when this returns `true`.
+    pub fn check_and_post(&mut self, db: &Database) -> bool {
+        let active = self.quota_panic_active(db);
+        if active != self.in_panic {
+            let post = if active {
+                format!(
+                    "QUOTA PANIC on {}: rate-limit sample crossed {:.1}% threshold. \
+                     `legion watch` is halting spawn cycles on this host until usage \
+                     drops back below the threshold.",
+                    self.host, self.threshold_pct,
+                )
+            } else {
+                format!(
+                    "QUOTA RECOVERED on {}: rate-limit sample fell below the {:.1}% \
+                     threshold. `legion watch` is resuming spawn cycles.",
+                    self.host, self.threshold_pct,
+                )
+            };
+            if let Err(e) = db.insert_reflection_with_meta(
+                &self.post_repo,
+                &post,
+                "team",
+                &crate::db::ReflectionMeta::default(),
+            ) {
+                eprintln!("[legion watch] quota panic bullpen post failed: {}", e);
+            }
+            self.in_panic = active;
+        }
+        active
+    }
+}
+
 /// Run the watch daemon main loop.
 ///
 /// Uses a dual-interval loop: health sampling every `health_poll_secs`
@@ -1261,6 +1366,19 @@ pub fn run(data_dir: &Path) -> Result<()> {
         host: &host,
         ttl: lease_ttl,
     };
+    // Pick a repo to attribute quota-panic bullpen posts to. The first watched
+    // repo's name reads naturally on the bullpen; absent any, fall back to
+    // "legion" so the alert still lands.
+    let quota_post_repo = config
+        .repos
+        .first()
+        .map(|r| r.name.clone())
+        .unwrap_or_else(|| "legion".to_string());
+    let mut quota_gate = QuotaPanicGate::new(
+        config.quota_panic_threshold_pct,
+        host.clone(),
+        quota_post_repo,
+    );
     // On startup, only look back 24 hours for unhandled signals.
     // Prevents historical flood when watch restarts after downtime.
     // The watch_handled table prevents re-processing, but without a
@@ -1326,7 +1444,12 @@ pub fn run(data_dir: &Path) -> Result<()> {
 
         // Spawn check on the poll interval
         if poll_timer.elapsed() >= poll_interval {
-            if sampler.can_spawn(config.health_threshold_pct) {
+            if quota_gate.check_and_post(&db) {
+                eprintln!(
+                    "[legion watch] quota panic active (>= {:.1}%) -- skipping spawn cycle",
+                    config.quota_panic_threshold_pct
+                );
+            } else if sampler.can_spawn(config.health_threshold_pct) {
                 match poll_cycle(
                     &db,
                     &config,
@@ -2640,5 +2763,187 @@ secret = "0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF"
         assert_eq!(cluster.interval_secs, 30, "default interval");
         assert!(cluster.instance_id.is_none());
         assert!(cluster.secret.is_none());
+    }
+
+    // -- Quota panic gate (#484) ---------------------------------------------
+
+    fn rate_sample(
+        id: &str,
+        host: &str,
+        sampled_at: &str,
+        five_hour_pct: Option<f64>,
+        seven_day_pct: Option<f64>,
+    ) -> crate::statusline::RateLimitSample {
+        crate::statusline::RateLimitSample {
+            id: id.to_string(),
+            hostname: host.to_string(),
+            session_id: "sess".to_string(),
+            sampled_at: sampled_at.to_string(),
+            five_hour_pct,
+            five_hour_resets_at: None,
+            seven_day_pct,
+            seven_day_resets_at: None,
+            model: None,
+        }
+    }
+
+    fn bullpen_panic_post_count(db: &Database) -> usize {
+        let posts = crate::board::bullpen(db, "legion").expect("read bullpen");
+        posts
+            .iter()
+            .filter(|p| p.text.contains("QUOTA PANIC") || p.text.contains("QUOTA RECOVERED"))
+            .count()
+    }
+
+    #[test]
+    fn panic_active_when_sample_crosses_threshold() {
+        let (db, _idx, _tmp) = test_storage();
+        db.insert_rate_limit_sample(&rate_sample(
+            "s1",
+            "this-host",
+            "2026-05-23T10:00:00Z",
+            Some(99.5),
+            Some(40.0),
+        ))
+        .unwrap();
+        let gate = QuotaPanicGate::new(99.0, "this-host".to_string(), "legion".to_string());
+        assert!(gate.quota_panic_active(&db));
+    }
+
+    #[test]
+    fn panic_inactive_when_sample_below_threshold() {
+        let (db, _idx, _tmp) = test_storage();
+        db.insert_rate_limit_sample(&rate_sample(
+            "s1",
+            "this-host",
+            "2026-05-23T10:00:00Z",
+            Some(50.0),
+            Some(60.0),
+        ))
+        .unwrap();
+        let gate = QuotaPanicGate::new(99.0, "this-host".to_string(), "legion".to_string());
+        assert!(!gate.quota_panic_active(&db));
+    }
+
+    #[test]
+    fn panic_inactive_when_no_sample_yet() {
+        let (db, _idx, _tmp) = test_storage();
+        let gate = QuotaPanicGate::new(99.0, "this-host".to_string(), "legion".to_string());
+        assert!(!gate.quota_panic_active(&db));
+    }
+
+    #[test]
+    fn panic_inactive_for_other_hosts_sample() {
+        // A peer node burning its cap must not gate this host.
+        let (db, _idx, _tmp) = test_storage();
+        db.insert_rate_limit_sample(&rate_sample(
+            "s1",
+            "other-host",
+            "2026-05-23T10:00:00Z",
+            Some(99.9),
+            Some(99.9),
+        ))
+        .unwrap();
+        let gate = QuotaPanicGate::new(99.0, "this-host".to_string(), "legion".to_string());
+        assert!(!gate.quota_panic_active(&db));
+    }
+
+    #[test]
+    fn panic_seven_day_window_independently_trips_gate() {
+        let (db, _idx, _tmp) = test_storage();
+        db.insert_rate_limit_sample(&rate_sample(
+            "s1",
+            "this-host",
+            "2026-05-23T10:00:00Z",
+            Some(10.0),
+            Some(99.5),
+        ))
+        .unwrap();
+        let gate = QuotaPanicGate::new(99.0, "this-host".to_string(), "legion".to_string());
+        assert!(gate.quota_panic_active(&db));
+    }
+
+    #[test]
+    fn edge_flip_emits_exactly_one_post_per_transition() {
+        let (db, _idx, _tmp) = test_storage();
+        let mut gate = QuotaPanicGate::new(99.0, "this-host".to_string(), "legion".to_string());
+
+        // Healthy at start, no post.
+        db.insert_rate_limit_sample(&rate_sample(
+            "s1",
+            "this-host",
+            "2026-05-23T10:00:00Z",
+            Some(50.0),
+            Some(50.0),
+        ))
+        .unwrap();
+        assert!(!gate.check_and_post(&db));
+        assert_eq!(bullpen_panic_post_count(&db), 0);
+
+        // Cross into panic -- one post.
+        db.insert_rate_limit_sample(&rate_sample(
+            "s2",
+            "this-host",
+            "2026-05-23T11:00:00Z",
+            Some(99.5),
+            Some(60.0),
+        ))
+        .unwrap();
+        assert!(gate.check_and_post(&db));
+        assert_eq!(bullpen_panic_post_count(&db), 1);
+
+        // Still in panic -- no additional post (no spam).
+        db.insert_rate_limit_sample(&rate_sample(
+            "s3",
+            "this-host",
+            "2026-05-23T12:00:00Z",
+            Some(99.8),
+            Some(70.0),
+        ))
+        .unwrap();
+        assert!(gate.check_and_post(&db));
+        assert_eq!(bullpen_panic_post_count(&db), 1);
+
+        // Recover -- one more post.
+        db.insert_rate_limit_sample(&rate_sample(
+            "s4",
+            "this-host",
+            "2026-05-23T13:00:00Z",
+            Some(50.0),
+            Some(50.0),
+        ))
+        .unwrap();
+        assert!(!gate.check_and_post(&db));
+        assert_eq!(bullpen_panic_post_count(&db), 2);
+
+        // Still healthy -- no additional post.
+        assert!(!gate.check_and_post(&db));
+        assert_eq!(bullpen_panic_post_count(&db), 2);
+    }
+
+    #[test]
+    fn db_error_returns_false_does_not_halt_watch() {
+        // Dropping the table makes latest_rate_limit_sample_for_host return
+        // Err. The gate must treat that as healthy (false) so a transient
+        // query failure cannot DoS the mesh by sticking watch in panic.
+        let (db, _idx, _tmp) = test_storage();
+        db.conn
+            .execute("DROP TABLE rate_limit_samples", [])
+            .expect("drop table");
+        let gate = QuotaPanicGate::new(99.0, "this-host".to_string(), "legion".to_string());
+        assert!(!gate.quota_panic_active(&db));
+    }
+
+    #[test]
+    fn default_threshold_is_ninety_nine_percent() {
+        let cfg = WatchConfig::default();
+        assert!((cfg.quota_panic_threshold_pct - 99.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn missing_pct_does_not_trip_gate() {
+        // A sample with both windows None should not be treated as panic.
+        let s = rate_sample("s1", "this-host", "2026-05-23T10:00:00Z", None, None);
+        assert!(!sample_crosses_threshold(&s, 99.0));
     }
 }

--- a/src/watch.rs
+++ b/src/watch.rs
@@ -1286,6 +1286,12 @@ impl QuotaPanicGate {
     /// Evaluate the gate, emit a single bullpen post on each state edge,
     /// and return the current panic state. Callers skip the spawn cycle
     /// when this returns `true`.
+    ///
+    /// Edge state (`in_panic`) only advances after the bullpen post lands.
+    /// On post failure the flag stays stale so the next poll retries the
+    /// same edge -- otherwise a single dropped post would leave peers
+    /// believing this node is still down (or still up) until the inverse
+    /// transition forces a re-announce.
     pub fn check_and_post(&mut self, db: &Database) -> bool {
         let active = self.quota_panic_active(db);
         if active != self.in_panic {
@@ -1303,15 +1309,23 @@ impl QuotaPanicGate {
                     self.host, self.threshold_pct,
                 )
             };
-            if let Err(e) = db.insert_reflection_with_meta(
+            match db.insert_reflection_with_meta(
                 &self.post_repo,
                 &post,
                 "team",
                 &crate::db::ReflectionMeta::default(),
             ) {
-                eprintln!("[legion watch] quota panic bullpen post failed: {}", e);
+                Ok(_) => {
+                    self.in_panic = active;
+                }
+                Err(e) => {
+                    eprintln!(
+                        "[legion watch] quota panic bullpen post failed (edge {} -> {}): {} \
+                         -- will retry on next poll; mesh state may be stale",
+                        self.in_panic, active, e
+                    );
+                }
             }
-            self.in_panic = active;
         }
         active
     }
@@ -2864,6 +2878,34 @@ secret = "0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF"
     }
 
     #[test]
+    fn panic_five_hour_window_independently_trips_gate() {
+        // Symmetric to the 7d test: a single high 5h reading with a quiet
+        // 7d window must still trip the gate. Guards against a refactor that
+        // drops the 5h disjunct or swaps `||` for `&&` in the predicate.
+        let (db, _idx, _tmp) = test_storage();
+        db.insert_rate_limit_sample(&rate_sample(
+            "s1",
+            "this-host",
+            "2026-05-23T10:00:00Z",
+            Some(99.5),
+            Some(10.0),
+        ))
+        .unwrap();
+        let gate = QuotaPanicGate::new(99.0, "this-host".to_string(), "legion".to_string());
+        assert!(gate.quota_panic_active(&db));
+    }
+
+    #[test]
+    fn panic_at_exactly_threshold_is_active() {
+        // The contract is "at or above" -- pin the >= boundary so a future
+        // refactor to `>` cannot silently let the last 1% slip.
+        let s = rate_sample("s1", "this-host", "t", Some(99.0), Some(40.0));
+        assert!(sample_crosses_threshold(&s, 99.0));
+        let s_below = rate_sample("s2", "this-host", "t", Some(98.999), Some(40.0));
+        assert!(!sample_crosses_threshold(&s_below, 99.0));
+    }
+
+    #[test]
     fn edge_flip_emits_exactly_one_post_per_transition() {
         let (db, _idx, _tmp) = test_storage();
         let mut gate = QuotaPanicGate::new(99.0, "this-host".to_string(), "legion".to_string());
@@ -2932,6 +2974,41 @@ secret = "0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF"
             .expect("drop table");
         let gate = QuotaPanicGate::new(99.0, "this-host".to_string(), "legion".to_string());
         assert!(!gate.quota_panic_active(&db));
+    }
+
+    #[test]
+    fn post_failure_does_not_advance_edge() {
+        // If the bullpen post fails on an edge, the gate must NOT flip
+        // `in_panic`. Otherwise the next tick sees no edge and the mesh
+        // is left believing the prior state. Simulate the failure by
+        // dropping the reflections table while leaving rate_limit_samples
+        // intact: the gate read succeeds, the post write fails.
+        let (db, _idx, _tmp) = test_storage();
+        let mut gate = QuotaPanicGate::new(99.0, "this-host".to_string(), "legion".to_string());
+
+        db.insert_rate_limit_sample(&rate_sample(
+            "s1",
+            "this-host",
+            "2026-05-23T10:00:00Z",
+            Some(99.5),
+            Some(40.0),
+        ))
+        .unwrap();
+        db.conn
+            .execute("DROP TABLE reflections", [])
+            .expect("drop reflections");
+
+        // active=true is observed (the gate read still succeeds), but the
+        // post insert fails. The contract is: in_panic stays false so the
+        // next poll sees the same edge and retries.
+        assert!(gate.check_and_post(&db), "active state still observed");
+        assert!(!gate.in_panic, "post failure must not advance in_panic");
+
+        // Second call mirrors the next poll cycle with the same broken
+        // write path. The edge must still re-fire (active != in_panic),
+        // not silently no-op.
+        assert!(gate.check_and_post(&db), "still active");
+        assert!(!gate.in_panic, "edge still pending after second failure");
     }
 
     #[test]


### PR DESCRIPTION
## Why

Defense-in-depth for the watch PTY migration (epic #495). On 2026-06-15, `claude --print -p` flips from subscription to billed API. Watch's auto-wake path still uses `-p` until the PTY migration lands. If rate limits exhaust during that window, every wake-worthy signal becomes a billed call. This PR halts spawn cycles when the host's most recent rate-limit sample shows either window at or above the configured threshold (default 99.0%), then resumes when it drops back below.

This is the independent issue from the epic table that ships first to buy headroom if the rest of the arc slips.

## What

- `WatchConfig::quota_panic_threshold_pct` (default 99.0%): single knob, documented in the struct doc-comment.
- `QuotaPanicGate` in `src/watch.rs`:
  - Reads `latest_rate_limit_sample_for_host` (new, per-host) -- a peer node burning its cap must not gate this node's spawns.
  - Edge-triggers exactly one bullpen post per state transition (healthy -> panic, panic -> healthy). No spam while a state holds.
  - DB read failures return `false`. A transient query error is not a reason to enter panic; stuck panic state would itself be a DoS.
  - Either window (5-hour OR 7-day) independently trips the gate. Missing pct values do not trip.
- `watch::run` gates the spawn arm: panic check first, then health-pressure check, then `poll_cycle`. Other arms unchanged.
- `Database::latest_rate_limit_sample_for_host(hostname)`: per-host variant of the existing global query.
- New free function `map_rate_limit_sample_row` extracted from three sites that decoded the same shape.

## Done when (per #484)

- [x] `quota_panic_active` returns true when most recent sample crosses threshold; false otherwise
- [x] `watch::run` skips `poll_cycle` while panic active
- [x] Single bullpen post on healthy->panic edge; single corresponding post on recovery edge (no spam)
- [x] Default threshold (99.0%) chosen and documented in `WatchConfig`
- [x] Unit tests: panic active when sample exceeds threshold; inactive otherwise; edge-flip emits exactly one post; DB read failure returns false (does NOT halt watch)
- [x] Synthetic samples drive transitions (`edge_flip_emits_exactly_one_post_per_transition` exercises the full healthy -> panic -> still-panic -> recovered -> still-healthy sequence and asserts post counts after each)
- [x] All tests pass, clippy clean, fmt clean (788 tests / clippy -D warnings / fmt --check)
- [x] PR created, simplify gate clean, linked to this issue and epic #495

## Test plan

- [x] `cargo test --bin legion` -- 788 passed
- [x] `cargo clippy --bin legion --all-targets -- -D warnings` -- clean
- [x] `cargo fmt -- --check` -- clean
- [x] `legion quality-gate record --skill legion-simplify --result clean` -- recorded (019e5650-6056-7ba1-82a6-2f191e9dd151)

Closes #484. Part of #495.