### PR TITLE
feat(#569): Stop reflection nudge via additionalContext; goal on the in-progress gate

### DIFF
--- a/plugin/hooks/stop.sh
+++ b/plugin/hooks/stop.sh
@@ -5,15 +5,20 @@
 #
 # 1. IN-PROGRESS GATE (#461 -> #523). If the agent has an Accepted
 #    (in-progress) kanban card for this repo, block the Stop until it
-#    reaches a real state. Reads the BOARD -- the persistent work substrate
-#    that `work`/`accept` actually move -- not the ephemeral per-session
-#    harness TaskList. Gates on Accepted, NOT Pending: Pending is the
-#    unconsented backlog, which would never let the agent stop; a declared
-#    blocker moves a card to Blocked, excluded here by construction. No
-#    silent abandonment of picked-up work.
+#    reaches a real state, via decision:block (a HARD refusal -- the agent
+#    cannot stop with picked-up work). Reads the BOARD -- the persistent work
+#    substrate that `work`/`accept` actually move -- not the ephemeral
+#    per-session harness TaskList. Gates on Accepted, NOT Pending: Pending is
+#    the unconsented backlog, which would never let the agent stop; a declared
+#    blocker moves a card to Blocked, excluded here by construction. No silent
+#    abandonment of picked-up work. The board-derived goal (#525) rides along.
 #
 # 2. REFLECTION PROMPT. If work happened this session and the reflection
-#    hasn't fired yet, prompt for one. Skip when nothing was learned.
+#    hasn't fired yet, nudge for one via hookSpecificOutput.additionalContext
+#    (#569) -- non-error feedback that continues the turn so the agent acts on
+#    it, WITHOUT the hook-error labeling and 8-block cap that decision:block
+#    incurs. One-shot per session ($MARKER) + stop_hook_active guarded. Skip
+#    when nothing was learned.
 #
 # Bypass: LEGION_SKIP_STOP_BLOCK=1 env skips both gates. Writes a
 # telemetry row via `legion telemetry record-bypass` so the escape is
@@ -22,6 +27,13 @@
 INPUT=$(cat)
 CWD=$(echo "$INPUT" | jq -r '.cwd // empty')
 SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // empty')
+# stop_hook_active is true when this Stop was itself triggered by a prior hook
+# continuation. The reflection nudge (which now continues the turn via
+# additionalContext, #569) honors it as a loop guard so a continuation we
+# caused does not re-nudge. The in-progress block deliberately ignores it --
+# that gate must keep firing while Accepted work exists (the 8-block cap is its
+# own backstop).
+STOP_ACTIVE=$(echo "$INPUT" | jq -r '.stop_hook_active // false')
 
 if [ -z "$CWD" ]; then
   exit 0
@@ -131,6 +143,16 @@ The board is the plan, and the plan is the permission -- \"should I keep going?\
 
 To bypass (rare, diagnostics or explicit operator session-end), set LEGION_SKIP_STOP_BLOCK=1. The bypass writes one row to bypass.jsonl."
 
+    # Surface the board-derived goal (#525) so the completion condition the
+    # agent must drive the Accepted card to is in front of it, not just "keep
+    # going." Fail-open: any error leaves GOAL empty and the block fires plain.
+    GOAL=$("$LEGION_BIN" goal --repo "$REPO" 2>/dev/null)
+    if [ -n "$GOAL" ]; then
+      REASON="${REASON}
+
+${GOAL}"
+    fi
+
     jq -n --arg reason "$REASON" '{decision: "block", reason: $reason}'
     exit 0
   fi
@@ -155,9 +177,27 @@ if [ ! -f "$WORK_MARKER" ]; then
   exit 0
 fi
 
+# Loop guard: if this Stop is itself a hook-induced continuation, the nudge
+# already fired -- do not re-emit. The on-disk $MARKER is the primary guard
+# (the next Stop hits the marker check above and exits 0); this is the
+# belt-and-suspenders for additionalContext's continue-the-turn behavior.
+if [ "$STOP_ACTIVE" = "true" ]; then
+  session_end_handoff
+  exit 0
+fi
+
 touch "$MARKER"
 
 REASON="Drop one thing a teammate would not have known walking in cold -- a gotcha, a hidden invariant, how something actually works. Not what you did; the finding itself. Store it: legion reflect --repo $REPO --text '<finding>'. Skip if nothing surprising came up."
+
+# Surface the board-derived goal (#525) with the nudge so the completion
+# condition carries across the turn. Fail-open: empty GOAL leaves it off.
+GOAL=$("$LEGION_BIN" goal --repo "$REPO" 2>/dev/null)
+if [ -n "$GOAL" ]; then
+  REASON="${REASON}
+
+${GOAL}"
+fi
 
 # Budget reminder (#524) -- the "on stop" half of surfacing the autonomy
 # budget. Tells the agent, as it wraps up, that it has sanctioned units left
@@ -170,7 +210,17 @@ if [ -n "$BUDGET" ]; then
 ${BUDGET}"
 fi
 
-jq -n --arg reason "$REASON" '{
-  "decision": "block",
-  "reason": $reason
+# #569: the reflection nudge continues the turn via additionalContext, NOT
+# decision:block. Verified against CC 2.1.168: Stop additionalContext is
+# "non-error feedback that continues the conversation" -- the agent receives
+# the nudge and acts on it, but without the hook-error labeling and the
+# 8-consecutive-block cap that decision:block incurs. The in-progress gate
+# above stays a hard decision:block on purpose (it must be able to refuse the
+# stop, and wants the cap as a safety valve); this softer nudge is the right
+# tool for a once-per-session prompt the agent should act on.
+jq -n --arg ctx "$REASON" '{
+  "hookSpecificOutput": {
+    "hookEventName": "Stop",
+    "additionalContext": $ctx
+  }
 }'

--- a/plugin/hooks/test-stop-task-block.sh
+++ b/plugin/hooks/test-stop-task-block.sh
@@ -1,9 +1,15 @@
 #!/bin/bash
-# Test runner for the stop-hook task-state block (#461).
+# Test runner for the stop-hook gates.
 #
-# Builds a fake CLAUDE_PLUGIN_ROOT and exercises both:
-# - post-task-state.sh: writes one event row per TaskCreate/TaskUpdate.
-# - stop.sh: reads the event log, blocks when any task is incomplete.
+# Exercises stop.sh's two-layer enforcement at its CURRENT contract:
+# - In-progress gate (#461 -> #523): reads the KANBAN BOARD via
+#   `legion kanban list --json`, not the per-session task log. Blocks with
+#   decision:block when an Accepted card exists. The board-derived goal (#525)
+#   rides along.
+# - Reflection nudge (#569): fires via hookSpecificOutput.additionalContext
+#   (non-error, continues the turn), NOT decision:block.
+# Also covers post-task-state.sh (still writes the task event log for other
+# consumers) and the watch-pty / session-end (#492/#493) bypass paths.
 #
 # Run from the repo root:
 #   bash plugin/hooks/test-stop-task-block.sh
@@ -26,6 +32,19 @@ assert_contains() {
   fi
 }
 
+assert_not_contains() {
+  local desc="$1" haystack="$2" needle="$3"
+  if echo "$haystack" | grep -q -- "$needle"; then
+    FAIL=$((FAIL + 1))
+    echo "  FAIL: $desc" >&2
+    echo "    expected NOT to find: $needle" >&2
+    echo "    in: $haystack" >&2
+  else
+    PASS=$((PASS + 1))
+    echo "  PASS: $desc"
+  fi
+}
+
 assert_empty() {
   local desc="$1" actual="$2"
   if [ -z "$actual" ]; then
@@ -39,19 +58,31 @@ assert_empty() {
 }
 
 WORK=$(mktemp -d)
-trap 'rm -rf "$WORK"' EXIT
 
 mkdir -p "$WORK/plugin/bin" "$WORK/plugin/hooks" "$WORK/state/legion"
 cp plugin/hooks/post-task-state.sh "$WORK/plugin/hooks/"
 cp plugin/hooks/stop.sh "$WORK/plugin/hooks/"
 
-# Stub legion binary that logs every invocation to $LEGION_STUB_LOG
-# (when set) so #493 handoff tests can assert call shape, then no-ops.
+# Stub legion. Logs every invocation to $LEGION_STUB_LOG when set (so the #493
+# handoff tests can assert call shape). Returns an Accepted kanban card when
+# STUB_ACCEPTED is set (so the in-progress gate fires), and a goal line when
+# STUB_GOAL is set (so the #525 enrichment is exercised). Everything else is a
+# silent no-op exit 0 -- matching a clean board / unsupported subcommand.
 cat > "$WORK/plugin/bin/legion" <<'EOF'
 #!/bin/bash
 if [ -n "${LEGION_STUB_LOG:-}" ]; then
   echo "$@" >> "$LEGION_STUB_LOG"
 fi
+case "$*" in
+  *"kanban list"*)
+    if [ -n "${STUB_ACCEPTED:-}" ]; then
+      echo '{"status":"accepted","id":"42","title":"Ship the thing"}'
+    fi
+    ;;
+  "goal "*|"goal")
+    [ -n "${STUB_GOAL:-}" ] && printf '%s\n' "${STUB_GOAL}"
+    ;;
+esac
 exit 0
 EOF
 chmod +x "$WORK/plugin/bin/legion"
@@ -64,8 +95,7 @@ STOP_HOOK="$WORK/plugin/hooks/stop.sh"
 
 SESSION="test-session-461"
 
-# Seed work marker so the reflection prompt would normally fire (we
-# want to verify the task-block path runs BEFORE the reflection path).
+# Seed work marker so the reflection nudge can fire.
 CWD="/tmp/legion-test"
 CWD_HASH=$(echo "$CWD" | md5 -q 2>/dev/null || echo "$CWD" | md5sum | cut -d' ' -f1)
 touch "/tmp/legion-work-${CWD_HASH}"
@@ -89,46 +119,52 @@ else
   FAIL=$((FAIL + 1)); echo "  FAIL: update event missing"
 fi
 
-echo "==> stop hook BLOCKS with in_progress task"
-out=$(echo "{\"cwd\":\"${CWD}\",\"session_id\":\"${SESSION}\"}" | bash "$STOP_HOOK")
+echo "==> stop hook BLOCKS (decision:block) on an Accepted kanban card"
+out=$(echo "{\"cwd\":\"${CWD}\",\"session_id\":\"${SESSION}\"}" \
+  | STUB_ACCEPTED=1 STUB_GOAL="GOAL: ship the thing" bash "$STOP_HOOK")
 assert_contains "block decision present" "$out" '"decision": "block"'
-assert_contains "lists incomplete task id" "$out" '- 1 \[in_progress\]'
-assert_contains "lists subject" "$out" 'Ship the thing'
+assert_contains "lists the accepted card title" "$out" 'Ship the thing'
 assert_contains "names bypass env" "$out" 'LEGION_SKIP_STOP_BLOCK=1'
+assert_contains "surfaces the board-derived goal" "$out" 'GOAL: ship the thing'
 
-echo "==> mark complete, then stop passes through to reflection path"
-echo "{\"session_id\":\"${SESSION}\",\"tool_name\":\"TaskUpdate\",\"tool_input\":{\"task_id\":\"1\",\"status\":\"completed\"}}" | bash "$POST_HOOK"
+echo "==> clean board: stop nudges for reflection via additionalContext (#569)"
+# No STUB_ACCEPTED -> in-progress gate does not fire -> reflection path. It must
+# emit hookSpecificOutput.additionalContext, NOT decision:block.
 out=$(echo "{\"cwd\":\"${CWD}\",\"session_id\":\"${SESSION}\"}" | bash "$STOP_HOOK")
-# With completed tasks but unfired reflection marker, the reflection
-# prompt should fire (since /tmp/legion-work marker exists from the
-# trap setup).
-assert_contains "reflection prompt fires" "$out" 'Drop one thing a teammate would not have known walking in cold'
+assert_contains "reflection nudge fires" "$out" 'Drop one thing a teammate would not have known walking in cold'
+assert_contains "nudge uses additionalContext" "$out" '"hookEventName": "Stop"'
+assert_not_contains "nudge is NOT a block decision" "$out" '"decision": "block"'
 
 # Clean up reflection marker for next test
 rm -f "/tmp/legion-reflected-${CWD_HASH}"
 
+echo "==> reflection nudge is one-shot (marker guard)"
+# First call set the marker above; a second call must not re-nudge.
+touch "/tmp/legion-reflected-${CWD_HASH}"
+out=$(echo "{\"cwd\":\"${CWD}\",\"session_id\":\"${SESSION}\"}" | bash "$STOP_HOOK")
+assert_empty "marker suppresses a second nudge" "$out"
+rm -f "/tmp/legion-reflected-${CWD_HASH}"
+
+echo "==> stop_hook_active suppresses the nudge (loop guard, #569)"
+out=$(echo "{\"cwd\":\"${CWD}\",\"session_id\":\"${SESSION}\",\"stop_hook_active\":true}" | bash "$STOP_HOOK")
+assert_empty "stop_hook_active path produces no nudge" "$out"
+rm -f "/tmp/legion-reflected-${CWD_HASH}"
+
 echo "==> bypass via LEGION_SKIP_STOP_BLOCK=1 exits 0"
-# Re-seed with an in_progress task.
-echo "{\"session_id\":\"${SESSION}\",\"tool_name\":\"TaskUpdate\",\"tool_input\":{\"task_id\":\"1\",\"status\":\"in_progress\"}}" | bash "$POST_HOOK"
-out=$(LEGION_SKIP_STOP_BLOCK=1 echo "{\"cwd\":\"${CWD}\",\"session_id\":\"${SESSION}\"}" | LEGION_SKIP_STOP_BLOCK=1 bash "$STOP_HOOK")
+out=$(echo "{\"cwd\":\"${CWD}\",\"session_id\":\"${SESSION}\"}" | STUB_ACCEPTED=1 LEGION_SKIP_STOP_BLOCK=1 bash "$STOP_HOOK")
 assert_empty "bypass produces no output" "$out"
 
 echo "==> watch-pty (#492) skips both gates"
-# Same in_progress task in the log; LEGION_SPAWN_SOURCE=watch-pty must
-# take precedence and exit 0 silently, just like LEGION_SKIP_STOP_BLOCK.
-out=$(echo "{\"cwd\":\"${CWD}\",\"session_id\":\"${SESSION}\"}" | LEGION_SPAWN_SOURCE=watch-pty bash "$STOP_HOOK")
+out=$(echo "{\"cwd\":\"${CWD}\",\"session_id\":\"${SESSION}\"}" | STUB_ACCEPTED=1 LEGION_SPAWN_SOURCE=watch-pty bash "$STOP_HOOK")
 assert_empty "watch-pty bypass produces no output" "$out"
 
 echo "==> watch-pty branch ignores non-matching values"
-# Any value other than "watch-pty" must NOT trip the bypass -- the
-# block gate should still fire on the in_progress task.
-out=$(echo "{\"cwd\":\"${CWD}\",\"session_id\":\"${SESSION}\"}" | LEGION_SPAWN_SOURCE=manual-test bash "$STOP_HOOK")
+# Any value other than "watch-pty" must NOT trip the bypass -- with an Accepted
+# card the in-progress block should still fire.
+out=$(echo "{\"cwd\":\"${CWD}\",\"session_id\":\"${SESSION}\"}" | STUB_ACCEPTED=1 LEGION_SPAWN_SOURCE=manual-test bash "$STOP_HOOK")
 assert_contains "manual-test does not trigger watch-pty bypass" "$out" '"decision": "block"'
 
 echo "==> session-end handoff (#493) fires under watch-pty when wake-attempt set"
-# LEGION_WAKE_ATTEMPT_ID set + LEGION_SPAWN_SOURCE=watch-pty: hook
-# must invoke `legion watch session-end --attempt-id <id>` via the
-# stub. Assert via the recorded call log.
 HANDOFF_LOG="$WORK/handoff.log"
 : > "$HANDOFF_LOG"
 out=$(echo "{\"cwd\":\"${CWD}\",\"session_id\":\"${SESSION}\"}" \
@@ -145,8 +181,6 @@ else
 fi
 
 echo "==> session-end handoff is gated on LEGION_WAKE_ATTEMPT_ID"
-# Without the env var, handoff must NOT fire (avoids polluting
-# non-watch sessions with spurious watch CLI calls).
 : > "$HANDOFF_LOG"
 out=$(echo "{\"cwd\":\"${CWD}\",\"session_id\":\"${SESSION}\"}" \
   | LEGION_SPAWN_SOURCE=watch-pty \
@@ -161,24 +195,18 @@ fi
 
 echo "==> no session_id: hook passes through"
 out=$(echo "{\"cwd\":\"${CWD}\"}" | bash "$STOP_HOOK")
-# Should NOT block on task state since no session = no task log.
-# May still emit reflection prompt if work marker is present, but
-# task-block path is bypassed cleanly.
-if echo "$out" | grep -q 'decision.*block.*incomplete tasks'; then
-  FAIL=$((FAIL + 1)); echo "  FAIL: missing session_id should not trigger task block"
+if echo "$out" | grep -q '"decision": "block"'; then
+  FAIL=$((FAIL + 1)); echo "  FAIL: missing session_id should not block"
 else
-  PASS=$((PASS + 1)); echo "  PASS: missing session_id skips task block"
+  PASS=$((PASS + 1)); echo "  PASS: missing session_id passes through"
 fi
 
-# Clean up reflection marker before missing-log test
+# Clean up reflection marker before final test
 rm -f "/tmp/legion-reflected-${CWD_HASH}"
 
-echo "==> no task log: hook passes through to reflection"
-SESSION2="no-tasks-session"
-out=$(echo "{\"cwd\":\"${CWD}\",\"session_id\":\"${SESSION2}\"}" | bash "$STOP_HOOK")
-# No task log for SESSION2 -> task-block path skipped -> reflection fires
-# (work marker present).
-assert_contains "no task log falls through to reflection" "$out" 'Drop one thing a teammate would not have known walking in cold'
+echo "==> clean board, work present: reflection nudge fires"
+out=$(echo "{\"cwd\":\"${CWD}\",\"session_id\":\"no-card-session\"}" | bash "$STOP_HOOK")
+assert_contains "nudge fires on a clean board" "$out" 'Drop one thing a teammate would not have known walking in cold'
 
 echo
 echo "==> $PASS passed, $FAIL failed"


### PR DESCRIPTION
## Summary

Adopts CC 2.1.163+ `hookSpecificOutput.additionalContext` in the Stop hook for the reflection nudge, and surfaces the board-derived goal on the in-progress gate. The empirical verification this issue's AC required overturned the plan's premise, so the design is wired to the observed contract, not the guessed one.

## Empirical finding (the AC-mandated verification)

Verified against the live CC 2.1.168 hooks reference: Stop `additionalContext` is, verbatim, "non-error feedback that **continues the conversation**." It does NOT let the session stop with a note for next time. A Stop hook therefore has only two continue-the-turn outcomes: `decision:block` (error-flavored, counts toward the 8-consecutive-block cap) and `additionalContext` (non-error, uncapped). The earlier claude-code-guide reconstruction (and the plan) assumed additionalContext "allows the stop with a breadcrumb" -- it doesn't. The behavior below is wired to the verified truth.

## Acceptance criteria mapping

### 1. All tests pass
No Rust changed. `bash -n` is clean on stop.sh, and the hook's test, `test-stop-task-block.sh`, now passes 19/0. That number is the real story: the test was stale (it asserted the obsolete #461 task-log block that #523 replaced with a kanban read), and "block decision present" was passing only because the reflection path *also* emitted `decision:block` -- a green-for-the-wrong-reason that this change exposed. I rewrote the test to the current contract: the stub `legion` now returns an Accepted kanban card so the in-progress gate genuinely fires, the goal enrichment is asserted, and the reflection path is asserted as `additionalContext` (`hookEventName: Stop`) and explicitly NOT a `decision:block`. New tests also cover the one-shot marker guard and the `stop_hook_active` loop guard.
Evidence: `bash plugin/hooks/test-stop-task-block.sh` -> 19 passed, 0 failed; `bash -n plugin/hooks/stop.sh` clean.

### 2. Simplify pass completed
The diff is two files (stop.sh + its test), no Rust, no duplicate logic. The reflection nudge moves from `decision:block` to `additionalContext`; the in-progress gate is unchanged in mechanism (still `decision:block`) and only gains a goal-enrichment block mirroring the existing budget-reminder pattern. The `stop_hook_active` read is a small, documented loop guard. Simplify gate recorded clean on HEAD.
Evidence: `legion quality-gate record --skill legion-simplify --result clean` on HEAD (98fbcc1).

### 3. Review pass completed and issues fixed
Automated review runs against this PR next; findings will be addressed before merge. The change surface is one hook + its test, and the one behavioral risk -- the reflection nudge changing fleet-wide -- is called out explicitly here with the empirical contract so a reviewer can judge it against the verified doc rather than a guess. The nudge wording is kept identical to the old block reason to preserve its forcefulness.
Evidence: workflow order PR -> /review-pr -> fix -> merge.

### 4. PR created and linked to this issue
Opened via `legion pr create` (clean simplify + pr-write gates enforced on HEAD) from `feat/569-stop-additionalcontext`; body closes the issue.
Evidence: `Closes #569` below.

## Not done

- **SubagentStop (#570)** -- the sibling, ships separately (it depends on the same #568 anchor and now on this verified additionalContext-continues contract).
- **In-progress gate left as decision:block** -- deliberately. It is a hard "you cannot stop with Accepted work" gate and wants the 8-block cap as a safety valve; additionalContext (uncapped continuation) would remove that backstop. Only the reflection nudge moved.
- **Checkpoint-at-stop surfacing** -- the issue mentioned goal+checkpoint; I surface the goal (high value: the completion condition) but not a stale checkpoint at stop (the agent just lived the session and is about to write a fresh one via /checkpoint; surfacing the old one is noise).

Closes #569.

🤖 Generated with [Claude Code](https://claude.com/claude-code)