### PR TITLE
feat(hooks): refuse soft sym-bypass for symbol patterns with local hits

### DIFF
--- a/plugin/hooks/pre-bash-grep.sh
+++ b/plugin/hooks/pre-bash-grep.sh
@@ -80,9 +80,53 @@ if [ -n "$HITS" ]; then
   HAD_SYM="true"
 fi
 
-# State 3: bypass wins. Record telemetry, allow.
+# Pre-compute LOCAL_HITS so both the bypass refusal path and the
+# State 2 BLOCK path can use them.
+LOCAL_HITS=""
+if [ "$HAD_SYM" = "true" ] && legion_indexed "$SESSION_ID" "$REPO"; then
+  LOCAL_HITS=$(legion_prequery_filter_hits_local "$HITS" "$REPO")
+fi
+
+# State 3: bypass. Two tiers.
+#
+# Soft bypass (`# legion-bypass: <reason>` or LEGION_BYPASS_GREP=1) is
+# REFUSED when the pattern resolves to a real symbol in THIS repo's
+# SCIP index. The bypass sentinel exists for free-text searches; it
+# cannot route around sym for symbol queries dressed up as text. The
+# refusal points the agent at sym + names the LEGION_BYPASS_GREP_HARD
+# hard escape for the rare case where the agent really does need a
+# grep-style file scan over symbol-shaped text (e.g. counting call
+# sites of a deprecated API across files outside the SCIP index).
+#
+# Hard bypass (LEGION_BYPASS_GREP_HARD=1) always allows but writes a
+# row with bypass_class=hard so /telemetry summary can show how often
+# the hard escape fires (loud signal that sym is under-serving).
 BYPASS_REASON=$(legion_prequery_bypass_reason "$COMMAND")
+HARD_BYPASS="${LEGION_BYPASS_GREP_HARD:-}"
+
+if [ "$HARD_BYPASS" = "1" ]; then
+  legion_prequery_record_bypass \
+    "$REPO" "$SESSION_ID" "Bash" "$PATTERN" "hard:${BYPASS_REASON:-no-reason}" \
+    "$HAD_SYM" "false"
+  exit 0
+fi
+
 if [ -n "$BYPASS_REASON" ]; then
+  # Refuse the soft bypass if the pattern matches a real local symbol.
+  if [ -n "$LOCAL_HITS" ] && [ "$LOCAL_HITS" != "[]" ]; then
+    REASON="Soft bypass refused: \`${PATTERN}\` resolves to a symbol in this repo's SCIP index. Use \`legion sym def ${PATTERN} --repo ${REPO}\` (or \`sym refs\` / \`sym hover\`) instead. The \`# legion-bypass:\` sentinel exists for free-text searches; it cannot route around sym for symbol queries.
+
+\`legion sym def ${PATTERN} --repo ${REPO}\` returned:
+
+\`\`\`json
+${LOCAL_HITS}
+\`\`\`
+
+If you genuinely need ${BINARY} against a symbol-shaped pattern (counting call sites in files outside the SCIP index, comparing line-by-line content for a refactor diff), use the hard escape: \`LEGION_BYPASS_GREP_HARD=1 ${COMMAND}\`. The hard bypass writes a row to bypass.jsonl with \`bypass_class=hard\` so /telemetry summary can see how often it fires."
+    legion_prequery_emit_block "$REASON"
+    exit 0
+  fi
+  # Soft bypass allowed: pattern is free-text or has no local symbol hits.
   legion_prequery_record_bypass \
     "$REPO" "$SESSION_ID" "Bash" "$PATTERN" "$BYPASS_REASON" \
     "$HAD_SYM" "false"
@@ -100,15 +144,16 @@ fi
 # In an unindexed repo, the agent has no sym alternative, so we keep the
 # softer State 1 (inject + nudge) shape.
 if legion_indexed "$SESSION_ID" "$REPO"; then
+  # LOCAL_HITS was pre-computed above for the bypass refusal path; reuse
+  # the value here rather than calling the relevance gate twice.
   # Relevance gate (#458): cluster-wide sym hits in unrelated repos are
   # not a useful redirect for a grep targeting THIS repo. Common
   # dictionary words like `name`, `data`, `value`, `type`, `id` are
   # symbol-shaped and exist as identifiers in every codebase, but a
   # grep on the operator's TOML config in legion's repo should not be
-  # blocked because huttspawn has a variable named `name`. Filter
-  # cluster-wide hits down to hits IN THIS REPO before deciding.
-  LOCAL_HITS=$(legion_prequery_filter_hits_local "$HITS" "$REPO")
-  if [ "$LOCAL_HITS" = "[]" ]; then
+  # blocked because huttspawn has a variable named `name`. The
+  # pre-computed LOCAL_HITS reflects that filter.
+  if [ -z "$LOCAL_HITS" ] || [ "$LOCAL_HITS" = "[]" ]; then
     # No relevant hits in this repo's index. Fall through to inject
     # below -- the cluster-wide hits may still be useful context but
     # don't justify blocking.
@@ -122,11 +167,11 @@ if legion_indexed "$SESSION_ID" "$REPO"; then
 ${LOCAL_HITS}
 \`\`\`
 
-If you genuinely need ${BINARY} (e.g. searching for a literal that is not a symbol in this repo, or comparing line numbers across files), retry with one of:
-- \`LEGION_BYPASS_GREP=1 ${COMMAND}\`
-- \`${COMMAND} # legion-bypass: <one-line reason>\`
+The soft bypass (\`# legion-bypass: <reason>\` or LEGION_BYPASS_GREP=1) is REFUSED for symbol-shaped patterns that resolve in this repo's SCIP index -- the sentinel exists for free-text searches, not for symbol queries dressed up as text. If you genuinely need ${BINARY} against this symbol-shaped pattern (counting call sites in files outside the SCIP index, comparing line-by-line content for a refactor diff), use the hard escape:
 
-Either path allows and writes one row to bypass.jsonl so we can see where sym is under-serving."
+\`LEGION_BYPASS_GREP_HARD=1 ${COMMAND}\`
+
+The hard bypass writes a row to bypass.jsonl with \`bypass_class=hard\` so /telemetry summary can see how often sym is under-serving."
     legion_prequery_emit_block "$REASON"
     exit 0
   fi

--- a/plugin/hooks/test-pre-bash-grep.sh
+++ b/plugin/hooks/test-pre-bash-grep.sh
@@ -187,31 +187,53 @@ else
   PASS=$((PASS + 1)); echo "  PASS: cross-repo-only hits do not trigger block"
 fi
 
-echo "==> hook end-to-end: bypass via env -> allow + telemetry"
+echo "==> harder bypass (#495 follow-up): soft env bypass REFUSED for symbol with local hit"
 export LEGION_TEST_MARKER="$WORK/state/bypass-marker.log"
+rm -f "$LEGION_TEST_MARKER"
+# Symbol resolves to a local-repo SCIP hit, so LEGION_BYPASS_GREP=1
+# is refused. The hook emits a block decision pointing at sym and
+# names the hard escape; no telemetry row is written for the refusal.
 out=$(LEGION_BYPASS_GREP=1 echo '{"cwd":"/tmp/legion","tool_name":"Bash","tool_input":{"command":"grep -r Symbol src/"},"session_id":"bypass-env-t"}' | LEGION_BYPASS_GREP=1 bash "$HOOK")
-assert_empty "env bypass exits 0 with no decision JSON" "$out"
+assert_contains "soft env bypass refused on local symbol" "$out" '"decision": "block"'
+assert_contains "refusal names hard escape" "$out" 'LEGION_BYPASS_GREP_HARD=1'
 if [ -f "$LEGION_TEST_MARKER" ] && grep -q "record-bypass" "$LEGION_TEST_MARKER"; then
-  PASS=$((PASS + 1)); echo "  PASS: env bypass writes telemetry row"
+  FAIL=$((FAIL + 1)); echo "  FAIL: refused soft bypass should NOT write telemetry row"
 else
-  FAIL=$((FAIL + 1)); echo "  FAIL: env bypass did not write telemetry row" >&2
+  PASS=$((PASS + 1)); echo "  PASS: refused soft bypass writes no telemetry row"
 fi
 unset LEGION_BYPASS_GREP
 
-echo "==> hook end-to-end: bypass via comment sentinel -> allow + telemetry"
+echo "==> harder bypass: soft sentinel bypass REFUSED for symbol with local hit"
 rm -f "$LEGION_TEST_MARKER"
 out=$(echo '{"cwd":"/tmp/legion","tool_name":"Bash","tool_input":{"command":"grep -r Symbol src/ # legion-bypass: testing"},"session_id":"bypass-sentinel-t"}' | bash "$HOOK")
-assert_empty "sentinel bypass exits 0 with no decision JSON" "$out"
+assert_contains "soft sentinel bypass refused on local symbol" "$out" '"decision": "block"'
+assert_contains "refusal explains the sentinel is for free text" "$out" 'free-text searches'
+
+echo "==> harder bypass: soft bypass STILL allowed for non-symbol pattern"
+# commonword stub returns hits ONLY in unrelated repos; the local
+# relevance filter empties LOCAL_HITS, so the soft bypass goes
+# through. This is the cross-cutting legitimate case (free-text
+# search that happens to look symbol-shaped to the static regex).
+rm -f "$LEGION_TEST_MARKER"
+out=$(echo '{"cwd":"/tmp/legion","tool_name":"Bash","tool_input":{"command":"grep -r commonword src/ # legion-bypass: free-text counter"},"session_id":"bypass-allow-t"}' | bash "$HOOK")
+assert_empty "soft bypass on non-local symbol exits 0" "$out"
 if [ -f "$LEGION_TEST_MARKER" ] && grep -q "record-bypass" "$LEGION_TEST_MARKER"; then
-  PASS=$((PASS + 1)); echo "  PASS: sentinel bypass writes telemetry row"
-  if grep -q "testing" "$LEGION_TEST_MARKER"; then
-    PASS=$((PASS + 1)); echo "  PASS: bypass reason captured"
-  else
-    FAIL=$((FAIL + 1)); echo "  FAIL: bypass reason not captured in telemetry args" >&2
-  fi
+  PASS=$((PASS + 1)); echo "  PASS: soft bypass allowed for free-text / non-local pattern"
 else
-  FAIL=$((FAIL + 1)); echo "  FAIL: sentinel bypass did not write telemetry row" >&2
+  FAIL=$((FAIL + 1)); echo "  FAIL: soft bypass should still allow free-text patterns" >&2
 fi
+
+echo "==> harder bypass: hard escape (LEGION_BYPASS_GREP_HARD=1) ALWAYS allows"
+rm -f "$LEGION_TEST_MARKER"
+out=$(LEGION_BYPASS_GREP_HARD=1 echo '{"cwd":"/tmp/legion","tool_name":"Bash","tool_input":{"command":"grep -r Symbol src/"},"session_id":"bypass-hard-t"}' | LEGION_BYPASS_GREP_HARD=1 bash "$HOOK")
+assert_empty "hard escape exits 0 with no decision JSON" "$out"
+if [ -f "$LEGION_TEST_MARKER" ] && grep -q "record-bypass" "$LEGION_TEST_MARKER" && grep -q "hard:" "$LEGION_TEST_MARKER"; then
+  PASS=$((PASS + 1)); echo "  PASS: hard escape writes telemetry row with bypass_class=hard prefix"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: hard escape did not write expected telemetry row" >&2
+  [ -f "$LEGION_TEST_MARKER" ] && cat "$LEGION_TEST_MARKER" >&2
+fi
+unset LEGION_BYPASS_GREP_HARD
 
 echo "==> hook end-to-end: skip via LEGION_SKIP_PRE_BASH_GREP=1"
 out=$(LEGION_SKIP_PRE_BASH_GREP=1 echo '{"cwd":"/tmp/legion","tool_name":"Bash","tool_input":{"command":"grep -r Symbol src/"},"session_id":"skip-t"}' | LEGION_SKIP_PRE_BASH_GREP=1 bash "$HOOK")


### PR DESCRIPTION
Surfaced by operator callout end-of-session 2026-05-23: agents (including the one that built the enforcement) keep using the `# legion-bypass:` sentinel for queries that are definitionally symbol lookups. The sentinel was too cheap -- the friction of typing "grep -n Foo # legion-bypass: ..." matched "legion sym def Foo" closely enough that muscle memory won.

## Behavior change

- **Soft bypass** (`LEGION_BYPASS_GREP=1` or `# legion-bypass: <reason>`) is now **REFUSED** when the pattern resolves to a symbol in THIS repo's SCIP index. The refusal emits a block decision pointing at `legion sym def` and names the hard escape.
- **Hard bypass** (`LEGION_BYPASS_GREP_HARD=1`) always allows but writes a row to bypass.jsonl with `bypass_class=hard` prefix so `/telemetry summary` can see how often the hard escape fires -- loud signal that sym is under-serving.
- Soft bypass continues to allow free-text patterns and patterns that resolve only in unrelated repos (relevance gate #458). The legitimate case (literal-string searches, conflict markers, raw-string content) still works without changing muscle memory.

## Test plan

- [x] soft env bypass refused on local symbol (was allowed)
- [x] soft sentinel bypass refused on local symbol (was allowed)
- [x] soft bypass STILL allowed for non-local symbol pattern
- [x] hard escape always allows + writes bypass_class=hard row
- [x] 41/41 hook tests pass
- [x] cargo unchanged (hook-only change)

## Reflection trail

- `019e578c` -- root-cause analysis: why agents ignore sym even after enforcement landed
- `019e5734` -- cascading registry-file conflicts (parallel)
- `019e5710` -- clippy --bin vs --all-targets (parallel gotcha)

## Follow-up

Apply symmetric hardening to `pre-read-sym.sh` (Read tool) once a clean source-file-vs-config heuristic is in place. The existing line-count gate already handles the cost-justification half; the symbol-resolves-to-local case needs more thought because Read is not a 1:1 match with sym hover.