### PR TITLE
feat(#517): legion whatami -- operating-contract surface parallel to whoami

### DIFF
--- a/plugin/hooks/session-start.sh
+++ b/plugin/hooks/session-start.sh
@@ -92,6 +92,13 @@ IDENTITY=$("$LEGION" whoami --repo "$REPO" --limit 5 2>>"$LOG")
 legion_check $? "whoami"
 append_block "$IDENTITY"
 
+# 1b. Operating contract -- how I operate (domain: workflow). Lands right after
+# identity so the agent reads WHO YOU ARE, then HOW YOU OPERATE. Banner-wrapped
+# by the binary; silent when the repo has no workflow roots yet.
+WHATAMI=$("$LEGION" whatami --repo "$REPO" --limit 5 2>>"$LOG")
+legion_check $? "whatami"
+append_block "$WHATAMI"
+
 # 2. Pending request-shaped signals -- directed asks waiting on a reply.
 # Strong "REQUIRES A REPLY" framing prevents the system-reminder wrapper
 # from causing the agent to no-op (the platform smugglr-fence RFC review

--- a/src/db.rs
+++ b/src/db.rs
@@ -1900,15 +1900,28 @@ impl Database {
     /// because their content is reachable via `legion chain --id <root>`
     /// and including them would bloat the whoami banner past the inline
     /// context budget. Ordered newest first.
-    pub fn get_identity_roots(&self, repo: &str, limit: usize) -> Result<Vec<Reflection>> {
+    /// Fetch the root reflections (no parent) for a repo in a given domain,
+    /// newest first. Backs the SessionStart boot banners: `whoami`
+    /// (domain=identity, who I am) and `whatami` (domain=workflow, how I operate).
+    pub fn get_domain_roots(
+        &self,
+        repo: &str,
+        domain: &str,
+        limit: usize,
+    ) -> Result<Vec<Reflection>> {
         let mut stmt = self.conn.prepare(
             "SELECT id, repo, text, created_at, updated_at, audience, domain, tags, recall_count, last_recalled_at, parent_id \
-             FROM reflections WHERE repo = ?1 AND domain = 'identity' AND parent_id IS NULL AND deleted_at IS NULL ORDER BY created_at DESC LIMIT ?2",
+             FROM reflections WHERE repo = ?1 AND domain = ?2 AND parent_id IS NULL AND deleted_at IS NULL ORDER BY created_at DESC LIMIT ?3",
         )?;
 
-        let rows = stmt.query_map(rusqlite::params![repo, limit], map_reflection_row)?;
+        let rows = stmt.query_map(rusqlite::params![repo, domain, limit], map_reflection_row)?;
         rows.collect::<std::result::Result<Vec<_>, _>>()
             .map_err(LegionError::Database)
+    }
+
+    /// Identity roots (domain=identity). Thin wrapper over [`get_domain_roots`].
+    pub fn get_identity_roots(&self, repo: &str, limit: usize) -> Result<Vec<Reflection>> {
+        self.get_domain_roots(repo, "identity", limit)
     }
 
     /// Retrieve active (non-archived) bullpen posts, ordered newest first.

--- a/src/main.rs
+++ b/src/main.rs
@@ -447,6 +447,18 @@ enum Commands {
         limit: usize,
     },
 
+    /// Print the operating contract for a repo -- how I operate, distinct from
+    /// whoami (who I am). Alias for recall --domain workflow.
+    Whatami {
+        /// Repository name
+        #[arg(long)]
+        repo: String,
+
+        /// Maximum number of operating-contract reflections to return
+        #[arg(long, default_value_t = 50)]
+        limit: usize,
+    },
+
     /// Build or refresh the SCIP code-intelligence index for a repo (#278).
     ///
     /// Resolves the repo path from `watch.toml`, detects every recognized
@@ -4527,6 +4539,25 @@ fn run() -> error::Result<()> {
                 });
             }
             let output = recall::format_whoami(&repo, &entries);
+            print!("{output}");
+        }
+        Commands::Whatami { repo, limit } => {
+            let base = data_dir()?;
+            let database = db::Database::open(&base.join("legion.db"))?;
+            let roots = database.get_domain_roots(&repo, "workflow", limit)?;
+            if roots.is_empty() {
+                return Ok(());
+            }
+            let mut entries = Vec::with_capacity(roots.len());
+            for r in roots {
+                let in_chain = database.is_in_chain(&r.id)?;
+                entries.push(recall::WhoamiEntry {
+                    id: r.id,
+                    text: r.text,
+                    in_chain,
+                });
+            }
+            let output = recall::format_whatami(&repo, &entries);
             print!("{output}");
         }
         Commands::Stats { repo } => {

--- a/src/recall.rs
+++ b/src/recall.rs
@@ -23,8 +23,20 @@ pub const WHOAMI_BANNER_CLOSE: &str = "=== END IDENTITY ===";
 /// the whole banner under this budget guarantees nothing is dropped.
 pub const WHOAMI_BYTE_CAP: usize = 2048;
 
-/// A single entry passed to `format_whoami`. The flag indicates whether
-/// the reflection has chain context worth pointing the reader at.
+/// Banner that wraps `legion whatami` output -- the operating contract (how I
+/// operate), distinct from whoami (who I am). Lands right after identity at
+/// SessionStart: WHO YOU ARE, then HOW YOU OPERATE.
+pub const WHATAMI_BANNER_OPEN: &str = "=== HOW YOU OPERATE -- READ THIS ===";
+pub const WHATAMI_BANNER_CLOSE: &str = "=== END OPERATING CONTRACT ===";
+
+/// Soft byte budget for `legion whatami` output. Same rationale and size as
+/// `WHOAMI_BYTE_CAP`: keep the SessionStart block under the harness's 2KB
+/// inline-context cutoff so nothing is silently dropped.
+pub const WHATAMI_BYTE_CAP: usize = 2048;
+
+/// A single entry passed to the banner formatters. The flag indicates whether
+/// the reflection has chain context worth pointing the reader at. Shared by
+/// `format_whoami` (identity roots) and `format_whatami` (workflow roots).
 pub struct WhoamiEntry {
     pub id: String,
     pub text: String,
@@ -37,12 +49,27 @@ pub struct WhoamiEntry {
 /// cap. The first entry is always emitted regardless of size to avoid an
 /// empty banner -- a single oversized root is preferable to silent absence.
 /// Remaining entries are summarized with a recall pointer.
-pub fn format_whoami(repo: &str, entries: &[WhoamiEntry]) -> String {
+/// Render a byte-capped boot banner from root reflections. Shared by
+/// `format_whoami` and `format_whatami`. Emits each entry in full while it fits
+/// under `cap`; the first entry always emits even if oversized (a single large
+/// root beats an empty banner), and the remainder is summarized with a recall
+/// pointer to `--domain {recall_domain}`.
+#[allow(clippy::too_many_arguments)]
+fn format_capped_banner(
+    open: &str,
+    close: &str,
+    header_line: &str,
+    truncation_noun: &str,
+    recall_domain: &str,
+    repo: &str,
+    cap: usize,
+    entries: &[WhoamiEntry],
+) -> String {
     if entries.is_empty() {
         return String::new();
     }
-    let header = format!("{WHOAMI_BANNER_OPEN}\n[Legion] Identity for {repo}:\n");
-    let footer = format!("{WHOAMI_BANNER_CLOSE}\n");
+    let header = format!("{open}\n{header_line}\n");
+    let footer = format!("{close}\n");
     let mut buf = header;
     let mut emitted = 0usize;
     for entry in entries {
@@ -52,7 +79,7 @@ pub fn format_whoami(repo: &str, entries: &[WhoamiEntry]) -> String {
             String::new()
         };
         let body = format!("- {} (id: {})\n{}", entry.text, entry.id, chain_line);
-        if buf.len() + body.len() + footer.len() > WHOAMI_BYTE_CAP && emitted > 0 {
+        if buf.len() + body.len() + footer.len() > cap && emitted > 0 {
             break;
         }
         buf.push_str(&body);
@@ -61,11 +88,40 @@ pub fn format_whoami(repo: &str, entries: &[WhoamiEntry]) -> String {
     let remaining = entries.len().saturating_sub(emitted);
     if remaining > 0 {
         buf.push_str(&format!(
-            "- ({remaining} more identity reflections truncated; recall via `legion recall --repo {repo} --domain identity`)\n"
+            "- ({remaining} more {truncation_noun} truncated; recall via `legion recall --repo {repo} --domain {recall_domain}`)\n"
         ));
     }
     buf.push_str(&footer);
     buf
+}
+
+/// Render the whoami banner (identity roots), capped at `WHOAMI_BYTE_CAP`.
+pub fn format_whoami(repo: &str, entries: &[WhoamiEntry]) -> String {
+    format_capped_banner(
+        WHOAMI_BANNER_OPEN,
+        WHOAMI_BANNER_CLOSE,
+        &format!("[Legion] Identity for {repo}:"),
+        "identity reflections",
+        "identity",
+        repo,
+        WHOAMI_BYTE_CAP,
+        entries,
+    )
+}
+
+/// Render the whatami banner (operating-contract / workflow roots), capped at
+/// `WHATAMI_BYTE_CAP`. This is HOW the agent operates, distinct from whoami.
+pub fn format_whatami(repo: &str, entries: &[WhoamiEntry]) -> String {
+    format_capped_banner(
+        WHATAMI_BANNER_OPEN,
+        WHATAMI_BANNER_CLOSE,
+        &format!("[Legion] How {repo} operates:"),
+        "operating-contract reflections",
+        "workflow",
+        repo,
+        WHATAMI_BYTE_CAP,
+        entries,
+    )
 }
 
 /// A set of recalled reflections matching a query, optionally scoped to a single repo.
@@ -1321,6 +1377,31 @@ mod tests {
             .collect();
         let out = format_whoami("kelex", &entries);
         assert!(out.contains("legion recall --repo kelex --domain identity"));
+    }
+
+    #[test]
+    fn format_whatami_empty_returns_empty() {
+        assert_eq!(format_whatami("legion", &[]), "");
+    }
+
+    #[test]
+    fn format_whatami_wraps_operating_banner() {
+        let out = format_whatami("legion", &[entry("w1", "work the board", false)]);
+        assert!(out.starts_with(WHATAMI_BANNER_OPEN));
+        assert!(out.contains("[Legion] How legion operates:"));
+        assert!(out.contains("- work the board (id: w1)"));
+        assert!(out.trim_end().ends_with(WHATAMI_BANNER_CLOSE));
+    }
+
+    #[test]
+    fn format_whatami_truncation_pointer_uses_workflow_domain() {
+        let big = "x".repeat(800);
+        let entries: Vec<WhoamiEntry> = (0..5)
+            .map(|i| entry(&format!("w{i}"), &big, false))
+            .collect();
+        let out = format_whatami("kelex", &entries);
+        assert!(out.contains("more operating-contract reflections truncated"));
+        assert!(out.contains("legion recall --repo kelex --domain workflow"));
     }
 
     #[test]


### PR DESCRIPTION
Closes #517. Part of epic #509.

## What changed

whoami carried the operating rulebook (workflow, decision-order, release discipline) -- which is HOW I operate, not WHO I am. This gives the operating contract its own surface, parallel to whoami.

- **`legion whatami --repo R`** recalls `domain=workflow` roots and prints a capped "HOW YOU OPERATE" banner.
- **SessionStart** injects it right after identity: WHO YOU ARE -> HOW YOU OPERATE (silent when the repo has no workflow roots).
- `get_identity_roots` generalized to `get_domain_roots(repo, domain, limit)`; identity is now a thin wrapper. whatami queries `domain=workflow`.
- `format_whoami` / `format_whatami` share a `format_capped_banner` helper (2KB cap, first-entry-always-emits, truncation -> recall pointer) -- no duplicated capping logic.

## AC -> evidence

- **`legion whatami` prints the operating contract from domain=workflow** -> verified live: renders `=== HOW YOU OPERATE -- READ THIS ===` + `[Legion] How legion operates:` + the workflow root.
- **SessionStart emits a distinct, 2KB-capped HOW-YOU-OPERATE block with overflow pointer** -> session-start.sh block (mirrors the whoami injection); `WHATAMI_BYTE_CAP=2048`; truncation pointer -> `--domain workflow`.
- **boot order is whoami then whatami** -> whatami appended immediately after the identity block.
- **tests + gates** -> 3 whatami formatter tests (empty / banner / workflow-domain truncation) + existing whoami tests still pass after the refactor; 843 lib + 144 integration; clippy `--all-targets` + fmt clean.

## Notes / out of scope

- **Surface only.** Populating `domain=workflow` with the operating contract (the loop, the three stop conditions, standing-authorization) and stripping the rulebook out of the identity root is a follow-on `legion reflect` data op -- it touches shared identity, so it needs Sean's ack (per the issue).
- The roots-only query (`parent_id IS NULL`) is intentional vs the existing `get_reflections_by_domain` (no parent filter): chain children are reachable via `legion chain`; including them would blow the banner past the 2KB inline-context cap.
- Precedence upgrade (injecting whoami/whatami as mid-conversation `role:system` messages, #529) is a separate issue; this ships the additionalContext block.