### PR TITLE
feat(#516): kanban list returns the working set; --all/--backlog for the rest

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -2683,19 +2683,32 @@ impl Database {
         &self,
         repo: &str,
         direction: crate::kanban::Direction,
+        scope: crate::kanban::CardScope,
     ) -> Result<Vec<crate::kanban::Card>> {
+        // Status predicate for the requested slice of the board. WorkingSet is the
+        // default consumer view (active work); Backlog is the raw inbox; All keeps
+        // every non-deleted row. Status literals match CardStatus::Display.
+        let status_filter = match scope {
+            crate::kanban::CardScope::WorkingSet => {
+                " AND status NOT IN ('backlog', 'done', 'cancelled')"
+            }
+            crate::kanban::CardScope::Backlog => " AND status = 'backlog'",
+            crate::kanban::CardScope::All => "",
+        };
         let sql = match direction {
             crate::kanban::Direction::Inbound => {
                 format!(
-                    "SELECT {} FROM tasks WHERE to_repo = ?1 AND deleted_at IS NULL ORDER BY {}, sort_order ASC, created_at DESC",
+                    "SELECT {} FROM tasks WHERE to_repo = ?1 AND deleted_at IS NULL{} ORDER BY {}, sort_order ASC, created_at DESC",
                     Self::CARD_COLUMNS,
+                    status_filter,
                     Self::PRIORITY_ORDER
                 )
             }
             crate::kanban::Direction::Outbound => {
                 format!(
-                    "SELECT {} FROM tasks WHERE from_repo = ?1 AND deleted_at IS NULL ORDER BY created_at DESC",
-                    Self::CARD_COLUMNS
+                    "SELECT {} FROM tasks WHERE from_repo = ?1 AND deleted_at IS NULL{} ORDER BY created_at DESC",
+                    Self::CARD_COLUMNS,
+                    status_filter
                 )
             }
         };

--- a/src/kanban.rs
+++ b/src/kanban.rs
@@ -197,6 +197,19 @@ pub enum Direction {
     Outbound,
 }
 
+/// Which slice of the board to return when listing cards.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum CardScope {
+    /// Active work only: Pending, Accepted, NeedsInput, InReview, Blocked.
+    /// Excludes Backlog (pre-consensus) and terminal (Done, Cancelled). This is
+    /// the default for `kanban list` and the SessionStart "Current work" banner.
+    WorkingSet,
+    /// The raw, unconsented inbox: Backlog cards only.
+    Backlog,
+    /// Everything non-deleted, regardless of status.
+    All,
+}
+
 /// Get the next pending card for a repo (the scheduler).
 ///
 /// Selects the highest-priority unblocked card assigned to the repo
@@ -286,8 +299,13 @@ pub fn create_card(
 }
 
 /// List cards for a repo filtered by direction.
-pub fn list_cards(db: &Database, repo: &str, direction: Direction) -> Result<Vec<Card>> {
-    db.get_cards(repo, direction)
+pub fn list_cards(
+    db: &Database,
+    repo: &str,
+    direction: Direction,
+    scope: CardScope,
+) -> Result<Vec<Card>> {
+    db.get_cards(repo, direction, scope)
 }
 
 /// Get all cards for the kanban board view.
@@ -855,7 +873,7 @@ mod tests {
         .expect("create");
         assert_eq!(id.len(), 36);
 
-        let cards = list_cards(&db, "legion", Direction::Inbound).expect("list");
+        let cards = list_cards(&db, "legion", Direction::Inbound, CardScope::All).expect("list");
         assert_eq!(cards.len(), 1);
         assert_eq!(cards[0].text, "implement search");
         // born-Backlog: a freshly created card lands in Backlog, not Pending.
@@ -894,6 +912,58 @@ mod tests {
             peek_work(&db, "kelex").expect("peek").is_some(),
             "an assigned (Pending) card is ready work"
         );
+    }
+
+    #[test]
+    fn list_cards_scopes_filter_by_status() {
+        let (db, _index, _dir) = test_storage();
+
+        // One card per relevant status. create_card yields Backlog; promote/transition
+        // the rest. WorkingSet = Pending + Accepted here; Backlog and terminal excluded.
+        let backlog_id = create_card(
+            &db,
+            "sean",
+            "kelex",
+            "raw inbox",
+            None,
+            "med",
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+        .expect("create backlog");
+        create_and_assign(&db, "sean", "kelex", "ready", "med"); // -> Pending
+        let accepted = create_and_assign(&db, "sean", "kelex", "in progress", "med");
+        transition_card(&db, &accepted, Action::Accept, None).expect("accept");
+        let done = create_and_assign(&db, "sean", "kelex", "shipped", "med");
+        transition_card(&db, &done, Action::Accept, None).expect("accept");
+        transition_card(&db, &done, Action::Done, None).expect("done");
+        let cancelled = create_card(
+            &db, "sean", "kelex", "scrapped", None, "med", None, None, None, None, None,
+        )
+        .expect("create cancelled");
+        transition_card(&db, &cancelled, Action::Cancel, None).expect("cancel");
+
+        // WorkingSet: only Pending + Accepted (Backlog, Done, Cancelled excluded).
+        let ws = list_cards(&db, "kelex", Direction::Inbound, CardScope::WorkingSet).expect("ws");
+        assert_eq!(ws.len(), 2, "working set should be Pending + Accepted only");
+        assert!(
+            ws.iter()
+                .all(|c| matches!(c.status, CardStatus::Pending | CardStatus::Accepted)),
+            "working set must exclude Backlog/Done/Cancelled"
+        );
+
+        // Backlog scope: only the raw inbox card.
+        let bl = list_cards(&db, "kelex", Direction::Inbound, CardScope::Backlog).expect("bl");
+        assert_eq!(bl.len(), 1);
+        assert_eq!(bl[0].id, backlog_id);
+        assert_eq!(bl[0].status, CardStatus::Backlog);
+
+        // All: every non-deleted card regardless of status.
+        let all = list_cards(&db, "kelex", Direction::Inbound, CardScope::All).expect("all");
+        assert_eq!(all.len(), 5, "All should return every non-deleted card");
     }
 
     #[test]
@@ -1083,7 +1153,7 @@ mod tests {
         )
         .expect("create");
 
-        let cards = list_cards(&db, "legion", Direction::Inbound).expect("list");
+        let cards = list_cards(&db, "legion", Direction::Inbound, CardScope::All).expect("list");
         let output = format_card_list(&cards, "legion", Direction::Inbound);
         assert!(output.contains("[Legion] Cards for legion"));
         assert!(output.contains("test card"));
@@ -1779,7 +1849,7 @@ mod tests {
         )
         .expect("create 2");
 
-        let cards = list_cards(&db, "kelex", Direction::Inbound).expect("list");
+        let cards = list_cards(&db, "kelex", Direction::Inbound, CardScope::All).expect("list");
         let output = format_card_list_json(&cards).expect("json");
         let lines: Vec<&str> = output.lines().collect();
         assert_eq!(lines.len(), 2, "two lines for two cards");
@@ -1821,7 +1891,7 @@ mod tests {
         )
         .expect("create");
 
-        let cards = list_cards(&db, "kelex", Direction::Inbound).expect("list");
+        let cards = list_cards(&db, "kelex", Direction::Inbound, CardScope::All).expect("list");
         let output = format_card_list_json(&cards).expect("json");
         let line = output.lines().next().expect("has output");
         let parsed: serde_json::Value = serde_json::from_str(line).expect("parse");

--- a/src/main.rs
+++ b/src/main.rs
@@ -1383,6 +1383,14 @@ enum KanbanAction {
         /// Emit JSONL (one summary object per line) instead of human-readable text
         #[arg(long)]
         json: bool,
+
+        /// Show all cards, including Backlog and terminal (Done/Cancelled)
+        #[arg(long, conflicts_with = "backlog")]
+        all: bool,
+
+        /// Show only the raw Backlog (the unconsented inbox)
+        #[arg(long)]
+        backlog: bool,
     },
 
     /// Accept a pending card (move to in-progress)
@@ -4828,13 +4836,27 @@ fn run() -> error::Result<()> {
                         outcome: "success",
                     });
                 }
-                KanbanAction::List { repo, from, json } => {
+                KanbanAction::List {
+                    repo,
+                    from,
+                    json,
+                    all,
+                    backlog,
+                } => {
                     let direction = if from {
                         kanban::Direction::Outbound
                     } else {
                         kanban::Direction::Inbound
                     };
-                    let cards = kanban::list_cards(&database, &repo, direction)?;
+                    // Default to the working set; --all and --backlog widen/redirect.
+                    let scope = if all {
+                        kanban::CardScope::All
+                    } else if backlog {
+                        kanban::CardScope::Backlog
+                    } else {
+                        kanban::CardScope::WorkingSet
+                    };
+                    let cards = kanban::list_cards(&database, &repo, direction, scope)?;
                     if json {
                         let output = kanban::format_card_list_json(&cards)?;
                         print!("{output}");

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -2120,8 +2120,10 @@ fn kanban_create_and_list() {
     let id = String::from_utf8_lossy(&out.stdout).trim().to_string();
     assert_eq!(id.len(), 36, "expected UUID, got: {id}");
 
+    // --all so the freshly created (Backlog) card is visible; bare list is the
+    // working set, which excludes Backlog (see kanban_list_scopes).
     let out = legion_cmd(dir.path())
-        .args(["kanban", "list", "--repo", "kelex"])
+        .args(["kanban", "list", "--repo", "kelex", "--all"])
         .output()
         .unwrap();
     assert!(out.status.success());
@@ -2140,6 +2142,87 @@ fn kanban_create_and_list() {
         "expected backlog status on a freshly created card, got: {stdout}"
     );
     // Labels are no longer shown inline -- they're stored but not displayed in list output
+}
+
+#[test]
+fn kanban_list_scopes() {
+    let dir = tempfile::tempdir().unwrap();
+
+    // A raw Backlog card (created, never promoted).
+    legion_cmd(dir.path())
+        .args([
+            "kanban",
+            "create",
+            "--from",
+            "sean",
+            "--to",
+            "kelex",
+            "--text",
+            "raw inbox card",
+        ])
+        .output()
+        .unwrap();
+
+    // A second card promoted to Pending via assign.
+    let promoted = legion_cmd(dir.path())
+        .args([
+            "kanban",
+            "create",
+            "--from",
+            "sean",
+            "--to",
+            "kelex",
+            "--text",
+            "promoted card",
+        ])
+        .output()
+        .unwrap();
+    let promoted_id = String::from_utf8_lossy(&promoted.stdout).trim().to_string();
+    legion_cmd(dir.path())
+        .args(["kanban", "assign", "--id", &promoted_id, "--to", "kelex"])
+        .output()
+        .unwrap();
+
+    // Bare list = working set: shows the promoted card, hides the raw Backlog one.
+    let out = legion_cmd(dir.path())
+        .args(["kanban", "list", "--repo", "kelex"])
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("promoted card"),
+        "working set should show the promoted card, got: {stdout}"
+    );
+    assert!(
+        !stdout.contains("raw inbox card"),
+        "working set must hide Backlog cards, got: {stdout}"
+    );
+
+    // --backlog = only the raw inbox.
+    let out = legion_cmd(dir.path())
+        .args(["kanban", "list", "--repo", "kelex", "--backlog"])
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("raw inbox card"),
+        "--backlog should show the Backlog card, got: {stdout}"
+    );
+    assert!(
+        !stdout.contains("promoted card"),
+        "--backlog must hide non-Backlog cards, got: {stdout}"
+    );
+
+    // --all = everything regardless of status.
+    let out = legion_cmd(dir.path())
+        .args(["kanban", "list", "--repo", "kelex", "--all"])
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("raw inbox card") && stdout.contains("promoted card"),
+        "--all should show both cards, got: {stdout}"
+    );
 }
 
 #[test]
@@ -2452,7 +2535,7 @@ fn kanban_with_source_url() {
     assert_eq!(id.len(), 36);
 
     let out = legion_cmd(dir.path())
-        .args(["kanban", "list", "--repo", "kelex"])
+        .args(["kanban", "list", "--repo", "kelex", "--all"])
         .output()
         .unwrap();
     let stdout = String::from_utf8_lossy(&out.stdout);
@@ -2795,7 +2878,7 @@ fn kanban_list_json_emits_jsonl() {
         .unwrap();
 
     let out = legion_cmd(dir.path())
-        .args(["kanban", "list", "--repo", "kelex", "--json"])
+        .args(["kanban", "list", "--repo", "kelex", "--all", "--json"])
         .output()
         .unwrap();
     assert!(
@@ -2848,7 +2931,7 @@ fn kanban_list_json_labels_are_array() {
         .unwrap();
 
     let out = legion_cmd(dir.path())
-        .args(["kanban", "list", "--repo", "kelex", "--json"])
+        .args(["kanban", "list", "--repo", "kelex", "--all", "--json"])
         .output()
         .unwrap();
     assert!(out.status.success());


### PR DESCRIPTION
Closes #516. Part of epic #508. Stacks on #515 (born-Backlog, merged).

## What changed

`get_cards`/`list_cards` gain a `CardScope { WorkingSet, Backlog, All }`. Bare `kanban list` now returns the **working set** (Pending, Accepted, NeedsInput, InReview, Blocked), excluding Backlog (pre-consensus) and terminal (Done/Cancelled). `--all` returns everything; `--backlog` returns the raw inbox. The flags are mutually exclusive (clap `conflicts_with`).

The SessionStart "Current work" block calls bare `kanban list`, so this is the fix for the 50KB banner: it now shows only actual in-flight work, not the entire 186-card table.

## AC -> evidence

- **Bare list excludes Backlog + Done + Cancelled** -> `CardScope::WorkingSet` SQL filter `status NOT IN ('backlog','done','cancelled')` (src/db.rs get_cards); `list_cards_scopes_filter_by_status` unit test asserts working set = Pending + Accepted only; `kanban_list_scopes` CLI test asserts bare list hides the Backlog card.
- **`--all` returns everything; `--backlog` returns the raw inbox** -> both flags on the `List` command (src/main.rs), mapped to `CardScope`; covered by both tests.
- **Fresh SessionStart banner shows only working-set cards** -> the hook calls bare `kanban list` (unchanged); verified end-to-end: a Backlog-only board returns empty from bare list and the card under `--backlog`.
- **All tests pass; clippy/fmt clean** -> 842 lib + 144 integration pass, 0 failed; clippy `--all-targets` clean; fmt clean.

## Notes

- Used behavioral tests (create cards in each status, assert which scope returns them) rather than EXPLAIN QUERY PLAN -- stronger guarantee of the actual filter behavior.
- Existing list/format tests that assert a freshly created (now Backlog) card pass `CardScope::All` / `--all`, since bare list correctly hides Backlog.
- The scope filter applies to both Inbound and Outbound for consistency.
- Minor (non-blocking, flagged in a comment): the status string literals in the SQL filter duplicate `CardStatus::Display`; a derived helper was judged overkill for three literals in one query.