### PR TITLE
feat(#487): wake_attempts table + FSM-enforced DB methods

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -4183,6 +4183,204 @@ impl Database {
             .optional()?;
         Ok(row)
     }
+
+    /// Apply an incoming sync delta with state-aware conflict resolution
+    /// (#488). Returns `Ok(true)` when the delta was applied or inserted,
+    /// `Ok(false)` when rejected (no-op / regression / forward-incompat).
+    ///
+    /// Conflict rule (in priority order):
+    ///
+    /// 1. Unknown state literal -> log + reject (forward-incompat from a
+    ///    newer peer; do not panic).
+    /// 2. No local row -> insert.
+    /// 3. Tombstone involved (either side has `deleted_at`) -> plain LWW
+    ///    on `updated_at`.
+    /// 4. Local terminal + incoming non-terminal -> REJECT. Terminal is
+    ///    sticky; a peer observing an earlier state must not regress us.
+    /// 5. Both terminal but disagree on state -> keep the row with the
+    ///    later `exited_at`; on tie, deterministic tiebreak on
+    ///    `acquired_by_host` (lexicographic, lower wins).
+    /// 6. Otherwise -> LWW on `updated_at`.
+    pub fn apply_wake_attempt_delta(&self, delta: &crate::sync::WakeAttemptDelta) -> Result<bool> {
+        // Forward-incompat guard: unknown state literal does not panic.
+        let delta_state = match crate::wake_attempts::WakeAttemptState::parse_state(&delta.state) {
+            Ok(s) => s,
+            Err(e) => {
+                eprintln!(
+                    "[legion sync] wake_attempt_delta rejected: unknown state {:?} \
+                         (attempt_id={}, err={})",
+                    delta.state, delta.attempt_id, e
+                );
+                return Ok(false);
+            }
+        };
+
+        let tx = self.conn.unchecked_transaction()?;
+        let local = tx
+            .query_row(
+                "SELECT state, exited_at, updated_at, deleted_at, acquired_by_host \
+                 FROM wake_attempts WHERE attempt_id = ?1",
+                rusqlite::params![&delta.attempt_id],
+                |r| {
+                    Ok((
+                        r.get::<_, String>(0)?,
+                        r.get::<_, Option<String>>(1)?,
+                        r.get::<_, String>(2)?,
+                        r.get::<_, Option<String>>(3)?,
+                        r.get::<_, Option<String>>(4)?,
+                    ))
+                },
+            )
+            .optional()?;
+
+        let signal_ids_json = serde_json::to_string(&delta.signal_ids)?;
+
+        let applied = match local {
+            None => {
+                tx.execute(
+                    "INSERT INTO wake_attempts \
+                     (attempt_id, persona_id, repo_name, signal_ids, state, \
+                      acquired_by_host, acquired_at, spawned_pid, spawned_at, \
+                      exit_observed_at, exited_at, exit_status, outcome, \
+                      deleted_at, updated_at) \
+                     VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15)",
+                    rusqlite::params![
+                        &delta.attempt_id,
+                        &delta.persona_id,
+                        &delta.repo_name,
+                        &signal_ids_json,
+                        &delta.state,
+                        &delta.acquired_by_host,
+                        &delta.acquired_at,
+                        delta.spawned_pid.map(|v| v as i64),
+                        &delta.spawned_at,
+                        &delta.exit_observed_at,
+                        &delta.exited_at,
+                        &delta.exit_status,
+                        &delta.outcome,
+                        &delta.deleted_at,
+                        &delta.updated_at,
+                    ],
+                )?;
+                true
+            }
+            Some((local_state_str, local_exited, local_updated, local_deleted, local_host)) => {
+                let local_state =
+                    match crate::wake_attempts::WakeAttemptState::parse_state(&local_state_str) {
+                        Ok(s) => s,
+                        Err(_) => {
+                            // Local row is corrupt -- treat any incoming
+                            // well-formed delta as the truth (forward-only
+                            // schema recovery). LWW still applies.
+                            if delta.updated_at <= local_updated {
+                                tx.commit()?;
+                                return Ok(false);
+                            }
+                            self.upsert_wake_attempt_overwrite(&tx, delta, &signal_ids_json)?;
+                            tx.commit()?;
+                            return Ok(true);
+                        }
+                    };
+
+                let tombstone_involved = local_deleted.is_some() || delta.deleted_at.is_some();
+                let local_terminal = local_state.is_terminal();
+                let delta_terminal = delta_state.is_terminal();
+
+                if tombstone_involved {
+                    // Plain LWW on updated_at for tombstones.
+                    if delta.updated_at > local_updated {
+                        self.upsert_wake_attempt_overwrite(&tx, delta, &signal_ids_json)?;
+                        true
+                    } else {
+                        false
+                    }
+                } else if local_terminal && !delta_terminal {
+                    // Terminal-is-sticky: reject the regression. The
+                    // local row keeps its terminal state regardless of
+                    // updated_at -- a newer non-terminal write is a
+                    // happens-before violation by definition.
+                    false
+                } else if local_terminal && delta_terminal {
+                    if local_state == delta_state {
+                        // Both same terminal -- LWW on updated_at to
+                        // accept fresher metadata (outcome label, etc).
+                        if delta.updated_at > local_updated {
+                            self.upsert_wake_attempt_overwrite(&tx, delta, &signal_ids_json)?;
+                            true
+                        } else {
+                            false
+                        }
+                    } else {
+                        // Both terminal but disagree -- keep the later
+                        // exited_at; on tie, deterministic tiebreak on
+                        // acquired_by_host (lower lexicographic wins).
+                        let delta_wins = match (&delta.exited_at, &local_exited) {
+                            (Some(d), Some(l)) if d != l => d > l,
+                            (Some(_), None) => true,
+                            (None, Some(_)) => false,
+                            _ => {
+                                // exited_at tie -- break on host id.
+                                match (&delta.acquired_by_host, &local_host) {
+                                    (Some(d), Some(l)) => d < l,
+                                    (Some(_), None) => true,
+                                    _ => false,
+                                }
+                            }
+                        };
+                        if delta_wins {
+                            self.upsert_wake_attempt_overwrite(&tx, delta, &signal_ids_json)?;
+                            true
+                        } else {
+                            false
+                        }
+                    }
+                } else if delta.updated_at > local_updated {
+                    // Live row, neither terminal -- plain LWW.
+                    self.upsert_wake_attempt_overwrite(&tx, delta, &signal_ids_json)?;
+                    true
+                } else {
+                    false
+                }
+            }
+        };
+
+        tx.commit()?;
+        Ok(applied)
+    }
+
+    fn upsert_wake_attempt_overwrite(
+        &self,
+        tx: &rusqlite::Transaction<'_>,
+        delta: &crate::sync::WakeAttemptDelta,
+        signal_ids_json: &str,
+    ) -> Result<()> {
+        tx.execute(
+            "UPDATE wake_attempts \
+             SET persona_id = ?1, repo_name = ?2, signal_ids = ?3, state = ?4, \
+                 acquired_by_host = ?5, acquired_at = ?6, spawned_pid = ?7, \
+                 spawned_at = ?8, exit_observed_at = ?9, exited_at = ?10, \
+                 exit_status = ?11, outcome = ?12, deleted_at = ?13, updated_at = ?14 \
+             WHERE attempt_id = ?15",
+            rusqlite::params![
+                &delta.persona_id,
+                &delta.repo_name,
+                signal_ids_json,
+                &delta.state,
+                &delta.acquired_by_host,
+                &delta.acquired_at,
+                delta.spawned_pid.map(|v| v as i64),
+                &delta.spawned_at,
+                &delta.exit_observed_at,
+                &delta.exited_at,
+                &delta.exit_status,
+                &delta.outcome,
+                &delta.deleted_at,
+                &delta.updated_at,
+                &delta.attempt_id,
+            ],
+        )?;
+        Ok(())
+    }
 }
 
 /// Map a database row to a HealthSample struct.
@@ -7880,5 +8078,184 @@ mod tests {
             .mark_wake_attempt_exit_observed("no-such")
             .expect_err("missing row must error");
         assert!(matches!(err, LegionError::WakeAttemptNotFound(_)));
+    }
+
+    // -- WakeAttemptDelta + apply_wake_attempt_delta (#488) ------------------
+
+    fn delta_for(attempt_id: &str, state: &str, updated_at: &str) -> crate::sync::WakeAttemptDelta {
+        crate::sync::WakeAttemptDelta {
+            attempt_id: attempt_id.to_string(),
+            persona_id: "legion".to_string(),
+            repo_name: "legion".to_string(),
+            signal_ids: vec!["sig-1".to_string()],
+            state: state.to_string(),
+            acquired_by_host: Some("peer-host".to_string()),
+            acquired_at: Some("2026-05-23T10:00:00Z".to_string()),
+            spawned_pid: None,
+            spawned_at: None,
+            exit_observed_at: None,
+            exited_at: None,
+            exit_status: None,
+            outcome: None,
+            deleted_at: None,
+            updated_at: updated_at.to_string(),
+        }
+    }
+
+    #[test]
+    fn delta_from_attempt_roundtrips() {
+        use crate::wake_attempts::WakeAttemptState;
+        let db = test_db();
+        let id = wake_id("delta-rt");
+        db.enqueue_wake_attempt(&id, "legion", "legion", &["a".into(), "b".into()])
+            .unwrap();
+        let attempt = db.get_wake_attempt(&id).unwrap().expect("row");
+        let delta = crate::sync::WakeAttemptDelta::from_attempt(&attempt);
+
+        assert_eq!(delta.attempt_id, id);
+        assert_eq!(delta.state, "queued");
+        assert_eq!(delta.signal_ids, vec!["a".to_string(), "b".to_string()]);
+        // Round-trip back through serde to confirm the state literal
+        // parses on the other side.
+        let json = serde_json::to_string(&delta).unwrap();
+        let back: crate::sync::WakeAttemptDelta = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.state, "queued");
+        assert!(matches!(
+            WakeAttemptState::parse_state(&back.state).unwrap(),
+            WakeAttemptState::Queued
+        ));
+    }
+
+    #[test]
+    fn apply_delta_inserts_when_no_local_row() {
+        let db = test_db();
+        let delta = delta_for("new-id", "queued", "2026-05-23T10:00:00Z");
+        let applied = db.apply_wake_attempt_delta(&delta).unwrap();
+        assert!(applied);
+        let row = db.get_wake_attempt("new-id").unwrap().expect("row");
+        assert_eq!(row.state.as_str(), "queued");
+    }
+
+    #[test]
+    fn apply_delta_lww_older_is_noop() {
+        let db = test_db();
+        // Local row is newer.
+        let new_delta = delta_for("lww-id", "claimed", "2026-05-23T12:00:00Z");
+        assert!(db.apply_wake_attempt_delta(&new_delta).unwrap());
+        // Older incoming -> rejected.
+        let old_delta = delta_for("lww-id", "queued", "2026-05-23T10:00:00Z");
+        assert!(!db.apply_wake_attempt_delta(&old_delta).unwrap());
+        let row = db.get_wake_attempt("lww-id").unwrap().expect("row");
+        assert_eq!(
+            row.state.as_str(),
+            "claimed",
+            "older delta must not regress"
+        );
+    }
+
+    #[test]
+    fn apply_delta_lww_newer_overwrites() {
+        let db = test_db();
+        let old = delta_for("over-id", "queued", "2026-05-23T10:00:00Z");
+        assert!(db.apply_wake_attempt_delta(&old).unwrap());
+        let new = delta_for("over-id", "claimed", "2026-05-23T11:00:00Z");
+        assert!(db.apply_wake_attempt_delta(&new).unwrap());
+        let row = db.get_wake_attempt("over-id").unwrap().expect("row");
+        assert_eq!(row.state.as_str(), "claimed");
+    }
+
+    #[test]
+    fn apply_delta_terminal_is_sticky_against_non_terminal() {
+        // Local row has reached Done; peer's non-terminal delta with a
+        // later updated_at must NOT regress us. This is the load-bearing
+        // happens-before guard that distinguishes wake_attempts from
+        // plain LWW rows.
+        let db = test_db();
+        let mut done = delta_for("sticky-id", "done", "2026-05-23T11:00:00Z");
+        done.exited_at = Some("2026-05-23T11:00:00Z".to_string());
+        done.exit_status = Some("ok".to_string());
+        done.outcome = Some("productive".to_string());
+        assert!(db.apply_wake_attempt_delta(&done).unwrap());
+
+        // Newer updated_at, but state regression: rejected.
+        let regress = delta_for("sticky-id", "running", "2026-05-23T12:00:00Z");
+        assert!(!db.apply_wake_attempt_delta(&regress).unwrap());
+
+        let row = db.get_wake_attempt("sticky-id").unwrap().expect("row");
+        assert_eq!(
+            row.state.as_str(),
+            "done",
+            "terminal must survive a newer non-terminal delta"
+        );
+    }
+
+    #[test]
+    fn apply_delta_both_terminal_disagree_keeps_later_exited_at() {
+        let db = test_db();
+        let mut early = delta_for("term-id", "done", "2026-05-23T11:00:00Z");
+        early.exited_at = Some("2026-05-23T11:00:00Z".to_string());
+        early.exit_status = Some("ok".to_string());
+        assert!(db.apply_wake_attempt_delta(&early).unwrap());
+
+        // Peer's terminal disagrees but exited later -> wins.
+        let mut later_failed = delta_for("term-id", "failed", "2026-05-23T11:30:00Z");
+        later_failed.exited_at = Some("2026-05-23T12:00:00Z".to_string());
+        later_failed.exit_status = Some("error".to_string());
+        assert!(db.apply_wake_attempt_delta(&later_failed).unwrap());
+
+        let row = db.get_wake_attempt("term-id").unwrap().expect("row");
+        assert_eq!(row.state.as_str(), "failed");
+    }
+
+    #[test]
+    fn apply_delta_both_terminal_tie_breaks_on_host() {
+        // Local "done" on host-b vs incoming "failed" on host-a. Equal
+        // exited_at; deterministic tiebreak picks lower lexicographic
+        // host (host-a < host-b).
+        let db = test_db();
+        let mut local = delta_for("tie-id", "done", "2026-05-23T11:00:00Z");
+        local.exited_at = Some("2026-05-23T12:00:00Z".to_string());
+        local.exit_status = Some("ok".to_string());
+        local.acquired_by_host = Some("host-b".to_string());
+        assert!(db.apply_wake_attempt_delta(&local).unwrap());
+
+        let mut peer = delta_for("tie-id", "failed", "2026-05-23T11:00:00Z");
+        peer.exited_at = Some("2026-05-23T12:00:00Z".to_string());
+        peer.exit_status = Some("error".to_string());
+        peer.acquired_by_host = Some("host-a".to_string());
+        assert!(db.apply_wake_attempt_delta(&peer).unwrap());
+
+        let row = db.get_wake_attempt("tie-id").unwrap().expect("row");
+        assert_eq!(
+            row.state.as_str(),
+            "failed",
+            "host-a wins the lexicographic tiebreak"
+        );
+    }
+
+    #[test]
+    fn apply_delta_unknown_state_is_rejected_no_panic() {
+        let db = test_db();
+        let delta = delta_for("unknown-id", "frobnicated", "2026-05-23T10:00:00Z");
+        let applied = db.apply_wake_attempt_delta(&delta).unwrap();
+        assert!(!applied, "forward-incompat state must be rejected");
+        assert!(
+            db.get_wake_attempt("unknown-id").unwrap().is_none(),
+            "rejected delta must not insert"
+        );
+    }
+
+    #[test]
+    fn apply_delta_tombstone_lww() {
+        let db = test_db();
+        // Local live row.
+        let live = delta_for("tomb-id", "running", "2026-05-23T10:00:00Z");
+        assert!(db.apply_wake_attempt_delta(&live).unwrap());
+        // Incoming tombstone with newer updated_at wins.
+        let mut tomb = delta_for("tomb-id", "running", "2026-05-23T11:00:00Z");
+        tomb.deleted_at = Some("2026-05-23T11:00:00Z".to_string());
+        assert!(db.apply_wake_attempt_delta(&tomb).unwrap());
+        let row = db.get_wake_attempt("tomb-id").unwrap().expect("row");
+        assert!(row.deleted_at.is_some());
     }
 }

--- a/src/db.rs
+++ b/src/db.rs
@@ -995,6 +995,55 @@ impl Database {
                 ON uncertainty_calibration_snapshot(computed_at) WHERE deleted_at IS NULL;",
         )?;
 
+        // Migration 23: wake_attempts -- ACID substrate for the watch PTY
+        // migration (#487, part of #495).
+        //
+        // Each row represents one wake spawn from queue through terminal
+        // classification. The FSM enforced in Rust
+        // (`wake_attempts::WakeAttemptState::can_transition_to`) and
+        // mirrored in every UPDATE here keeps `state = from` in the WHERE
+        // clause so a sync-resolved late-loser cannot regress a peer's
+        // already-terminal row.
+        //
+        // persona_wake_leases (Migration 17) keeps its TTL-based mutual
+        // exclusion role; wake_attempts records what actually happened
+        // on each individual spawn so the reaper has a persistent,
+        // cluster-visible work item to operate on.
+        //
+        // signal_ids stored as a JSON array TEXT column to avoid a
+        // wake_attempt_signals join table -- N is small (a wake batches
+        // a handful of signals at most) and the column is opaque to the
+        // SQL layer.
+        //
+        // Indices target the two hot read paths: crash recovery scans
+        // by (acquired_by_host, state) on startup, and operator history
+        // queries scan by (persona_id, spawned_at DESC).
+        conn.execute_batch(
+            "CREATE TABLE IF NOT EXISTS wake_attempts (
+                attempt_id TEXT PRIMARY KEY,
+                persona_id TEXT NOT NULL,
+                repo_name TEXT NOT NULL,
+                signal_ids TEXT NOT NULL,
+                state TEXT NOT NULL,
+                acquired_by_host TEXT,
+                acquired_at TEXT,
+                spawned_pid INTEGER,
+                spawned_at TEXT,
+                exit_observed_at TEXT,
+                exited_at TEXT,
+                exit_status TEXT,
+                outcome TEXT,
+                deleted_at TEXT,
+                updated_at TEXT NOT NULL
+            );
+            CREATE INDEX IF NOT EXISTS idx_wake_attempts_host_state
+                ON wake_attempts(acquired_by_host, state)
+                WHERE deleted_at IS NULL;
+            CREATE INDEX IF NOT EXISTS idx_wake_attempts_persona_recent
+                ON wake_attempts(persona_id, spawned_at DESC)
+                WHERE deleted_at IS NULL;",
+        )?;
+
         Ok(())
     }
 
@@ -3848,6 +3897,291 @@ impl Database {
 
         tx.commit()?;
         Ok(late_loser)
+    }
+}
+
+// -- wake_attempts (#487, part of #495) --------------------------------------
+//
+// Until #488 (sync delta) and #489/#490 (consumer wiring) land, these
+// items are reachable only from tests. The wake_attempts module carries
+// its own `#![allow(dead_code)]`; here we only need the allow on
+// `map_wake_attempt_row` and the new `impl Database` block since the
+// surrounding db.rs is mostly live.
+
+#[allow(dead_code)]
+fn map_wake_attempt_row(
+    row: &rusqlite::Row<'_>,
+) -> rusqlite::Result<crate::wake_attempts::WakeAttempt> {
+    let state_str: String = row.get(4)?;
+    let state = crate::wake_attempts::WakeAttemptState::parse_state(&state_str).map_err(|e| {
+        rusqlite::Error::FromSqlConversionFailure(
+            4,
+            rusqlite::types::Type::Text,
+            Box::new(std::io::Error::other(format!("state decode: {}", e))),
+        )
+    })?;
+    let signal_ids_json: String = row.get(3)?;
+    let signal_ids: Vec<String> = serde_json::from_str(&signal_ids_json).map_err(|e| {
+        rusqlite::Error::FromSqlConversionFailure(3, rusqlite::types::Type::Text, Box::new(e))
+    })?;
+    let spawned_pid_i64: Option<i64> = row.get(7)?;
+    Ok(crate::wake_attempts::WakeAttempt {
+        attempt_id: row.get(0)?,
+        persona_id: row.get(1)?,
+        repo_name: row.get(2)?,
+        signal_ids,
+        state,
+        acquired_by_host: row.get(5)?,
+        acquired_at: row.get(6)?,
+        spawned_pid: spawned_pid_i64.map(|v| v as u32),
+        spawned_at: row.get(8)?,
+        exit_observed_at: row.get(9)?,
+        exited_at: row.get(10)?,
+        exit_status: row.get(11)?,
+        outcome: row.get(12)?,
+        deleted_at: row.get(13)?,
+        updated_at: row.get(14)?,
+    })
+}
+
+#[allow(dead_code)] // wired by #488 / #489 / #490
+impl Database {
+    /// Insert a new wake_attempts row in the `queued` state. The caller
+    /// is expected to mint a fresh UUIDv7 for `attempt_id`; reusing an
+    /// existing id is a programming error and the PK constraint will
+    /// surface as `LegionError::Database`.
+    pub fn enqueue_wake_attempt(
+        &self,
+        attempt_id: &str,
+        persona_id: &str,
+        repo_name: &str,
+        signal_ids: &[String],
+    ) -> Result<()> {
+        let now = Utc::now().to_rfc3339();
+        let signal_ids_json = serde_json::to_string(signal_ids)?;
+        self.conn.execute(
+            "INSERT INTO wake_attempts \
+             (attempt_id, persona_id, repo_name, signal_ids, state, updated_at) \
+             VALUES (?1, ?2, ?3, ?4, 'queued', ?5)",
+            rusqlite::params![attempt_id, persona_id, repo_name, &signal_ids_json, &now],
+        )?;
+        Ok(())
+    }
+
+    /// Atomic claim. Returns `Ok(true)` when this host won the claim,
+    /// `Ok(false)` when the row is either gone, already claimed by
+    /// another host, or in a non-`queued` state. Mirrors
+    /// `try_acquire_persona_lease`'s atomic UPDATE...WHERE pattern.
+    pub fn try_claim_wake_attempt(&self, attempt_id: &str, host: &str) -> Result<bool> {
+        let now = Utc::now().to_rfc3339();
+        let updated = self.conn.execute(
+            "UPDATE wake_attempts \
+             SET state = 'claimed', acquired_by_host = ?1, acquired_at = ?2, updated_at = ?2 \
+             WHERE attempt_id = ?3 \
+               AND state = 'queued' \
+               AND acquired_by_host IS NULL \
+               AND deleted_at IS NULL",
+            rusqlite::params![host, &now, attempt_id],
+        )?;
+        Ok(updated == 1)
+    }
+
+    /// FSM-enforced state transition. Two-layer safety: the Rust-side
+    /// `can_transition_to` rejects illegal pairs before SQL, and the
+    /// `state = from` predicate in the UPDATE rejects races where the
+    /// row has already moved.
+    ///
+    /// Returns `Ok(())` on a successful transition;
+    /// `IllegalWakeAttemptTransition` when the row's current state does
+    /// not match `from` or the table forbids `from -> to`;
+    /// `WakeAttemptNotFound` when the row is absent or soft-deleted.
+    pub fn transition_wake_attempt(
+        &self,
+        attempt_id: &str,
+        from: crate::wake_attempts::WakeAttemptState,
+        to: crate::wake_attempts::WakeAttemptState,
+    ) -> Result<()> {
+        if !from.can_transition_to(to) {
+            return self.illegal_transition(attempt_id, from, to);
+        }
+
+        let now = Utc::now().to_rfc3339();
+        let updated = self.conn.execute(
+            "UPDATE wake_attempts \
+             SET state = ?1, updated_at = ?2 \
+             WHERE attempt_id = ?3 AND state = ?4 AND deleted_at IS NULL",
+            rusqlite::params![to.as_str(), &now, attempt_id, from.as_str()],
+        )?;
+        if updated == 1 {
+            return Ok(());
+        }
+        // Distinguish "no such row" from "row exists in a different
+        // state". One get_wake_attempt lookup either way -- the FSM
+        // pre-check above already filtered out callable-but-illegal pairs.
+        match self.get_wake_attempt(attempt_id)? {
+            None => Err(LegionError::WakeAttemptNotFound(attempt_id.to_string())),
+            Some(row) => Err(LegionError::IllegalWakeAttemptTransition {
+                attempt_id: attempt_id.to_string(),
+                from: from.as_str().to_string(),
+                to: to.as_str().to_string(),
+                current: row.state.as_str().to_string(),
+            }),
+        }
+    }
+
+    fn illegal_transition(
+        &self,
+        attempt_id: &str,
+        from: crate::wake_attempts::WakeAttemptState,
+        to: crate::wake_attempts::WakeAttemptState,
+    ) -> Result<()> {
+        let current = self
+            .get_wake_attempt(attempt_id)?
+            .map(|r| r.state.as_str().to_string())
+            .unwrap_or_else(|| "<missing>".to_string());
+        Err(LegionError::IllegalWakeAttemptTransition {
+            attempt_id: attempt_id.to_string(),
+            from: from.as_str().to_string(),
+            to: to.as_str().to_string(),
+            current,
+        })
+    }
+
+    /// Record the PID of a spawned PTY child. Called after the child
+    /// reaches `Spawning`; the value is a hint for `kill -0` style
+    /// liveness probes, not the authority on completion (the PTY fd is).
+    pub fn set_wake_attempt_pid(&self, attempt_id: &str, pid: u32) -> Result<()> {
+        let now = Utc::now().to_rfc3339();
+        let updated = self.conn.execute(
+            "UPDATE wake_attempts \
+             SET spawned_pid = ?1, spawned_at = ?2, updated_at = ?2 \
+             WHERE attempt_id = ?3 AND deleted_at IS NULL",
+            rusqlite::params![pid as i64, &now, attempt_id],
+        )?;
+        if updated == 1 {
+            Ok(())
+        } else {
+            Err(LegionError::WakeAttemptNotFound(attempt_id.to_string()))
+        }
+    }
+
+    /// Stop-hook expediter: mark `exit_observed_at` so the reaper can
+    /// short-circuit its next poll cycle. NOT authoritative -- the
+    /// reaper still confirms via PTY EOF + PID-poll before writing a
+    /// terminal state. The hook may legitimately never fire (8-block
+    /// stop-hook cap in Claude Code 2.1.143).
+    pub fn mark_wake_attempt_exit_observed(&self, attempt_id: &str) -> Result<()> {
+        let now = Utc::now().to_rfc3339();
+        let updated = self.conn.execute(
+            "UPDATE wake_attempts \
+             SET exit_observed_at = ?1, updated_at = ?1 \
+             WHERE attempt_id = ?2 AND deleted_at IS NULL",
+            rusqlite::params![&now, attempt_id],
+        )?;
+        if updated == 1 {
+            Ok(())
+        } else {
+            Err(LegionError::WakeAttemptNotFound(attempt_id.to_string()))
+        }
+    }
+
+    /// Terminal classification + outcome stamp. Sets `exited_at`,
+    /// `exit_status`, `outcome`, and transitions the row to a terminal
+    /// FSM state based on `exit_status` (ok -> Done, error -> Failed,
+    /// killed -> Failed). The reaper may short-circuit from any
+    /// in-flight state when a stop hook + PID-dead race collapses the
+    /// lifecycle, so we accept any of claimed/spawning/running/exiting
+    /// as the source. Terminal-is-sticky stays load-bearing: the
+    /// WHERE clause excludes already-terminal rows so a late hook
+    /// cannot rewrite a settled outcome (the call surfaces as
+    /// `WakeAttemptNotFound` so the caller notices).
+    pub fn record_wake_attempt_outcome(
+        &self,
+        attempt_id: &str,
+        exit_status: &str,
+        outcome: &str,
+    ) -> Result<()> {
+        let terminal = match exit_status {
+            "ok" => "done",
+            "error" | "killed" => "failed",
+            other => {
+                return Err(LegionError::IllegalWakeAttemptTransition {
+                    attempt_id: attempt_id.to_string(),
+                    from: "<reaper>".to_string(),
+                    to: other.to_string(),
+                    current: "<unknown exit_status>".to_string(),
+                });
+            }
+        };
+        let now = Utc::now().to_rfc3339();
+        let updated = self.conn.execute(
+            "UPDATE wake_attempts \
+             SET state = ?1, exited_at = ?2, exit_status = ?3, outcome = ?4, updated_at = ?2 \
+             WHERE attempt_id = ?5 \
+               AND state IN ('claimed', 'spawning', 'running', 'exiting') \
+               AND deleted_at IS NULL",
+            rusqlite::params![terminal, &now, exit_status, outcome, attempt_id],
+        )?;
+        if updated == 1 {
+            return Ok(());
+        }
+        // Distinguish "no such row" from "row exists but is already
+        // terminal (or queued)". Same diagnostic shape as
+        // transition_wake_attempt -- callers can branch on the variant
+        // without retrying a corruption case as if it were absence.
+        match self.get_wake_attempt(attempt_id)? {
+            None => Err(LegionError::WakeAttemptNotFound(attempt_id.to_string())),
+            Some(row) => Err(LegionError::IllegalWakeAttemptTransition {
+                attempt_id: attempt_id.to_string(),
+                from: "<reaper>".to_string(),
+                to: terminal.to_string(),
+                current: row.state.as_str().to_string(),
+            }),
+        }
+    }
+
+    /// Strictly host-scoped orphan scan: rows owned by `self_host` that
+    /// are in any pre-terminal in-flight state. The host filter is
+    /// load-bearing -- a two-node sweep race could reap a peer's still-
+    /// running attempt and stick its persona lease until TTL.
+    pub fn list_local_orphans(
+        &self,
+        self_host: &str,
+    ) -> Result<Vec<crate::wake_attempts::WakeAttempt>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT attempt_id, persona_id, repo_name, signal_ids, state, \
+                    acquired_by_host, acquired_at, spawned_pid, spawned_at, \
+                    exit_observed_at, exited_at, exit_status, outcome, \
+                    deleted_at, updated_at \
+             FROM wake_attempts \
+             WHERE acquired_by_host = ?1 \
+               AND state IN ('claimed', 'spawning', 'running', 'exiting') \
+               AND deleted_at IS NULL \
+             ORDER BY acquired_at ASC",
+        )?;
+        Ok(stmt
+            .query_map(rusqlite::params![self_host], map_wake_attempt_row)?
+            .collect::<rusqlite::Result<Vec<_>>>()?)
+    }
+
+    /// Fetch a single row by id (including soft-deleted ones, for sync
+    /// reconciliation). Returns `Ok(None)` when no row exists.
+    pub fn get_wake_attempt(
+        &self,
+        attempt_id: &str,
+    ) -> Result<Option<crate::wake_attempts::WakeAttempt>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT attempt_id, persona_id, repo_name, signal_ids, state, \
+                    acquired_by_host, acquired_at, spawned_pid, spawned_at, \
+                    exit_observed_at, exited_at, exit_status, outcome, \
+                    deleted_at, updated_at \
+             FROM wake_attempts \
+             WHERE attempt_id = ?1",
+        )?;
+        let row = stmt
+            .query_row(rusqlite::params![attempt_id], map_wake_attempt_row)
+            .optional()?;
+        Ok(row)
     }
 }
 
@@ -7222,5 +7556,329 @@ mod tests {
         let result = db.cleanup_tombstones(30).unwrap();
         assert_eq!(result.uncertainty_predictions, 1);
         assert_eq!(result.uncertainty_calibration_snapshots, 1);
+    }
+
+    // -- wake_attempts (#487) ------------------------------------------------
+
+    fn wake_id(tag: &str) -> String {
+        format!("attempt-{}-{}", tag, uuid::Uuid::now_v7())
+    }
+
+    #[test]
+    fn wake_attempts_migration_creates_table() {
+        let db = test_db();
+        // sqlite_master lookup is a stable way to assert the table
+        // and indices applied without rebinding to private types.
+        let exists: i64 = db
+            .conn
+            .query_row(
+                "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='wake_attempts'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(exists, 1);
+        let indices: i64 = db
+            .conn
+            .query_row(
+                "SELECT COUNT(*) FROM sqlite_master WHERE type='index' \
+                 AND name IN ('idx_wake_attempts_host_state', 'idx_wake_attempts_persona_recent')",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(indices, 2);
+    }
+
+    #[test]
+    fn enqueue_wake_attempt_inserts_queued_row() {
+        use crate::wake_attempts::WakeAttemptState;
+        let db = test_db();
+        let id = wake_id("enqueue");
+        db.enqueue_wake_attempt(&id, "legion", "legion", &["sig-1".to_string()])
+            .unwrap();
+        let row = db.get_wake_attempt(&id).unwrap().expect("row exists");
+        assert_eq!(row.state, WakeAttemptState::Queued);
+        assert_eq!(row.persona_id, "legion");
+        assert_eq!(row.repo_name, "legion");
+        assert_eq!(row.signal_ids, vec!["sig-1".to_string()]);
+        assert!(row.acquired_by_host.is_none());
+    }
+
+    #[test]
+    fn try_claim_wake_attempt_is_atomic_one_winner() {
+        let db = test_db();
+        let id = wake_id("claim");
+        db.enqueue_wake_attempt(&id, "legion", "legion", &[])
+            .unwrap();
+
+        let host_a_won = db.try_claim_wake_attempt(&id, "host-a").unwrap();
+        let host_b_won = db.try_claim_wake_attempt(&id, "host-b").unwrap();
+        // First claimer wins; second sees state != queued and returns false.
+        assert!(host_a_won, "first host must win the claim");
+        assert!(!host_b_won, "second claim must return false");
+
+        let row = db.get_wake_attempt(&id).unwrap().expect("row");
+        assert_eq!(row.acquired_by_host.as_deref(), Some("host-a"));
+        assert_eq!(row.state, crate::wake_attempts::WakeAttemptState::Claimed);
+    }
+
+    #[test]
+    fn try_claim_wake_attempt_rejects_already_claimed() {
+        let db = test_db();
+        let id = wake_id("re-claim");
+        db.enqueue_wake_attempt(&id, "legion", "legion", &[])
+            .unwrap();
+        assert!(db.try_claim_wake_attempt(&id, "host-a").unwrap());
+        // Same host trying twice still loses -- claim is one-shot.
+        assert!(!db.try_claim_wake_attempt(&id, "host-a").unwrap());
+    }
+
+    #[test]
+    fn try_claim_wake_attempt_returns_false_for_unknown_row() {
+        let db = test_db();
+        assert!(!db.try_claim_wake_attempt("no-such-id", "host-a").unwrap());
+    }
+
+    #[test]
+    fn transition_wake_attempt_walks_happy_path() {
+        use crate::wake_attempts::WakeAttemptState::*;
+        let db = test_db();
+        let id = wake_id("happy");
+        db.enqueue_wake_attempt(&id, "legion", "legion", &[])
+            .unwrap();
+        assert!(db.try_claim_wake_attempt(&id, "host-a").unwrap());
+
+        db.transition_wake_attempt(&id, Claimed, Spawning).unwrap();
+        db.transition_wake_attempt(&id, Spawning, Running).unwrap();
+        db.transition_wake_attempt(&id, Running, Exiting).unwrap();
+        db.transition_wake_attempt(&id, Exiting, Done).unwrap();
+
+        let row = db.get_wake_attempt(&id).unwrap().expect("row");
+        assert_eq!(row.state, Done);
+    }
+
+    #[test]
+    fn transition_wake_attempt_rejects_illegal_pair() {
+        use crate::wake_attempts::WakeAttemptState::*;
+        let db = test_db();
+        let id = wake_id("illegal");
+        db.enqueue_wake_attempt(&id, "legion", "legion", &[])
+            .unwrap();
+        assert!(db.try_claim_wake_attempt(&id, "host-a").unwrap());
+
+        // Claimed -> Done is not in the table.
+        let err = db
+            .transition_wake_attempt(&id, Claimed, Done)
+            .expect_err("illegal transition must error");
+        match err {
+            LegionError::IllegalWakeAttemptTransition {
+                attempt_id,
+                from,
+                to,
+                ..
+            } => {
+                assert_eq!(attempt_id, id);
+                assert_eq!(from, "claimed");
+                assert_eq!(to, "done");
+            }
+            other => panic!("expected IllegalWakeAttemptTransition, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn transition_wake_attempt_rejects_stale_from() {
+        use crate::wake_attempts::WakeAttemptState::*;
+        let db = test_db();
+        let id = wake_id("stale");
+        db.enqueue_wake_attempt(&id, "legion", "legion", &[])
+            .unwrap();
+        assert!(db.try_claim_wake_attempt(&id, "host-a").unwrap());
+        db.transition_wake_attempt(&id, Claimed, Spawning).unwrap();
+        // Caller still thinks the row is `Claimed` but the DB has moved on.
+        let err = db
+            .transition_wake_attempt(&id, Claimed, Spawning)
+            .expect_err("stale `from` must error");
+        match err {
+            LegionError::IllegalWakeAttemptTransition { current, .. } => {
+                assert_eq!(current, "spawning");
+            }
+            other => panic!("expected IllegalWakeAttemptTransition, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn transition_wake_attempt_errors_on_missing_row() {
+        use crate::wake_attempts::WakeAttemptState::*;
+        let db = test_db();
+        let err = db
+            .transition_wake_attempt("no-such", Queued, Claimed)
+            .expect_err("missing row");
+        assert!(matches!(err, LegionError::WakeAttemptNotFound(_)));
+    }
+
+    #[test]
+    fn record_wake_attempt_outcome_sets_terminal_and_status() {
+        use crate::wake_attempts::WakeAttemptState::*;
+        let db = test_db();
+        let id = wake_id("outcome-ok");
+        db.enqueue_wake_attempt(&id, "legion", "legion", &[])
+            .unwrap();
+        db.try_claim_wake_attempt(&id, "host-a").unwrap();
+        db.transition_wake_attempt(&id, Claimed, Spawning).unwrap();
+        db.transition_wake_attempt(&id, Spawning, Running).unwrap();
+
+        db.record_wake_attempt_outcome(&id, "ok", "productive")
+            .unwrap();
+        let row = db.get_wake_attempt(&id).unwrap().expect("row");
+        assert_eq!(row.state, Done);
+        assert_eq!(row.exit_status.as_deref(), Some("ok"));
+        assert_eq!(row.outcome.as_deref(), Some("productive"));
+        assert!(row.exited_at.is_some());
+    }
+
+    #[test]
+    fn record_wake_attempt_outcome_maps_error_to_failed() {
+        use crate::wake_attempts::WakeAttemptState::*;
+        let db = test_db();
+        let id = wake_id("outcome-fail");
+        db.enqueue_wake_attempt(&id, "legion", "legion", &[])
+            .unwrap();
+        db.try_claim_wake_attempt(&id, "host-a").unwrap();
+        db.record_wake_attempt_outcome(&id, "killed", "errored")
+            .unwrap();
+        let row = db.get_wake_attempt(&id).unwrap().expect("row");
+        assert_eq!(row.state, Failed);
+    }
+
+    #[test]
+    fn record_wake_attempt_outcome_leaves_terminal_rows_alone() {
+        // Late stop hook + already-settled row must not rewrite the
+        // outcome. Terminal-is-sticky is the FSM invariant the
+        // transition table protects; record_outcome must respect it
+        // and surface the rejection as IllegalWakeAttemptTransition
+        // with the actual current state, not WakeAttemptNotFound
+        // (which would invite a retry loop on a real corruption).
+        let db = test_db();
+        let id = wake_id("sticky");
+        db.enqueue_wake_attempt(&id, "legion", "legion", &[])
+            .unwrap();
+        db.try_claim_wake_attempt(&id, "host-a").unwrap();
+        db.record_wake_attempt_outcome(&id, "ok", "productive")
+            .unwrap();
+        let err = db
+            .record_wake_attempt_outcome(&id, "killed", "errored")
+            .expect_err("terminal row must reject re-stamp");
+        match err {
+            LegionError::IllegalWakeAttemptTransition { current, .. } => {
+                assert_eq!(current, "done");
+            }
+            other => {
+                panic!("expected IllegalWakeAttemptTransition with current=done, got {other:?}")
+            }
+        }
+        let row = db.get_wake_attempt(&id).unwrap().expect("row");
+        assert_eq!(row.exit_status.as_deref(), Some("ok"));
+        assert_eq!(row.outcome.as_deref(), Some("productive"));
+    }
+
+    #[test]
+    fn list_local_orphans_is_strictly_host_scoped() {
+        use crate::wake_attempts::WakeAttemptState::*;
+        let db = test_db();
+
+        // This host: one in-flight + one terminal (terminal must NOT appear).
+        let local_inflight = wake_id("local-inflight");
+        db.enqueue_wake_attempt(&local_inflight, "legion", "legion", &[])
+            .unwrap();
+        db.try_claim_wake_attempt(&local_inflight, "this-host")
+            .unwrap();
+        db.transition_wake_attempt(&local_inflight, Claimed, Spawning)
+            .unwrap();
+
+        let local_done = wake_id("local-done");
+        db.enqueue_wake_attempt(&local_done, "legion", "legion", &[])
+            .unwrap();
+        db.try_claim_wake_attempt(&local_done, "this-host").unwrap();
+        db.record_wake_attempt_outcome(&local_done, "ok", "productive")
+            .unwrap();
+
+        // Peer host: in-flight on a DIFFERENT host must NOT appear here.
+        let peer_inflight = wake_id("peer-inflight");
+        db.enqueue_wake_attempt(&peer_inflight, "legion", "legion", &[])
+            .unwrap();
+        db.try_claim_wake_attempt(&peer_inflight, "other-host")
+            .unwrap();
+
+        let orphans = db.list_local_orphans("this-host").unwrap();
+        let ids: Vec<&str> = orphans.iter().map(|r| r.attempt_id.as_str()).collect();
+        assert_eq!(
+            ids,
+            vec![local_inflight.as_str()],
+            "only this-host's in-flight row should be returned"
+        );
+    }
+
+    #[test]
+    fn set_wake_attempt_pid_records_pid_and_spawned_at() {
+        let db = test_db();
+        let id = wake_id("pid");
+        db.enqueue_wake_attempt(&id, "legion", "legion", &[])
+            .unwrap();
+        db.set_wake_attempt_pid(&id, 12345).unwrap();
+        let row = db.get_wake_attempt(&id).unwrap().expect("row");
+        assert_eq!(row.spawned_pid, Some(12345));
+        assert!(row.spawned_at.is_some());
+    }
+
+    #[test]
+    fn mark_wake_attempt_exit_observed_writes_timestamp() {
+        let db = test_db();
+        let id = wake_id("exit-obs");
+        db.enqueue_wake_attempt(&id, "legion", "legion", &[])
+            .unwrap();
+        db.mark_wake_attempt_exit_observed(&id).unwrap();
+        let row = db.get_wake_attempt(&id).unwrap().expect("row");
+        assert!(row.exit_observed_at.is_some());
+    }
+
+    #[test]
+    fn get_wake_attempt_returns_none_for_missing() {
+        let db = test_db();
+        assert!(db.get_wake_attempt("no-such").unwrap().is_none());
+    }
+
+    #[test]
+    fn record_wake_attempt_outcome_rejects_unknown_exit_status() {
+        let db = test_db();
+        let id = wake_id("bad-status");
+        db.enqueue_wake_attempt(&id, "legion", "legion", &[])
+            .unwrap();
+        db.try_claim_wake_attempt(&id, "host-a").unwrap();
+        let err = db
+            .record_wake_attempt_outcome(&id, "purple", "productive")
+            .expect_err("unknown exit_status must error");
+        assert!(matches!(
+            err,
+            LegionError::IllegalWakeAttemptTransition { .. }
+        ));
+    }
+
+    #[test]
+    fn set_wake_attempt_pid_errors_on_missing_row() {
+        let db = test_db();
+        let err = db
+            .set_wake_attempt_pid("no-such", 1234)
+            .expect_err("missing row must error");
+        assert!(matches!(err, LegionError::WakeAttemptNotFound(_)));
+    }
+
+    #[test]
+    fn mark_wake_attempt_exit_observed_errors_on_missing_row() {
+        let db = test_db();
+        let err = db
+            .mark_wake_attempt_exit_observed("no-such")
+            .expect_err("missing row must error");
+        assert!(matches!(err, LegionError::WakeAttemptNotFound(_)));
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -127,6 +127,22 @@ pub enum LegionError {
 
     #[error("pty wait failed: {0}")]
     PtyWaitFailed(String),
+
+    #[error(
+        "illegal wake attempt transition for {attempt_id}: {from} -> {to} (current state: {current})"
+    )]
+    IllegalWakeAttemptTransition {
+        attempt_id: String,
+        from: String,
+        to: String,
+        current: String,
+    },
+
+    #[error("wake attempt not found: {0}")]
+    WakeAttemptNotFound(String),
+
+    #[error("wake attempt state decode error: {0}")]
+    WakeAttemptStateDecodeError(String),
 }
 
 pub type Result<T> = std::result::Result<T, LegionError>;

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,6 +35,7 @@ mod telemetry;
 mod testutil;
 mod uncertainty;
 mod usage;
+mod wake_attempts;
 mod watch;
 mod worksource;
 

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -268,6 +268,59 @@ pub struct PersonaWakeLeaseDelta {
     pub deleted_at: Option<String>,
 }
 
+/// A wake-attempt row serialized for sync transmission (#488, part of #495).
+///
+/// Unlike leases (which only need LWW), wake-attempt rows have
+/// happens-before lifecycle semantics: a peer observing `state=running`
+/// after this node wrote `state=done` must NOT regress the terminal
+/// state. `db::apply_wake_attempt_delta` enforces the state-aware
+/// conflict rule; this struct is the wire shape.
+///
+/// `state` carries the lowercase string form of `WakeAttemptState`. An
+/// unknown literal from a forward-incompatible peer is rejected at
+/// apply time without panicking -- see the apply method's docstring.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WakeAttemptDelta {
+    pub attempt_id: String,
+    pub persona_id: String,
+    pub repo_name: String,
+    pub signal_ids: Vec<String>,
+    pub state: String,
+    pub acquired_by_host: Option<String>,
+    pub acquired_at: Option<String>,
+    pub spawned_pid: Option<u32>,
+    pub spawned_at: Option<String>,
+    pub exit_observed_at: Option<String>,
+    pub exited_at: Option<String>,
+    pub exit_status: Option<String>,
+    pub outcome: Option<String>,
+    pub deleted_at: Option<String>,
+    pub updated_at: String,
+}
+
+#[allow(dead_code)] // wired by #489 / #490 consumers
+impl WakeAttemptDelta {
+    pub fn from_attempt(a: &crate::wake_attempts::WakeAttempt) -> Self {
+        Self {
+            attempt_id: a.attempt_id.clone(),
+            persona_id: a.persona_id.clone(),
+            repo_name: a.repo_name.clone(),
+            signal_ids: a.signal_ids.clone(),
+            state: a.state.as_str().to_string(),
+            acquired_by_host: a.acquired_by_host.clone(),
+            acquired_at: a.acquired_at.clone(),
+            spawned_pid: a.spawned_pid,
+            spawned_at: a.spawned_at.clone(),
+            exit_observed_at: a.exit_observed_at.clone(),
+            exited_at: a.exited_at.clone(),
+            exit_status: a.exit_status.clone(),
+            outcome: a.outcome.clone(),
+            deleted_at: a.deleted_at.clone(),
+            updated_at: a.updated_at.clone(),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/wake_attempts.rs
+++ b/src/wake_attempts.rs
@@ -205,7 +205,8 @@ mod tests {
             assert!(s.is_terminal(), "{s:?} should be terminal");
             assert!(!s.is_in_flight(), "{s:?} should not be in flight");
         }
-        for s in [Queued] {
+        {
+            let s = Queued;
             assert!(!s.is_terminal());
             assert!(!s.is_in_flight());
         }

--- a/src/wake_attempts.rs
+++ b/src/wake_attempts.rs
@@ -1,0 +1,292 @@
+//! Wake-attempt FSM types for the watch PTY migration (#487, part of #495).
+//!
+//! `wake_attempts` is the ACID substrate for the per-attempt lifecycle:
+//! enqueue -> claim -> spawn -> run -> exit -> terminal. The persona
+//! lease layer (`persona_wake_leases`) keeps its TTL-based mutual
+//! exclusion role; the attempt row records what actually happened on a
+//! given spawn so peer nodes can see in-flight wakes and crash recovery
+//! can reap orphans without racing peers.
+//!
+//! FSM enforcement mirrors `uncertainty::types::PredictionState` -- the
+//! transition table is the load-bearing safety property. An illegal
+//! `done -> running` regression coming back via sync conflict resolution
+//! is silently rejected at the DB layer rather than ever taking effect.
+//!
+//! DB methods live in `src/db.rs` (Migration 23 + `try_claim_wake_attempt`
+//! and friends). Sync delta + consumer wiring are in #488 / #489 / #490.
+//!
+//! Until consumers land, `#![allow(dead_code)]` keeps clippy quiet
+//! during the soak window.
+
+#![allow(dead_code)]
+
+use serde::{Deserialize, Serialize};
+
+use crate::error::{LegionError, Result};
+
+/// Lifecycle states for a wake_attempts row.
+///
+/// String literals match the column form so [`WakeAttemptState::as_str`]
+/// and [`WakeAttemptState::from_str`] round-trip through the database
+/// without an intermediate mapping table.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum WakeAttemptState {
+    /// Row written; no host has claimed it yet.
+    Queued,
+    /// A host has won the atomic claim and is preparing to spawn.
+    Claimed,
+    /// PTY process started; prompt not yet written.
+    Spawning,
+    /// Prompt written; output flowing.
+    Running,
+    /// Stop-hook observed OR PTY EOF observed (whichever comes first).
+    /// Terminal classification still pending the reaper.
+    Exiting,
+    /// Terminal: child exited cleanly.
+    Done,
+    /// Terminal: child exited with non-zero status.
+    Failed,
+    /// Terminal: reaper timed the attempt out.
+    Timeout,
+    /// Terminal: crash recovery could not locate the process; gave up.
+    Abandoned,
+}
+
+impl WakeAttemptState {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            WakeAttemptState::Queued => "queued",
+            WakeAttemptState::Claimed => "claimed",
+            WakeAttemptState::Spawning => "spawning",
+            WakeAttemptState::Running => "running",
+            WakeAttemptState::Exiting => "exiting",
+            WakeAttemptState::Done => "done",
+            WakeAttemptState::Failed => "failed",
+            WakeAttemptState::Timeout => "timeout",
+            WakeAttemptState::Abandoned => "abandoned",
+        }
+    }
+
+    /// Inherent parser, named `parse_state` to avoid shadowing the
+    /// std `FromStr::from_str` ambient. Returns
+    /// `WakeAttemptStateDecodeError` on an unknown literal -- the row
+    /// existed, its `state` column is corrupt. A `WakeAttemptNotFound`
+    /// would be a category error since a future caller branching on
+    /// not-found to retry would silently swallow real corruption.
+    pub fn parse_state(s: &str) -> Result<Self> {
+        match s {
+            "queued" => Ok(WakeAttemptState::Queued),
+            "claimed" => Ok(WakeAttemptState::Claimed),
+            "spawning" => Ok(WakeAttemptState::Spawning),
+            "running" => Ok(WakeAttemptState::Running),
+            "exiting" => Ok(WakeAttemptState::Exiting),
+            "done" => Ok(WakeAttemptState::Done),
+            "failed" => Ok(WakeAttemptState::Failed),
+            "timeout" => Ok(WakeAttemptState::Timeout),
+            "abandoned" => Ok(WakeAttemptState::Abandoned),
+            other => Err(LegionError::WakeAttemptStateDecodeError(format!(
+                "unknown wake attempt state: {other}"
+            ))),
+        }
+    }
+
+    /// True when one of the four terminal classifications.
+    pub fn is_terminal(&self) -> bool {
+        matches!(
+            self,
+            WakeAttemptState::Done
+                | WakeAttemptState::Failed
+                | WakeAttemptState::Timeout
+                | WakeAttemptState::Abandoned
+        )
+    }
+
+    /// True when one of the in-progress states crash-recovery cares about
+    /// (claimed/spawning/running/exiting -- anything pre-terminal that
+    /// owns a host).
+    pub fn is_in_flight(&self) -> bool {
+        matches!(
+            self,
+            WakeAttemptState::Claimed
+                | WakeAttemptState::Spawning
+                | WakeAttemptState::Running
+                | WakeAttemptState::Exiting
+        )
+    }
+
+    /// Lifecycle transition table.
+    ///
+    /// The legal moves follow the documented path
+    /// queued -> claimed -> spawning -> running -> exiting ->
+    /// { done | failed | timeout | abandoned }. Two additional shortcuts
+    /// reflect real failure modes: any claimed-and-beyond non-terminal
+    /// state can short-circuit to `failed` or `abandoned` when the
+    /// reaper observes a dead pid before the optimistic stop-hook fires.
+    pub fn can_transition_to(&self, next: WakeAttemptState) -> bool {
+        use WakeAttemptState::*;
+        matches!(
+            (self, next),
+            (Queued, Claimed)
+                | (Queued, Abandoned)
+                | (Claimed, Spawning)
+                | (Claimed, Abandoned)
+                | (Claimed, Failed)
+                | (Spawning, Running)
+                | (Spawning, Failed)
+                | (Spawning, Abandoned)
+                | (Running, Exiting)
+                | (Running, Failed)
+                | (Running, Timeout)
+                | (Running, Abandoned)
+                | (Exiting, Done)
+                | (Exiting, Failed)
+                | (Exiting, Timeout)
+                | (Exiting, Abandoned)
+        )
+    }
+}
+
+/// Row representation of a wake_attempts record.
+///
+/// `signal_ids` is stored as a JSON array TEXT column; the in-memory
+/// shape is a flat Vec<String> for callers. `outcome` and `exit_status`
+/// stay as free-form strings to avoid roundtripping the existing
+/// "productive | unproductive | errored | unknown" + "ok | error | killed"
+/// vocabularies through a second enum the rest of the codebase would
+/// then have to know about.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WakeAttempt {
+    pub attempt_id: String,
+    pub persona_id: String,
+    pub repo_name: String,
+    pub signal_ids: Vec<String>,
+    pub state: WakeAttemptState,
+    pub acquired_by_host: Option<String>,
+    pub acquired_at: Option<String>,
+    pub spawned_pid: Option<u32>,
+    pub spawned_at: Option<String>,
+    pub exit_observed_at: Option<String>,
+    pub exited_at: Option<String>,
+    pub exit_status: Option<String>,
+    pub outcome: Option<String>,
+    pub deleted_at: Option<String>,
+    pub updated_at: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn all_states() -> [WakeAttemptState; 9] {
+        use WakeAttemptState::*;
+        [
+            Queued, Claimed, Spawning, Running, Exiting, Done, Failed, Timeout, Abandoned,
+        ]
+    }
+
+    #[test]
+    fn state_strings_round_trip() {
+        for s in all_states() {
+            let parsed = WakeAttemptState::parse_state(s.as_str()).expect("known state");
+            assert_eq!(parsed, s);
+        }
+    }
+
+    #[test]
+    fn parse_state_rejects_unknown() {
+        assert!(WakeAttemptState::parse_state("nope").is_err());
+    }
+
+    #[test]
+    fn is_terminal_classification() {
+        use WakeAttemptState::*;
+        for s in [Done, Failed, Timeout, Abandoned] {
+            assert!(s.is_terminal(), "{s:?} should be terminal");
+            assert!(!s.is_in_flight(), "{s:?} should not be in flight");
+        }
+        for s in [Queued] {
+            assert!(!s.is_terminal());
+            assert!(!s.is_in_flight());
+        }
+        for s in [Claimed, Spawning, Running, Exiting] {
+            assert!(!s.is_terminal());
+            assert!(s.is_in_flight(), "{s:?} should be in flight");
+        }
+    }
+
+    #[test]
+    fn legal_transitions_match_the_documented_path() {
+        use WakeAttemptState::*;
+        // Happy path: queued -> claimed -> spawning -> running -> exiting -> done.
+        assert!(Queued.can_transition_to(Claimed));
+        assert!(Claimed.can_transition_to(Spawning));
+        assert!(Spawning.can_transition_to(Running));
+        assert!(Running.can_transition_to(Exiting));
+        assert!(Exiting.can_transition_to(Done));
+
+        // Failure short-circuits: any in-flight pre-Exiting can fail or
+        // be abandoned; any Running can additionally time out.
+        assert!(Queued.can_transition_to(Abandoned));
+        assert!(Claimed.can_transition_to(Abandoned));
+        assert!(Claimed.can_transition_to(Failed));
+        assert!(Spawning.can_transition_to(Failed));
+        assert!(Spawning.can_transition_to(Abandoned));
+        assert!(Running.can_transition_to(Failed));
+        assert!(Running.can_transition_to(Timeout));
+        assert!(Running.can_transition_to(Abandoned));
+        assert!(Exiting.can_transition_to(Failed));
+        assert!(Exiting.can_transition_to(Timeout));
+        assert!(Exiting.can_transition_to(Abandoned));
+    }
+
+    #[test]
+    fn illegal_transitions_are_rejected() {
+        use WakeAttemptState::*;
+        // No reverse moves.
+        assert!(!Claimed.can_transition_to(Queued));
+        assert!(!Running.can_transition_to(Claimed));
+        assert!(!Exiting.can_transition_to(Running));
+
+        // No skipping forward.
+        assert!(!Queued.can_transition_to(Running));
+        assert!(!Queued.can_transition_to(Done));
+        assert!(!Claimed.can_transition_to(Running));
+        assert!(!Spawning.can_transition_to(Done));
+
+        // Terminal is sticky -- no transition from any terminal state.
+        for terminal in [Done, Failed, Timeout, Abandoned] {
+            for target in all_states() {
+                assert!(
+                    !terminal.can_transition_to(target),
+                    "{terminal:?} -> {target:?} must be rejected (terminal is sticky)"
+                );
+            }
+        }
+
+        // No self-loops on non-terminal states either.
+        for s in [Queued, Claimed, Spawning, Running, Exiting] {
+            assert!(
+                !s.can_transition_to(s),
+                "{s:?} -> {s:?} must be rejected (self-loops poison sync)"
+            );
+        }
+    }
+
+    #[test]
+    fn transition_table_is_exhaustive_check() {
+        // Enumerate every pair; legal count must match the documented
+        // list to catch accidental additions or deletions to the table.
+        let mut legal = 0usize;
+        for from in all_states() {
+            for to in all_states() {
+                if from.can_transition_to(to) {
+                    legal += 1;
+                }
+            }
+        }
+        // 2 (from Queued) + 3 (from Claimed) + 3 (from Spawning) +
+        // 4 (from Running) + 4 (from Exiting) = 16.
+        assert_eq!(legal, 16, "transition table size drifted from spec");
+    }
+}


### PR DESCRIPTION
Implements #487, third card on the #495 PTY-migration critical path.

## Summary

ACID substrate for the per-attempt wake lifecycle. `persona_wake_leases` (Migration 17) keeps its TTL-based mutual-exclusion role; `wake_attempts` records what actually happened on each individual spawn so peer nodes can see in-flight wakes and crash recovery can reap orphans without racing peers.

**New `src/wake_attempts.rs`**
- `WakeAttemptState` enum (queued/claimed/spawning/running/exiting/done/failed/timeout/abandoned), mirroring `PredictionState`.
- `can_transition_to` FSM with 16 legal pairs. Self-loops and reverse moves rejected.
- `WakeAttempt` struct (flat row; `signal_ids` as `Vec<String>`, JSON in storage).
- `is_terminal` / `is_in_flight` helpers; `parse_state` inherent (not `from_str` -- avoids shadowing `std::FromStr`).
- Decode failures use a new `WakeAttemptStateDecodeError` variant (not `WakeAttemptNotFound` -- corruption should not be silently retried).

**Migration 23 + 8 Database methods in `src/db.rs`**
- Table with `attempt_id` PK (UUIDv7), LWW columns for smugglr sync (delta in #488), two partial indices targeting crash-recovery and operator history scans.
- `enqueue_wake_attempt`, `try_claim_wake_attempt` (atomic UPDATE pattern, mirror of `try_acquire_persona_lease`), `transition_wake_attempt` (two-layer FSM enforcement), `set_wake_attempt_pid`, `mark_wake_attempt_exit_observed`, `record_wake_attempt_outcome`, `list_local_orphans` (strictly host-scoped), `get_wake_attempt`.
- `record_wake_attempt_outcome` and `transition_wake_attempt` distinguish missing-row from illegal-transition: a row in a terminal state surfaces as `IllegalWakeAttemptTransition` with `current=<actual state>` so callers cannot mistake corruption for absence and retry.

## Test plan

- [x] 6 FSM unit tests pin every transition (16 legal pairs, includes count assertion so accidental additions fail loudly).
- [x] 17 db::tests:: integration tests cover: migration creation, queue + get round-trip, atomic claim with one winner, repeat-claim rejection, unknown-id claim, happy-path transition walk, illegal-pair rejection, stale-from rejection, missing-row error on transition / set_pid / mark_exit_observed, ok-to-Done mapping, killed-to-Failed mapping, terminal-is-sticky rejects re-stamp (with IllegalWakeAttemptTransition), unknown exit_status, host-scoped orphan filter (peer excluded), pid / exit_observed_at writes, missing-row get returns None.
- [x] cargo test --bin legion: 803 passed
- [x] cargo clippy --bin legion -- -D warnings: clean
- [x] cargo fmt --check: clean

Closes #487. Part of #495.