### PR TITLE
refactor(#530): grep-enforcement stays in hooks; allowlists guard surfaces

### DIFF
--- a/docs/decisions/2026-05-grep-enforcement-stays-in-hooks.md
+++ b/docs/decisions/2026-05-grep-enforcement-stays-in-hooks.md
@@ -1,0 +1,66 @@
+# Grep-enforcement stays in hooks; allowlists guard command/skill surfaces
+
+Date: 2026-05-30
+Issue: #530 (refactor: replace grep-enforcement hooks with skill disallowed-tools where viable)
+Parent epic: #513 (harness embraces -- Opus 4.8 / CC v2.1.154)
+
+## Question
+
+CC v2.1.152 added `disallowed-tools` frontmatter (remove a tool while a skill/command is
+active). #530 asked: can we move grep-enforcement out of the always-on PreToolUse hooks and
+into declarative frontmatter, shrinking the hook stack without weakening enforcement?
+
+## Audit
+
+The four grep-enforcement hooks were read in full and classified:
+
+| Hook | Tool(s) | Behavior | Can it move to frontmatter? |
+|------|---------|----------|------------------------------|
+| `pre-grep-recall.sh` | Grep, Glob | **Never blocks.** Runs `legion recall`, injects hits as `additionalContext`, always `allow`. | No -- `disallowed-tools` removes the tool; there is no block here to replace, and removal would lose the injection. |
+| `pre-grep-scip.sh` | Grep, Glob | **Never blocks.** Runs `legion sym def`, injects hits, always `allow`. | No -- same: it is an injector, not a blocker. |
+| `pre-bash-grep.sh` | Bash | **Dynamic ladder.** Blocks only when the extracted pattern is symbol-shaped AND the repo is SCIP-indexed AND `sym def` returns a *local* hit; soft-bypass (refused on local symbol hits) and hard-bypass tiers. | No -- frontmatter cannot express "block `grep` only when the pattern resolves to a local symbol." Static removal of Bash is absurd. |
+| `pre-read-sym.sh` | Read | **Dynamic ladder.** Blocks only when the path is a source extension AND indexed AND the file is >500 lines AND no small `limit` is set. | No -- frontmatter cannot express "block Read only on large unbounded source reads." |
+
+**Conclusion: none of the four hooks is static, unconditional grep-blocking.** Two are pure
+injectors (allow + context); two are stateful conditional ladders. `disallowed-tools` is a
+static, unconditional tool removal and can express none of them without weakening enforcement
+(losing the injected sym/recall context, the size/symbol conditions, and the bypass ladder).
+AC #2 ("dynamic ladder/bypass retained in hooks where frontmatter can't express it") is therefore
+satisfied by retaining all four hooks unchanged.
+
+## Where declarative tool-restriction already lives
+
+The premise that grep-restriction was missing from command/skill frontmatter was already false:
+legion surfaces use `allowed-tools` (an **allowlist**, strictly stronger than the `disallowed-tools`
+denylist #530 proposed).
+
+- 8 of 9 `plugin/commands/*.md` declare `allowed-tools: ["Bash"]` -- Grep/Glob/Read already
+  unavailable while they run. (`migrate-memory` is `Bash, Read, Write`; still no Grep/Glob.)
+- `plugin/skills/legion-memory/SKILL.md` was already `Bash, Read`.
+
+These surfaces were built right. There is nothing to "move" into them.
+
+## The one real change
+
+`plugin/skills/legion-simplify/SKILL.md` declared `allowed-tools: Bash, Read, Glob, Grep`. The
+simplify skill's core question -- "is this logic duplicated elsewhere / does this helper already
+exist?" -- is a `legion sym` / `legion recall` question by doctrine, not a grep. Granting Grep/Glob
+invited the exact anti-pattern the doctrine forbids. Tightened to `allowed-tools: Bash, Read`.
+Bash remains, so a genuinely necessary scan still routes through `pre-bash-grep`'s sym ladder.
+
+## Parity (AC #3 -- no enforcement weakening)
+
+- The dynamic symbol-block is already pinned by `plugin/hooks/test-pre-bash-grep.sh:170-173`
+  ("indexed repo + symbol-shape pattern with LOCAL-REPO hit -> BLOCK"). Because #530 does not
+  touch the hooks, that guarantee holds by construction.
+- New: `tests/integration.rs::legion_command_and_skill_surfaces_never_grant_grep` asserts no
+  legion command/skill allowlist grants Grep/Glob -- so a future "just grep here" edit fails CI
+  rather than silently weakening the doctrine. This is the parity lock for the surface that
+  actually changed (the allowlists), and it runs in CI (the `plugin/hooks/test-*.sh` scripts do not).
+
+## Unaddressed-but-noted: the subagent surface
+
+PreToolUse hooks do not fire on subagents, so Explore/general-purpose subagents grep unenforced.
+`disallowed-tools`/`tools` on agent definitions is the only mechanism there. That is agent-def
+work (shared config, separate from this hook/command refactor) and is tracked separately; it is
+out of scope for #530, whose named file locations are hooks + commands.

--- a/plugin/skills/legion-simplify/SKILL.md
+++ b/plugin/skills/legion-simplify/SKILL.md
@@ -8,7 +8,7 @@ description: |
   creating a PR.
 version: 1.0.0
 user-invocable: true
-allowed-tools: Bash, Read, Glob, Grep
+allowed-tools: Bash, Read
 ---
 
 # Legion Simplify

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -6013,3 +6013,131 @@ fn uncertainty_emit_witness_end_to_end_via_hook_against_real_binary() {
         "re-witnessing should fail (already witnessed)"
     );
 }
+
+// #530: grep-enforcement parity lock.
+//
+// legion's own command/skill surfaces must never grant Grep or Glob. The
+// recall/sym-before-grep doctrine is enforced for the main session by the
+// PreToolUse hooks (pre-grep-recall, pre-grep-scip, pre-bash-grep,
+// pre-read-sym), but those hooks do NOT fire while a slash command's or
+// skill's own tool allowlist is active, and they do NOT fire on subagents.
+// The allowlist (`allowed-tools`) is the only enforcement on those surfaces
+// and is strictly stronger than `disallowed-tools` (whitelist vs blacklist).
+//
+// This test fails if anyone re-grants Grep/Glob to a legion surface, so a
+// future "let me just grep here" edit has to be deliberate -- it can't slip
+// in silently and weaken the doctrine. See #530 and
+// docs/decisions/2026-05-grep-enforcement-stays-in-hooks.md.
+#[test]
+fn legion_command_and_skill_surfaces_never_grant_grep() {
+    let plugin = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("plugin");
+
+    // Collect every frontmatter-bearing surface: commands/*.md + skills/*/SKILL.md.
+    let mut surfaces: Vec<std::path::PathBuf> = Vec::new();
+    let commands = plugin.join("commands");
+    for entry in std::fs::read_dir(&commands).expect("plugin/commands must exist") {
+        let path = entry.expect("readable commands entry").path();
+        if path.extension().and_then(|e| e.to_str()) == Some("md") {
+            surfaces.push(path);
+        }
+    }
+    let skills = plugin.join("skills");
+    for entry in std::fs::read_dir(&skills).expect("plugin/skills must exist") {
+        let skill_md = entry
+            .expect("readable skills entry")
+            .path()
+            .join("SKILL.md");
+        if skill_md.is_file() {
+            surfaces.push(skill_md);
+        }
+    }
+    assert!(
+        !surfaces.is_empty(),
+        "expected to find legion command/skill surfaces under plugin/"
+    );
+
+    for path in surfaces {
+        let body = std::fs::read_to_string(&path).expect("readable surface");
+        let tools = parse_allowed_tools(&body);
+        let Some(tools) = tools else {
+            // A surface with no allowlist inherits the full toolset and is
+            // governed by the main-session hooks instead -- not this test's
+            // concern. (All legion surfaces currently declare one.)
+            continue;
+        };
+        for forbidden in ["Grep", "Glob"] {
+            assert!(
+                !tools.iter().any(|t| t == forbidden),
+                "{} grants {} in its allowed-tools -- legion surfaces must use sym/recall, \
+                 not grep (see #530). If a scan is genuinely needed, route it through Bash \
+                 where pre-bash-grep applies the sym ladder.",
+                path.display(),
+                forbidden
+            );
+        }
+    }
+}
+
+// Extract the tool identifiers granted by an `allowed-tools:` frontmatter
+// key, handling both forms legion surfaces use:
+//   - inline:     `allowed-tools: Bash, Read`  or  `allowed-tools: ["Bash"]`
+//   - block list: `allowed-tools:` then indented `  - Bash` lines
+// Returns None when the key is absent (no allowlist declared). Tokens are
+// split on the structural delimiters so a coincidental substring cannot
+// match -- only a standalone tool identifier does.
+fn parse_allowed_tools(body: &str) -> Option<Vec<String>> {
+    let lines: Vec<&str> = body.lines().collect();
+    let idx = lines
+        .iter()
+        .position(|l| l.trim_start().starts_with("allowed-tools:"))?;
+
+    let split_tokens = |s: &str| -> Vec<String> {
+        s.split([',', '[', ']', '"', '\'', '-'])
+            .map(|t| t.trim())
+            .filter(|t| !t.is_empty())
+            .map(|t| t.to_string())
+            .collect()
+    };
+
+    // Inline value after the colon (empty for the block-list form).
+    let inline = lines[idx].split_once(':').map(|(_, v)| v).unwrap_or("");
+    let mut tools = split_tokens(inline);
+
+    // Block-list form: indented `- Tool` continuation lines follow the key
+    // until the next frontmatter key or the closing `---`.
+    if tools.is_empty() {
+        for line in &lines[idx + 1..] {
+            let trimmed = line.trim_start();
+            if trimmed.starts_with("- ") {
+                tools.extend(split_tokens(trimmed));
+            } else if line.starts_with(|c: char| !c.is_whitespace()) {
+                break; // dedent to a new key (or `---`) ends the list
+            }
+        }
+    }
+
+    Some(tools)
+}
+
+#[test]
+fn parse_allowed_tools_handles_inline_and_block_forms() {
+    // Inline comma form (skills).
+    assert_eq!(
+        parse_allowed_tools("---\nallowed-tools: Bash, Read\n---\n"),
+        Some(vec!["Bash".to_string(), "Read".to_string()])
+    );
+    // Inline JSON-array form (commands).
+    assert_eq!(
+        parse_allowed_tools("---\nallowed-tools: [\"Bash\"]\n---\n"),
+        Some(vec!["Bash".to_string()])
+    );
+    // Block-list form -- the blind spot the inline-only parser would miss.
+    let block = "---\nname: x\nallowed-tools:\n  - Bash\n  - Grep\nversion: 1\n---\n";
+    let tools = parse_allowed_tools(block).expect("block form parsed");
+    assert!(
+        tools.iter().any(|t| t == "Grep"),
+        "block-list Grep must be detected, got {tools:?}"
+    );
+    // Absent key.
+    assert_eq!(parse_allowed_tools("---\nname: x\n---\n"), None);
+}


### PR DESCRIPTION
Closes #530.

## Audit verdict

#530 asked whether grep-enforcement could move from always-on PreToolUse hooks to declarative `disallowed-tools` frontmatter. The audit (all four hooks read in full) says: **none of the four is static, unconditional blocking**, so none can be replaced without weakening enforcement.

| Hook | Behavior | Movable? |
|------|----------|----------|
| `pre-grep-recall` / `pre-grep-scip` (Grep/Glob) | **Never block** -- inject recall/sym context, always `allow` | No -- there is no block to replace; removal loses the injection |
| `pre-bash-grep` (Bash) | **Dynamic ladder** -- block only when pattern is symbol-shaped AND repo indexed AND a *local* sym hit exists; soft/hard bypass tiers | No -- frontmatter can't express "block only on a local symbol hit" |
| `pre-read-sym` (Read) | **Dynamic ladder** -- block only when source-ext AND indexed AND >500 lines AND no small `limit` | No -- frontmatter can't express "block only on large unbounded reads" |

All four retained unchanged (satisfies AC: dynamic ladder/bypass retained in hooks).

## What actually changed

The premise that command/skill frontmatter lacked grep-restriction was already false: legion surfaces use `allowed-tools` (an **allowlist**, strictly stronger than the proposed `disallowed-tools` denylist). 8/9 commands are `[Bash]`; `legion-memory` is `[Bash, Read]`.

The one real gap: **`legion-simplify` granted `Grep, Glob` it should not use** -- its "is this duplicated / does this helper exist?" question is a `sym`/`recall` question by doctrine. Tightened to `[Bash, Read]`; Bash still routes any genuine scan through `pre-bash-grep`'s sym ladder.

## Parity (no enforcement weakening)

- The dynamic symbol-block is already pinned by `test-pre-bash-grep.sh:170-173`; the hooks are untouched, so it holds by construction.
- New `tests/integration.rs::legion_command_and_skill_surfaces_never_grant_grep` locks every legion command/skill allowlist against re-granting Grep/Glob -- and runs in CI (the `plugin/hooks/test-*.sh` scripts do not). Handles inline and YAML block-list frontmatter forms; the parser is unit-tested (`parse_allowed_tools_handles_inline_and_block_forms`).

Full reasoning: `docs/decisions/2026-05-grep-enforcement-stays-in-hooks.md`.

## Out of scope / noted

PreToolUse hooks don't fire on subagents, so Explore/general-purpose subagents grep unenforced. That's agent-def work (shared config) tracked separately -- #530's named file locations are hooks + commands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)