### PR TITLE
feat(#570): SubagentStop hook -- persist subagent work as a checkpoint + inform parent

### DIFF
--- a/plugin/hooks/hooks.json
+++ b/plugin/hooks/hooks.json
@@ -1,5 +1,5 @@
 {
-  "description": "Legion hooks: recall on start, reflect on stop, checkpoint on compact, bullpen awareness on tool use",
+  "description": "Legion hooks: recall on start, reflect on stop, checkpoint on compact and on subagent stop, bullpen awareness on tool use",
   "hooks": {
     "SessionStart": [
       {
@@ -34,6 +34,18 @@
           {
             "type": "command",
             "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/stop.sh",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "SubagentStop": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/subagent-stop.sh",
             "timeout": 10
           }
         ]

--- a/plugin/hooks/subagent-stop.sh
+++ b/plugin/hooks/subagent-stop.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+# Legion SubagentStop hook (#570).
+#
+# When a spawned subagent ends, its work otherwise lives only in the parent's
+# context -- nothing durable reaches legion memory, and a long delegated task
+# vanishes the moment the parent's session compacts or ends. This hook:
+#
+#   1. Persists the subagent's final output as a domain=checkpoint reflection
+#      (the unified resume-anchor, #568), tagged subagent,auto so it is
+#      distinguishable from a deliberate /checkpoint and ages out via decay.
+#   2. Injects a one-line pointer to the PARENT via
+#      hookSpecificOutput.additionalContext. Verified against CC 2.1.168:
+#      SubagentStop additionalContext is delivered to the parent (the spawning
+#      agent), and is "non-error feedback that continues the conversation" --
+#      the parent was resuming after the subagent anyway, so this just tells it
+#      the work is checkpointed and recallable.
+#
+# Never blocks the parent: every failure path exits 0. Cheap by design
+# (bounded transcript tail) to stay well under the hook timeout.
+
+INPUT=$(cat)
+CWD=$(echo "$INPUT" | jq -r '.cwd // empty' 2>/dev/null)
+if [ -z "$CWD" ]; then
+  exit 0
+fi
+
+REPO="${LEGION_REPO:-$(basename "$CWD")}"
+AGENT_TYPE=$(echo "$INPUT" | jq -r '.agent_type // "subagent"' 2>/dev/null)
+TRANSCRIPT=$(echo "$INPUT" | jq -r '.agent_transcript_path // empty' 2>/dev/null)
+
+LEGION_BIN="${CLAUDE_PLUGIN_ROOT}/bin/legion"
+if [ ! -x "$LEGION_BIN" ]; then
+  exit 0
+fi
+
+# Scrape the subagent's final output from its transcript tail. Same extraction
+# shape as precompact.sh, with the alternate-format fallback. Bounded to the
+# last ~1500 chars to keep the reflection (and this hook) small.
+SUMMARY=""
+if [ -n "$TRANSCRIPT" ] && [ -f "$TRANSCRIPT" ]; then
+  SUMMARY=$(tail -200 "$TRANSCRIPT" 2>/dev/null | \
+    jq -r 'select(.type == "assistant") | .message.content[]? | select(.type == "text") | .text // empty' 2>/dev/null | \
+    tail -c 1500)
+  if [ -z "$SUMMARY" ]; then
+    SUMMARY=$(tail -200 "$TRANSCRIPT" 2>/dev/null | \
+      jq -r 'select(.role == "assistant") | .content // empty' 2>/dev/null | \
+      tail -c 1500)
+  fi
+fi
+
+# Persist the subagent checkpoint. Fail-open: a reflect error must never block
+# the parent, so swallow it (|| true). No transcript text -> skip the reflect
+# entirely rather than store an empty marker; the parent pointer below still
+# fires so the parent knows the subagent ended.
+if [ -n "$SUMMARY" ]; then
+  "$LEGION_BIN" reflect --repo "$REPO" --domain checkpoint --tags subagent,auto \
+    --text "[SUBAGENT CHECKPOINT] ${AGENT_TYPE}: ${SUMMARY}" >/dev/null 2>&1 || true
+fi
+
+# Inform the parent. additionalContext continues the parent turn (it was
+# resuming regardless); point it at the persisted artifact rather than
+# restating the subagent's output, which the parent already received.
+CTX="Subagent ${AGENT_TYPE} finished. Its work is checkpointed in legion (domain=checkpoint); recall with: legion recall --repo ${REPO} --domain checkpoint --limit 1."
+
+jq -n --arg ctx "$CTX" '{
+  "hookSpecificOutput": {
+    "hookEventName": "SubagentStop",
+    "additionalContext": $ctx
+  }
+}' 2>/dev/null || true
+
+exit 0

--- a/plugin/hooks/test-subagent-stop.sh
+++ b/plugin/hooks/test-subagent-stop.sh
@@ -1,0 +1,108 @@
+#!/bin/bash
+# Test runner for the SubagentStop hook (#570).
+#
+# subagent-stop.sh persists a finished subagent's transcript tail as a
+# domain=checkpoint reflection (tagged subagent,auto) and injects a one-line
+# pointer to the parent via hookSpecificOutput.additionalContext. Every failure
+# path must exit 0 (never block the parent).
+#
+# Run from the repo root:
+#   bash plugin/hooks/test-subagent-stop.sh
+
+set -u
+
+PASS=0
+FAIL=0
+
+assert_contains() {
+  local desc="$1" haystack="$2" needle="$3"
+  if echo "$haystack" | grep -q -- "$needle"; then
+    PASS=$((PASS + 1)); echo "  PASS: $desc"
+  else
+    FAIL=$((FAIL + 1)); echo "  FAIL: $desc" >&2
+    echo "    expected to find: $needle" >&2
+    echo "    in: $haystack" >&2
+  fi
+}
+
+assert_not_contains() {
+  local desc="$1" haystack="$2" needle="$3"
+  if echo "$haystack" | grep -q -- "$needle"; then
+    FAIL=$((FAIL + 1)); echo "  FAIL: $desc" >&2
+    echo "    expected NOT to find: $needle" >&2
+  else
+    PASS=$((PASS + 1)); echo "  PASS: $desc"
+  fi
+}
+
+assert_empty() {
+  local desc="$1" actual="$2"
+  if [ -z "$actual" ]; then
+    PASS=$((PASS + 1)); echo "  PASS: $desc"
+  else
+    FAIL=$((FAIL + 1)); echo "  FAIL: $desc" >&2
+    echo "    expected empty, got: $actual" >&2
+  fi
+}
+
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+
+mkdir -p "$WORK/plugin/bin" "$WORK/plugin/hooks"
+cp plugin/hooks/subagent-stop.sh "$WORK/plugin/hooks/"
+
+# Stub legion: logs every invocation to $LEGION_STUB_LOG, then exit 0.
+cat > "$WORK/plugin/bin/legion" <<'EOF'
+#!/bin/bash
+if [ -n "${LEGION_STUB_LOG:-}" ]; then
+  echo "$@" >> "$LEGION_STUB_LOG"
+fi
+exit 0
+EOF
+chmod +x "$WORK/plugin/bin/legion"
+
+export CLAUDE_PLUGIN_ROOT="$WORK/plugin"
+HOOK="$WORK/plugin/hooks/subagent-stop.sh"
+CWD="/tmp/legion-subagent-test"
+STUB_LOG="$WORK/legion-calls.log"
+
+# A fake subagent transcript with assistant text content.
+TRANSCRIPT="$WORK/agent-transcript.jsonl"
+{
+  echo '{"type":"assistant","message":{"content":[{"type":"text","text":"Explored the auth module and found the token refresh bug."}]}}'
+  echo '{"type":"assistant","message":{"content":[{"type":"text","text":"Root cause: cookie SameSite=Strict drops the refresh on cross-site nav."}]}}'
+} > "$TRANSCRIPT"
+
+echo "==> persists a subagent checkpoint + informs the parent"
+: > "$STUB_LOG"
+out=$(echo "{\"cwd\":\"${CWD}\",\"agent_type\":\"Explore\",\"agent_transcript_path\":\"${TRANSCRIPT}\"}" \
+  | LEGION_STUB_LOG="$STUB_LOG" bash "$HOOK")
+assert_contains "reflect called with domain=checkpoint" "$(cat "$STUB_LOG")" 'reflect --repo legion-subagent-test --domain checkpoint'
+assert_contains "tagged subagent,auto" "$(cat "$STUB_LOG")" 'subagent,auto'
+assert_contains "checkpoint text names the agent_type" "$(cat "$STUB_LOG")" 'SUBAGENT CHECKPOINT] Explore'
+assert_contains "scraped the transcript summary" "$(cat "$STUB_LOG")" 'token refresh bug'
+assert_contains "parent context is additionalContext" "$out" '"hookEventName": "SubagentStop"'
+assert_contains "parent pointer names recall" "$out" 'legion recall --repo legion-subagent-test --domain checkpoint'
+
+echo "==> missing transcript: skip reflect, still inform parent, exit 0"
+: > "$STUB_LOG"
+out=$(echo "{\"cwd\":\"${CWD}\",\"agent_type\":\"Explore\",\"agent_transcript_path\":\"/no/such/file.jsonl\"}" \
+  | LEGION_STUB_LOG="$STUB_LOG" bash "$HOOK")
+assert_not_contains "no reflect call on missing transcript" "$(cat "$STUB_LOG")" 'reflect'
+assert_contains "parent still informed" "$out" '"hookEventName": "SubagentStop"'
+
+echo "==> no cwd: pass through silently"
+out=$(echo '{}' | bash "$HOOK")
+assert_empty "no cwd produces no output" "$out"
+
+echo "==> missing legion binary: exit 0, no output"
+out=$(echo "{\"cwd\":\"${CWD}\",\"agent_type\":\"Explore\",\"agent_transcript_path\":\"${TRANSCRIPT}\"}" \
+  | CLAUDE_PLUGIN_ROOT="/no/such/plugin" bash "$HOOK")
+assert_empty "missing binary produces no output" "$out"
+
+echo
+echo "==> $PASS passed, $FAIL failed"
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Adds a SubagentStop hook (CC 2.1.163+) so a spawned subagent's work is persisted to legion memory instead of living only in the parent's context and vanishing on compaction or session end. On subagent stop it (1) scrapes the subagent's transcript tail and writes a `domain=checkpoint` reflection tagged `subagent,auto` (the unified resume-anchor from #568), and (2) injects a one-line pointer to the parent via `hookSpecificOutput.additionalContext`. Plugin-only; new hook + hooks.json registration + test.

## Acceptance criteria mapping

### 1. All tests pass
The new hook ships with `test-subagent-stop.sh`, 10/0, and it exercises the real branches rather than asserting trivially: it feeds a fake subagent transcript and confirms (via a stub `legion` that logs its invocations) that `reflect --domain checkpoint --tags subagent,auto` is called with the agent_type and the scraped summary, and that the parent output is `additionalContext` with `hookEventName: SubagentStop` pointing at a recall command. It also covers the fail-open paths: a missing transcript skips the reflect but still informs the parent; no `cwd` and a missing legion binary both exit 0 with no output. `bash -n` is clean on the hook and test, and `hooks.json` parses as valid JSON with `SubagentStop` registered at matcher `*`.
Evidence: `bash plugin/hooks/test-subagent-stop.sh` -> 10 passed, 0 failed; `python3 json.load` of hooks.json lists `SubagentStop`.

### 2. Simplify pass completed
The hook reuses the existing precompact transcript-scrape shape (including the alternate-format fallback) rather than inventing a new one, so there is no duplicated-but-divergent extraction logic. Control flow is linear with early exits; every external call is fail-open. The hooks.json change is a single registration block mirroring the Stop entry. Simplify gate recorded clean on HEAD.
Evidence: `legion quality-gate record --skill legion-simplify --result clean` on HEAD (b2bc5b8).

### 3. Review pass completed and issues fixed
Automated review runs against this PR next; findings addressed before merge. The surface is one new hook + one registration + one test, and the design decisions a reviewer should check are stated explicitly here: additionalContext goes to the parent (verified) and continues its turn (the parent resumes after a subagent anyway), and the hook is strictly fail-open so it can never block a parent on a subagent's exit.
Evidence: workflow order PR -> /review-pr -> fix -> merge.

### 4. PR created and linked to this issue
Opened via `legion pr create` (clean simplify + pr-write gates enforced on HEAD) from `feat/570-subagent-stop`; body closes the issue.
Evidence: `Closes #570` below.

## Not done

- **No per-agent-type matcher routing** -- registered at `*` per the issue; any type-specific handling would live inside the script later.
- **No content filtering of trivial subagent runs** -- every subagent stop with transcript text writes a checkpoint (tagged `subagent,auto`); decay handles noise rather than a heuristic gate, keeping the hook cheap and predictable.
- **Cluster fan-out result-return** -- a future consumer may reuse this hook to persist remote cmd results; deliberately not coupled here (noted in #562-567).

Closes #570.

🤖 Generated with [Claude Code](https://claude.com/claude-code)