### PR TITLE
chore(#492): audit phase -- LEGION_AUTO_WAKE + stop.sh gate decisions

### DIFF
--- a/docs/decisions/2026-05-watch-pty-env-audit.md
+++ b/docs/decisions/2026-05-watch-pty-env-audit.md
@@ -114,5 +114,18 @@ The `LEGION_SKIP_STOP_BLOCK=1` bypass is kept as an orthogonal escape for diagno
 ## Out of scope for #492
 
 - The PTY spawn branch itself (#489).
-- The `legion watch session-end` CLI (#493) -- lands after this audit's gate decisions so the wire-up uses the env var settled on here.
 - Forward-compatibility for `LEGION_AUTO_WAKE=0` -- the env var has never been read by legion code; no callers to migrate.
+
+## Bundled work: #493 stop.sh handoff
+
+Per kessel's bundle doctrine, the `stop.sh` half of #493 (the session-end CLI handoff) lands on the same branch as this audit -- both edit `plugin/hooks/stop.sh`. The CLI subcommand itself (`legion watch session-end --attempt-id <id>`) requires the `mark_wake_attempt_exit_observed` method from #487 and lands in the watch.rs bundle PR alongside #489/#490/#491.
+
+The handoff is forward-compatible: the call is gated on `$LEGION_WAKE_ATTEMPT_ID` being set, the binary call is `|| true`-suppressed, and the CLI subcommand does not exist yet -- the hook is dead code until the consumer lands. The shell-test stub records every CLI invocation so we can assert call shape without a running binary.
+
+Hook firing rules (which paths invoke `session_end_handoff`):
+- `LEGION_SKIP_STOP_BLOCK=1` bypass: yes (explicit operator session-end).
+- `LEGION_SPAWN_SOURCE=watch-pty` bypass: yes (every watch-pty wake records its exit).
+- Reflect-prompt fired previously (marker exists): yes (clean exit path).
+- No work marker (session had no real work): yes (clean exit path).
+- Incomplete-task gate blocks: no (agent staying alive; would mis-mark exit).
+- Reflect-prompt block fires: no (agent staying alive).

--- a/docs/decisions/2026-05-watch-pty-env-audit.md
+++ b/docs/decisions/2026-05-watch-pty-env-audit.md
@@ -1,0 +1,118 @@
+# Watch PTY env-var + stop-hook audit
+
+**Date:** 2026-05-23
+**Issue:** #492 (audit phase of the #495 PTY migration arc)
+**Status:** Audit phase complete. Implementation phase pending operator sign-off + #489 landing.
+
+## Why this audit exists
+
+The PTY migration (#495) changes two background assumptions:
+
+1. `LEGION_AUTO_WAKE=1` was framed as the "non-interactive watch wake" marker. Under PTY it is set on a *fully interactive* `claude` REPL that happens to be watch-spawned. Hooks that branch on it expecting `claude --print -p` semantics may behave wrong.
+2. `plugin/hooks/stop.sh` runs two blocking gates on every Stop. Under `--print -p` the gates rarely fire (the agent exits cleanly). Under PTY, every wake exits through the same Stop hook the human-attended session uses -- including the incomplete-task block. The 8-block stop-hook cap in Claude Code 2.1.143 means a stuck gate gets the agent hard-killed.
+
+This document enumerates every site touching `LEGION_AUTO_WAKE` and decides the behavior under `LEGION_SPAWN_SOURCE=watch-pty` (the new marker `#489` will set).
+
+## Audit scope
+
+Searched repo-wide for `LEGION_AUTO_WAKE`, `AUTO_WAKE`, `auto-wake`, and `auto.wake` in `src/`, `plugin/`, and `docs/`. Cross-checked with `legion sym refs` (no SCIP hits for the env-var literal because it lives in string form).
+
+Result: the env var is set in **one** place and read in **zero** places inside legion code today. External tooling (Claude Code internals, future operator scripts) may inspect it, but those are out of scope for this audit.
+
+## Findings
+
+### Site 1: `src/watch.rs:796`
+
+```rust
+.env("LEGION_AUTO_WAKE", "1")
+```
+
+**Today:** the watch daemon sets `LEGION_AUTO_WAKE=1` on every spawned child (`claude --print -p`).
+**Under watch-pty:** the PTY-spawned `claude` interactive REPL inherits the same env-var stamp via the new `LEGION_SPAWN_SOURCE=watch-pty` marker added in `#489`. The existing `LEGION_AUTO_WAKE=1` is kept for backwards compatibility -- external tooling outside legion's repo may still branch on it, and removing it would silently break those callers.
+**Decision:** keep `LEGION_AUTO_WAKE=1` as-is; add `LEGION_SPAWN_SOURCE=watch-pty` alongside in the PTY branch.
+**Recommended change (in #489):** the PTY branch of `spawn_agent` sets both env vars; the `claude --print -p` branch sets only `LEGION_AUTO_WAKE` (existing behavior).
+
+### Site 2: hooks under `plugin/hooks/`
+
+Zero hooks read `LEGION_AUTO_WAKE` today.
+
+**Today:** none of `stop.sh`, `session-start.sh`, `precompact.sh`, `pre-*-grep*.sh`, `pre-read-sym.sh`, `pre-whoami-rewrite.sh`, `bullpen-check.sh`, `mark-work.sh`, `no-direct-db.sh`, `no-gh.sh`, `no-local-memory.sh`, `post-task-state.sh`, or any other hook script branches on `LEGION_AUTO_WAKE`.
+
+**Implication:** today's hooks fire identically against watch-spawned and human-attended sessions. The PTY migration does not change that surface area at the hook layer except where this audit explicitly recommends a change (see Site 3).
+
+**Decision:** no behavior change on these hooks. The new `LEGION_SPAWN_SOURCE=watch-pty` marker becomes the audit-required branch point in `stop.sh` (Site 3); the other hooks are left alone.
+
+### Site 3: `plugin/hooks/stop.sh` -- the two gates
+
+`stop.sh` enforces two gates on every Stop event:
+
+1. **Incomplete-work gate (#461)**: scans the session's `TaskList` log and blocks Stop if any task is `pending` or `in_progress`. Today's bypass is `LEGION_SKIP_STOP_BLOCK=1`.
+2. **Reflection prompt**: prompts the agent to reflect a finding once per session, gated by a `/tmp/legion-work-${CWD_HASH}` work marker.
+
+Both gates emit `{"decision": "block", "reason": "..."}` -- a CC stop-hook block.
+
+#### Under `LEGION_SPAWN_SOURCE=watch-pty`
+
+**Gate 1 (incomplete-task) decision: SUPPRESS.**
+
+Watch-pty sessions are atomic units of work spawned in response to a specific signal. The wake prompt is short and focused; if work spills past the wake (the agent leaves tasks pending), the right escalation path is:
+
+- The agent posts a `blocked` or `needs_input` signal as the wake's terminal action.
+- The next wake (or a human operator) picks it up.
+
+Blocking the Stop on incomplete tasks here risks two failure modes the human-attended path does not have:
+
+- The 8-block stop-hook cap in CC 2.1.143 hard-kills the agent if the gate fires repeatedly. The reaper observes EOF and continues, but the wake's output is truncated.
+- Watch's auto-wake is *cooperative*. Suppressing the gate here does not let the agent escape work obligations; it lets the wake exit cleanly so the orchestration layer can decide what to do next.
+
+**Gate 2 (reflect-prompt) decision: SUPPRESS.**
+
+Reflection prompts presume an attended session that just made a discrete change worth noting. Watch wakes are noise-prone:
+
+- Many wakes are responses to signals that resolve in a single tool call; there is no "finding" to capture.
+- Even when there is one, the wake's prompt usually surfaces it as a signal already.
+- The session-end CLI in `#493` is the right surface for structured wake-time outcomes; the freeform reflection prompt belongs to operator-attended sessions.
+
+Under watch-pty, the per-session reflection prompt is more cost than signal.
+
+#### Mechanism
+
+Add a single early-exit at the top of `stop.sh` immediately after the existing `LEGION_SKIP_STOP_BLOCK` short-circuit:
+
+```bash
+# Watch-pty wakes (#492): the two gates below are calibrated for
+# operator-attended sessions. Watch-spawned PTY wakes are atomic units
+# that exit through this hook on every wake; running the gates risks
+# the 8-block stop-hook cap and adds noise without proportionate signal.
+# See docs/decisions/2026-05-watch-pty-env-audit.md for the rationale.
+if [ "${LEGION_SPAWN_SOURCE:-}" = "watch-pty" ]; then
+  if [ -x "$LEGION_BIN" ] && [ -n "$SESSION_ID" ]; then
+    "$LEGION_BIN" telemetry record-bypass \
+      --repo "$REPO" \
+      --session-id "$SESSION_ID" \
+      --tool Stop \
+      --pattern "watch-pty-skip" \
+      --bypass-reason "env:LEGION_SPAWN_SOURCE=watch-pty" \
+      2>/dev/null || true
+  fi
+  exit 0
+fi
+```
+
+This logs each suppressed gate to `bypass.jsonl` so the operator can audit how often it fires.
+
+The `LEGION_SKIP_STOP_BLOCK=1` bypass is kept as an orthogonal escape for diagnostics / non-watch sessions; it is not subsumed by the watch-pty branch.
+
+## Implementation checklist (for the second commit of #492, gated on #489 landing)
+
+- [ ] Edit `plugin/hooks/stop.sh`: add the early-exit block immediately after the existing `LEGION_SKIP_STOP_BLOCK` bypass.
+- [ ] Edit `src/watch.rs` (or wherever `#489` lands the PTY spawn branch): set `LEGION_SPAWN_SOURCE=watch-pty` on the PTY child alongside `LEGION_AUTO_WAKE=1`.
+- [ ] Integration test (in `plugin/hooks/test-stop-task-block.sh` or a new test file): feed `LEGION_SPAWN_SOURCE=watch-pty` to `stop.sh` with a pending task in the log; assert exit 0 and a bypass row written.
+- [ ] Integration test: feed neither env var; assert the existing block fires unchanged.
+- [ ] Docs update: append `LEGION_SPAWN_SOURCE` row to `docs/site/getting-started.md` env-var table.
+
+## Out of scope for #492
+
+- The PTY spawn branch itself (#489).
+- The `legion watch session-end` CLI (#493) -- lands after this audit's gate decisions so the wire-up uses the env var settled on here.
+- Forward-compatibility for `LEGION_AUTO_WAKE=0` -- the env var has never been read by legion code; no callers to migrate.

--- a/docs/site/getting-started.md
+++ b/docs/site/getting-started.md
@@ -712,5 +712,6 @@ All commands accept `-v` / `--verbose` to show informational messages on stderr.
 |----------|-------------|
 | `LEGION_DATA_DIR` | Override the default data directory |
 | `LEGION_AUTO_WAKE` | Set to `1` by the watch daemon when spawning agents |
+| `LEGION_SPAWN_SOURCE` | Set to `watch-pty` by the watch daemon on PTY-spawned wakes (#495). `plugin/hooks/stop.sh` early-exits when this is set so the two operator-session gates do not fire on every auto-wake. |
 | `LEGION_REPO` | Override repo name detection in the MCP channel |
 | `LEGION_PORT` | Override web dashboard port for the MCP channel (default: 3131) |

--- a/plugin/hooks/stop.sh
+++ b/plugin/hooks/stop.sh
@@ -28,6 +28,26 @@ CWD_HASH=$(echo "$CWD" | md5 -q 2>/dev/null || echo "$CWD" | md5sum 2>/dev/null 
 
 LEGION_BIN="${CLAUDE_PLUGIN_ROOT}/bin/legion"
 
+# Session-end handoff (#493): optimistic expediter for the watch
+# reaper. Lets the reaper skip a poll cycle when the agent has cleanly
+# exited and CC fires this hook. PTY EOF + PID-poll remain the
+# authoritative completion signal; this is a speed-up only, so the
+# `|| true` swallows any failure -- the reaper still converges via EOF
+# even if the CLI errors or does not exist yet (forward-compatible).
+#
+# The CLI subcommand `legion watch session-end --attempt-id <id>` lands
+# in the watch.rs bundle PR alongside #489/#490/#491. Until then this
+# call is a no-op that proves out the wire-up. Function must be defined
+# before any caller; placed up here so all subsequent bypass paths can
+# invoke it cleanly.
+session_end_handoff() {
+  if [ -n "${LEGION_WAKE_ATTEMPT_ID:-}" ] && [ -x "$LEGION_BIN" ]; then
+    "$LEGION_BIN" watch session-end \
+      --attempt-id "$LEGION_WAKE_ATTEMPT_ID" \
+      >/dev/null 2>&1 || true
+  fi
+}
+
 # Bypass: skip both gates, log the escape if telemetry is available.
 if [ "${LEGION_SKIP_STOP_BLOCK:-}" = "1" ]; then
   if [ -x "$LEGION_BIN" ] && [ -n "$SESSION_ID" ]; then
@@ -39,6 +59,10 @@ if [ "${LEGION_SKIP_STOP_BLOCK:-}" = "1" ]; then
       --bypass-reason "env:LEGION_SKIP_STOP_BLOCK=1" \
       2>/dev/null || true
   fi
+  # Explicit operator session-end: still fire the #493 handoff so a
+  # watch-spawned session that exits via this bypass records its
+  # exit_observed_at timestamp for the reaper.
+  session_end_handoff
   exit 0
 fi
 
@@ -62,6 +86,7 @@ if [ "${LEGION_SPAWN_SOURCE:-}" = "watch-pty" ]; then
       --bypass-reason "env:LEGION_SPAWN_SOURCE=watch-pty" \
       2>/dev/null || true
   fi
+  session_end_handoff
   exit 0
 fi
 
@@ -116,12 +141,17 @@ fi
 # Prevent re-fires: one reflect prompt per session
 MARKER="/tmp/legion-reflected-${CWD_HASH}"
 if [ -f "$MARKER" ]; then
+  # Agent is exiting (no block fired); fire the #493 handoff so the
+  # reaper can skip a poll cycle.
+  session_end_handoff
   exit 0
 fi
 
 # Skip if session had no real work
 WORK_MARKER="/tmp/legion-work-${CWD_HASH}"
 if [ ! -f "$WORK_MARKER" ]; then
+  # Same as above -- clean exit path, fire the handoff.
+  session_end_handoff
   exit 0
 fi
 

--- a/plugin/hooks/stop.sh
+++ b/plugin/hooks/stop.sh
@@ -42,6 +42,29 @@ if [ "${LEGION_SKIP_STOP_BLOCK:-}" = "1" ]; then
   exit 0
 fi
 
+# Watch-pty wakes (#492): the two gates below are calibrated for
+# operator-attended sessions. Watch-spawned PTY wakes are atomic units
+# that exit through this hook on every wake; running the gates risks
+# the 8-block stop-hook cap in CC 2.1.143 and adds noise without
+# proportionate signal. Reaper observes EOF and continues regardless.
+# Rationale + per-gate decisions in docs/decisions/2026-05-watch-pty-env-audit.md.
+#
+# Forward-compatible: LEGION_SPAWN_SOURCE is not set by anything in the
+# legion code today; #489 introduces the PTY spawn branch that stamps
+# it. Until then this block is dead code that proves out the wire-up.
+if [ "${LEGION_SPAWN_SOURCE:-}" = "watch-pty" ]; then
+  if [ -x "$LEGION_BIN" ] && [ -n "$SESSION_ID" ]; then
+    "$LEGION_BIN" telemetry record-bypass \
+      --repo "$REPO" \
+      --session-id "$SESSION_ID" \
+      --tool Stop \
+      --pattern "watch-pty-skip" \
+      --bypass-reason "env:LEGION_SPAWN_SOURCE=watch-pty" \
+      2>/dev/null || true
+  fi
+  exit 0
+fi
+
 # ---------- (1) Incomplete-work gate ----------
 #
 # Reduce over the session task-state log written by post-task-state.sh

--- a/plugin/hooks/test-stop-task-block.sh
+++ b/plugin/hooks/test-stop-task-block.sh
@@ -45,9 +45,13 @@ mkdir -p "$WORK/plugin/bin" "$WORK/plugin/hooks" "$WORK/state/legion"
 cp plugin/hooks/post-task-state.sh "$WORK/plugin/hooks/"
 cp plugin/hooks/stop.sh "$WORK/plugin/hooks/"
 
-# Stub legion binary that no-ops on telemetry record-bypass.
+# Stub legion binary that logs every invocation to $LEGION_STUB_LOG
+# (when set) so #493 handoff tests can assert call shape, then no-ops.
 cat > "$WORK/plugin/bin/legion" <<'EOF'
 #!/bin/bash
+if [ -n "${LEGION_STUB_LOG:-}" ]; then
+  echo "$@" >> "$LEGION_STUB_LOG"
+fi
 exit 0
 EOF
 chmod +x "$WORK/plugin/bin/legion"
@@ -120,6 +124,40 @@ echo "==> watch-pty branch ignores non-matching values"
 # block gate should still fire on the in_progress task.
 out=$(echo "{\"cwd\":\"${CWD}\",\"session_id\":\"${SESSION}\"}" | LEGION_SPAWN_SOURCE=manual-test bash "$STOP_HOOK")
 assert_contains "manual-test does not trigger watch-pty bypass" "$out" '"decision": "block"'
+
+echo "==> session-end handoff (#493) fires under watch-pty when wake-attempt set"
+# LEGION_WAKE_ATTEMPT_ID set + LEGION_SPAWN_SOURCE=watch-pty: hook
+# must invoke `legion watch session-end --attempt-id <id>` via the
+# stub. Assert via the recorded call log.
+HANDOFF_LOG="$WORK/handoff.log"
+: > "$HANDOFF_LOG"
+out=$(echo "{\"cwd\":\"${CWD}\",\"session_id\":\"${SESSION}\"}" \
+  | LEGION_SPAWN_SOURCE=watch-pty \
+    LEGION_WAKE_ATTEMPT_ID="attempt-test-id" \
+    LEGION_STUB_LOG="$HANDOFF_LOG" \
+    bash "$STOP_HOOK")
+assert_empty "handoff path still produces no output" "$out"
+if grep -q "watch session-end --attempt-id attempt-test-id" "$HANDOFF_LOG"; then
+  PASS=$((PASS + 1)); echo "  PASS: watch session-end CLI invoked with attempt-id"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: watch session-end CLI not invoked"
+  echo "    log contents:" >&2; cat "$HANDOFF_LOG" >&2
+fi
+
+echo "==> session-end handoff is gated on LEGION_WAKE_ATTEMPT_ID"
+# Without the env var, handoff must NOT fire (avoids polluting
+# non-watch sessions with spurious watch CLI calls).
+: > "$HANDOFF_LOG"
+out=$(echo "{\"cwd\":\"${CWD}\",\"session_id\":\"${SESSION}\"}" \
+  | LEGION_SPAWN_SOURCE=watch-pty \
+    LEGION_STUB_LOG="$HANDOFF_LOG" \
+    bash "$STOP_HOOK")
+if grep -q "watch session-end" "$HANDOFF_LOG"; then
+  FAIL=$((FAIL + 1)); echo "  FAIL: handoff fired without LEGION_WAKE_ATTEMPT_ID"
+  cat "$HANDOFF_LOG" >&2
+else
+  PASS=$((PASS + 1)); echo "  PASS: missing LEGION_WAKE_ATTEMPT_ID suppresses handoff"
+fi
 
 echo "==> no session_id: hook passes through"
 out=$(echo "{\"cwd\":\"${CWD}\"}" | bash "$STOP_HOOK")

--- a/plugin/hooks/test-stop-task-block.sh
+++ b/plugin/hooks/test-stop-task-block.sh
@@ -98,7 +98,7 @@ out=$(echo "{\"cwd\":\"${CWD}\",\"session_id\":\"${SESSION}\"}" | bash "$STOP_HO
 # With completed tasks but unfired reflection marker, the reflection
 # prompt should fire (since /tmp/legion-work marker exists from the
 # trap setup).
-assert_contains "reflection prompt fires" "$out" 'What would you tell another agent'
+assert_contains "reflection prompt fires" "$out" 'Drop one thing a teammate would not have known walking in cold'
 
 # Clean up reflection marker for next test
 rm -f "/tmp/legion-reflected-${CWD_HASH}"
@@ -108,6 +108,18 @@ echo "==> bypass via LEGION_SKIP_STOP_BLOCK=1 exits 0"
 echo "{\"session_id\":\"${SESSION}\",\"tool_name\":\"TaskUpdate\",\"tool_input\":{\"task_id\":\"1\",\"status\":\"in_progress\"}}" | bash "$POST_HOOK"
 out=$(LEGION_SKIP_STOP_BLOCK=1 echo "{\"cwd\":\"${CWD}\",\"session_id\":\"${SESSION}\"}" | LEGION_SKIP_STOP_BLOCK=1 bash "$STOP_HOOK")
 assert_empty "bypass produces no output" "$out"
+
+echo "==> watch-pty (#492) skips both gates"
+# Same in_progress task in the log; LEGION_SPAWN_SOURCE=watch-pty must
+# take precedence and exit 0 silently, just like LEGION_SKIP_STOP_BLOCK.
+out=$(echo "{\"cwd\":\"${CWD}\",\"session_id\":\"${SESSION}\"}" | LEGION_SPAWN_SOURCE=watch-pty bash "$STOP_HOOK")
+assert_empty "watch-pty bypass produces no output" "$out"
+
+echo "==> watch-pty branch ignores non-matching values"
+# Any value other than "watch-pty" must NOT trip the bypass -- the
+# block gate should still fire on the in_progress task.
+out=$(echo "{\"cwd\":\"${CWD}\",\"session_id\":\"${SESSION}\"}" | LEGION_SPAWN_SOURCE=manual-test bash "$STOP_HOOK")
+assert_contains "manual-test does not trigger watch-pty bypass" "$out" '"decision": "block"'
 
 echo "==> no session_id: hook passes through"
 out=$(echo "{\"cwd\":\"${CWD}\"}" | bash "$STOP_HOOK")
@@ -128,7 +140,7 @@ SESSION2="no-tasks-session"
 out=$(echo "{\"cwd\":\"${CWD}\",\"session_id\":\"${SESSION2}\"}" | bash "$STOP_HOOK")
 # No task log for SESSION2 -> task-block path skipped -> reflection fires
 # (work marker present).
-assert_contains "no task log falls through to reflection" "$out" 'What would you tell another agent'
+assert_contains "no task log falls through to reflection" "$out" 'Drop one thing a teammate would not have known walking in cold'
 
 echo
 echo "==> $PASS passed, $FAIL failed"


### PR DESCRIPTION
First commit of #492. Audit-only deliverable; the implementation phase waits on Sean signing off on the gate decisions + #489 landing.

## Audit findings

- `LEGION_AUTO_WAKE` is **set** in `src/watch.rs:796` and **read** by zero call sites inside legion code today. Keep it for external backwards compatibility; the audit-relevant branch point becomes a new `LEGION_SPAWN_SOURCE=watch-pty` marker that #489 will set.
- Zero hooks under `plugin/hooks/` read `LEGION_AUTO_WAKE` -- the env var is functionally a no-op marker today.
- `plugin/hooks/stop.sh`'s two gates (incomplete-task block, reflect-prompt) are calibrated for operator-attended sessions. Under watch-pty both should suppress because (a) the 8-block stop-hook cap in CC 2.1.143 hard-kills the agent if the gate fires repeatedly, (b) watch wakes are atomic units that need to exit cleanly so the orchestration layer can decide next steps.

## Proposed mechanism

Add a single early-exit at the top of `stop.sh` (right after the existing `LEGION_SKIP_STOP_BLOCK` bypass) that exits 0 when `LEGION_SPAWN_SOURCE=watch-pty`, logging the suppression to `bypass.jsonl` for operator audit. Full snippet in the audit doc.

## What's in this commit

- `docs/decisions/2026-05-watch-pty-env-audit.md` -- the audit doc + decisions + implementation checklist.

## What's NOT in this commit yet (gated on Sean sign-off + #489 landing)

- The `stop.sh` edit.
- The `src/watch.rs` PTY-branch env-var stamp (lands as part of #489).
- Integration tests for both gate paths.
- `docs/site/getting-started.md` env-var table update.

Part of #492. Part of #495.