### PR TITLE
chore(release): 0.16.4

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
     {
       "name": "legion",
       "description": "Agent memory layer with recall, reflect, consult, bullpen, and cross-agent coordination. Includes health monitoring and auto-wake. Hooks wire legion into every session automatically.",
-      "version": "0.16.3",
+      "version": "0.16.4",
       "author": {
         "name": "Sean Silvius",
         "email": "sean@silvius.me"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1473,7 +1473,7 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "legion"
-version = "0.16.3"
+version = "0.16.4"
 dependencies = [
  "async-stream",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "legion"
-version = "0.16.3"
+version = "0.16.4"
 edition = "2024"
 description = "Agent specialization through deliberate practice"
 

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "legion",
-  "version": "0.16.3",
+  "version": "0.16.4",
   "description": "Institutional memory for Claude Code agents with real-time team channel.",
   "author": {
     "name": "Sean Silvius",

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Legion Changelog
 
+## 0.16.4
+
+Watch reliability fix. The auto-wake daemon now honors the subscription-quota panic-stop gate it had been bypassing. Patch release: one fix, no schema migration, no wire-format change.
+
+### Fixed
+
+- **daemon watch loop evaluates the quota panic-stop gate** (PR #579, #578): the Bun->Rust port forked the watch poll loop into `watch::run` (standalone `legion watch`) and `daemon::run_watch_task` (the copy that actually runs under `legion daemon`, auto-started every session). The daemon copy silently dropped the subscription-quota panic-stop gate (#496) and the pressure-skip log -- so the daemon could spawn wake agents with this host's 5h/7d rate-limit window already at the panic threshold, and went completely silent when health-gated, making a live loop look dead. The per-poll gate decision is now extracted into one shared `watch::evaluate_spawn_gate` returning `SpawnGate { Proceed, QuotaPanic, Pressure(f64) }`, called by both loops so the gate set cannot diverge again; both loops log the skip reason. Three new tests cover the branches, including quota panic taking priority over a healthy system. A `#[cfg(test)]` `HealthSampler::push_pressure_for_test` seam makes the pressure branch deterministic.
+
 ## 0.16.3
 
 The checkpoint resume-anchor and harness-primitive adoption. `/snooze` becomes `/checkpoint` -- the name primed agents to go dormant -- and the split resume-anchor unifies onto one `domain=checkpoint` read path. The Stop and SubagentStop hooks adopt CC 2.1.163's `hookSpecificOutput.additionalContext`. The watch loop stops mistaking an idle PTY REPL for a live session. Grep-blocking is codified as the operator's `permissions.deny`. Patch release: behavior changes plus additive features; no schema migration (the `checkpoint` domain already existed) and no wire-format change.


### PR DESCRIPTION
Patch release. Single fix: the daemon watch loop now evaluates the subscription-quota panic-stop gate it had been bypassing since the Bun->Rust port (#578 / PR #579). No schema migration, no wire-format change.

After merge, tag v0.16.4 to trigger the release build (release.yml builds the 4-platform artifacts the plugin pulls).

Release PR -- no acceptance criteria to map, so gates are skipped via --skip-gates (audit-logged), matching the 0.16.3 release (#576).