### PR TITLE
feat(#551): burn-rate gate -- pause self-directed work near rate-limit exhaustion

### DIFF
--- a/src/autonomy.rs
+++ b/src/autonomy.rs
@@ -13,8 +13,17 @@
 // rate-limit headroom (legion ingests statusline usage samples) -- more
 // headroom raises it; no samples falls back to a conservative default so the
 // agent never runs unbounded when it cannot see its own quota.
+//
+// The burn-rate gate (#551) complements the work-unit budget: it pauses
+// self-directed work when the host's real rate-limit headroom (5h or 7d) is
+// near exhaustion, independently of abstract autonomy-unit accounting.
 
 use chrono::{DateTime, Duration, Utc};
+
+/// Threshold at which the burn-rate gate denies self-directed work.
+/// 90% used means 10% headroom remaining -- enough warning to avoid
+/// accidental quota exhaustion while still allowing most of the window.
+pub const DEFAULT_BURN_RATE_THRESHOLD_PCT: f64 = 90.0;
 
 /// Length of the rolling budget window, in days.
 pub const WINDOW_DAYS: i64 = 7;
@@ -127,12 +136,164 @@ pub fn rolled_over(
     }
 }
 
+/// The verdict returned by the burn-rate gate.
+///
+/// Mirrors the shape of `SpendOutcome` so callers chain the two gates
+/// with a consistent match arm. The burn-rate check runs first; a
+/// `Throttled` result short-circuits before `decide_spend` is reached.
+#[derive(Debug, Clone, PartialEq)]
+pub enum BurnRateOutcome {
+    /// Operator-requested work: never rate-gated; bypass recorded in output.
+    OperatorBypass,
+    /// Both windows are below threshold (or no sample exists): work may proceed.
+    Allowed {
+        /// The five-hour used-% at decision time, if a sample existed.
+        five_hour_pct: Option<f64>,
+        /// The seven-day used-% at decision time, if a sample existed.
+        seven_day_pct: Option<f64>,
+    },
+    /// At least one window is at or above threshold: self-directed work paused.
+    ///
+    /// Operator work still proceeds.
+    Throttled {
+        /// Which window triggered the gate ("5h", "7d", or "5h and 7d").
+        window: String,
+        /// The used-% that exceeded the threshold.
+        used_pct: f64,
+        /// The threshold that was exceeded.
+        threshold_pct: f64,
+    },
+}
+
+/// Evaluate the burn-rate gate from a rate-limit sample.
+///
+/// - `operator = true` always returns `OperatorBypass`, regardless of sample.
+/// - `sample = None` (no row for this host) returns `Allowed` with both
+///   percentages as `None` -- fail-open so the work-unit budget remains the
+///   sole governor when no usage data exists.
+/// - Returns `Throttled` when `five_hour_pct >= threshold` OR
+///   `seven_day_pct >= threshold`. If both exceed, the `window` field names
+///   both ("5h and 7d"). The `used_pct` field carries the higher of the two.
+/// - `None` fields within a sample count as below threshold: not observed is
+///   not the same as exhausted; the work-unit budget is the backstop.
+/// - `threshold_pct` is clamped to `[0.0, 100.0]` before comparison.
+pub fn decide_burn_rate(
+    sample: Option<&crate::statusline::RateLimitSample>,
+    operator: bool,
+    threshold_pct: f64,
+) -> BurnRateOutcome {
+    if operator {
+        return BurnRateOutcome::OperatorBypass;
+    }
+    let threshold = threshold_pct.clamp(0.0, 100.0);
+    let (five_hour_pct, seven_day_pct) = match sample {
+        None => {
+            return BurnRateOutcome::Allowed {
+                five_hour_pct: None,
+                seven_day_pct: None,
+            };
+        }
+        Some(s) => (s.five_hour_pct, s.seven_day_pct),
+    };
+
+    let fh_over = five_hour_pct.is_some_and(|p| p >= threshold);
+    let sd_over = seven_day_pct.is_some_and(|p| p >= threshold);
+
+    match (fh_over, sd_over) {
+        (false, false) => BurnRateOutcome::Allowed {
+            five_hour_pct,
+            seven_day_pct,
+        },
+        (true, false) => BurnRateOutcome::Throttled {
+            window: "5h".to_string(),
+            used_pct: five_hour_pct.unwrap_or(0.0),
+            threshold_pct: threshold,
+        },
+        (false, true) => BurnRateOutcome::Throttled {
+            window: "7d".to_string(),
+            used_pct: seven_day_pct.unwrap_or(0.0),
+            threshold_pct: threshold,
+        },
+        (true, true) => {
+            // Report the higher of the two in used_pct.
+            let fh = five_hour_pct.unwrap_or(0.0);
+            let sd = seven_day_pct.unwrap_or(0.0);
+            BurnRateOutcome::Throttled {
+                window: "5h and 7d".to_string(),
+                used_pct: f64::max(fh, sd),
+                threshold_pct: threshold,
+            }
+        }
+    }
+}
+
+/// Human-readable burn-rate status line for `autonomy status --banner`.
+///
+/// Returns `None` when no sample exists -- the caller omits the line silently
+/// so a host with no rate data does not add noise. When a sample exists,
+/// returns a non-empty string describing headroom and, if appropriate, a
+/// warning that the gate will fire.
+///
+/// Example outputs:
+///   "Rate headroom: 5h 23% remaining, 7d 41% remaining."
+///   "Rate limit warning: 5h 8% remaining (threshold 10%). Self-directed
+///    work will be paused at the gate."
+pub fn burn_rate_status_line(
+    sample: Option<&crate::statusline::RateLimitSample>,
+    threshold_pct: f64,
+) -> Option<String> {
+    let s = sample?;
+    let threshold = threshold_pct.clamp(0.0, 100.0);
+
+    let fmt_remaining = |pct: Option<f64>| -> Option<String> {
+        pct.map(|p| format!("{:.0}%", (100.0 - p).max(0.0)))
+    };
+
+    let fh_remaining = fmt_remaining(s.five_hour_pct);
+    let sd_remaining = fmt_remaining(s.seven_day_pct);
+
+    let fh_over = s.five_hour_pct.is_some_and(|p| p >= threshold);
+    let sd_over = s.seven_day_pct.is_some_and(|p| p >= threshold);
+
+    let headroom_str = match (&fh_remaining, &sd_remaining) {
+        (Some(fh), Some(sd)) => format!("5h {fh} remaining, 7d {sd} remaining"),
+        (Some(fh), None) => format!("5h {fh} remaining"),
+        (None, Some(sd)) => format!("7d {sd} remaining"),
+        (None, None) => return None,
+    };
+
+    if fh_over || sd_over {
+        let threshold_remaining = format!("{:.0}%", (100.0 - threshold).max(0.0));
+        Some(format!(
+            "Rate limit warning: {headroom_str} (threshold {threshold_remaining}). \
+             Self-directed work will be paused at the gate."
+        ))
+    } else {
+        Some(format!("Rate headroom: {headroom_str}."))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::statusline::RateLimitSample;
 
     fn t(s: &str) -> DateTime<Utc> {
         DateTime::parse_from_rfc3339(s).unwrap().with_timezone(&Utc)
+    }
+
+    fn make_sample(five_hour_pct: Option<f64>, seven_day_pct: Option<f64>) -> RateLimitSample {
+        RateLimitSample {
+            id: "test-id".to_string(),
+            hostname: "testhost".to_string(),
+            session_id: "test-session".to_string(),
+            sampled_at: "2026-05-31T00:00:00Z".to_string(),
+            five_hour_pct,
+            five_hour_resets_at: None,
+            seven_day_pct,
+            seven_day_resets_at: None,
+            model: None,
+        }
     }
 
     #[test]
@@ -213,5 +374,206 @@ mod tests {
         assert!(budget.window_expired(t("2026-05-08T00:00:00Z")));
         assert!(!budget.window_expired(t("2026-05-07T23:59:59Z")));
         assert_eq!(budget.resets_at(), t("2026-05-08T00:00:00Z"));
+    }
+
+    // --- burn-rate gate tests ---
+
+    #[test]
+    fn burn_rate_operator_bypasses_regardless_of_sample() {
+        let sample = make_sample(Some(95.0), Some(95.0));
+        assert_eq!(
+            decide_burn_rate(Some(&sample), true, 90.0),
+            BurnRateOutcome::OperatorBypass
+        );
+        // Also operator bypass with no sample.
+        assert_eq!(
+            decide_burn_rate(None, true, 90.0),
+            BurnRateOutcome::OperatorBypass
+        );
+    }
+
+    #[test]
+    fn burn_rate_no_sample_is_fail_open() {
+        // No sample means no data -- gate must not fire; work-unit budget is the backstop.
+        assert_eq!(
+            decide_burn_rate(None, false, 90.0),
+            BurnRateOutcome::Allowed {
+                five_hour_pct: None,
+                seven_day_pct: None,
+            }
+        );
+    }
+
+    #[test]
+    fn burn_rate_both_below_threshold_is_allowed() {
+        let sample = make_sample(Some(80.0), Some(80.0));
+        assert_eq!(
+            decide_burn_rate(Some(&sample), false, 90.0),
+            BurnRateOutcome::Allowed {
+                five_hour_pct: Some(80.0),
+                seven_day_pct: Some(80.0),
+            }
+        );
+    }
+
+    #[test]
+    fn burn_rate_five_hour_over_threshold_throttles() {
+        let sample = make_sample(Some(95.0), Some(50.0));
+        let outcome = decide_burn_rate(Some(&sample), false, 90.0);
+        assert_eq!(
+            outcome,
+            BurnRateOutcome::Throttled {
+                window: "5h".to_string(),
+                used_pct: 95.0,
+                threshold_pct: 90.0,
+            }
+        );
+    }
+
+    #[test]
+    fn burn_rate_seven_day_over_threshold_throttles() {
+        let sample = make_sample(Some(50.0), Some(92.0));
+        let outcome = decide_burn_rate(Some(&sample), false, 90.0);
+        assert_eq!(
+            outcome,
+            BurnRateOutcome::Throttled {
+                window: "7d".to_string(),
+                used_pct: 92.0,
+                threshold_pct: 90.0,
+            }
+        );
+    }
+
+    #[test]
+    fn burn_rate_both_over_threshold_names_both_windows() {
+        let sample = make_sample(Some(91.0), Some(93.0));
+        let outcome = decide_burn_rate(Some(&sample), false, 90.0);
+        assert_eq!(
+            outcome,
+            BurnRateOutcome::Throttled {
+                window: "5h and 7d".to_string(),
+                used_pct: 93.0, // higher of 91 and 93
+                threshold_pct: 90.0,
+            }
+        );
+    }
+
+    #[test]
+    fn burn_rate_absent_five_hour_counts_as_below_threshold() {
+        // None for 5h, over-threshold 7d -> 7d fires, 5h does not.
+        let sample = make_sample(None, Some(95.0));
+        assert_eq!(
+            decide_burn_rate(Some(&sample), false, 90.0),
+            BurnRateOutcome::Throttled {
+                window: "7d".to_string(),
+                used_pct: 95.0,
+                threshold_pct: 90.0,
+            }
+        );
+    }
+
+    #[test]
+    fn burn_rate_both_absent_is_allowed() {
+        // Both None within a sample -- treated as below threshold (fail-open).
+        let sample = make_sample(None, None);
+        assert_eq!(
+            decide_burn_rate(Some(&sample), false, 90.0),
+            BurnRateOutcome::Allowed {
+                five_hour_pct: None,
+                seven_day_pct: None,
+            }
+        );
+    }
+
+    #[test]
+    fn burn_rate_threshold_clamped_below_zero() {
+        // A threshold < 0 clamps to 0, so any non-negative used_pct fires.
+        let sample = make_sample(Some(0.0), Some(0.0));
+        // 0.0 >= 0.0 (clamped threshold) -> throttled on both.
+        let outcome = decide_burn_rate(Some(&sample), false, -5.0);
+        assert!(matches!(outcome, BurnRateOutcome::Throttled { .. }));
+    }
+
+    #[test]
+    fn burn_rate_threshold_clamped_above_100() {
+        // A threshold > 100 clamps to 100, so nothing below 100 fires.
+        let sample = make_sample(Some(99.9), Some(99.9));
+        let outcome = decide_burn_rate(Some(&sample), false, 110.0);
+        assert_eq!(
+            outcome,
+            BurnRateOutcome::Allowed {
+                five_hour_pct: Some(99.9),
+                seven_day_pct: Some(99.9),
+            }
+        );
+    }
+
+    #[test]
+    fn burn_rate_at_exact_threshold_fires() {
+        // Boundary: >= threshold means exactly at threshold fires.
+        let sample = make_sample(Some(90.0), Some(50.0));
+        let outcome = decide_burn_rate(Some(&sample), false, 90.0);
+        assert_eq!(
+            outcome,
+            BurnRateOutcome::Throttled {
+                window: "5h".to_string(),
+                used_pct: 90.0,
+                threshold_pct: 90.0,
+            }
+        );
+    }
+
+    #[test]
+    fn burn_rate_status_line_returns_none_when_no_sample() {
+        assert_eq!(burn_rate_status_line(None, 90.0), None);
+    }
+
+    #[test]
+    fn burn_rate_status_line_healthy_shows_remaining() {
+        let sample = make_sample(Some(60.0), Some(40.0));
+        let line = burn_rate_status_line(Some(&sample), 90.0).expect("should produce a line");
+        // 60% used -> 40% remaining for 5h; 40% used -> 60% remaining for 7d.
+        assert!(
+            line.contains("40%"),
+            "5h remaining should be 40%, got: {line}"
+        );
+        assert!(
+            line.contains("60%"),
+            "7d remaining should be 60%, got: {line}"
+        );
+        assert!(
+            line.starts_with("Rate headroom:"),
+            "healthy line must start with 'Rate headroom:', got: {line}"
+        );
+        assert!(
+            !line.contains("warning"),
+            "healthy line must not say warning, got: {line}"
+        );
+    }
+
+    #[test]
+    fn burn_rate_status_line_warning_when_near_threshold() {
+        // 5h at 93% -> 7% remaining, which is below 10% (threshold 90%).
+        let sample = make_sample(Some(93.0), Some(50.0));
+        let line = burn_rate_status_line(Some(&sample), 90.0).expect("should produce a line");
+        assert!(
+            line.contains("warning"),
+            "near-threshold line must say warning, got: {line}"
+        );
+        assert!(
+            line.contains("threshold"),
+            "near-threshold line must mention threshold, got: {line}"
+        );
+        assert!(
+            line.contains("paused"),
+            "near-threshold line must say paused, got: {line}"
+        );
+    }
+
+    #[test]
+    fn burn_rate_status_line_both_none_returns_none() {
+        // A sample where both pct fields are None produces no line.
+        let sample = make_sample(None, None);
+        assert_eq!(burn_rate_status_line(Some(&sample), 90.0), None);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2075,6 +2075,11 @@ enum AutonomyAction {
         /// Units to spend (default 1).
         #[arg(long, default_value = "1")]
         cost: u64,
+
+        /// Deny self-directed work when rate-limit used-% reaches this value
+        /// (0-100). Default 90 means 10% headroom remaining triggers the gate.
+        #[arg(long, default_value = "90.0")]
+        burn_rate_threshold: f64,
     },
 }
 
@@ -6905,6 +6910,14 @@ fn run() -> error::Result<()> {
                 AutonomyAction::Status { repo, banner } => {
                     let budget = load(&repo)?;
                     let resets = budget.resets_at().format("%Y-%m-%d");
+
+                    // Fetch the latest rate-limit sample for the burn-rate status line.
+                    // Fail-open: a DB error here is not fatal to the status display.
+                    let host = statusline::resolve_hostname();
+                    let rate_sample: Option<crate::statusline::RateLimitSample> = database
+                        .latest_rate_limit_sample_for_host(&host)
+                        .unwrap_or(None);
+
                     if !banner {
                         println!(
                             "[legion] autonomy budget for {repo}: {}/{} units spent, {} remaining. \
@@ -6913,6 +6926,12 @@ fn run() -> error::Result<()> {
                             budget.ceiling,
                             budget.remaining(),
                         );
+                        if let Some(line) = autonomy::burn_rate_status_line(
+                            rate_sample.as_ref(),
+                            autonomy::DEFAULT_BURN_RATE_THRESHOLD_PCT,
+                        ) {
+                            println!("[legion] {line}");
+                        }
                     } else if budget.remaining() > 0 {
                         // The reminder that turns the primitive into behavior:
                         // the agent self-directs because it knows the budget is
@@ -6924,11 +6943,34 @@ fn run() -> error::Result<()> {
                             budget.remaining(),
                             budget.ceiling,
                         );
+                        // Include burn-rate line in banner only when headroom is
+                        // approaching threshold (remaining < 2x threshold means
+                        // used > 100 - 2*(100 - threshold) = 2*threshold - 100).
+                        let threshold = autonomy::DEFAULT_BURN_RATE_THRESHOLD_PCT;
+                        let approaching_cutoff = 2.0 * threshold - 100.0;
+                        let near = rate_sample.as_ref().is_some_and(|s| {
+                            s.five_hour_pct.is_some_and(|p| p > approaching_cutoff)
+                                || s.seven_day_pct.is_some_and(|p| p > approaching_cutoff)
+                        });
+                        if near
+                            && let Some(line) =
+                                autonomy::burn_rate_status_line(rate_sample.as_ref(), threshold)
+                        {
+                            println!("[Legion] {line}");
+                        }
                     } else {
                         println!(
                             "[Legion] Autonomy budget spent for this week (resets {resets}). \
                              Pause self-directed initiative; operator-requested work still proceeds."
                         );
+                        // Always include burn-rate in exhausted banner so the
+                        // agent has full picture.
+                        if let Some(line) = autonomy::burn_rate_status_line(
+                            rate_sample.as_ref(),
+                            autonomy::DEFAULT_BURN_RATE_THRESHOLD_PCT,
+                        ) {
+                            println!("[Legion] {line}");
+                        }
                     }
                 }
                 AutonomyAction::Gate {
@@ -6936,7 +6978,48 @@ fn run() -> error::Result<()> {
                     kind,
                     operator,
                     cost,
+                    burn_rate_threshold,
                 } => {
+                    // Burn-rate check runs first, before the work-unit budget.
+                    // Fail-open on DB error: log to stderr, proceed to work-unit gate.
+                    let host = statusline::resolve_hostname();
+                    let rate_sample: Option<crate::statusline::RateLimitSample> = database
+                        .latest_rate_limit_sample_for_host(&host)
+                        .map_err(|e| {
+                            eprintln!(
+                                "[legion] warning: could not read rate-limit sample: {e}. \
+                                 Proceeding with work-unit budget only."
+                            );
+                        })
+                        .unwrap_or(None);
+
+                    match autonomy::decide_burn_rate(
+                        rate_sample.as_ref(),
+                        operator,
+                        burn_rate_threshold,
+                    ) {
+                        autonomy::BurnRateOutcome::OperatorBypass => {
+                            // Operator bypass from burn-rate gate -- proceed directly
+                            // to work-unit budget check, which also has operator bypass.
+                        }
+                        autonomy::BurnRateOutcome::Throttled {
+                            window,
+                            used_pct,
+                            threshold_pct,
+                        } => {
+                            // Self-directed work paused. No write needed (read-only gate).
+                            println!(
+                                "[legion] rate-limit headroom low: {window} window at {used_pct:.0}% \
+                                 used (threshold {threshold_pct:.0}%). Self-directed work paused; \
+                                 operator-requested work still proceeds."
+                            );
+                            std::process::exit(1);
+                        }
+                        autonomy::BurnRateOutcome::Allowed { .. } => {
+                            // Headroom is fine; fall through to work-unit budget check.
+                        }
+                    }
+
                     let budget = load(&repo)?;
                     match autonomy::decide_spend(&budget, cost, operator) {
                         autonomy::SpendOutcome::OperatorBypass => {

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -6526,3 +6526,158 @@ fn board_goal_sets_on_accept_and_clears_off_accepted() {
         "goal clears once the card leaves Accepted"
     );
 }
+
+// #551 burn-rate gate: self-directed work is paused when the latest rate-limit
+// sample exceeds the threshold. The gate fires on the 5h OR 7d window.
+
+// Missing sample (fresh DB) does not fire: fail-open so the work-unit budget
+// remains the sole governor when no rate data exists.
+#[test]
+fn burn_rate_gate_no_sample_is_fail_open() {
+    let dir = tempfile::tempdir().unwrap();
+    let data = dir.path();
+
+    // No statusline seed -> no rate_limit_samples row for this host.
+    let out = legion_cmd(data)
+        .args([
+            "autonomy",
+            "gate",
+            "--repo",
+            "kelex",
+            "--kind",
+            "self-accept",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "gate must succeed when no rate sample exists (fail-open): stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+// Seeded sample above threshold -> gate denies self-directed work (non-zero exit,
+// calm message, no panic).
+#[test]
+fn burn_rate_gate_throttled_when_sample_exceeds_threshold() {
+    let dir = tempfile::tempdir().unwrap();
+    let data = dir.path();
+
+    // Seed a sample with 5h at 95% (above the default 90% threshold).
+    seed_rate_limit_sample(data, 95.0, 50.0);
+
+    let out = legion_cmd(data)
+        .args([
+            "autonomy",
+            "gate",
+            "--repo",
+            "kelex",
+            "--kind",
+            "self-accept",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        !out.status.success(),
+        "gate must deny self-directed work when rate headroom is low"
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("paused"),
+        "throttled message must say paused, got: {stdout}"
+    );
+    assert!(
+        stdout.contains("5h"),
+        "throttled message must name the triggering window, got: {stdout}"
+    );
+    // No panic, no Rust backtrace in stderr.
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        !stderr.contains("thread 'main' panicked"),
+        "gate must not panic, got stderr: {stderr}"
+    );
+}
+
+// --operator bypasses the burn-rate gate even when the sample is above threshold.
+#[test]
+fn burn_rate_gate_operator_bypasses_throttle() {
+    let dir = tempfile::tempdir().unwrap();
+    let data = dir.path();
+
+    // Seed a sample that would throttle self-directed work.
+    seed_rate_limit_sample(data, 95.0, 95.0);
+
+    let out = legion_cmd(data)
+        .args([
+            "autonomy",
+            "gate",
+            "--repo",
+            "kelex",
+            "--kind",
+            "self-accept",
+            "--operator",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "operator work must proceed even when rate headroom is low: stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+// The 7d window alone triggers the gate.
+#[test]
+fn burn_rate_gate_fires_on_seven_day_window() {
+    let dir = tempfile::tempdir().unwrap();
+    let data = dir.path();
+
+    // 5h is fine, 7d is above threshold.
+    seed_rate_limit_sample(data, 40.0, 92.0);
+
+    let out = legion_cmd(data)
+        .args([
+            "autonomy",
+            "gate",
+            "--repo",
+            "kelex",
+            "--kind",
+            "self-accept",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        !out.status.success(),
+        "gate must deny when 7d window exceeds threshold"
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("7d"),
+        "throttled message must name the 7d window, got: {stdout}"
+    );
+}
+
+// autonomy status includes burn-rate line when a sample exists.
+#[test]
+fn autonomy_status_includes_burn_rate_line_when_sample_exists() {
+    let dir = tempfile::tempdir().unwrap();
+    let data = dir.path();
+
+    seed_rate_limit_sample(data, 40.0, 55.0);
+
+    let out = legion_cmd(data)
+        .args(["autonomy", "status", "--repo", "kelex"])
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    // Should have a rate headroom line.
+    assert!(
+        stdout.contains("Rate headroom:") || stdout.contains("Rate limit warning:"),
+        "status must include burn-rate line when a sample exists, got: {stdout}"
+    );
+    assert!(
+        stdout.contains("remaining"),
+        "burn-rate line must describe remaining headroom, got: {stdout}"
+    );
+}


### PR DESCRIPTION
## Summary

Adds a burn-rate gate to the autonomy loop (#524): self-directed work pauses when this host's real rate-limit headroom is near exhaustion (5h or 7d USED-% >= a configurable threshold, default 90), complementary to and separate from the work-volume budget. Reads the raw latest `RateLimitSample` for the host; operator work bypasses; no sample = fail-open to the work-unit budget (never blocks while blind to spend). Answers the market's loudest cost complaint ("20% of weekly limit on day one"). Built to the frozen issue spec by an isolated rust implementer; independently reviewed + gated here.

## Acceptance criteria mapping

### 1. All tests pass
Full bin suite green plus 5 new burn-rate integration tests and 15 unit tests. Evidence: `cargo test` passes; src/autonomy.rs::burn_rate_five_hour_over_threshold_throttles, ::burn_rate_no_sample_is_fail_open, ::burn_rate_operator_bypasses_regardless_of_sample, ::burn_rate_threshold_clamped_above_100; tests/integration.rs::burn_rate_gate_throttled_when_sample_exceeds_threshold, ::burn_rate_gate_no_sample_is_fail_open, ::burn_rate_gate_operator_bypasses_throttle.

### 2. Simplify pass completed
Independent /legion-simplify review of the agent-built diff (second set of eyes, not self-attestation): decide_burn_rate is clean -- operator bypass, threshold clamp, None->fail-open, exhaustive (5h,7d) match. One MED finding surfaced and judged acceptable with rationale (Throttled.window is a display-only String, not branched logic; flagged to the operator rather than enum-ified). Evidence: quality-gate row 019e8102-43e9 (legion-simplify, clean, with documented accepted findings) on HEAD.

### 3. Review pass completed and issues fixed
Reviewed the fail-open direction specifically (the safety-critical choice): no rate sample -> gate does NOT fire, deferring to the work-unit budget, so a missing sample never traps the agent. Operator bypass verified end-to-end. No blocking issues. Evidence: tests/integration.rs::burn_rate_gate_no_sample_is_fail_open and ::burn_rate_gate_operator_bypasses_throttle.

### 4. PR created and linked to this issue
This PR is opened against #551 with the linked kanban card. Evidence: the PR itself, --task 551.

## Not done

Dollar-cost accounting is out of scope -- legion only has rate-limit percentages, not plan pricing; this gates on headroom %, not $. The work-volume budget (#524) semantics are unchanged; this is an additional, independent gate. The `--banner` approaching-threshold cutoff (2*threshold-100, i.e. 80% at the default) is a tunable policy left at the spec's intent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)