### PR TITLE
feat(#520): verify gate -- audit AC, gate the kanban ->Done transition

### DIFF
--- a/plugin/skills/legion-verify/SKILL.md
+++ b/plugin/skills/legion-verify/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: legion-verify
+description: |
+  The final gate before a card reaches Done. Read the card's acceptance criteria, the diff,
+  and the test output, and emit one verdict per criterion -- pass, fail, or uncertain -- each
+  with cited evidence (a test name, a file:line, an observable behavior). `legion verify`
+  records the verdict and decides the card's fate: all-pass unblocks Done, any fail hard-blocks,
+  any uncertain (or a pass with no evidence) routes the card to NeedsInput for a human. For a
+  solo engineering team this is the QA the operator does not have -- run it after review,
+  before Done.
+version: 1.0.0
+user-invocable: true
+allowed-tools: Bash, Read, Write
+---
+
+# Legion Verify
+
+The terminal gate. Build, simplify, PR-write, and review came before; verify confirms the work
+actually satisfies what the issue asked for, criterion by criterion, with evidence. It is
+non-skippable: `legion done` refuses a card that has acceptance criteria until verify records a
+clean verdict.
+
+You are auditing, not advocating. You wrote (or reviewed) this work; now read it as the QA
+engineer the operator cannot hire. A criterion you cannot mechanically confirm is `uncertain`,
+never `pass` -- verify never asserts an unprovable claim.
+
+## Procedure
+
+1. **Load the criteria.** They are the card's, not your memory of them:
+
+   ```bash
+   legion kanban view <card-id>
+   ```
+
+   Every line under "Acceptance criteria" needs exactly one verdict.
+
+2. **Gather evidence.** For each criterion, find the proof:
+   - `git diff main..HEAD` -- the change that addresses it.
+   - Run the tests (`cargo test`, the relevant suite) and note the test that exercises it.
+   - For a behavioral criterion, describe the observable behavior you confirmed.
+
+3. **Judge each criterion** honestly:
+   - `pass` -- satisfied, and you can cite the test / file:line / behavior that proves it.
+   - `fail` -- not satisfied, or the evidence contradicts it.
+   - `uncertain` -- you cannot mechanically confirm it (e.g. a performance or UX claim with no
+     test). Do not round up to pass.
+
+4. **Write the verdicts** to a JSON file (e.g. `/tmp/verdicts-<card>.json`) -- a list, one
+   object per criterion:
+
+   ```json
+   [
+     {"criterion": "<criterion text>", "verdict": "pass", "evidence": "tests::foo_does_x"},
+     {"criterion": "<criterion text>", "verdict": "uncertain", "evidence": "perf claim, no benchmark"}
+   ]
+   ```
+
+   Provide one entry per criterion. A `pass` with empty evidence is treated as `uncertain`.
+
+5. **Record the verdict:**
+
+   ```bash
+   legion verify --repo <repo> --card <card-id> --verdicts-file /tmp/verdicts-<card>.json
+   ```
+
+   - All `pass` (with evidence) -> records a clean gate; `legion done <card>` is unblocked.
+   - Any `fail` -> exits non-zero; Done stays blocked. Finish the work and re-verify.
+   - Any `uncertain` -> the card is moved to NeedsInput for a human; Done stays blocked.
+   - No criteria on the card -> blocked: the issue was not SOLID. Add checkable criteria upstream.
+
+## Notes
+
+- Verify owns acceptance (does the work meet the stated criteria). Vault owns intent (is this
+  the right work / is the spec serviced). They are separate gates; do not conflate them.
+- The verdict is card-keyed, so it survives the commit `legion done` runs on (e.g. post-merge).
+  Re-verify if the work materially changed after you recorded a verdict.
+- Do not pad evidence to clear a verdict. "uncertain" routed to a human is the correct, honest
+  outcome for an unprovable criterion -- that is the gate working, not failing.

--- a/src/db.rs
+++ b/src/db.rs
@@ -4535,6 +4535,42 @@ impl Database {
             None => Ok(None),
         }
     }
+
+    /// Return the most recent gate row for `skill` across all commits, if any.
+    ///
+    /// Unlike `get_quality_gate`, this ignores the commit hash. Used by the
+    /// verify gate (#520): a verify verdict is keyed on the card
+    /// (`legion-verify:<card_id>`) and must still satisfy the ->Done check even
+    /// when `legion done` runs on a different commit than verify did (e.g.
+    /// after the branch merged). Staleness is the caller's concern -- re-verify
+    /// after material changes.
+    pub fn get_latest_quality_gate_by_skill(&self, skill: &str) -> Result<Option<QualityGateRow>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT id, branch, commit_hash, skill, result, findings_count, details, created_at \
+             FROM quality_gates \
+             WHERE skill = ?1 \
+             ORDER BY created_at DESC \
+             LIMIT 1",
+        )?;
+        let mut rows = stmt.query_map(rusqlite::params![skill], |row| {
+            let findings_count_i64: i64 = row.get(5)?;
+            Ok(QualityGateRow {
+                id: row.get(0)?,
+                branch: row.get(1)?,
+                commit_hash: row.get(2)?,
+                skill: row.get(3)?,
+                result: row.get(4)?,
+                findings_count: findings_count_i64.unsigned_abs(),
+                details: row.get(6)?,
+                created_at: row.get(7)?,
+            })
+        })?;
+        match rows.next() {
+            Some(Ok(row)) => Ok(Some(row)),
+            Some(Err(e)) => Err(LegionError::Database(e)),
+            None => Ok(None),
+        }
+    }
 }
 
 /// An entry in the audit log tracking work source actions.
@@ -6069,6 +6105,36 @@ mod tests {
             .unwrap()
             .unwrap();
         assert_eq!(fetched.details.as_deref(), Some(details));
+    }
+
+    #[test]
+    fn latest_quality_gate_by_skill_ignores_commit() {
+        // #520: the verify gate is card-keyed (legion-verify:<card>) and must
+        // resolve regardless of the commit it was recorded on, since `legion
+        // done` may run on a different commit than verify did.
+        let db = test_db();
+        let skill = "legion-verify:card-7";
+        db.record_quality_gate("feat/x", "commit-old", skill, "issues", 1, None)
+            .unwrap();
+        db.record_quality_gate("main", "commit-new", skill, "clean", 0, None)
+            .unwrap();
+
+        let latest = db
+            .get_latest_quality_gate_by_skill(skill)
+            .unwrap()
+            .expect("a verify gate should exist for the card");
+        assert_eq!(
+            latest.result, "clean",
+            "most recent row wins across commits"
+        );
+        assert_eq!(latest.commit_hash, "commit-new");
+
+        // A different card's skill key does not match.
+        assert!(
+            db.get_latest_quality_gate_by_skill("legion-verify:card-99")
+                .unwrap()
+                .is_none()
+        );
     }
 
     #[test]

--- a/src/kanban.rs
+++ b/src/kanban.rs
@@ -106,6 +106,10 @@ pub fn transition(current: CardStatus, action: Action) -> Result<CardStatus> {
         (CardStatus::Accepted, Action::Done) => CardStatus::Done,
         (CardStatus::Blocked, Action::Unblock) => CardStatus::Accepted,
         (CardStatus::NeedsInput, Action::Resume) => CardStatus::Accepted,
+        // Verify (#520) runs after review and can find an unprovable criterion;
+        // routing the card from InReview to NeedsInput lets a human adjudicate
+        // rather than rubber-stamping ->Done.
+        (CardStatus::InReview, Action::NeedInput) => CardStatus::NeedsInput,
         (CardStatus::InReview, Action::Resume) => CardStatus::Accepted,
         (CardStatus::InReview, Action::Done) => CardStatus::Done,
         (CardStatus::Done, Action::Reopen) => CardStatus::Backlog,
@@ -1396,6 +1400,16 @@ mod tests {
     fn cannot_assign_from_accepted() {
         let result = transition(CardStatus::Accepted, Action::Assign);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn verify_routes_inreview_to_needs_input() {
+        // #520: verify runs after review and can find an unprovable criterion.
+        let result = transition(CardStatus::InReview, Action::NeedInput);
+        assert_eq!(
+            result.expect("InReview->NeedInput is valid"),
+            CardStatus::NeedsInput
+        );
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,6 +36,7 @@ mod telemetry;
 mod testutil;
 mod uncertainty;
 mod usage;
+mod verify;
 mod wake_attempts;
 mod watch;
 mod worksource;
@@ -804,6 +805,29 @@ enum Commands {
     QualityGate {
         #[command(subcommand)]
         action: QualityGateAction,
+    },
+
+    /// Verify a card's acceptance criteria before it can reach Done (#520).
+    /// Reads per-criterion verdicts (pass/fail/uncertain + evidence) as JSON
+    /// from --verdicts-file or stdin, loads the card's acceptance criteria,
+    /// and decides the card's fate: every criterion Pass with evidence allows
+    /// ->Done (records a clean legion-verify:<card> gate); any Fail hard-blocks;
+    /// any Uncertain (or a Pass with no evidence) routes the card to NeedsInput
+    /// for a human. A card with no acceptance criteria is blocked outright.
+    Verify {
+        /// Repository name (resolves work source config from watch.toml)
+        #[arg(long)]
+        repo: String,
+
+        /// Kanban card ID whose acceptance criteria are being verified.
+        #[arg(long)]
+        card: String,
+
+        /// Path to a JSON file with the per-criterion verdicts. Reads stdin
+        /// when omitted. Shape: `[{"criterion": "...", "verdict":
+        /// "pass|fail|uncertain", "evidence": "..."}, ...]`.
+        #[arg(long)]
+        verdicts_file: Option<String>,
     },
 
     /// Show current system health and recent trend
@@ -2674,6 +2698,25 @@ fn git_head_commit_and_branch() -> Result<(String, String), error::LegionError> 
         "unknown".to_owned()
     };
     Ok((commit_hash, branch))
+}
+
+/// Read input from `path` (the value of a `--*-file` flag) or, when it is
+/// `None`, from stdin. `flag` names the originating flag for the error
+/// message. Shared by the pr-write and verify gates, which both accept their
+/// payload as either a file or a stdin pipe.
+fn read_file_or_stdin(path: Option<&str>, flag: &str) -> Result<String, error::LegionError> {
+    match path {
+        Some(p) => std::fs::read_to_string(p)
+            .map_err(|e| error::LegionError::WorkSource(format!("failed to read {flag} {p}: {e}"))),
+        None => {
+            use std::io::Read as _;
+            let mut buf = String::new();
+            std::io::stdin().read_to_string(&mut buf).map_err(|e| {
+                error::LegionError::WorkSource(format!("failed to read stdin: {e}"))
+            })?;
+            Ok(buf)
+        }
+    }
 }
 
 fn fmt_pct(v: Option<f64>) -> String {
@@ -4749,6 +4792,37 @@ fn run() -> error::Result<()> {
 
             // Validate card transition BEFORE posting announcements
             if let Some(ref card_id) = id {
+                // Verify gate (#520): a card with acceptance criteria cannot
+                // reach Done until `legion verify` recorded a clean verdict for
+                // it. The gate is card-keyed (legion-verify:<card_id>), so it
+                // holds regardless of the commit `legion done` runs on. Cards
+                // with no criteria (chores) are not gated. Done is the terminal
+                // QA gate for a solo team, so there is no --skip here.
+                if let Some(card) = database.get_card_by_id(card_id)? {
+                    let acceptance = verify::acceptance_items(card.acceptance.as_deref());
+                    if !acceptance.is_empty() {
+                        let skill = format!("legion-verify:{card_id}");
+                        match database.get_latest_quality_gate_by_skill(&skill)? {
+                            Some(gate) if gate.result == "clean" => {}
+                            Some(_) => {
+                                eprintln!(
+                                    "[legion] error: verify gate is not clean for card {card_id}. \
+                                     Resolve the failing/uncertain criteria and re-run verify \
+                                     before Done."
+                                );
+                                std::process::exit(1);
+                            }
+                            None => {
+                                eprintln!(
+                                    "[legion] error: card {card_id} has acceptance criteria but no \
+                                     verify verdict. Run the verify skill before Done."
+                                );
+                                std::process::exit(1);
+                            }
+                        }
+                    }
+                }
+
                 let card =
                     kanban::transition_card(&database, card_id, kanban::Action::Done, Some(&text))?;
                 println!("{card_id}");
@@ -6043,21 +6117,7 @@ fn run() -> error::Result<()> {
                 let parsed = card_parse::parse_issue_body(ext.body.as_deref().unwrap_or(""));
 
                 // Read the drafted body from --body-file, or stdin when omitted.
-                let body = match body_file {
-                    Some(path) => std::fs::read_to_string(&path).map_err(|e| {
-                        error::LegionError::WorkSource(format!(
-                            "failed to read --body-file {path}: {e}"
-                        ))
-                    })?,
-                    None => {
-                        use std::io::Read as _;
-                        let mut buf = String::new();
-                        std::io::stdin().read_to_string(&mut buf).map_err(|e| {
-                            error::LegionError::WorkSource(format!("failed to read stdin: {e}"))
-                        })?;
-                        buf
-                    }
-                };
+                let body = read_file_or_stdin(body_file.as_deref(), "--body-file")?;
 
                 let report = pr_write::validate_pr_body(&parsed.acceptance, &body);
 
@@ -6621,6 +6681,124 @@ fn run() -> error::Result<()> {
                 println!("{}", row.id);
             }
         },
+        Commands::Verify {
+            repo: _repo,
+            card,
+            verdicts_file,
+        } => {
+            let base = data_dir()?;
+            let database = db::Database::open(&base.join("legion.db"))?;
+
+            let card_row = database
+                .get_card_by_id(&card)?
+                .ok_or_else(|| error::LegionError::CardNotFound(card.clone()))?;
+            let acceptance = verify::acceptance_items(card_row.acceptance.as_deref());
+
+            // Read the agent's per-criterion verdicts (file or stdin).
+            let raw = read_file_or_stdin(verdicts_file.as_deref(), "--verdicts-file")?;
+            let results: Vec<verify::AcResult> = serde_json::from_str(&raw).map_err(|e| {
+                error::LegionError::WorkSource(format!(
+                    "failed to parse verdicts JSON (expected a list of \
+                     {{criterion, verdict, evidence}}): {e}"
+                ))
+            })?;
+
+            let decision = verify::decide(&acceptance, &results);
+
+            // Record the verdict as a card-keyed gate so `legion done` can gate
+            // on it regardless of which commit it runs on (e.g. post-merge).
+            let skill = format!("legion-verify:{card}");
+            let (commit_hash, branch) = git_head_commit_and_branch()?;
+            let details = serde_json::json!({
+                "skill": "legion-verify",
+                "card": card,
+                "decision": format!("{decision:?}"),
+                "results": results,
+            })
+            .to_string();
+            let findings = match &decision {
+                verify::VerifyDecision::Block { failed } => failed.len() as u64,
+                verify::VerifyDecision::NeedsInput { uncertain } => uncertain.len() as u64,
+                verify::VerifyDecision::Incomplete { unaddressed } => *unaddressed as u64,
+                verify::VerifyDecision::NoCheckableAc => 1,
+                verify::VerifyDecision::Proceed => 0,
+            };
+            database.record_quality_gate(
+                &branch,
+                &commit_hash,
+                &skill,
+                if decision.allows_done() {
+                    "clean"
+                } else {
+                    "issues"
+                },
+                findings,
+                Some(&details),
+            )?;
+
+            match decision {
+                verify::VerifyDecision::Proceed => {
+                    println!(
+                        "[legion] verify PASS for card {card} ({} criteria). ->Done is unblocked.",
+                        acceptance.len()
+                    );
+                }
+                verify::VerifyDecision::NoCheckableAc => {
+                    eprintln!(
+                        "[legion] verify BLOCKED for card {card}: no acceptance criteria to check. \
+                         A card cannot reach Done without checkable criteria -- add them upstream."
+                    );
+                    std::process::exit(1);
+                }
+                verify::VerifyDecision::Incomplete { unaddressed } => {
+                    eprintln!(
+                        "[legion] verify BLOCKED for card {card}: {unaddressed} of {} criteria have \
+                         no verdict. Emit one verdict per criterion.",
+                        acceptance.len()
+                    );
+                    std::process::exit(1);
+                }
+                verify::VerifyDecision::Block { failed } => {
+                    eprintln!(
+                        "[legion] verify FAIL for card {card} -- {} criterion(s) not satisfied:",
+                        failed.len()
+                    );
+                    for c in &failed {
+                        eprintln!("  - {c}");
+                    }
+                    eprintln!("\n->Done is blocked. Finish the work and re-verify.");
+                    std::process::exit(1);
+                }
+                verify::VerifyDecision::NeedsInput { uncertain } => {
+                    eprintln!(
+                        "[legion] verify UNCERTAIN for card {card} -- {} criterion(s) cannot be \
+                         mechanically confirmed:",
+                        uncertain.len()
+                    );
+                    for c in &uncertain {
+                        eprintln!("  - {c}");
+                    }
+                    // Route to a human rather than rubber-stamp ->Done. The gate
+                    // is already recorded non-clean, so ->Done stays blocked even
+                    // if the card is not in a state this transition accepts.
+                    match kanban::transition_card(
+                        &database,
+                        &card,
+                        kanban::Action::NeedInput,
+                        Some("verify: unprovable acceptance criteria, needs human adjudication"),
+                    ) {
+                        Ok(_) => eprintln!(
+                            "\nCard routed to NeedsInput. ->Done stays blocked until resolved."
+                        ),
+                        Err(e) => eprintln!(
+                            "\n->Done stays blocked. (Could not auto-move card to NeedsInput: \
+                             {e}; move it manually.)"
+                        ),
+                    }
+                    std::process::exit(1);
+                }
+            }
+        }
         Commands::Statusline { json } => {
             // Never surface an error to the Claude Code UI: statusline::run
             // already swallows internal failures and logs them, and its

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -1,0 +1,236 @@
+// Verify gate (#520).
+//
+// The final gate before a card reaches Done. After build, simplify, PR-write,
+// and review, verify confirms each acceptance criterion is actually satisfied
+// -- with cited evidence -- and emits a per-criterion verdict. For a solo
+// engineering team this is the QA the operator does not have: non-skippable,
+// gating the kanban ->Done transition.
+//
+// This module is the decision engine. The verify skill does the judging (reads
+// the criteria, the diff, and the test output, and decides per criterion);
+// this code makes the judgment binding. Given the criteria and the agent's
+// per-criterion verdicts it:
+//   - refuses an issue with no checkable criteria (forces SOLID issues),
+//   - refuses to proceed unless every criterion has a verdict,
+//   - never lets an unprovable criterion pass -- a Pass with no cited evidence
+//     is downgraded to Uncertain ("never assert an unprovable criterion"),
+//   - maps the verdict set to one routing decision: any Fail hard-blocks
+//     ->Done; any Uncertain (no Fail) routes the card to NeedsInput; all Pass
+//     proceeds.
+
+/// One verdict for one acceptance criterion.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum AcVerdict {
+    Pass,
+    Fail,
+    Uncertain,
+}
+
+/// The agent's assessment of a single acceptance criterion.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct AcResult {
+    pub criterion: String,
+    pub verdict: AcVerdict,
+    /// A test name, a file:line, or an observable behavior. Required for a
+    /// Pass to stand; a Pass with empty evidence is treated as Uncertain.
+    pub evidence: String,
+}
+
+/// The aggregate routing decision for a card's ->Done transition.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum VerifyDecision {
+    /// Every criterion passed with evidence. Allow ->Done.
+    Proceed,
+    /// At least one criterion failed. Hard block; the work is not done.
+    Block { failed: Vec<String> },
+    /// At least one criterion is unprovable (and none failed). Route the card
+    /// to NeedsInput so a human adjudicates -- never rubber-stamped to Done.
+    NeedsInput { uncertain: Vec<String> },
+    /// The issue declared no acceptance criteria. Block: there is nothing to
+    /// verify against, which means the issue was not SOLID. Forces criteria
+    /// upstream rather than letting unverifiable work reach Done.
+    NoCheckableAc,
+    /// Fewer verdicts than criteria: some criterion was never assessed. Block
+    /// until every criterion has a verdict.
+    Incomplete { unaddressed: usize },
+}
+
+impl VerifyDecision {
+    /// True only for `Proceed`: the single state that may reach Done.
+    pub fn allows_done(&self) -> bool {
+        matches!(self, VerifyDecision::Proceed)
+    }
+}
+
+/// Decide a card's fate from its acceptance criteria and the agent's verdicts.
+///
+/// `acceptance` is the criterion list (one per item). `results` is one verdict
+/// per criterion. The function is total and side-effect free; the caller
+/// records the gate and performs any card transition.
+pub fn decide(acceptance: &[String], results: &[AcResult]) -> VerifyDecision {
+    if acceptance.is_empty() {
+        return VerifyDecision::NoCheckableAc;
+    }
+    if results.len() < acceptance.len() {
+        return VerifyDecision::Incomplete {
+            unaddressed: acceptance.len() - results.len(),
+        };
+    }
+
+    // A Pass with no cited evidence is not a provable pass -- demote it to
+    // Uncertain so it routes to a human instead of rubber-stamping ->Done.
+    let effective = |r: &AcResult| -> AcVerdict {
+        if r.verdict == AcVerdict::Pass && r.evidence.trim().is_empty() {
+            AcVerdict::Uncertain
+        } else {
+            r.verdict
+        }
+    };
+
+    let failed: Vec<String> = results
+        .iter()
+        .filter(|r| effective(r) == AcVerdict::Fail)
+        .map(|r| r.criterion.clone())
+        .collect();
+    if !failed.is_empty() {
+        return VerifyDecision::Block { failed };
+    }
+
+    let uncertain: Vec<String> = results
+        .iter()
+        .filter(|r| effective(r) == AcVerdict::Uncertain)
+        .map(|r| r.criterion.clone())
+        .collect();
+    if !uncertain.is_empty() {
+        return VerifyDecision::NeedsInput { uncertain };
+    }
+
+    VerifyDecision::Proceed
+}
+
+/// Split a card's stored `acceptance` field (newline-joined criteria, as
+/// `db::insert_card` stores them) into individual criteria, dropping blank
+/// lines. Returns an empty vec for `None` or an all-blank field, which
+/// `decide` reports as `NoCheckableAc`.
+pub fn acceptance_items(stored: Option<&str>) -> Vec<String> {
+    stored
+        .unwrap_or("")
+        .lines()
+        .map(str::trim)
+        .filter(|l| !l.is_empty())
+        .map(str::to_owned)
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn res(criterion: &str, verdict: AcVerdict, evidence: &str) -> AcResult {
+        AcResult {
+            criterion: criterion.to_owned(),
+            verdict,
+            evidence: evidence.to_owned(),
+        }
+    }
+
+    #[test]
+    fn all_pass_proceeds() {
+        let ac = vec!["A".to_owned(), "B".to_owned()];
+        let results = vec![
+            res("A", AcVerdict::Pass, "tests::a"),
+            res("B", AcVerdict::Pass, "src/x.rs:10"),
+        ];
+        assert_eq!(decide(&ac, &results), VerifyDecision::Proceed);
+        assert!(decide(&ac, &results).allows_done());
+    }
+
+    #[test]
+    fn any_fail_blocks() {
+        let ac = vec!["A".to_owned(), "B".to_owned()];
+        let results = vec![
+            res("A", AcVerdict::Pass, "tests::a"),
+            res("B", AcVerdict::Fail, "no handler for the empty case"),
+        ];
+        let d = decide(&ac, &results);
+        assert_eq!(
+            d,
+            VerifyDecision::Block {
+                failed: vec!["B".to_owned()]
+            }
+        );
+        assert!(!d.allows_done());
+    }
+
+    #[test]
+    fn uncertain_routes_to_needs_input() {
+        let ac = vec!["A".to_owned(), "B".to_owned()];
+        let results = vec![
+            res("A", AcVerdict::Pass, "tests::a"),
+            res(
+                "B",
+                AcVerdict::Uncertain,
+                "cannot mechanically check perf claim",
+            ),
+        ];
+        assert_eq!(
+            decide(&ac, &results),
+            VerifyDecision::NeedsInput {
+                uncertain: vec!["B".to_owned()]
+            }
+        );
+    }
+
+    #[test]
+    fn fail_outranks_uncertain() {
+        let ac = vec!["A".to_owned(), "B".to_owned()];
+        let results = vec![
+            res("A", AcVerdict::Uncertain, "unprovable"),
+            res("B", AcVerdict::Fail, "broken"),
+        ];
+        // A Fail anywhere is a hard block regardless of uncertain criteria.
+        assert!(matches!(
+            decide(&ac, &results),
+            VerifyDecision::Block { .. }
+        ));
+    }
+
+    #[test]
+    fn pass_without_evidence_is_uncertain_never_pass() {
+        let ac = vec!["A".to_owned()];
+        // Claims Pass but cites nothing -- not a provable pass.
+        let results = vec![res("A", AcVerdict::Pass, "   ")];
+        assert_eq!(
+            decide(&ac, &results),
+            VerifyDecision::NeedsInput {
+                uncertain: vec!["A".to_owned()]
+            }
+        );
+    }
+
+    #[test]
+    fn empty_acceptance_is_blocked() {
+        assert_eq!(decide(&[], &[]), VerifyDecision::NoCheckableAc);
+    }
+
+    #[test]
+    fn fewer_verdicts_than_criteria_is_incomplete() {
+        let ac = vec!["A".to_owned(), "B".to_owned(), "C".to_owned()];
+        let results = vec![res("A", AcVerdict::Pass, "tests::a")];
+        assert_eq!(
+            decide(&ac, &results),
+            VerifyDecision::Incomplete { unaddressed: 2 }
+        );
+    }
+
+    #[test]
+    fn acceptance_items_splits_and_trims() {
+        assert_eq!(
+            acceptance_items(Some("First\n  Second  \n\nThird\n")),
+            vec!["First".to_owned(), "Second".to_owned(), "Third".to_owned()]
+        );
+        assert!(acceptance_items(None).is_empty());
+        assert!(acceptance_items(Some("\n  \n")).is_empty());
+    }
+}

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -6141,3 +6141,170 @@ fn parse_allowed_tools_handles_inline_and_block_forms() {
     // Absent key.
     assert_eq!(parse_allowed_tools("---\nname: x\n---\n"), None);
 }
+
+// #520 verify gate, end-to-end at the CLI boundary: a card with acceptance
+// criteria cannot reach Done until `legion verify` records a clean verdict.
+#[test]
+fn verify_gate_blocks_done_until_clean_then_allows() {
+    let dir = tempfile::tempdir().unwrap();
+    let data = dir.path();
+
+    // Create a card carrying two acceptance criteria (parsed from --context).
+    let create = legion_cmd(data)
+        .args([
+            "kanban",
+            "create",
+            "--from",
+            "kelex",
+            "--to",
+            "kelex",
+            "--text",
+            "ship the thing",
+            "--context",
+            "## Acceptance criteria\n- crit one\n- crit two\n",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        create.status.success(),
+        "create failed: {}",
+        String::from_utf8_lossy(&create.stderr)
+    );
+    let card = String::from_utf8_lossy(&create.stdout).trim().to_string();
+
+    // Promote to a Done-eligible state: Backlog -> Pending -> Accepted.
+    assert!(
+        legion_cmd(data)
+            .args(["kanban", "assign", "--id", &card, "--to", "kelex"])
+            .output()
+            .unwrap()
+            .status
+            .success()
+    );
+    assert!(
+        legion_cmd(data)
+            .args(["kanban", "accept", "--id", &card])
+            .output()
+            .unwrap()
+            .status
+            .success()
+    );
+
+    // Done must be refused: the card has criteria but no verify verdict.
+    let blocked = legion_cmd(data)
+        .args(["done", "--repo", "kelex", "--text", "done", "--id", &card])
+        .output()
+        .unwrap();
+    assert!(
+        !blocked.status.success(),
+        "Done should be blocked before verify ran"
+    );
+    assert!(
+        String::from_utf8_lossy(&blocked.stderr).contains("verify verdict"),
+        "expected a verify-gate error, got: {}",
+        String::from_utf8_lossy(&blocked.stderr)
+    );
+
+    // Record a clean verify verdict (both criteria pass with evidence).
+    let verdicts = data.join("verdicts.json");
+    std::fs::write(
+        &verdicts,
+        r#"[
+          {"criterion":"crit one","verdict":"pass","evidence":"tests::crit_one"},
+          {"criterion":"crit two","verdict":"pass","evidence":"src/x.rs:10 behavior"}
+        ]"#,
+    )
+    .unwrap();
+    let verified = legion_cmd(data)
+        .args([
+            "verify",
+            "--repo",
+            "kelex",
+            "--card",
+            &card,
+            "--verdicts-file",
+            verdicts.to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        verified.status.success(),
+        "verify should pass with all-pass verdicts: {}",
+        String::from_utf8_lossy(&verified.stderr)
+    );
+
+    // Done now succeeds.
+    let allowed = legion_cmd(data)
+        .args(["done", "--repo", "kelex", "--text", "done", "--id", &card])
+        .output()
+        .unwrap();
+    assert!(
+        allowed.status.success(),
+        "Done should be allowed after a clean verify: {}",
+        String::from_utf8_lossy(&allowed.stderr)
+    );
+}
+
+// #520: a Fail verdict keeps the card blocked from Done.
+#[test]
+fn verify_gate_fail_keeps_done_blocked() {
+    let dir = tempfile::tempdir().unwrap();
+    let data = dir.path();
+
+    let create = legion_cmd(data)
+        .args([
+            "kanban",
+            "create",
+            "--from",
+            "kelex",
+            "--to",
+            "kelex",
+            "--text",
+            "wip",
+            "--context",
+            "## Acceptance criteria\n- only crit\n",
+        ])
+        .output()
+        .unwrap();
+    let card = String::from_utf8_lossy(&create.stdout).trim().to_string();
+    legion_cmd(data)
+        .args(["kanban", "assign", "--id", &card, "--to", "kelex"])
+        .output()
+        .unwrap();
+    legion_cmd(data)
+        .args(["kanban", "accept", "--id", &card])
+        .output()
+        .unwrap();
+
+    let verdicts = data.join("v.json");
+    std::fs::write(
+        &verdicts,
+        r#"[{"criterion":"only crit","verdict":"fail","evidence":"not implemented"}]"#,
+    )
+    .unwrap();
+    let verified = legion_cmd(data)
+        .args([
+            "verify",
+            "--repo",
+            "kelex",
+            "--card",
+            &card,
+            "--verdicts-file",
+            verdicts.to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        !verified.status.success(),
+        "verify with a Fail should exit non-zero"
+    );
+
+    let blocked = legion_cmd(data)
+        .args(["done", "--repo", "kelex", "--text", "done", "--id", &card])
+        .output()
+        .unwrap();
+    assert!(
+        !blocked.status.success(),
+        "Done stays blocked after a Fail verdict"
+    );
+}


### PR DESCRIPTION
## Summary

Adds the verify gate -- the terminal QA step for a solo engineering team. After build, simplify, PR-write, and review, verify reads a card's acceptance criteria and the agent's per-criterion verdicts, then decides the card's fate. It is non-skippable: `legion done` refuses a card with acceptance criteria until verify records a clean verdict. Pairs with #519 (PR-write produces the claims; verify audits them).

## Acceptance criteria mapping

### 1. verify emits one verdict + evidence per AC item
`AcResult { criterion, verdict, evidence }` is the per-criterion unit; the verify CLI loads the card's acceptance items and `decide()` requires one result per criterion (fewer -> Incomplete). The verify skill instructs the agent to emit exactly one verdict, with cited evidence, per criterion.
Evidence: src/verify.rs::all_pass_proceeds and ::fewer_verdicts_than_criteria_is_incomplete; AcResult struct in src/verify.rs.

### 2. Fail hard-blocks ->Done; Uncertain routes to NeedsInput; Pass proceeds
`decide()` returns Block on any Fail, NeedsInput on any Uncertain (no Fail), Proceed only when all pass; the Done handler refuses the ->Done transition unless a clean legion-verify gate exists, and the verify CLI moves the card to NeedsInput on Uncertain via a new (InReview,NeedInput) FSM transition.
Evidence: src/verify.rs::any_fail_blocks, ::uncertain_routes_to_needs_input, ::all_pass_proceeds; the e2e tests tests/integration.rs::verify_gate_blocks_done_until_clean_then_allows and ::verify_gate_fail_keeps_done_blocked.

### 3. Unprovable AC is Uncertain, never Pass
In `decide()`, a result with verdict Pass but empty evidence is demoted to Uncertain before aggregation, so an unprovable criterion can never reach Proceed/Done -- it routes to a human instead.
Evidence: src/verify.rs::pass_without_evidence_is_uncertain_never_pass.

### 4. Empty-AC issue is blocked
`decide()` returns NoCheckableAc when the criterion list is empty, and the verify CLI exits non-zero with a "no acceptance criteria" error; the Done gate only applies to cards that have criteria, so an empty-AC card cannot be silently verified-clean.
Evidence: src/verify.rs::empty_acceptance_is_blocked; the Done-gate branch in src/main.rs guards on a non-empty acceptance list.

### 5. PR created and linked
This PR is opened against issue #520 via legion pr create with the linked kanban card.
Evidence: the PR itself, created with --task linking the #520 card.

## Not done

The verify judging itself is the agent's (the skill), as designed -- this module enforces structure (coverage by count, evidence-for-pass, uncertain-routing) and trusts the per-criterion verdict, exactly as legion-simplify trusts its quality judgment; verdicts are matched to criteria by count, not by criterion-text identity (documented in decide()'s contract). Running the whole pipeline as a Workflow is #513 child 6.4. Auto-skip/bootstrap for the Done gate is deliberately omitted -- Done is the terminal gate and is non-skippable for cards with criteria.

🤖 Generated with [Claude Code](https://claude.com/claude-code)