### PR TITLE
feat(#515): born-Backlog -- cards default to Backlog, explicit promotion to Pending

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -2616,10 +2616,12 @@ impl Database {
         source_url: Option<&str>,
         source_type: Option<&str>,
         created_at_override: Option<&str>,
+        status: crate::kanban::CardStatus,
     ) -> Result<String> {
         let id = uuid::Uuid::now_v7().to_string();
         let now = chrono::Utc::now().to_rfc3339();
         let created_at = created_at_override.unwrap_or(&now);
+        let status_str = status.to_string();
 
         let parsed = context.map(crate::card_parse::parse_issue_body);
         let problem = parsed.as_ref().and_then(|p| p.problem.as_deref());
@@ -2634,7 +2636,7 @@ impl Database {
             "INSERT INTO tasks (id, from_repo, to_repo, text, context, priority, status, \
              labels, parent_card_id, source_url, source_type, created_at, updated_at, \
              problem, solution, acceptance) \
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, 'pending', ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15)",
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?16, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15)",
             rusqlite::params![
                 id,
                 from_repo,
@@ -2651,6 +2653,7 @@ impl Database {
                 problem,
                 solution,
                 acceptance,
+                status_str,
             ],
         )?;
         Ok(id)
@@ -6086,6 +6089,7 @@ mod tests {
                 None,
                 None,
                 None,
+                crate::kanban::CardStatus::Backlog,
             )
             .unwrap();
         assert!(db.get_card_by_id(&id).unwrap().is_some());
@@ -6149,6 +6153,7 @@ mod tests {
                 None,
                 None,
                 None,
+                crate::kanban::CardStatus::Backlog,
             )
             .unwrap();
         assert!(db.get_card_by_id(&id).unwrap().is_some());
@@ -6291,12 +6296,32 @@ mod tests {
         // Insert two cards.
         let id1 = db
             .insert_card(
-                "kelex", "legion", "task 1", None, "med", None, None, None, None, None,
+                "kelex",
+                "legion",
+                "task 1",
+                None,
+                "med",
+                None,
+                None,
+                None,
+                None,
+                None,
+                crate::kanban::CardStatus::Pending,
             )
             .unwrap();
         let _id2 = db
             .insert_card(
-                "kelex", "legion", "task 2", None, "high", None, None, None, None, None,
+                "kelex",
+                "legion",
+                "task 2",
+                None,
+                "high",
+                None,
+                None,
+                None,
+                None,
+                None,
+                crate::kanban::CardStatus::Pending,
             )
             .unwrap();
 
@@ -6331,6 +6356,7 @@ mod tests {
                 None,
                 None,
                 None,
+                crate::kanban::CardStatus::Backlog,
             )
             .unwrap();
 
@@ -6446,6 +6472,7 @@ mod tests {
                 None,
                 None,
                 None,
+                crate::kanban::CardStatus::Backlog,
             )
             .unwrap();
         db.soft_delete_card(&card_id).unwrap();

--- a/src/db.rs
+++ b/src/db.rs
@@ -2632,6 +2632,11 @@ impl Database {
             .filter(|a| !a.is_empty())
             .map(|a| a.join("\n"));
 
+        // NOTE: placeholder numbers are NOT sequential. `status` was added late and
+        // binds `?16` (the last param) in the 7th column slot to keep the original
+        // ?1..?15 mapping untouched. When adding a new column, append its param to the
+        // list and give it the next free number (?17, ...) in the correct column slot
+        // -- do not reuse ?16 or assume position == placeholder number.
         self.conn.execute(
             "INSERT INTO tasks (id, from_repo, to_repo, text, context, priority, status, \
              labels, parent_card_id, source_url, source_type, created_at, updated_at, \

--- a/src/kanban.rs
+++ b/src/kanban.rs
@@ -863,6 +863,40 @@ mod tests {
     }
 
     #[test]
+    fn backlog_card_is_not_worked_until_assigned() {
+        let (db, _index, _dir) = test_storage();
+
+        let id = create_card(
+            &db,
+            "sean",
+            "kelex",
+            "unconsented",
+            None,
+            "high",
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+        .expect("create");
+
+        // The born-Backlog safety property: an unconsented (Backlog) card must NOT
+        // be handed to the agent as ready work. pick/peek filter on status=pending.
+        assert!(
+            peek_work(&db, "kelex").expect("peek").is_none(),
+            "a Backlog card must not be picked up as ready work"
+        );
+
+        // An explicit Assign (operator consensus / planfile) promotes it to ready.
+        transition_card(&db, &id, Action::Assign, None).expect("assign");
+        assert!(
+            peek_work(&db, "kelex").expect("peek").is_some(),
+            "an assigned (Pending) card is ready work"
+        );
+    }
+
+    #[test]
     fn create_with_all_fields() {
         let (db, _index, _dir) = test_storage();
 

--- a/src/kanban.rs
+++ b/src/kanban.rs
@@ -268,6 +268,8 @@ pub fn create_card(
     source_type: Option<&str>,
     created_at: Option<&str>,
 ) -> Result<String> {
+    // born-Backlog: every card is created in Backlog. Promotion to Pending is an
+    // explicit transition (Action::Assign), never a side effect of creation.
     db.insert_card(
         from_repo,
         to_repo,
@@ -279,6 +281,7 @@ pub fn create_card(
         source_url,
         source_type,
         created_at,
+        CardStatus::Backlog,
     )
 }
 
@@ -815,6 +818,23 @@ mod tests {
 
     // --- DB integration tests ---
 
+    /// Create a card and Assign it to Pending -- the real born-Backlog -> consented
+    /// flow. Returns the card id. Flow tests start from a ready (Pending) card.
+    fn create_and_assign(
+        db: &Database,
+        from: &str,
+        to: &str,
+        text: &str,
+        priority: &str,
+    ) -> String {
+        let id = create_card(
+            db, from, to, text, None, priority, None, None, None, None, None,
+        )
+        .expect("create");
+        transition_card(db, &id, Action::Assign, None).expect("assign");
+        id
+    }
+
     #[test]
     fn create_and_list_cards() {
         let (db, _index, _dir) = test_storage();
@@ -838,7 +858,8 @@ mod tests {
         let cards = list_cards(&db, "legion", Direction::Inbound).expect("list");
         assert_eq!(cards.len(), 1);
         assert_eq!(cards[0].text, "implement search");
-        assert_eq!(cards[0].status, CardStatus::Pending);
+        // born-Backlog: a freshly created card lands in Backlog, not Pending.
+        assert_eq!(cards[0].status, CardStatus::Backlog);
     }
 
     #[test]
@@ -875,20 +896,7 @@ mod tests {
     fn full_lifecycle() {
         let (db, _index, _dir) = test_storage();
 
-        let id = create_card(
-            &db,
-            "kelex",
-            "legion",
-            "do the thing",
-            None,
-            "med",
-            None,
-            None,
-            None,
-            None,
-            None,
-        )
-        .expect("create");
+        let id = create_and_assign(&db, "kelex", "legion", "do the thing", "med");
 
         let card = transition_card(&db, &id, Action::Accept, None).expect("accept");
         assert_eq!(card.status, CardStatus::Accepted);
@@ -904,20 +912,7 @@ mod tests {
     fn block_unblock_flow() {
         let (db, _index, _dir) = test_storage();
 
-        let id = create_card(
-            &db,
-            "kelex",
-            "legion",
-            "blocked task",
-            None,
-            "med",
-            None,
-            None,
-            None,
-            None,
-            None,
-        )
-        .expect("create");
+        let id = create_and_assign(&db, "kelex", "legion", "blocked task", "med");
 
         transition_card(&db, &id, Action::Accept, None).expect("accept");
         let card =
@@ -932,48 +927,9 @@ mod tests {
     fn next_work_picks_highest_priority() {
         let (db, _index, _dir) = test_storage();
 
-        create_card(
-            &db,
-            "sean",
-            "kelex",
-            "low priority",
-            None,
-            "low",
-            None,
-            None,
-            None,
-            None,
-            None,
-        )
-        .expect("create low");
-        create_card(
-            &db,
-            "sean",
-            "kelex",
-            "high priority",
-            None,
-            "high",
-            None,
-            None,
-            None,
-            None,
-            None,
-        )
-        .expect("create high");
-        create_card(
-            &db,
-            "sean",
-            "kelex",
-            "med priority",
-            None,
-            "med",
-            None,
-            None,
-            None,
-            None,
-            None,
-        )
-        .expect("create med");
+        create_and_assign(&db, "sean", "kelex", "low priority", "low");
+        create_and_assign(&db, "sean", "kelex", "high priority", "high");
+        create_and_assign(&db, "sean", "kelex", "med priority", "med");
 
         let card = next_work(&db, "kelex").expect("work").expect("has work");
         assert_eq!(card.text, "high priority");
@@ -991,20 +947,7 @@ mod tests {
     fn peek_does_not_accept() {
         let (db, _index, _dir) = test_storage();
 
-        create_card(
-            &db,
-            "sean",
-            "kelex",
-            "peek test",
-            None,
-            "med",
-            None,
-            None,
-            None,
-            None,
-            None,
-        )
-        .expect("create");
+        create_and_assign(&db, "sean", "kelex", "peek test", "med");
 
         let card = peek_work(&db, "kelex").expect("peek").expect("has work");
         assert_eq!(card.status, CardStatus::Pending);
@@ -1150,18 +1093,9 @@ mod tests {
     fn agent_workloads_summary() {
         let (db, _index, _dir) = test_storage();
 
-        create_card(
-            &db, "sean", "kelex", "task 1", None, "med", None, None, None, None, None,
-        )
-        .expect("create");
-        create_card(
-            &db, "sean", "kelex", "task 2", None, "high", None, None, None, None, None,
-        )
-        .expect("create");
-        create_card(
-            &db, "sean", "rafters", "task 3", None, "med", None, None, None, None, None,
-        )
-        .expect("create");
+        create_and_assign(&db, "sean", "kelex", "task 1", "med");
+        create_and_assign(&db, "sean", "kelex", "task 2", "high");
+        create_and_assign(&db, "sean", "rafters", "task 3", "med");
 
         let workloads = agent_workloads(&db).expect("workloads");
         assert!(workloads.len() >= 2);
@@ -1203,20 +1137,7 @@ mod tests {
     #[test]
     fn cancel_sets_completed_at() {
         let (db, _index, _dir) = test_storage();
-        let id = create_card(
-            &db,
-            "sean",
-            "kelex",
-            "cancel test",
-            None,
-            "med",
-            None,
-            None,
-            None,
-            None,
-            None,
-        )
-        .expect("create");
+        let id = create_and_assign(&db, "sean", "kelex", "cancel test", "med");
         transition_card(&db, &id, Action::Accept, None).expect("accept");
         let card = transition_card(&db, &id, Action::Cancel, None).expect("cancel");
         assert_eq!(card.status, CardStatus::Cancelled);
@@ -1229,20 +1150,7 @@ mod tests {
     #[test]
     fn block_unblock_does_not_clobber_started_at() {
         let (db, _index, _dir) = test_storage();
-        let id = create_card(
-            &db,
-            "sean",
-            "kelex",
-            "block test",
-            None,
-            "med",
-            None,
-            None,
-            None,
-            None,
-            None,
-        )
-        .expect("create");
+        let id = create_and_assign(&db, "sean", "kelex", "block test", "med");
         let card = transition_card(&db, &id, Action::Accept, None).expect("accept");
         let started = card.started_at.clone();
         assert!(started.is_some());
@@ -1283,7 +1191,7 @@ mod tests {
         let (db, _index, _dir) = test_storage();
 
         // Create a "new" issue first (inserted first, but newer date)
-        create_card(
+        let new_id = create_card(
             &db,
             "sean",
             "kelex",
@@ -1297,9 +1205,10 @@ mod tests {
             Some("2026-04-07T00:00:00Z"),
         )
         .expect("create new");
+        transition_card(&db, &new_id, Action::Assign, None).expect("assign new");
 
         // Create an "old" issue second (inserted second, but older date)
-        create_card(
+        let old_id = create_card(
             &db,
             "sean",
             "kelex",
@@ -1313,6 +1222,7 @@ mod tests {
             Some("2026-04-03T00:00:00Z"),
         )
         .expect("create old");
+        transition_card(&db, &old_id, Action::Assign, None).expect("assign old");
 
         // Scheduler should pick the older issue first
         let card = peek_work(&db, "kelex").expect("peek").expect("has work");
@@ -1324,7 +1234,7 @@ mod tests {
         let (db, _index, _dir) = test_storage();
 
         // Manual card created now (no override, gets Utc::now())
-        create_card(
+        let manual_id = create_card(
             &db,
             "sean",
             "kelex",
@@ -1338,9 +1248,10 @@ mod tests {
             None,
         )
         .expect("create manual");
+        transition_card(&db, &manual_id, Action::Assign, None).expect("assign manual");
 
         // Synced card with an older GitHub creation date
-        create_card(
+        let synced_id = create_card(
             &db,
             "sean",
             "kelex",
@@ -1354,6 +1265,7 @@ mod tests {
             Some("2026-03-01T00:00:00Z"),
         )
         .expect("create synced");
+        transition_card(&db, &synced_id, Action::Assign, None).expect("assign synced");
 
         // Synced card's older date should win over manual card's recent date
         let card = peek_work(&db, "kelex").expect("peek").expect("has work");

--- a/src/worksource.rs
+++ b/src/worksource.rs
@@ -891,6 +891,10 @@ pub fn sync_issues(
             "med"
         };
 
+        // born-Backlog: synced issues are created in Backlog via create_card's
+        // default. Do NOT introduce a status here -- promotion to Pending is an
+        // explicit Assign (operator consensus / planfile), never a side effect of
+        // import. Routing imports through create_card is what keeps AC #2 true.
         kanban::create_card(
             db,
             legion_repo,

--- a/src/worksource.rs
+++ b/src/worksource.rs
@@ -862,6 +862,12 @@ pub fn sync_issues(
 
     let mut created = 0u64;
     for issue in &issues {
+        // Skip issues that already have a card. This skip is load-bearing for
+        // born-Backlog: an already-imported card may have been promoted past
+        // Backlog (Assign -> Pending -> ...) by operator consensus. Re-importing
+        // it -- or turning this skip into an upsert -- would silently reset that
+        // status back to Backlog and discard the consent. Do not change to an
+        // upsert without preserving the existing card's status.
         if issue.url.is_empty() || existing_urls.contains(&issue.url) {
             continue;
         }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -2142,7 +2142,7 @@ fn kanban_work_picks_up_card() {
     let dir = tempfile::tempdir().unwrap();
 
     // Create two cards with different priorities
-    legion_cmd(dir.path())
+    let low = legion_cmd(dir.path())
         .args([
             "kanban",
             "create",
@@ -2157,7 +2157,8 @@ fn kanban_work_picks_up_card() {
         ])
         .output()
         .unwrap();
-    legion_cmd(dir.path())
+    let low_id = String::from_utf8_lossy(&low.stdout).trim().to_string();
+    let high = legion_cmd(dir.path())
         .args([
             "kanban",
             "create",
@@ -2172,6 +2173,15 @@ fn kanban_work_picks_up_card() {
         ])
         .output()
         .unwrap();
+    let high_id = String::from_utf8_lossy(&high.stdout).trim().to_string();
+
+    // born-Backlog: promote both to Pending before work can pick them up.
+    for id in [&low_id, &high_id] {
+        legion_cmd(dir.path())
+            .args(["kanban", "assign", "--id", id, "--to", "kelex"])
+            .output()
+            .unwrap();
+    }
 
     // Work should pick up the high priority card
     let out = legion_cmd(dir.path())
@@ -2216,7 +2226,7 @@ fn kanban_work_empty_queue() {
 fn kanban_work_peek_does_not_accept() {
     let dir = tempfile::tempdir().unwrap();
 
-    legion_cmd(dir.path())
+    let out = legion_cmd(dir.path())
         .args([
             "kanban",
             "create",
@@ -2229,6 +2239,12 @@ fn kanban_work_peek_does_not_accept() {
             "--priority",
             "med",
         ])
+        .output()
+        .unwrap();
+    let id = String::from_utf8_lossy(&out.stdout).trim().to_string();
+    // born-Backlog: promote to Pending so work/peek can see it.
+    legion_cmd(dir.path())
+        .args(["kanban", "assign", "--id", &id, "--to", "kelex"])
         .output()
         .unwrap();
 
@@ -2274,6 +2290,12 @@ fn kanban_full_lifecycle() {
         .unwrap();
     assert!(out.status.success());
     let id = String::from_utf8_lossy(&out.stdout).trim().to_string();
+
+    // born-Backlog: promote to Pending before accept.
+    legion_cmd(dir.path())
+        .args(["kanban", "assign", "--id", &id, "--to", "kelex"])
+        .output()
+        .unwrap();
 
     // Accept
     let out = legion_cmd(dir.path())
@@ -2327,6 +2349,12 @@ fn kanban_block_unblock() {
         .output()
         .unwrap();
     let id = String::from_utf8_lossy(&out.stdout).trim().to_string();
+
+    // born-Backlog: promote to Pending before accept.
+    legion_cmd(dir.path())
+        .args(["kanban", "assign", "--id", &id, "--to", "kelex"])
+        .output()
+        .unwrap();
 
     legion_cmd(dir.path())
         .args(["kanban", "accept", "--id", &id])

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -2134,6 +2134,11 @@ fn kanban_create_and_list() {
         stdout.contains("[high]"),
         "expected priority, got: {stdout}"
     );
+    // born-Backlog: a newly created card lands in Backlog (AC #1 at the CLI boundary).
+    assert!(
+        stdout.contains("[backlog]"),
+        "expected backlog status on a freshly created card, got: {stdout}"
+    );
     // Labels are no longer shown inline -- they're stored but not displayed in list output
 }
 


### PR DESCRIPTION
Closes #515. Part of epic #508.

## What changed

`Database::insert_card` hardcoded `'pending'` for every card, so GitHub sync flooded the Pending column with unconsented issues and `Backlog` was an orphan status with no creation path. This threads a `status` param through `insert_card` and makes `create_card` always create `Backlog`. Promotion to Pending is now exclusively `Action::Assign` (the consent gate).

## AC -> evidence

- **A card created via `kanban create` has status `backlog`** -> `create_card` passes `CardStatus::Backlog` to `insert_card` (src/kanban.rs); `create_and_list_cards` test asserts `cards[0].status == Backlog`.
- **`sync_issues` imports land `backlog`** -> `worksource::sync_issues` calls `create_card` (unchanged call site), which now yields Backlog; inherited transitively.
- **`Assign` is the only transition into `pending`** -> FSM untouched: the sole arm producing `Pending` is `(Backlog, Assign)` (src/kanban.rs:101); covered by `assign_from_backlog` and `cannot_assign_from_accepted`.
- **All tests pass; clippy/fmt clean** -> 840 lib + 143 integration pass, 0 failed; `cargo clippy --all-targets -- -D warnings` clean; `cargo fmt -- --check` clean.

## Notes / not done

- `insert_card` gained the `status` param (bound as `?16` into the existing status column; the other 15 placeholders are untouched). The delta round-trip tests pass an explicit `Pending` to prove the param flows through.
- Tests model the real born-Backlog -> consented flow via a `create_and_assign` unit helper and explicit `kanban assign` steps in the integration tests (net -135 lines in kanban.rs from collapsing duplicated create blocks).
- Working-set list filtering (so the SessionStart banner stops showing Backlog) is the sibling issue #516, intentionally out of scope here. Until #516 lands, `kanban list` still shows Backlog cards.
- Did NOT touch `task.rs::create_task` (directed signals) -- a directed ask is not "backlog", out of scope.