### PR TITLE
chore(#556): source smugglr-core from crates.io 0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1210,7 +1210,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2",
+ "socket2 0.6.3",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -2186,7 +2186,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.2",
  "rustls",
- "socket2",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -2223,7 +2223,7 @@ dependencies = [
  "cfg_aliases 0.2.1",
  "libc",
  "once_cell",
- "socket2",
+ "socket2 0.6.3",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -2871,8 +2871,9 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "smugglr-core"
-version = "0.2.1"
-source = "git+https://github.com/rafters-studio/smugglr#4d58527e3120695835292544b64ebacab909ffe9"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e41ba9c13a82ea180f63547220ee44ebb4f763be7e2c7c0b98fbd364a68702da"
 dependencies = [
  "anyhow",
  "chacha20poly1305",
@@ -2886,12 +2887,23 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
+ "socket2 0.5.10",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "toml",
  "tracing",
  "url",
+]
+
+[[package]]
+name = "socket2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3322,7 +3334,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.6.3",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,8 +33,10 @@ sha2 = "0.10"
 scip = "0.7"
 protobuf = "3"
 
-# Multi-node sync via LAN broadcast
-smugglr-core = { git = "https://github.com/rafters-studio/smugglr", default-features = false, features = ["native"] }
+# Multi-node sync via LAN broadcast. Published crate (not the git source):
+# 0.4.0 carries the masterless multicast Gossip API + protocol v2. The old
+# unpinned git dep was frozen at 0.2.1 (TCP-era) by the lockfile.
+smugglr-core = { version = "0.4.0", default-features = false, features = ["native"] }
 rand = "0.9"
 hex = "0.4"
 hostname = "0.4"


### PR DESCRIPTION
## Summary

Sources smugglr-core from the published crate (crates.io 0.4.0) instead of the unpinned git source, which the lockfile had frozen at 0.2.1 (TCP-era, two minors stale). 0.4.0 carries the masterless multicast Gossip API + protocol v2 that #536 needs. legion's usage compiles unchanged.

## Acceptance criteria mapping

### 1. Cargo.toml sources smugglr-core from crates.io at 0.4.0
Replaced `git = ".../smugglr"` with `version = "0.4.0"` (keeping default-features=false + the native feature). Evidence: the Cargo.toml diff -- the dependency line is now a registry version requirement, no git URL.

### 2. Cargo.lock resolves it from the registry with a checksum
After build, the lockfile entry for smugglr-core is `source = "registry+https://github.com/rust-lang/crates.io-index"` with a `checksum`, not `git+...#<sha>`. Evidence: Cargo.lock diff (was `git+...#4d58527`, now `registry+...` + checksum `e41ba9c1...`).

### 3. legion's existing usage compiles unchanged against 0.4.0
The symbols legion uses (BroadcastConfig, PeerDiscovery, hash_db_path in sync_actor.rs + watch.rs) are stable across 0.2.1->0.4.0, so no call-site edits were needed. Evidence: `cargo build` succeeds with zero source changes outside Cargo.toml/Cargo.lock; full bin suite (896 tests) + clippy --all-targets + fmt all green.

### 4. PR created and linked
This PR is opened against #556 with the linked card. Evidence: the PR itself, --task 556.

## Not done

Wiring `multicast::Gossip` into sync_actor to actually transfer cluster data is the body of #536, not this issue -- this only puts the correct published crate in place. No legion version bump here (rides the next release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)