### PR TITLE
feat(#525): board-derived goal -- the Accepted card's AC as the completion condition

### DIFF
--- a/docs/decisions/2026-05-board-derived-goal.md
+++ b/docs/decisions/2026-05-board-derived-goal.md
@@ -1,0 +1,51 @@
+# Board-derived goal: native `/goal` is not programmatically settable
+
+Date: 2026-05-30
+Issue: #525 (board-derived /goal -- set native completion-condition from the active card)
+Parent epic: #511 (autonomy loop)
+
+## Question
+
+#525 asked legion to set Claude Code's native `/goal` automatically from the active kanban
+card, so continuation is board-driven instead of the operator typing `/goal`.
+
+## Finding
+
+**There is no programmatic way to set the native `/goal`.** Verified (claude-code-guide,
+against CC v2.1.154 docs, `claude --help`, the hook-output schema, and settings schema):
+
+- No hook event output sets it -- `hookSpecificOutput` exposes `additionalContext`,
+  `systemMessage`, `permissionDecision`, `sessionTitle`, but no goal field.
+- No `--goal` CLI flag, no settings.json key, no env var.
+- `/goal` is user-typed only.
+
+Mechanism (useful to know): **`/goal` is itself a session-scoped, prompt-type Stop hook.**
+After each turn a fast model evaluates "is the condition met?" and auto-continues until yes.
+It shipped in v2.1.139; surface unchanged through v2.1.154.
+
+## Decision
+
+#525's own AC anticipated this ("degrades silently when /goal is unavailable"). Since native
+`/goal` is *always* unavailable to a hook, the degrade path is the only path, and legion ships
+the supported **equivalent** rather than the native set:
+
+- **The board is the goal state.** `legion goal --repo <r>` derives the completion condition
+  from the active *Accepted* card's acceptance criteria (`kanban::format_active_goal`). There is
+  no separate goal to set or clear -- it is re-derived from board state every time.
+- **Set on accept:** `legion kanban accept` echoes the accepted card's AC as the goal.
+- **Carried across turns/sessions:** SessionStart emits `legion goal` so a fresh session opens
+  with the active card's AC as its stated completion condition.
+- **Clears on terminal/blocked:** once the card is no longer Accepted, `legion goal` returns
+  empty. No state to reset.
+- **Enforcement** (the auto-continue half that native `/goal` does via its prompt Stop hook) is
+  provided by legion's existing kanban Stop gate (#523): it blocks stopping while a card is
+  Accepted. So the board-derived goal states *what* "done" means; the Stop gate keeps the agent
+  going until the card leaves Accepted. The two together are legion's `/goal`.
+
+## Not done
+
+A prompt-type Stop hook that evaluates the card's AC per turn (the closest literal clone of
+`/goal`'s auto-continue) is not added: hooks.json prompts are static and cannot inject the
+current card's AC at runtime, and the command-type Stop gate (#523) already provides
+board-derived continuation. If CC later exposes a goal-set API, `legion goal` is the natural
+place to call it.

--- a/plugin/hooks/session-start.sh
+++ b/plugin/hooks/session-start.sh
@@ -128,10 +128,20 @@ if [ -n "$KANBAN" ]; then
 ${KANBAN}"
 fi
 
-# 6. Autonomy budget (#524) -- remind the agent it has sanctioned units to
+# 6. Board-derived goal (#525) -- the active Accepted card's acceptance
+# criteria, framed as the completion condition the agent carries this session.
+# Native /goal cannot be set programmatically, so legion re-derives it from the
+# board here. Empty when nothing is in progress (the goal is cleared by board
+# state alone). Lands right after the work list: "here is your work, and here
+# is the one you committed to finishing."
+GOAL=$("$LEGION" goal --repo "$REPO" 2>>"$LOG")
+legion_check $? "goal"
+append_block "$GOAL"
+
+# 7. Autonomy budget (#524) -- remind the agent it has sanctioned units to
 # spend on self-directed work, so it acts on the board instead of waiting to
-# be told. Lands after the work list: first "here is your work," then "and you
-# are cleared to pick it up yourself."
+# be told. Lands after the goal: first "finish this," then "and you are
+# cleared to pick up more yourself."
 BUDGET=$("$LEGION" autonomy status --repo "$REPO" --banner 2>>"$LOG")
 legion_check $? "autonomy status"
 append_block "$BUDGET"

--- a/src/kanban.rs
+++ b/src/kanban.rs
@@ -332,6 +332,43 @@ pub fn agent_workloads(db: &Database) -> Result<Vec<AgentWorkload>> {
     db.get_agent_workloads()
 }
 
+/// Build the board-derived goal banner (#525): the active Accepted card(s)
+/// framed as the agent's completion condition, to carry across turns.
+///
+/// The native `/goal` cannot be set programmatically (no hook/flag/settings
+/// surface as of CC v2.1.154), so this is the supported equivalent: the goal
+/// is re-derived from the board on every SessionStart and printed on accept.
+/// It "clears" with no separate state -- once nothing is Accepted (the card
+/// reached a terminal or blocked status), this returns `None` and no goal is
+/// shown. Returns `None` when no card is in progress.
+pub fn format_active_goal(cards: &[Card]) -> Option<String> {
+    let accepted: Vec<&Card> = cards
+        .iter()
+        .filter(|c| c.status == CardStatus::Accepted)
+        .collect();
+    if accepted.is_empty() {
+        return None;
+    }
+
+    let mut out = String::from(
+        "[Legion] Your goal -- the board's completion condition, carried across turns \
+         (legion sets this from the card you accepted; you do not type /goal):",
+    );
+    for card in accepted {
+        out.push_str(&format!("\n\n- {}  [card {}]", card.text.trim(), card.id));
+        if let Some(ac) = card.acceptance.as_deref() {
+            for item in ac.lines().map(str::trim).filter(|l| !l.is_empty()) {
+                out.push_str(&format!("\n    - [ ] {item}"));
+            }
+        }
+    }
+    out.push_str(
+        "\n\nKeep working until these acceptance criteria are met, then run verify. \
+         The Stop gate holds you to it; \"should I keep going?\" is already answered -- yes.",
+    );
+    Some(out)
+}
+
 /// Format a priority tag for display.
 fn priority_tag(priority: &str) -> String {
     if priority != "med" {
@@ -1474,6 +1511,53 @@ mod tests {
         assert!(!output.contains("Context:"));
         assert!(!output.contains("Labels:"));
         assert!(!output.contains("Source:"));
+    }
+
+    #[test]
+    fn active_goal_derives_from_the_accepted_card() {
+        let mk = |status: CardStatus, text: &str, ac: Option<&str>| Card {
+            id: "card-1".to_string(),
+            from_repo: "kelex".to_string(),
+            to_repo: "kelex".to_string(),
+            text: text.to_string(),
+            context: None,
+            priority: "med".to_string(),
+            status,
+            note: None,
+            labels: None,
+            parent_card_id: None,
+            source_url: None,
+            source_type: None,
+            sort_order: 0,
+            created_at: "2026-04-03T00:00:00Z".to_string(),
+            updated_at: "2026-04-03T00:00:00Z".to_string(),
+            assigned_at: None,
+            started_at: None,
+            completed_at: None,
+            problem: None,
+            solution: None,
+            acceptance: ac.map(str::to_string),
+        };
+
+        // An Accepted card with AC becomes the goal, listing its criteria.
+        let goal = format_active_goal(&[mk(
+            CardStatus::Accepted,
+            "ship the gate",
+            Some("crit one\ncrit two"),
+        )])
+        .expect("an accepted card yields a goal");
+        assert!(goal.contains("ship the gate"));
+        assert!(goal.contains("crit one") && goal.contains("crit two"));
+        assert!(goal.contains("card card-1"));
+
+        // Nothing Accepted -> no goal (cleared by board state alone, AC #2).
+        assert!(format_active_goal(&[mk(CardStatus::Pending, "not yet", Some("x"))]).is_none());
+        assert!(format_active_goal(&[]).is_none());
+
+        // Accepted but no AC -> still a goal, titled by the card text.
+        let goal2 =
+            format_active_goal(&[mk(CardStatus::Accepted, "chore card", None)]).expect("goal");
+        assert!(goal2.contains("chore card"));
     }
 
     // --- view_card tests ---

--- a/src/main.rs
+++ b/src/main.rs
@@ -840,6 +840,16 @@ enum Commands {
         action: AutonomyAction,
     },
 
+    /// Board-derived goal (#525): print the active Accepted card's acceptance
+    /// criteria framed as the agent's completion condition, to carry across
+    /// turns. Native `/goal` cannot be set programmatically, so SessionStart
+    /// emits this each session; it is empty when nothing is in progress.
+    Goal {
+        /// Repository name (the agent whose active card to read).
+        #[arg(long)]
+        repo: String,
+    },
+
     /// Show current system health and recent trend
     Health {
         /// Show history for the last N duration (e.g., "1h", "30m", "24h")
@@ -5104,8 +5114,15 @@ fn run() -> error::Result<()> {
                     }
                 }
                 KanbanAction::Accept { id } => {
-                    kanban::transition_card(&database, &id, kanban::Action::Accept, None)?;
+                    let card =
+                        kanban::transition_card(&database, &id, kanban::Action::Accept, None)?;
                     println!("{id}");
+                    // #525: accepting a card sets the board-derived goal -- echo
+                    // the just-accepted card's acceptance criteria as the
+                    // completion condition the agent now carries.
+                    if let Some(goal) = kanban::format_active_goal(std::slice::from_ref(&card)) {
+                        eprintln!("{goal}");
+                    }
                 }
                 KanbanAction::Block { id, reason } => {
                     kanban::transition_card(
@@ -6963,6 +6980,21 @@ fn run() -> error::Result<()> {
                         }
                     }
                 }
+            }
+        }
+        Commands::Goal { repo } => {
+            let base = data_dir()?;
+            let database = db::Database::open(&base.join("legion.db"))?;
+            let cards = kanban::list_cards(
+                &database,
+                &repo,
+                kanban::Direction::Inbound,
+                kanban::CardScope::WorkingSet,
+            )?;
+            // Prints nothing when no card is Accepted -- the goal is "cleared"
+            // by board state alone (AC: clears on terminal/blocked).
+            if let Some(goal) = kanban::format_active_goal(&cards) {
+                println!("{goal}");
             }
         }
         Commands::Statusline { json } => {

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -6452,3 +6452,77 @@ fn autonomy_status_banner_reminds_to_spend_or_pause() {
         "got: {spent}"
     );
 }
+
+// #525 board-derived goal: set from the Accepted card's AC, cleared once the
+// card leaves Accepted (terminal/blocked). No separate goal state -- the board
+// is the source of truth, re-derived on each `legion goal` call.
+#[test]
+fn board_goal_sets_on_accept_and_clears_off_accepted() {
+    let dir = tempfile::tempdir().unwrap();
+    let data = dir.path();
+
+    let goal = || {
+        let out = legion_cmd(data)
+            .args(["goal", "--repo", "kelex"])
+            .output()
+            .unwrap();
+        assert!(out.status.success());
+        String::from_utf8_lossy(&out.stdout).to_string()
+    };
+
+    let create = legion_cmd(data)
+        .args([
+            "kanban",
+            "create",
+            "--from",
+            "kelex",
+            "--to",
+            "kelex",
+            "--text",
+            "ship the goal",
+            "--context",
+            "## Acceptance criteria\n- crit alpha\n- crit beta\n",
+        ])
+        .output()
+        .unwrap();
+    let card = String::from_utf8_lossy(&create.stdout).trim().to_string();
+
+    // Pending (assigned, not accepted) -> no goal yet.
+    legion_cmd(data)
+        .args(["kanban", "assign", "--id", &card, "--to", "kelex"])
+        .output()
+        .unwrap();
+    assert!(
+        goal().trim().is_empty(),
+        "no goal before the card is accepted"
+    );
+
+    // Accepted -> the card's AC becomes the goal.
+    legion_cmd(data)
+        .args(["kanban", "accept", "--id", &card])
+        .output()
+        .unwrap();
+    let active = goal();
+    assert!(active.contains("ship the goal"), "got: {active}");
+    assert!(
+        active.contains("crit alpha") && active.contains("crit beta"),
+        "got: {active}"
+    );
+
+    // Blocked (off Accepted) -> goal clears, by board state alone.
+    legion_cmd(data)
+        .args([
+            "kanban",
+            "block",
+            "--id",
+            &card,
+            "--reason",
+            "waiting on upstream",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        goal().trim().is_empty(),
+        "goal clears once the card leaves Accepted"
+    );
+}


### PR DESCRIPTION
## Summary

Board-derived goal: legion sets the agent's completion condition from the active kanban card, so continuation is board-driven, not operator-typed. The feasibility spike found native `/goal` cannot be set programmatically (no hook-output field, no `--goal` flag, no settings key as of CC v2.1.154 -- `/goal` is user-typed only). #525's AC anticipated this ("degrades silently when /goal unavailable"), so legion ships the supported equivalent: the board IS the goal state, re-derived each session, with the existing #523 Stop gate providing the auto-continue enforcement.

## Acceptance criteria mapping

### 1. Accepting a card sets the native /goal from its AC
Since native /goal is unsettable, the equivalent: `legion kanban accept` echoes the accepted card's acceptance criteria as the goal, and SessionStart re-derives it via `legion goal`. format_active_goal frames the Accepted card's AC as the completion condition the agent carries.
Evidence: src/kanban.rs::active_goal_derives_from_the_accepted_card; the Accept handler in src/main.rs prints format_active_goal; the e2e tests/integration.rs::board_goal_sets_on_accept_and_clears_off_accepted asserts the goal contains the card's AC after accept.

### 2. Goal clears on terminal/blocked
There is no separate goal state -- format_active_goal returns None unless a card is Accepted, so moving a card to a terminal or blocked status clears the goal by board state alone. `legion goal` then prints nothing.
Evidence: the e2e blocks the card and asserts `legion goal` output is empty; unit test asserts None for a Pending card and an empty slice.

### 3. Degrades silently when /goal is unavailable
Native /goal is always unavailable to a hook, so the degrade path is the only path and there is nothing to fall back from -- legion never calls a /goal API. SessionStart emits the goal as additionalContext (the supported injection surface); if the goal command errors, legion_check logs it and the banner is simply absent (fail-open, no error to the agent).
Evidence: session-start.sh guards the goal call with legion_check $? and append_block (empty on error); the decision doc records the finding. No code path attempts to set native /goal.

### 4. PR created and linked
This PR is opened against issue #525 via legion pr create with the linked kanban card.
Evidence: the PR itself, created with --task linking the #525 card.

## Not done

A prompt-type Stop hook that evaluates the card's AC per turn (the literal clone of /goal's auto-continue) is not added: hooks.json prompts are static and cannot inject the current card's AC at runtime, and the #523 command-type Stop gate already provides board-derived continuation (blocks stopping while Accepted). The autonomy-loop consumer that ties goal + budget + Stop gate into a full self-direction loop remains the sibling concern. If CC later exposes a goal-set API, `legion goal` is the call site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)