### PR TITLE
chore(#560): codify grep-blocking as operator permissions.deny; retire the hard-bypass

### DIFF
--- a/docs/decisions/2026-06-02-grep-blocking-is-operator-permissions.md
+++ b/docs/decisions/2026-06-02-grep-blocking-is-operator-permissions.md
@@ -1,0 +1,99 @@
+# Grep-blocking is operator `permissions.deny`, not plugin hooks
+
+Date: 2026-06-02
+Issue: #560
+Supersedes the enforcement half of: 2026-05-grep-enforcement-stays-in-hooks.md (#530)
+Verified against: Claude Code v2.1.159
+
+## The problem
+
+Agents grep/find by 30-year habit. Legion tried to stop this with PreToolUse hooks
+(`pre-bash-grep.sh` and friends) plus an env-var bypass ladder. It did not work, and the
+telemetry showed why on two axes:
+
+1. **The block was optional.** `LEGION_BYPASS_GREP_HARD=1` always allowed. A one-env-var
+   escape against a 30-year habit is a speed bump, not a gate. The agents (this one included)
+   leaned on it reflexively.
+2. **The block didn't reach subagents.** PreToolUse hooks defined in `settings.json` / a
+   plugin do **not** fire on a subagent's tool calls. Every spawned agent grepped ungated.
+
+A hook is the wrong tool for a mandatory rule: it is advisory, bypassable, and main-session
+only.
+
+## The mechanism that is right
+
+CC v2.1.x has `permissions.deny` in settings.json, and it is everything the hook was not:
+
+- **Evaluated before `allow`** and **cannot be overridden** by the agent (no env-var escape).
+- **Inherits to subagents** — one rule covers the main session and every spawned agent.
+- **Matches Bash command patterns** (prefix form, e.g. `Bash(grep:*)`), so shell-grep is
+  blocked at the harness, before any hook runs, including inside pipes (each subcommand of a
+  compound command is checked).
+
+`permissionDecision: "deny"` is also now the documented clean PreToolUse block (the old
+implicit exit-2 model).
+
+## The decision
+
+**Mandatory shell-grep blocking is the operator's `permissions.deny`. The plugin does not
+(and cannot) enforce it.**
+
+Recommended ruleset, in `~/.claude/settings.json` (user-global, covers every repo) or
+`/etc/claude-code/managed-settings.json` (org-wide, unbypassable even by the operator):
+
+```json
+{
+  "permissions": {
+    "deny": [
+      "Bash(grep:*)",
+      "Bash(rg:*)",
+      "Bash(find:*)",
+      "Bash(fd:*)",
+      "Bash(ag:*)",
+      "Bash(ack:*)"
+    ]
+  }
+}
+```
+
+**The escape is a tool, not a bypass.** `Grep` and `Glob` are deliberately **not** denied.
+They are the supervised path for the one real need sym cannot serve: free-text / non-indexed
+content (an `.astro` file has no SCIP index, so `sym` has nothing — the Grep tool searches its
+content). The agent never loses access to information sym can't provide; it loses only the
+*shell* duplicate that was the habit and the bypass surface. The Grep-tool hooks
+(`pre-grep-recall`, `pre-grep-scip`) still inject sym/recall context and redirect symbol
+queries to `sym` / `sym list` — but they only redirect when sym has an answer, so for `.astro`
+they simply allow. The escape opens exactly when the agent genuinely can't get the info another
+way.
+
+For a context that must deny the Grep *tool* too, the escape becomes human-gated
+(`permissions.ask`) or a sanctioned audited `legion` command — never an agent-set env var.
+
+## Why the plugin can't just ship it
+
+Verified against CC v2.1.159: plugin manifests expose `skills`, `commands`, `agents`, `hooks`,
+`mcpServers`, `lspServers`, `outputStyles`, `channels`, `userConfig` — **no `permissions`
+field**, and plugin-shipped `settings.json` supports only `agent` / `subagentStatusLine`. So
+the deny ruleset is documented here for operators to apply, not bundled. The plugin's
+contribution is sym coverage (`sym def/refs/hover` + `sym list` #558), the Grep-tool guidance
+hooks, and this doc.
+
+## What changes in the plugin
+
+- The `LEGION_BYPASS_GREP_HARD` hard-bypass is **removed** from `pre-bash-grep.sh` — it was the
+  frictionless escape that made enforcement optional. The hook remains as soft fallback
+  guidance for operators who have not yet set the deny rule (inject sym context, refuse the
+  soft bypass on a local symbol hit), but it no longer advertises an always-allow escape.
+- Fully retiring `pre-bash-grep.sh` (now that `permissions.deny` is the real mechanism) is a
+  separate follow-up.
+
+## The shape, stated plainly
+
+1. **sym / sym list / recall** — the answer when one exists (indexed code, symbols, memory).
+2. **Grep / Glob tool** — the sanctioned escape for non-indexed / free-text content; allowed,
+   hooked, observable; auto-allows when sym can't serve.
+3. **shell grep / rg / find** — denied by operator `permissions.deny`. The redundant,
+   bypass-prone path. Gone.
+
+A gate is only as good as the path it forces you onto. The mandatory gate is the harness's;
+the plugin's job is to make the path it forces you onto — sym — actually serve the need.

--- a/plugin/hooks/pre-bash-grep.sh
+++ b/plugin/hooks/pre-bash-grep.sh
@@ -6,13 +6,20 @@
 #                 Emit additionalContext with whatever sym found.
 #   2. BLOCK   -- repo indexed AND `legion sym def` returned >=1 result.
 #                 Block the Bash call; the agent should call sym instead.
-#   3. BYPASS  -- LEGION_BYPASS_GREP=1 env or `# legion-bypass:` sentinel
-#                 substring in the command. Always allows; logs telemetry.
+#   3. SOFT BYPASS -- LEGION_BYPASS_GREP=1 env or `# legion-bypass:`
+#                 sentinel, for free-text searches. REFUSED for
+#                 symbol-shaped patterns with a local hit. There is NO
+#                 hard escape (#560): mandatory shell-grep blocking is the
+#                 operator's permissions.deny, not this hook.
 #
 # Sibling of pre-grep-scip.sh and pre-grep-recall.sh which cover the
-# Grep and Glob tools. This hook closes the Bash escape gap demonstrated
-# in #438: agents typing `grep -r ...` via Bash slipped past the existing
-# tool-matched hooks entirely.
+# Grep and Glob tools. This hook is now SOFT FALLBACK GUIDANCE: the
+# mandatory shell-grep block is the operator's settings.json
+# permissions.deny (Bash(grep:*)/Bash(rg:*)/...), which is evaluated
+# before this hook runs and inherits to subagents. See
+# docs/decisions/2026-06-02-grep-blocking-is-operator-permissions.md.
+# This hook still injects sym context and refuses the soft bypass on a
+# local symbol hit, for repos/operators that have not set the deny rule.
 #
 # Skip discipline:
 # - LEGION_SKIP_PRE_BASH_GREP=1: skip this hook specifically.
@@ -93,23 +100,12 @@ fi
 # REFUSED when the pattern resolves to a real symbol in THIS repo's
 # SCIP index. The bypass sentinel exists for free-text searches; it
 # cannot route around sym for symbol queries dressed up as text. The
-# refusal points the agent at sym + names the LEGION_BYPASS_GREP_HARD
-# hard escape for the rare case where the agent really does need a
-# grep-style file scan over symbol-shaped text (e.g. counting call
-# sites of a deprecated API across files outside the SCIP index).
-#
-# Hard bypass (LEGION_BYPASS_GREP_HARD=1) always allows but writes a
-# row with bypass_class=hard so /telemetry summary can show how often
-# the hard escape fires (loud signal that sym is under-serving).
+# refusal points the agent at sym. There is NO env-var hard escape: a
+# frictionless LEGION_BYPASS_GREP_HARD only made enforcement optional
+# (#560). Mandatory shell-grep blocking is the operator's permissions.deny
+# (docs/decisions/2026-06-02-grep-blocking-is-operator-permissions.md); this
+# hook is soft fallback guidance for operators who have not set the deny rule.
 BYPASS_REASON=$(legion_prequery_bypass_reason "$COMMAND")
-HARD_BYPASS="${LEGION_BYPASS_GREP_HARD:-}"
-
-if [ "$HARD_BYPASS" = "1" ]; then
-  legion_prequery_record_bypass \
-    "$REPO" "$SESSION_ID" "Bash" "$PATTERN" "hard:${BYPASS_REASON:-no-reason}" \
-    "$HAD_SYM" "false"
-  exit 0
-fi
 
 if [ -n "$BYPASS_REASON" ]; then
   # Refuse the soft bypass if the pattern matches a real local symbol.
@@ -122,7 +118,7 @@ if [ -n "$BYPASS_REASON" ]; then
 ${LOCAL_HITS}
 \`\`\`
 
-If you genuinely need ${BINARY} against a symbol-shaped pattern (counting call sites in files outside the SCIP index, comparing line-by-line content for a refactor diff), use the hard escape: \`LEGION_BYPASS_GREP_HARD=1 ${COMMAND}\`. The hard bypass writes a row to bypass.jsonl with \`bypass_class=hard\` so /telemetry summary can see how often it fires."
+For symbols, \`legion sym def ${PATTERN}\` / \`sym refs\` / \`sym list\` answer in bytes. For genuinely non-symbol, non-indexed content (e.g. an .astro file), use the Grep tool -- not shell ${BINARY}. Your operator may block shell ${BINARY} outright via permissions.deny; that is the intended mandatory gate, and there is no env-var escape from it."
     legion_prequery_emit_block "$REASON"
     exit 0
   fi
@@ -167,11 +163,7 @@ if legion_indexed "$SESSION_ID" "$REPO"; then
 ${LOCAL_HITS}
 \`\`\`
 
-The soft bypass (\`# legion-bypass: <reason>\` or LEGION_BYPASS_GREP=1) is REFUSED for symbol-shaped patterns that resolve in this repo's SCIP index -- the sentinel exists for free-text searches, not for symbol queries dressed up as text. If you genuinely need ${BINARY} against this symbol-shaped pattern (counting call sites in files outside the SCIP index, comparing line-by-line content for a refactor diff), use the hard escape:
-
-\`LEGION_BYPASS_GREP_HARD=1 ${COMMAND}\`
-
-The hard bypass writes a row to bypass.jsonl with \`bypass_class=hard\` so /telemetry summary can see how often sym is under-serving."
+The soft bypass (\`# legion-bypass: <reason>\` or LEGION_BYPASS_GREP=1) is REFUSED for symbol-shaped patterns that resolve in this repo's SCIP index -- the sentinel exists for free-text searches, not for symbol queries dressed up as text. For symbols use \`legion sym def ${PATTERN}\` / \`sym refs\` / \`sym list\`; for genuinely non-symbol, non-indexed content use the Grep tool, not shell ${BINARY}. There is no env-var hard escape -- the mandatory shell-grep block is the operator's permissions.deny."
     legion_prequery_emit_block "$REASON"
     exit 0
   fi

--- a/plugin/hooks/test-pre-bash-grep.sh
+++ b/plugin/hooks/test-pre-bash-grep.sh
@@ -195,7 +195,7 @@ rm -f "$LEGION_TEST_MARKER"
 # names the hard escape; no telemetry row is written for the refusal.
 out=$(LEGION_BYPASS_GREP=1 echo '{"cwd":"/tmp/legion","tool_name":"Bash","tool_input":{"command":"grep -r Symbol src/"},"session_id":"bypass-env-t"}' | LEGION_BYPASS_GREP=1 bash "$HOOK")
 assert_contains "soft env bypass refused on local symbol" "$out" '"decision": "block"'
-assert_contains "refusal names hard escape" "$out" 'LEGION_BYPASS_GREP_HARD=1'
+assert_contains "refusal points to sym list, not a hard escape" "$out" 'sym list'
 if [ -f "$LEGION_TEST_MARKER" ] && grep -q "record-bypass" "$LEGION_TEST_MARKER"; then
   FAIL=$((FAIL + 1)); echo "  FAIL: refused soft bypass should NOT write telemetry row"
 else
@@ -223,17 +223,12 @@ else
   FAIL=$((FAIL + 1)); echo "  FAIL: soft bypass should still allow free-text patterns" >&2
 fi
 
-echo "==> harder bypass: hard escape (LEGION_BYPASS_GREP_HARD=1) ALWAYS allows"
-rm -f "$LEGION_TEST_MARKER"
-out=$(LEGION_BYPASS_GREP_HARD=1 echo '{"cwd":"/tmp/legion","tool_name":"Bash","tool_input":{"command":"grep -r Symbol src/"},"session_id":"bypass-hard-t"}' | LEGION_BYPASS_GREP_HARD=1 bash "$HOOK")
-assert_empty "hard escape exits 0 with no decision JSON" "$out"
-if [ -f "$LEGION_TEST_MARKER" ] && grep -q "record-bypass" "$LEGION_TEST_MARKER" && grep -q "hard:" "$LEGION_TEST_MARKER"; then
-  PASS=$((PASS + 1)); echo "  PASS: hard escape writes telemetry row with bypass_class=hard prefix"
-else
-  FAIL=$((FAIL + 1)); echo "  FAIL: hard escape did not write expected telemetry row" >&2
-  [ -f "$LEGION_TEST_MARKER" ] && cat "$LEGION_TEST_MARKER" >&2
-fi
-unset LEGION_BYPASS_GREP_HARD
+echo "==> #560: LEGION_BYPASS_GREP_HARD is RETIRED -- it no longer escapes the block"
+# The frictionless hard escape is gone; mandatory shell-grep blocking is the
+# operator's permissions.deny. Setting the old env var must NOT bypass: a
+# symbol with a local hit still blocks.
+out=$(LEGION_BYPASS_GREP_HARD=1 echo '{"cwd":"/tmp/legion","tool_name":"Bash","tool_input":{"command":"grep -r Symbol src/"},"session_id":"hard-gone-t"}' | LEGION_BYPASS_GREP_HARD=1 bash "$HOOK")
+assert_contains "retired hard-bypass env no longer escapes -- still blocks" "$out" '"decision": "block"'
 
 echo "==> hook end-to-end: skip via LEGION_SKIP_PRE_BASH_GREP=1"
 out=$(LEGION_SKIP_PRE_BASH_GREP=1 echo '{"cwd":"/tmp/legion","tool_name":"Bash","tool_input":{"command":"grep -r Symbol src/"},"session_id":"skip-t"}' | LEGION_SKIP_PRE_BASH_GREP=1 bash "$HOOK")


### PR DESCRIPTION
## Summary

Codifies the answer to "why are they optional?": mandatory shell-grep blocking is the operator's settings.json `permissions.deny` (evaluated before allow, unbypassable by env var, inherits to subagents) -- the CC v2.1.x mechanism that PreToolUse hooks never were. The plugin cannot ship permissions, so the deny ruleset is documented for operators; the frictionless `LEGION_BYPASS_GREP_HARD` hard-bypass is retired. (The deny rules themselves are applied operator-side, in ~/.claude/settings.json -- not in this PR.)

## Acceptance criteria mapping

### 1. A decision doc records the model
docs/decisions/2026-06-02-grep-blocking-is-operator-permissions.md records: the recommended deny ruleset (grep/rg/find/fd/ag/ack); that Grep/Glob tools are deliberately NOT denied (the supervised escape for non-indexed/free-text content like .astro); that plugins cannot contribute permissions (verified against v2.1.159); and why a hook is the wrong tool for a mandatory rule.
Evidence: the new docs/decisions/2026-06-02-grep-blocking-is-operator-permissions.md file.

### 2. The LEGION_BYPASS_GREP_HARD hard-bypass is removed; messages point to sym/Grep-tool
pre-bash-grep.sh no longer reads LEGION_BYPASS_GREP_HARD or has the always-allow block; the soft-bypass-refusal and State-2 block messages now point to `legion sym def/refs/sym list` (symbols) and the Grep tool (free-text), and state there is no env-var escape.
Evidence: the pre-bash-grep.sh diff removes the HARD_BYPASS var + if-block; the two REASON strings reference "sym list" and "Grep tool" instead of the hard escape; the header comment documents the new model.

### 3. test-pre-bash-grep.sh no longer asserts the hard-escape; remaining cases pass, shellcheck clean
The "hard escape ALWAYS allows" test became "#560: hard escape is RETIRED -- still blocks" (asserts a block decision despite the env var); the refusal assertion now checks the message points to "sym list".
Evidence: test-pre-bash-grep.sh diff; `bash test-pre-bash-grep.sh` reports 40 passed, 0 failed; `shellcheck pre-bash-grep.sh test-pre-bash-grep.sh` clean.

### 4. CHANGELOG records the enforcement-model change
Deferred to the 0.16.3 release, by necessity: legion's sync-version pre-commit gate pins the CHANGELOG top section to Cargo.toml's version (0.16.2), so a per-PR CHANGELOG section is structurally impossible. The model is recorded NOW in the decision doc; the CHANGELOG line lands with the 0.16.3 release alongside the other post-0.16.2 merges.
Evidence: the decision doc is the immediate record; CHANGELOG entry follows legion's release-time convention (cf. how #549/#551/#558 also carry no per-PR CHANGELOG).

### 5. PR created and linked
This PR is opened against #560 via legion pr create with --task linking the kanban card, and it passes through the live dual-gate (legion-simplify AND legion-pr-write must be clean on HEAD) before it can open -- so the act of creating it is itself gated proof, not a checkbox.
Evidence: the PR URL; the card's stored PR link; the legion-simplify and legion-pr-write quality-gate rows recorded on this HEAD that pr create verifies.

## Not done

Fully retiring pre-bash-grep.sh (now that permissions.deny is the real mechanism) is left as a follow-up -- the hook remains as soft fallback guidance for operators who have not set the deny rule. Applying the deny ruleset to settings is operator-side (done in ~/.claude/settings.json, and rzr still needs it) -- not a repo change. The CHANGELOG line is release-time (AC 4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)