### PR TITLE
feat(#539): daemon-stop / daemon-restart -- bounded restart, no graceful-drain wait

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -199,16 +199,31 @@ pub fn stop_detached(data_dir: &Path) -> Result<bool> {
         return Ok(false);
     }
 
-    send_signal(pid, "TERM");
-    if !wait_for_exit(pid, GRACEFUL_STOP_TIMEOUT) {
+    if !send_signal(pid, "TERM") {
+        eprintln!("[legion] warning: failed to send SIGTERM to daemon {pid}");
+    }
+    let mut exited = wait_for_exit(pid, GRACEFUL_STOP_TIMEOUT);
+    if !exited {
         eprintln!(
             "[legion] daemon {pid} did not exit within {}s; sending SIGKILL",
             GRACEFUL_STOP_TIMEOUT.as_secs()
         );
-        send_signal(pid, "KILL");
+        if !send_signal(pid, "KILL") {
+            eprintln!("[legion] warning: failed to send SIGKILL to daemon {pid}");
+        }
         // SIGKILL is uncatchable; a short wait lets the kernel reap it and free
         // the bound port before the caller respawns.
-        let _ = wait_for_exit(pid, SIGKILL_REAP_TIMEOUT);
+        exited = wait_for_exit(pid, SIGKILL_REAP_TIMEOUT);
+    }
+
+    if !exited {
+        // Still alive after SIGKILL (D-state, EPERM, a failed signal send, or a slow
+        // reap). Do NOT remove the pidfile -- it is the only handle to re-target this
+        // process -- and do NOT claim success. Fail loud so restart_detached's `?`
+        // short-circuits instead of spawning a duplicate into the still-bound port.
+        return Err(LegionError::DaemonStopFailed(format!(
+            "daemon {pid} did not stop (survived SIGKILL); pidfile left in place"
+        )));
     }
 
     let _ = std::fs::remove_file(&pid_path);

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -137,6 +137,97 @@ fn is_process_alive(pid: u32) -> bool {
     }
 }
 
+/// How long to wait for a SIGTERM'd daemon to exit before escalating to SIGKILL.
+const GRACEFUL_STOP_TIMEOUT: Duration = Duration::from_secs(3);
+/// How long to wait for a SIGKILL'd process to be reaped (and release its port).
+const SIGKILL_REAP_TIMEOUT: Duration = Duration::from_secs(2);
+
+/// Read the daemon PID from the pidfile, if present and parseable.
+fn read_daemon_pid(pid_path: &Path) -> Option<u32> {
+    let contents = std::fs::read_to_string(pid_path).ok()?;
+    contents.trim().parse::<u32>().ok()
+}
+
+/// Send a signal (e.g. "TERM", "KILL") to a process. Unix-only; returns false on
+/// other platforms. Uses `kill` to avoid a libc dependency, matching
+/// `is_process_alive`.
+fn send_signal(pid: u32, signal: &str) -> bool {
+    #[cfg(unix)]
+    {
+        std::process::Command::new("kill")
+            .args([format!("-{signal}"), pid.to_string()])
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status()
+            .map(|s| s.success())
+            .unwrap_or(false)
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = (pid, signal);
+        false
+    }
+}
+
+/// Poll until the process exits or `timeout` elapses. Returns true if it exited.
+fn wait_for_exit(pid: u32, timeout: Duration) -> bool {
+    let start = std::time::Instant::now();
+    while start.elapsed() < timeout {
+        if !is_process_alive(pid) {
+            return true;
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    }
+    !is_process_alive(pid)
+}
+
+/// Stop a running daemon and wait for it to release its port.
+///
+/// Sends SIGTERM, then polls for up to `GRACEFUL_STOP_TIMEOUT`. If the process has
+/// not exited by then -- e.g. axum's graceful HTTP shutdown is draining a long-lived
+/// SSE connection and will not release the port promptly -- it escalates to SIGKILL,
+/// so a restart never blocks on the drain. Removes the pidfile and returns `true` if
+/// a running daemon was stopped, `false` if none was running.
+pub fn stop_detached(data_dir: &Path) -> Result<bool> {
+    let pid_path = data_dir.join(DAEMON_PID_FILE);
+    let Some(pid) = read_daemon_pid(&pid_path) else {
+        return Ok(false);
+    };
+    if !is_process_alive(pid) {
+        // Stale pidfile -- nothing to stop, clean it up.
+        let _ = std::fs::remove_file(&pid_path);
+        return Ok(false);
+    }
+
+    send_signal(pid, "TERM");
+    if !wait_for_exit(pid, GRACEFUL_STOP_TIMEOUT) {
+        eprintln!(
+            "[legion] daemon {pid} did not exit within {}s; sending SIGKILL",
+            GRACEFUL_STOP_TIMEOUT.as_secs()
+        );
+        send_signal(pid, "KILL");
+        // SIGKILL is uncatchable; a short wait lets the kernel reap it and free
+        // the bound port before the caller respawns.
+        let _ = wait_for_exit(pid, SIGKILL_REAP_TIMEOUT);
+    }
+
+    let _ = std::fs::remove_file(&pid_path);
+    Ok(true)
+}
+
+/// Restart the background daemon: stop the running one (bounded), then spawn fresh.
+///
+/// This is the supported way to bounce the daemon. A bare `daemon-spawn` after a
+/// manual kill can race the dying daemon's graceful-shutdown drain (port still
+/// bound -> "Address already in use", or "already running" while it exits); restart
+/// removes that wait by stopping deterministically before spawning.
+pub fn restart_detached(data_dir: &Path, port: u16) -> Result<()> {
+    if stop_detached(data_dir)? {
+        eprintln!("[legion] stopped running daemon");
+    }
+    spawn_detached(data_dir, port)
+}
+
 /// Configuration for the daemon.
 pub struct DaemonConfig {
     /// Directory that holds legion.db, watch.toml, etc.
@@ -454,6 +545,45 @@ async fn shutdown_signal() {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn read_daemon_pid_parses_valid_pidfile() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let pid_path = dir.path().join(DAEMON_PID_FILE);
+        std::fs::write(&pid_path, "12345\n").expect("write");
+        assert_eq!(read_daemon_pid(&pid_path), Some(12345));
+    }
+
+    #[test]
+    fn read_daemon_pid_none_for_missing_or_garbage() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let pid_path = dir.path().join(DAEMON_PID_FILE);
+        assert_eq!(read_daemon_pid(&pid_path), None, "missing file -> None");
+        std::fs::write(&pid_path, "not-a-pid").expect("write");
+        assert_eq!(read_daemon_pid(&pid_path), None, "garbage -> None");
+    }
+
+    #[test]
+    fn stop_detached_no_pidfile_is_noop() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        assert!(
+            !stop_detached(dir.path()).expect("stop"),
+            "no pidfile -> nothing stopped"
+        );
+    }
+
+    #[test]
+    fn stop_detached_removes_stale_pidfile() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let pid_path = dir.path().join(DAEMON_PID_FILE);
+        // A PID far above any real process on this host -- not alive.
+        std::fs::write(&pid_path, "2147483646").expect("write");
+        assert!(
+            !stop_detached(dir.path()).expect("stop"),
+            "stale (dead) pid -> nothing stopped"
+        );
+        assert!(!pid_path.exists(), "stale pidfile should be removed");
+    }
 
     #[tokio::test]
     async fn daemon_starts_channel_and_responds_to_feed() {

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -222,7 +222,7 @@ pub fn stop_detached(data_dir: &Path) -> Result<bool> {
         // process -- and do NOT claim success. Fail loud so restart_detached's `?`
         // short-circuits instead of spawning a duplicate into the still-bound port.
         return Err(LegionError::DaemonStopFailed(format!(
-            "daemon {pid} did not stop (survived SIGKILL); pidfile left in place"
+            "pid {pid} survived SIGKILL; pidfile left in place"
         )));
     }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -27,6 +27,9 @@ pub enum LegionError {
     #[error("home directory not available")]
     NoHomeDir,
 
+    #[error("daemon did not stop: {0}")]
+    DaemonStopFailed(String),
+
     #[error("embedding error: {0}")]
     Embedding(String),
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -777,6 +777,16 @@ enum Commands {
         port: u16,
     },
 
+    /// Stop the running background daemon (SIGTERM, then SIGKILL if it does not exit)
+    DaemonStop,
+
+    /// Restart the background daemon: stop the running one, then spawn a fresh one
+    DaemonRestart {
+        /// HTTP port for the channel server
+        #[arg(long, default_value = "3131")]
+        port: u16,
+    },
+
     /// Record a quality gate result for a skill run
     QualityGate {
         #[command(subcommand)]
@@ -6410,6 +6420,18 @@ fn run() -> error::Result<()> {
         Commands::DaemonSpawn { port } => {
             let base = data_dir()?;
             daemon::spawn_detached(&base, port)?;
+        }
+        Commands::DaemonStop => {
+            let base = data_dir()?;
+            if daemon::stop_detached(&base)? {
+                eprintln!("[legion] daemon stopped");
+            } else {
+                eprintln!("[legion] no running daemon to stop");
+            }
+        }
+        Commands::DaemonRestart { port } => {
+            let base = data_dir()?;
+            daemon::restart_detached(&base, port)?;
         }
         Commands::QualityGate { action } => match action {
             QualityGateAction::Record {


### PR DESCRIPTION
Closes #539.

## What changed

There was no way to stop/restart the daemon, and killing it triggers axum's graceful HTTP shutdown, which drains long-lived SSE connections (every session's MCP holds one) before releasing the port -- so a respawn hung, hit "Address already in use", or `daemon-spawn` said "already running" while the old one was still dying. ("This wait for spawn is unacceptable.")

Adds `legion daemon-stop` and `legion daemon-restart`: bounded SIGTERM -> wait <=3s -> SIGKILL -> remove pidfile, then (for restart) spawn fresh. The SIGKILL fallback guarantees the port releases fast, so a restart never blocks on the drain.

## AC -> evidence

- **restart stops old + spawns fresh without waiting/racing** -> `restart_detached` = `stop_detached` then `spawn_detached`. **Verified e2e**: spawn (pid 19869) -> restart -> old dead, fresh pid 19882 up, bounded -> stop -> pidfile removed.
- **stop removes pidfile; no-op when none running** -> `stop_detached` returns false + cleans stale pidfile; `daemon-stop` prints "no running daemon to stop" when absent.
- **SIGKILL bounds the wait at ~3s** -> `GRACEFUL_STOP_TIMEOUT` poll, then `send_signal(pid,"KILL")` + brief reap wait.
- **tests + gates** -> 5 daemon tests pass (pidfile parse, missing, garbage, no-pidfile no-op, stale-pidfile removal); clippy `--all-targets` clean; fmt clean.

## Notes

- Signals via `kill` (no libc dep), matching the existing `is_process_alive`.
- Out of scope: bounding axum's graceful shutdown itself (the SIGKILL fallback covers the restart path; a daemon-side drain cap is a separate change).
- Inherent read-pid->check->signal PID-reuse race matches the pre-existing pidfile model; not introduced here.