### PR TITLE
feat(#519): PR-write forcing function -- map diff to AC, gate refuses boilerplate

### DIFF
--- a/plugin/skills/legion-pr-write/SKILL.md
+++ b/plugin/skills/legion-pr-write/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: legion-pr-write
+description: |
+  Compose the PR body as a forcing function before opening a PR. Map each of the issue's
+  acceptance criteria to the change that satisfies it -- in your own prose, with evidence --
+  and state what you deliberately did NOT do. Articulation is verification: writing the
+  mapping makes you re-read your own diff as a reader and catch what you talked past while
+  coding. Validate the body with `legion pr write-check`, which refuses an empty or
+  boilerplate mapping and records the gate `legion pr create` requires. Run this after
+  `/legion-simplify`, before review.
+version: 1.0.0
+user-invocable: true
+allowed-tools: Bash, Read, Write
+---
+
+# Legion PR-Write
+
+The step between simplify and review. You write the PR body that maps the issue's
+acceptance criteria to your change, then validate it. The body you produce is the claim
+set the verify gate (#520) and the human reviewer read -- so write it for a reader who
+has not seen your work.
+
+`legion pr create` will not open the PR until this gate is clean on HEAD (alongside the
+simplify gate).
+
+## Procedure
+
+1. **Load the acceptance criteria.** You are mapping against the issue, not your memory of it:
+
+   ```bash
+   legion issue view --repo <repo> --number <issue>
+   ```
+
+   Note every item under "Acceptance criteria". You will write one mapping entry per item.
+
+2. **Re-read your own diff.** `git diff main..HEAD`. For each acceptance criterion, find the
+   hunk that satisfies it. If you cannot point to one, the criterion is not met -- stop and
+   finish the work (or move it to "Not done" with a reason).
+
+3. **Write the body to a file** (e.g. `/tmp/pr-body-<issue>.md`) with exactly these sections:
+
+   ```markdown
+   ## Summary
+
+   One paragraph: what the change does and why.
+
+   ## Acceptance criteria mapping
+
+   ### 1. <criterion, paraphrased>
+   Prose: which change satisfies this criterion and how. Explain the mechanism -- do not
+   restate the criterion. This is the forcing function; write it as an explanation.
+   Evidence: <a test name, a file:line, or an observable behavior>
+
+   ### 2. <next criterion>
+   ...
+
+   ## Not done
+
+   What you deliberately left out of scope, and why. Write "nothing" only if that is true.
+   ```
+
+   One `### ` entry per acceptance criterion. Each entry needs real explanatory prose and a
+   line of evidence. The mapping must be composed prose, not a checklist -- a fill-in form
+   defeats the purpose.
+
+4. **Validate.** This records the gate and refuses boilerplate:
+
+   ```bash
+   legion pr write-check --repo <repo> --issue <issue> --body-file /tmp/pr-body-<issue>.md
+   ```
+
+   - Clean -> the gate is recorded; proceed to open the PR.
+   - Gaps reported -> fix the body (each gap names the entry and what is missing) and re-run.
+     Do not pad to clear the word count; write the real explanation. If a criterion genuinely
+     is not addressed, that is a signal the work is not done.
+
+5. **Open the PR** with the validated body:
+
+   ```bash
+   legion pr create --repo <repo> --title "<type>(#<issue>): <summary>" \
+     --body "$(cat /tmp/pr-body-<issue>.md)" --task <card-id>
+   ```
+
+## Notes
+
+- The validator checks structure, not prose quality: one substantive entry per criterion,
+  each citing evidence, plus a non-empty "Not done" section. It cannot tell a good
+  explanation from a mediocre one -- that is your job and the reviewer's. It can tell when
+  you pasted the criteria back, and it will refuse.
+- If you commit again after a clean gate, the gate no longer matches HEAD -- re-run step 4.
+- Re-running write-check overwrites the previous gate row for HEAD; the most recent wins.
+- Bootstrap only: a branch that ships these skills themselves cannot gate on them. Use
+  `legion pr create --skip-gates` (it writes an audit row so the skip is never silent).

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,6 +15,7 @@ mod mcp;
 mod mesh;
 mod now;
 mod pr_view;
+mod pr_write;
 mod pty;
 mod recall;
 mod reflect;
@@ -1828,6 +1829,26 @@ enum PrAction {
         json: bool,
     },
 
+    /// Validate a drafted PR body against an issue's acceptance criteria
+    /// (#519 PR-write forcing function). Reads the body from --body-file (or
+    /// stdin), loads the issue's acceptance criteria, and refuses an empty or
+    /// boilerplate criterion-to-work mapping. On success it records a clean
+    /// `legion-pr-write` quality gate for HEAD so `legion pr create` can gate
+    /// on it; on failure it records issues and exits non-zero with the gaps.
+    WriteCheck {
+        /// Repository name (resolves work source config from watch.toml)
+        #[arg(long)]
+        repo: String,
+
+        /// Issue number whose acceptance criteria the body must map.
+        #[arg(long)]
+        issue: u64,
+
+        /// Path to the drafted PR body (markdown). Reads stdin when omitted.
+        #[arg(long)]
+        body_file: Option<String>,
+    },
+
     /// List comments on a pull request (top-level + inline review comments)
     /// in chronological order.
     Comments {
@@ -2610,6 +2631,37 @@ fn resolve_stale_cutoff() -> std::time::Duration {
 fn round_f64(v: f64, digits: i32) -> f64 {
     let factor = 10f64.powi(digits);
     (v * factor).round() / factor
+}
+
+/// Read the current HEAD commit hash and branch name. Errors if `git
+/// rev-parse HEAD` fails (not a git repo / no commits); the branch falls back
+/// to "unknown" when its lookup fails, since a detached HEAD still has a valid
+/// commit to key a quality gate on. Shared by the quality-gate recorder and
+/// the `pr create` / `pr write-check` gate checks.
+fn git_head_commit_and_branch() -> Result<(String, String), error::LegionError> {
+    let head = std::process::Command::new("git")
+        .args(["rev-parse", "HEAD"])
+        .output()
+        .map_err(|e| error::LegionError::WorkSource(format!("failed to read git HEAD: {e}")))?;
+    if !head.status.success() {
+        return Err(error::LegionError::WorkSource(
+            "git rev-parse HEAD failed -- is this a git repo?".to_owned(),
+        ));
+    }
+    let commit_hash = String::from_utf8_lossy(&head.stdout).trim().to_owned();
+
+    let branch_out = std::process::Command::new("git")
+        .args(["rev-parse", "--abbrev-ref", "HEAD"])
+        .output()
+        .map_err(|e| error::LegionError::WorkSource(format!("failed to read git branch: {e}")))?;
+    let branch = if branch_out.status.success() {
+        String::from_utf8_lossy(&branch_out.stdout)
+            .trim()
+            .to_owned()
+    } else {
+        "unknown".to_owned()
+    };
+    Ok((commit_hash, branch))
 }
 
 fn fmt_pct(v: Option<f64>) -> String {
@@ -5674,12 +5726,12 @@ fn run() -> error::Result<()> {
                 task,
                 skip_gates,
             } => {
-                // Quality gate: verify legion-simplify ran clean on HEAD before
-                // calling the work source. This runs before worksource::resolve_config
-                // so the gate error is always surfaced, even if the worksource is not
-                // configured. --skip-gates is a bootstrap escape hatch for the branch
-                // that ships the skill itself; it writes an audit entry so it cannot
-                // be done silently.
+                // Quality gates: verify legion-simplify AND legion-pr-write ran
+                // clean on HEAD before calling the work source. This runs before
+                // worksource::resolve_config so the gate error is always surfaced,
+                // even if the worksource is not configured. --skip-gates is a
+                // bootstrap escape hatch for the branch that ships the skills
+                // themselves; it writes an audit entry so it cannot be done silently.
                 if skip_gates {
                     audit(&db::AuditInput {
                         agent: &repo,
@@ -5688,46 +5740,46 @@ fn run() -> error::Result<()> {
                         target_ref: "pending",
                         task_id: task.as_deref(),
                         source_type: "unknown",
-                        details: Some(r#"{"skill":"legion-simplify","reason":"bootstrap"}"#),
+                        details: Some(
+                            r#"{"skills":["legion-simplify","legion-pr-write"],"reason":"bootstrap"}"#,
+                        ),
                         outcome: "skipped",
                     });
                     eprintln!("[legion] warning: quality gate skipped (--skip-gates bootstrap)");
                 } else {
-                    let head_hash = std::process::Command::new("git")
-                        .args(["rev-parse", "HEAD"])
-                        .output()
-                        .map_err(|e| {
-                            error::LegionError::WorkSource(format!("failed to read git HEAD: {e}"))
-                        })?;
-                    if !head_hash.status.success() {
-                        return Err(error::LegionError::WorkSource(
-                            "git rev-parse HEAD failed -- is this a git repo?".to_owned(),
-                        ));
-                    }
-                    let commit_hash: String =
-                        String::from_utf8_lossy(&head_hash.stdout).trim().to_owned();
+                    let (commit_hash, _branch) = git_head_commit_and_branch()?;
                     let short_hash: &str = &commit_hash[..commit_hash.len().min(8)];
 
                     let db_base = data_dir()?;
                     let gate_db = db::Database::open(&db_base.join("legion.db"))?;
-                    match gate_db.get_quality_gate(&commit_hash, "legion-simplify")? {
-                        None => {
-                            eprintln!(
-                                "[legion] error: no clean legion-simplify gate on HEAD ({short_hash}). \
-                                 Run /legion-simplify before creating the PR."
-                            );
-                            std::process::exit(1);
-                        }
-                        Some(gate) if gate.result != "clean" => {
-                            eprintln!(
-                                "[legion] error: legion-simplify recorded issues on HEAD ({short_hash}), \
-                                 {} findings. Fix them and re-run the skill before creating the PR.",
-                                gate.findings_count
-                            );
-                            std::process::exit(1);
-                        }
-                        Some(_) => {
-                            // Gate is clean -- proceed.
+                    // Both forcing-function gates must be clean on HEAD before the
+                    // PR opens: simplify (structural quality) and pr-write (the
+                    // articulated criterion-to-work mapping the verify gate later
+                    // audits). Each is recorded by its own skill on the current
+                    // commit, so a post-gate commit invalidates them (re-run).
+                    for (skill, run_hint) in [
+                        ("legion-simplify", "/legion-simplify"),
+                        ("legion-pr-write", "/legion-pr-write"),
+                    ] {
+                        match gate_db.get_quality_gate(&commit_hash, skill)? {
+                            None => {
+                                eprintln!(
+                                    "[legion] error: no clean {skill} gate on HEAD ({short_hash}). \
+                                     Run {run_hint} before creating the PR."
+                                );
+                                std::process::exit(1);
+                            }
+                            Some(gate) if gate.result != "clean" => {
+                                eprintln!(
+                                    "[legion] error: {skill} recorded issues on HEAD ({short_hash}), \
+                                     {} findings. Fix them and re-run the skill before creating the PR.",
+                                    gate.findings_count
+                                );
+                                std::process::exit(1);
+                            }
+                            Some(_) => {
+                                // Gate is clean -- continue to the next.
+                            }
                         }
                     }
                 }
@@ -5938,6 +5990,89 @@ fn run() -> error::Result<()> {
                     );
                 } else {
                     pr_view::render_pr(&pr);
+                }
+            }
+            PrAction::WriteCheck {
+                repo,
+                issue,
+                body_file,
+            } => {
+                let (plugin_name, source_repo, _workdir) = worksource::resolve_config(&repo)
+                    .ok_or_else(|| {
+                        error::LegionError::WorkSource(format!(
+                            "no work source configured for repo '{}' in watch.toml",
+                            repo
+                        ))
+                    })?;
+
+                // Load the issue's acceptance criteria -- the claim set the body
+                // must map. Parsed from the same template card_parse reads for
+                // `issue view`, so the criteria match what the agent saw.
+                let ext = worksource::view_issue(&plugin_name, &source_repo, issue)?;
+                let parsed = card_parse::parse_issue_body(ext.body.as_deref().unwrap_or(""));
+
+                // Read the drafted body from --body-file, or stdin when omitted.
+                let body = match body_file {
+                    Some(path) => std::fs::read_to_string(&path).map_err(|e| {
+                        error::LegionError::WorkSource(format!(
+                            "failed to read --body-file {path}: {e}"
+                        ))
+                    })?,
+                    None => {
+                        use std::io::Read as _;
+                        let mut buf = String::new();
+                        std::io::stdin().read_to_string(&mut buf).map_err(|e| {
+                            error::LegionError::WorkSource(format!("failed to read stdin: {e}"))
+                        })?;
+                        buf
+                    }
+                };
+
+                let report = pr_write::validate_pr_body(&parsed.acceptance, &body);
+
+                // Record the gate on HEAD so `legion pr create` can gate on it,
+                // exactly as it does for legion-simplify.
+                let (commit_hash, branch) = git_head_commit_and_branch()?;
+                let result = if report.ok { "clean" } else { "issues" };
+                let details = serde_json::json!({
+                    "skill": "legion-pr-write",
+                    "issue": issue,
+                    "mapping_entries": report.mapping_entries,
+                    "findings": report.findings,
+                })
+                .to_string();
+
+                let base = data_dir()?;
+                let database = db::Database::open(&base.join("legion.db"))?;
+                database.record_quality_gate(
+                    &branch,
+                    &commit_hash,
+                    "legion-pr-write",
+                    result,
+                    report.findings.len() as u64,
+                    Some(&details),
+                )?;
+
+                if report.ok {
+                    println!(
+                        "[legion] pr-write gate clean for issue #{issue} ({} mapping entries). \
+                         Open the PR with this body.",
+                        report.mapping_entries
+                    );
+                } else {
+                    eprintln!(
+                        "[legion] pr-write gate FAILED for issue #{issue} -- {} gap(s):",
+                        report.findings.len()
+                    );
+                    for f in &report.findings {
+                        eprintln!("  - {f}");
+                    }
+                    eprintln!(
+                        "\nThe mapping must be composed prose -- one entry per acceptance \
+                         criterion, each citing evidence (a test, a file:line, an observable \
+                         behavior) -- plus a 'Not done' section. Fix the body and re-run."
+                    );
+                    std::process::exit(1);
                 }
             }
             PrAction::Comments { repo, number, json } => {
@@ -6440,34 +6575,7 @@ fn run() -> error::Result<()> {
                 findings_count,
                 details_json,
             } => {
-                let head_output = std::process::Command::new("git")
-                    .args(["rev-parse", "HEAD"])
-                    .output()
-                    .map_err(|e| {
-                        error::LegionError::WorkSource(format!("failed to read git HEAD: {e}"))
-                    })?;
-                if !head_output.status.success() {
-                    return Err(error::LegionError::WorkSource(
-                        "git rev-parse HEAD failed -- is this a git repo?".to_owned(),
-                    ));
-                }
-                let commit_hash: String = String::from_utf8_lossy(&head_output.stdout)
-                    .trim()
-                    .to_owned();
-
-                let branch_output = std::process::Command::new("git")
-                    .args(["rev-parse", "--abbrev-ref", "HEAD"])
-                    .output()
-                    .map_err(|e| {
-                        error::LegionError::WorkSource(format!("failed to read git branch: {e}"))
-                    })?;
-                let branch: String = if branch_output.status.success() {
-                    String::from_utf8_lossy(&branch_output.stdout)
-                        .trim()
-                        .to_owned()
-                } else {
-                    "unknown".to_owned()
-                };
+                let (commit_hash, branch) = git_head_commit_and_branch()?;
 
                 let base = data_dir()?;
                 let database = db::Database::open(&base.join("legion.db"))?;

--- a/src/pr_write.rs
+++ b/src/pr_write.rs
@@ -1,0 +1,342 @@
+// PR-write forcing function (#519).
+//
+// Articulation is verification. Before a PR can be opened, the agent must
+// write -- in prose -- how each acceptance criterion is satisfied by the
+// change, cite evidence (a test, a file:line, an observable behavior), and
+// state what was deliberately NOT done. Composing that mapping forces the
+// agent to re-read its own diff as a reader and catch what it talked past
+// while coding. The written body is also the explicit claim set the verify
+// gate (#520) later audits.
+//
+// This module is the objective half of the gate: a structural validator that
+// refuses an empty or boilerplate mapping. It does not judge prose quality --
+// it enforces that prose of substance exists, one entry per criterion, each
+// carrying evidence, plus a non-empty not-done section. The skill
+// (plugin/skills/legion-pr-write) tells the agent how to compose a body that
+// passes; this code makes "I'll just paste the ACs back" fail.
+
+use crate::card_parse::parse_issue_body;
+
+/// Minimum words of prose per acceptance-criterion mapping entry, after the
+/// heading and the evidence line are stripped. A genuine "this change
+/// satisfies it because..." explanation clears this easily; a verbatim
+/// restatement of a short criterion does not.
+const MIN_MAPPING_WORDS: usize = 12;
+
+/// Finding emitted when the body has no "Not done" section. Shared by the
+/// early-return (no mapping) path and the main flow so the two cannot drift.
+const NOT_DONE_MISSING: &str =
+    "Missing the 'Not done' section. State what was deliberately left out of scope.";
+
+/// Result of validating a PR body against an issue's acceptance criteria.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PrWriteReport {
+    /// True when the body satisfies every structural requirement.
+    pub ok: bool,
+    /// Human-readable gaps, one per failed requirement. Empty when `ok`.
+    pub findings: Vec<String>,
+    /// Number of acceptance-criterion mapping entries found in the body.
+    pub mapping_entries: usize,
+}
+
+/// Validate a drafted PR `body` against the issue's `acceptance` criteria.
+///
+/// `acceptance` is the criterion list parsed from the issue (see
+/// `card_parse::parse_issue_body`). An empty list means the issue declared no
+/// machine-readable criteria; the validator still requires a mapping section
+/// with at least one substantive entry plus a not-done section, so the
+/// forcing function is never a no-op.
+pub fn validate_pr_body(acceptance: &[String], body: &str) -> PrWriteReport {
+    let mut findings: Vec<String> = Vec::new();
+
+    let parsed = parse_issue_body(body);
+
+    // Locate the two required sections by heading heuristic. parse_issue_body
+    // routes "acceptance criteria" / "acceptance" exactly to its own field, so
+    // the mapping heading is deliberately distinct ("... mapping") and lands
+    // in the generic `sections` bucket.
+    let mapping = parsed
+        .sections
+        .iter()
+        .find(|(h, _)| {
+            let h = h.to_lowercase();
+            h.contains("acceptance") && h.contains("mapping")
+        })
+        .map(|(_, c)| c.as_str());
+
+    let not_done = parsed
+        .sections
+        .iter()
+        .find(|(h, _)| {
+            let h = h.to_lowercase();
+            h.contains("not done") || h.contains("out of scope") || h.contains("deliberately")
+        })
+        .map(|(_, c)| c.as_str());
+
+    let Some(mapping) = mapping else {
+        findings.push(
+            "Missing the 'Acceptance criteria mapping' section. Map each criterion to the \
+             change that satisfies it, in prose, with evidence."
+                .to_owned(),
+        );
+        // No mapping means nothing else to check meaningfully; still report
+        // the not-done gap so the agent fixes both at once.
+        if not_done.is_none() {
+            findings.push(NOT_DONE_MISSING.to_owned());
+        }
+        return PrWriteReport {
+            ok: false,
+            findings,
+            mapping_entries: 0,
+        };
+    };
+
+    let entries = split_entries(mapping);
+
+    // Coverage: at least one mapping entry per acceptance criterion (or, when
+    // the issue declared none, at least one entry overall).
+    let required = acceptance.len().max(1);
+    if entries.len() < required {
+        findings.push(format!(
+            "Only {} mapping entr{} for {} acceptance criteri{} -- map every criterion.",
+            entries.len(),
+            if entries.len() == 1 { "y" } else { "ies" },
+            acceptance.len(),
+            if acceptance.len() == 1 { "on" } else { "a" },
+        ));
+    }
+
+    // Per-entry substance + evidence.
+    for (i, entry) in entries.iter().enumerate() {
+        let prose = strip_evidence_lines(entry);
+        let words = prose.split_whitespace().count();
+        if words < MIN_MAPPING_WORDS {
+            findings.push(format!(
+                "Mapping entry {} is too thin ({} words) -- explain how the change satisfies the \
+                 criterion, do not restate it.",
+                i + 1,
+                words,
+            ));
+        }
+        if !has_evidence(entry) {
+            findings.push(format!(
+                "Mapping entry {} cites no evidence -- name a test, a file:line, or an observable \
+                 behavior (an `Evidence:` line).",
+                i + 1,
+            ));
+        }
+    }
+
+    match not_done {
+        None => findings.push(NOT_DONE_MISSING.to_owned()),
+        Some(c) if c.split_whitespace().count() < 3 => findings.push(
+            "The 'Not done' section is empty -- state what was deliberately left out, or 'nothing'."
+                .to_owned(),
+        ),
+        Some(_) => {}
+    }
+
+    PrWriteReport {
+        ok: findings.is_empty(),
+        findings,
+        mapping_entries: entries.len(),
+    }
+}
+
+/// Split a mapping section's content into per-criterion entries on `### `
+/// subheadings. Text before the first `### ` is ignored (it is preamble, not
+/// an entry). Each returned string includes the subheading line and its body.
+fn split_entries(mapping: &str) -> Vec<String> {
+    let mut entries: Vec<String> = Vec::new();
+    let mut current: Option<String> = None;
+
+    for line in mapping.lines() {
+        if line.trim_start().starts_with("### ") {
+            if let Some(prev) = current.take() {
+                entries.push(prev.trim().to_string());
+            }
+            current = Some(format!("{line}\n"));
+        } else if let Some(buf) = current.as_mut() {
+            buf.push_str(line);
+            buf.push('\n');
+        }
+    }
+    if let Some(last) = current {
+        entries.push(last.trim().to_string());
+    }
+    entries
+}
+
+/// Strip the `### ` heading and any `Evidence:`-prefixed line from an entry,
+/// leaving the explanatory prose to be word-counted. The heading restates the
+/// criterion and the evidence line is checked separately, so neither should
+/// count toward the substance threshold.
+fn strip_evidence_lines(entry: &str) -> String {
+    entry
+        .lines()
+        .filter(|l| {
+            let t = l.trim_start();
+            !t.starts_with("### ") && !t.to_lowercase().starts_with("evidence:")
+        })
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+/// True when an entry cites evidence: an explicit `Evidence:` line, a test
+/// function, a source path, or an issue/PR reference. Deliberately generous --
+/// the goal is to confirm the agent pointed at something checkable, not to
+/// validate the citation itself (that is the verify gate's job).
+fn has_evidence(entry: &str) -> bool {
+    let lower = entry.to_lowercase();
+    if lower.contains("evidence:") {
+        return true;
+    }
+    // A test/fn marker or a source path.
+    if entry.contains("::") || entry.contains("fn ") || has_source_path(entry) {
+        return true;
+    }
+    // Behavioral cues, matched as whole words so "latest"/"fastest" don't
+    // count as "test" and a stray "testing" prose word doesn't slip through.
+    lower.split(|c: char| !c.is_alphanumeric()).any(|w| {
+        matches!(
+            w,
+            "test" | "tests" | "behavior" | "behaviour" | "behavioral"
+        )
+    })
+}
+
+/// True when the entry mentions a file with a recognized source extension --
+/// the token ends with the extension (`foo.rs`) or carries a line suffix
+/// (`bar.ts:42`). A bare substring match would fire on prose like "command".
+fn has_source_path(entry: &str) -> bool {
+    const EXTS: [&str; 12] = [
+        ".rs", ".ts", ".tsx", ".js", ".py", ".go", ".sh", ".md", ".toml", ".json", ".sql", ".rb",
+    ];
+    entry.split_whitespace().any(|raw| {
+        // Strip trailing punctuation so "src/pr_write.rs." still matches.
+        let tok = raw.trim_end_matches([',', '.', ';', ')', ']']);
+        EXTS.iter()
+            .any(|ext| tok.ends_with(ext) || tok.contains(&format!("{ext}:")))
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn good_body() -> String {
+        "## Summary\n\nDoes the thing.\n\n\
+         ## Acceptance criteria mapping\n\n\
+         ### 1. Cards default to Backlog\n\
+         insert_card now binds the status column to a CardStatus param instead of \
+         hardcoding pending, so freshly created and synced cards land in Backlog.\n\
+         Evidence: tests/integration.rs::born_backlog_default\n\n\
+         ### 2. Assign promotes to Pending\n\
+         The only transition into Pending is Action::Assign, which the FSM enforces; \
+         every other creation path stays in Backlog.\n\
+         Evidence: src/kanban.rs:120 transition table\n\n\
+         ## Not done\n\n\
+         Did not migrate existing pending rows -- out of scope, tracked separately.\n"
+            .to_owned()
+    }
+
+    #[test]
+    fn accepts_a_substantive_mapping() {
+        let ac = vec![
+            "Cards default to Backlog".to_owned(),
+            "Assign promotes to Pending".to_owned(),
+        ];
+        let report = validate_pr_body(&ac, &good_body());
+        assert!(report.ok, "expected clean, got {:?}", report.findings);
+        assert_eq!(report.mapping_entries, 2);
+    }
+
+    #[test]
+    fn refuses_missing_mapping_section() {
+        let ac = vec!["Something".to_owned()];
+        let body = "## Summary\n\nDid stuff.\n\n## Not done\n\nNothing skipped here really.\n";
+        let report = validate_pr_body(&ac, body);
+        assert!(!report.ok);
+        assert!(report.findings.iter().any(|f| f.contains("mapping")));
+    }
+
+    #[test]
+    fn refuses_missing_not_done_section() {
+        let ac = vec!["Something".to_owned()];
+        let body = "## Acceptance criteria mapping\n\n\
+                    ### 1. Something\n\
+                    The change wires the handler through the dispatch table and covers it.\n\
+                    Evidence: foo.rs::handles_something\n";
+        let report = validate_pr_body(&ac, body);
+        assert!(!report.ok);
+        assert!(report.findings.iter().any(|f| f.contains("Not done")));
+    }
+
+    #[test]
+    fn refuses_boilerplate_restatement() {
+        // Entry just restates the AC -- under the word threshold, no evidence.
+        let ac = vec!["Cards default to Backlog".to_owned()];
+        let body = "## Acceptance criteria mapping\n\n\
+                    ### 1. Cards default to Backlog\n\
+                    Cards default to Backlog.\n\n\
+                    ## Not done\n\nNothing was skipped.\n";
+        let report = validate_pr_body(&ac, body);
+        assert!(!report.ok);
+        assert!(report.findings.iter().any(|f| f.contains("too thin")));
+        assert!(report.findings.iter().any(|f| f.contains("no evidence")));
+    }
+
+    #[test]
+    fn refuses_under_coverage() {
+        // Two ACs, one mapping entry.
+        let ac = vec!["First criterion".to_owned(), "Second criterion".to_owned()];
+        let body = "## Acceptance criteria mapping\n\n\
+                    ### 1. First criterion\n\
+                    The dispatch path now threads the flag through and the handler honors it.\n\
+                    Evidence: foo.rs::first\n\n\
+                    ## Not done\n\nSecond criterion deferred.\n";
+        let report = validate_pr_body(&ac, body);
+        assert!(!report.ok);
+        assert!(
+            report
+                .findings
+                .iter()
+                .any(|f| f.contains("map every criterion"))
+        );
+    }
+
+    #[test]
+    fn requires_one_entry_even_without_declared_acceptance() {
+        // Issue declared no AC; the forcing function must not become a no-op.
+        let ac: Vec<String> = vec![];
+        // Mapping section present (non-empty so it survives parsing) but with
+        // no `### ` entries -- coverage still requires at least one.
+        let empty =
+            "## Acceptance criteria mapping\n\nSee below.\n\n## Not done\n\nNothing skipped.\n";
+        let report = validate_pr_body(&ac, empty);
+        assert!(!report.ok);
+        assert!(
+            report
+                .findings
+                .iter()
+                .any(|f| f.contains("map every criterion"))
+        );
+    }
+
+    #[test]
+    fn evidence_detected_in_several_forms() {
+        assert!(has_evidence("Evidence: see the new behavior"));
+        assert!(has_evidence("covered by foo::bar"));
+        assert!(has_evidence("added fn validate_thing"));
+        assert!(has_evidence("see src/pr_write.rs for the change"));
+        assert!(has_evidence("observable behavior changed"));
+        assert!(!has_evidence("just words with no citation at all here"));
+        // Word-boundary: "latest"/"fastest"/"greatest" embed "test" but are
+        // not evidence, and ".md" inside a prose word is not a source path.
+        assert!(!has_evidence(
+            "the latest greatest fastest command we shipped"
+        ));
+        assert!(has_evidence("see src/pr_write.rs."));
+        assert!(has_evidence("the change at main.rs:5763 wires both gates"));
+    }
+}


### PR DESCRIPTION
## Summary

Adds the PR-write step between simplify and review. The agent must write, in prose, how each acceptance criterion is satisfied by the change, cite evidence, and state what was deliberately not done. A structural validator (`legion pr write-check`) refuses an empty or boilerplate mapping and records a `legion-pr-write` quality gate that `legion pr create` now requires.

## Acceptance criteria mapping

### 1. PR-write step requires a per-AC written mapping + evidence + not-done section
`validate_pr_body` requires a "Acceptance criteria mapping" section with one `### ` entry per criterion, each carrying explanatory prose and an evidence citation, plus a non-empty "Not done" section; any missing piece becomes a finding. The legion-pr-write skill tells the agent how to compose exactly that body.
Evidence: src/pr_write.rs::accepts_a_substantive_mapping and refuses_missing_not_done_section.

### 2. Boilerplate/empty mapping is refused
An entry that merely restates the criterion falls under the MIN_MAPPING_WORDS prose threshold and carries no evidence, so the validator emits "too thin" and "no evidence" findings and the gate records result=issues, which blocks pr create. A missing mapping section is refused outright.
Evidence: src/pr_write.rs::refuses_boilerplate_restatement, refuses_missing_mapping_section, refuses_under_coverage.

### 3. The produced body is consumable by the verify gate
The body is composed of structured, machine-parseable sections (the same parse_issue_body the rest of legion uses), and the write-check records mapping_entries plus the per-criterion findings into the gate's details_json, so the verify gate (#520) reads explicit per-criterion claims rather than free text. This is the claim set #520 audits.
Evidence: PrWriteReport.mapping_entries and the details_json recorded by the pr write-check handler in src/main.rs; behavior verified by this very dogfood run against issue #519.

### 4. PR created and linked
This PR is opened against issue #519 via legion pr create with the validated body and the linked kanban card.
Evidence: the PR itself, created with --task linking the #519 card.

## Not done

The verify gate that audits these claims is the sibling issue #520, not this PR -- this PR produces a body in a structure verify can consume, but does not implement verify. Running the whole pipeline as a Workflow is #513 child 6.4. CLI end-to-end coverage of the write-check handler is not added here because it depends on worksource::view_issue (a gh round-trip); the validator logic it wraps is covered by the src/pr_write.rs unit tests, and this dogfood exercises the full path manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)