### PR TITLE
fix(#578): daemon watch loop evaluates the quota panic-stop gate

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -435,6 +435,22 @@ async fn run_watch_task(data_dir: &Path) {
     let lease_ttl = std::time::Duration::from_secs(config.persona_lease_ttl_secs);
     let mut sampler = crate::health::HealthSampler::new(config.health_window_size);
 
+    // Subscription-quota panic-stop gate (#496). The standalone `watch::run`
+    // loop has always had this; the daemon copy dropped it in the Bun->Rust
+    // port (#578), so the daemon could wake agents with the rate-limit cap
+    // already exhausted. Attribute the healthy<->panic bullpen edge posts to
+    // the first watched repo, falling back to "legion".
+    let quota_post_repo = config
+        .repos
+        .first()
+        .map(|r| r.name.clone())
+        .unwrap_or_else(|| "legion".to_string());
+    let mut quota_gate = watch::QuotaPanicGate::new(
+        config.quota_panic_threshold_pct,
+        host.clone(),
+        quota_post_repo,
+    );
+
     let poll_interval = std::time::Duration::from_secs(config.poll_interval_secs);
     let health_interval = std::time::Duration::from_secs(config.health_poll_secs);
     let retention_cutoff = chrono::Duration::days(config.retention_days as i64);
@@ -473,29 +489,48 @@ async fn run_watch_task(data_dir: &Path) {
         }
 
         if poll_timer.elapsed() >= poll_interval {
-            if sampler.can_spawn(config.health_threshold_pct) {
-                let lease_gate = watch::PersonaLeaseGate {
-                    db: &db,
-                    host: &host,
-                    ttl: lease_ttl,
-                };
-                match watch::poll_cycle(
-                    &db,
-                    &config,
-                    &mut cooldown,
-                    &mut tracker,
-                    Some(&session_locks),
-                    Some(&lease_gate),
-                    Some(&lookback),
-                    spawn_mode,
-                ) {
-                    Ok(n) if n > 0 => {
-                        eprintln!("[legion daemon] watch: {} agent(s) spawned", n);
+            match watch::evaluate_spawn_gate(
+                &mut quota_gate,
+                &sampler,
+                &db,
+                config.health_threshold_pct,
+            ) {
+                watch::SpawnGate::Proceed => {
+                    let lease_gate = watch::PersonaLeaseGate {
+                        db: &db,
+                        host: &host,
+                        ttl: lease_ttl,
+                    };
+                    match watch::poll_cycle(
+                        &db,
+                        &config,
+                        &mut cooldown,
+                        &mut tracker,
+                        Some(&session_locks),
+                        Some(&lease_gate),
+                        Some(&lookback),
+                        spawn_mode,
+                    ) {
+                        Ok(n) if n > 0 => {
+                            eprintln!("[legion daemon] watch: {} agent(s) spawned", n);
+                        }
+                        Ok(_) => {}
+                        Err(e) => {
+                            eprintln!("[legion daemon] watch poll error: {e}");
+                        }
                     }
-                    Ok(_) => {}
-                    Err(e) => {
-                        eprintln!("[legion daemon] watch poll error: {e}");
-                    }
+                }
+                watch::SpawnGate::QuotaPanic => {
+                    eprintln!(
+                        "[legion daemon] quota panic active (>= {:.1}%) -- skipping spawn cycle",
+                        config.quota_panic_threshold_pct
+                    );
+                }
+                watch::SpawnGate::Pressure(pressure) => {
+                    eprintln!(
+                        "[legion daemon] pressure {:.1}% >= threshold {:.0}% -- skipping spawn cycle",
+                        pressure, config.health_threshold_pct
+                    );
                 }
             }
 

--- a/src/health.rs
+++ b/src/health.rs
@@ -207,6 +207,14 @@ impl HealthSampler {
     pub fn hostname(&self) -> &str {
         &self.hostname
     }
+
+    /// Test-only: push a synthetic pressure reading into the rolling window so
+    /// `can_spawn` / `pressure` can be driven deterministically from other
+    /// modules' tests (e.g. `watch::evaluate_spawn_gate`).
+    #[cfg(test)]
+    pub(crate) fn push_pressure_for_test(&mut self, pressure: f64) {
+        self.window.push_back(pressure);
+    }
 }
 
 /// Compute instantaneous pressure from a single snapshot.

--- a/src/watch.rs
+++ b/src/watch.rs
@@ -1748,6 +1748,41 @@ impl QuotaPanicGate {
     }
 }
 
+/// Outcome of evaluating the per-poll spawn gates. Shared by `watch::run` and
+/// the daemon's `run_watch_task` so the two loops cannot drift on which gates
+/// guard a spawn cycle (#578 -- the daemon copy had silently dropped the quota
+/// panic-stop gate after the Bun->Rust port).
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum SpawnGate {
+    /// Every gate is clear; run the spawn cycle.
+    Proceed,
+    /// Subscription-quota panic is active; skip the cycle.
+    QuotaPanic,
+    /// System pressure is at or over the health threshold; skip the cycle.
+    /// Carries the measured pressure for the skip log.
+    Pressure(f64),
+}
+
+/// Evaluate the gates guarding a spawn cycle, in priority order: the
+/// subscription-quota panic-stop first (it protects the operator's rate-limit
+/// cap and must never be skipped), then system-health pressure.
+/// `quota_gate.check_and_post` advances the panic edge and emits the
+/// healthy<->panic bullpen transition post as a side effect.
+pub fn evaluate_spawn_gate(
+    quota_gate: &mut QuotaPanicGate,
+    sampler: &crate::health::HealthSampler,
+    db: &Database,
+    health_threshold_pct: f64,
+) -> SpawnGate {
+    if quota_gate.check_and_post(db) {
+        SpawnGate::QuotaPanic
+    } else if sampler.can_spawn(health_threshold_pct) {
+        SpawnGate::Proceed
+    } else {
+        SpawnGate::Pressure(sampler.pressure())
+    }
+}
+
 /// Run the watch daemon main loop.
 ///
 /// Uses a dual-interval loop: health sampling every `health_poll_secs`
@@ -1877,13 +1912,8 @@ pub fn run(data_dir: &Path) -> Result<()> {
 
         // Spawn check on the poll interval
         if poll_timer.elapsed() >= poll_interval {
-            if quota_gate.check_and_post(&db) {
-                eprintln!(
-                    "[legion watch] quota panic active (>= {:.1}%) -- skipping spawn cycle",
-                    config.quota_panic_threshold_pct
-                );
-            } else if sampler.can_spawn(config.health_threshold_pct) {
-                match poll_cycle(
+            match evaluate_spawn_gate(&mut quota_gate, &sampler, &db, config.health_threshold_pct) {
+                SpawnGate::Proceed => match poll_cycle(
                     &db,
                     &config,
                     &mut cooldown,
@@ -1900,13 +1930,19 @@ pub fn run(data_dir: &Path) -> Result<()> {
                     Err(e) => {
                         eprintln!("[legion watch] poll error: {}", e);
                     }
+                },
+                SpawnGate::QuotaPanic => {
+                    eprintln!(
+                        "[legion watch] quota panic active (>= {:.1}%) -- skipping spawn cycle",
+                        config.quota_panic_threshold_pct
+                    );
                 }
-            } else {
-                let pressure: f64 = sampler.pressure();
-                eprintln!(
-                    "[legion watch] pressure {:.1}% >= threshold {:.0}% -- skipping spawn cycle",
-                    pressure, config.health_threshold_pct
-                );
+                SpawnGate::Pressure(pressure) => {
+                    eprintln!(
+                        "[legion watch] pressure {:.1}% >= threshold {:.0}% -- skipping spawn cycle",
+                        pressure, config.health_threshold_pct
+                    );
+                }
             }
 
             // Prune old health samples and stale watch_handled records (non-fatal)
@@ -1929,6 +1965,64 @@ pub fn run(data_dir: &Path) -> Result<()> {
 mod tests {
     use super::*;
     use crate::testutil::test_storage;
+
+    fn rate_limit_sample(
+        hostname: &str,
+        five_hour_pct: Option<f64>,
+    ) -> crate::statusline::RateLimitSample {
+        crate::statusline::RateLimitSample {
+            id: "test-id".to_string(),
+            hostname: hostname.to_string(),
+            session_id: "test-session".to_string(),
+            sampled_at: "2026-06-09T00:00:00Z".to_string(),
+            five_hour_pct,
+            five_hour_resets_at: None,
+            seven_day_pct: None,
+            seven_day_resets_at: None,
+            model: None,
+        }
+    }
+
+    #[test]
+    fn evaluate_spawn_gate_proceeds_when_all_clear() {
+        let (db, _index, _dir) = test_storage();
+        let mut quota = QuotaPanicGate::new(90.0, "host-a".to_string(), "legion".to_string());
+        // Empty window -> can_spawn true; no rate-limit sample -> no panic.
+        let sampler = crate::health::HealthSampler::new(6);
+        assert_eq!(
+            evaluate_spawn_gate(&mut quota, &sampler, &db, 80.0),
+            SpawnGate::Proceed
+        );
+    }
+
+    #[test]
+    fn evaluate_spawn_gate_quota_panic_takes_priority_over_healthy_system() {
+        let (db, _index, _dir) = test_storage();
+        // A sample for this host crosses the 90% panic threshold.
+        db.insert_rate_limit_sample(&rate_limit_sample("host-a", Some(99.0)))
+            .expect("insert rate-limit sample");
+        let mut quota = QuotaPanicGate::new(90.0, "host-a".to_string(), "legion".to_string());
+        // Fresh sampler would otherwise allow spawning -- proves the quota gate
+        // wins. This is the regression #578 fixes: the daemon loop never even
+        // consulted this gate.
+        let sampler = crate::health::HealthSampler::new(6);
+        assert_eq!(
+            evaluate_spawn_gate(&mut quota, &sampler, &db, 80.0),
+            SpawnGate::QuotaPanic
+        );
+    }
+
+    #[test]
+    fn evaluate_spawn_gate_reports_pressure_when_over_threshold() {
+        let (db, _index, _dir) = test_storage();
+        let mut quota = QuotaPanicGate::new(90.0, "host-a".to_string(), "legion".to_string());
+        let mut sampler = crate::health::HealthSampler::new(6);
+        sampler.push_pressure_for_test(95.0); // over the 80.0 threshold
+        match evaluate_spawn_gate(&mut quota, &sampler, &db, 80.0) {
+            SpawnGate::Pressure(p) => assert!(p >= 80.0, "pressure {p} should exceed threshold"),
+            other => panic!("expected Pressure, got {other:?}"),
+        }
+    }
 
     #[test]
     fn parse_config_basic() {


### PR DESCRIPTION
## Summary

The Bun->Rust port forked the watch poll loop into `watch::run` and `daemon::run_watch_task`. The daemon copy -- the one that runs under `legion daemon` every session -- silently dropped the subscription-quota panic-stop gate (#496), so it could spawn wake agents with this host's rate-limit cap already exhausted. It also dropped the pressure-skip log, so a health-gated daemon went silent and looked dead. This extracts the per-poll gate decision into one shared `watch::evaluate_spawn_gate` called by both loops, so the gate set cannot diverge again.

## Acceptance criteria mapping

### 1. The daemon loop evaluates the quota gate before every spawn cycle
The daemon poll branch now calls `watch::evaluate_spawn_gate(&mut quota_gate, &sampler, &db, config.health_threshold_pct)`, and `quota_gate` is constructed in the task setup mirroring `watch::run`. Previously the daemon branch checked only `sampler.can_spawn(...)` with no quota gate at all, which is the bug.
Evidence: src/daemon.rs `run_watch_task` -- the `evaluate_spawn_gate` call plus the new `QuotaPanicGate::new` construction.

### 2. Quota panic active skips the spawn cycle and logs it
The `SpawnGate::QuotaPanic` arm emits `[legion daemon] quota panic active (>= X%) -- skipping spawn cycle` rather than spawning, matching the standalone loop and protecting the operator's cap.
Evidence: test src/watch.rs `evaluate_spawn_gate_quota_panic_takes_priority_over_healthy_system` asserts QuotaPanic is returned even when a fresh sampler would allow spawning.

### 3. Health pressure over threshold skips and logs it
The `SpawnGate::Pressure(pressure)` arm restores the pressure-skip log that the port had dropped, so a health-gated daemon is no longer completely silent and observability is recovered.
Evidence: test src/watch.rs `evaluate_spawn_gate_reports_pressure_when_over_threshold`.

### 4. A single shared gate-decision function is used by both loops
`watch::evaluate_spawn_gate` and the `SpawnGate` enum are the one decision site; both `watch::run` and `daemon::run_watch_task` match on its result, so the two loops can no longer drift on which gates guard a spawn cycle.
Evidence: src/watch.rs `evaluate_spawn_gate` and its two call sites in src/watch.rs and src/daemon.rs.

### 5. Unit tests cover all three gate branches
Three tests exercise Proceed, QuotaPanic, and Pressure; a `#[cfg(test)]` `HealthSampler::push_pressure_for_test` seam makes the pressure branch deterministic when driven from watch's tests.
Evidence: src/watch.rs `evaluate_spawn_gate_proceeds_when_all_clear` and its two siblings, plus src/health.rs `push_pressure_for_test`.

### 6. cargo test, clippy with warnings denied, and fmt all pass
The full test suite passes and the lint and format gates are clean, satisfying the repo's mandatory build checks.
Evidence: 908 binary-unit tests and 156 integration tests passed with 0 failures; `cargo clippy --all-targets -- -D warnings` and `cargo fmt -- --check` both reported clean this session (observable behavior).

## Not done

- Full consolidation of the two loops into one. The residual match-arm and log duplication (differing only by the `[legion watch]` vs `[legion daemon]` prefix) is left as a follow-up; this PR de-dupes the gate decision, which is the part that actually drifted and caused the bug.
- Idle heartbeat log so an idle daemon does not look dead even when no gate fires -- a separate observability enhancement.
- `broadcast_tags` / `@all` broadcast wake -- a separate feature.