### PR TITLE
feat(#581): watch heartbeat + legion watch status (observability)

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -463,6 +463,16 @@ async fn run_watch_task(data_dir: &Path) {
         .checked_sub(health_interval)
         .unwrap_or_else(tokio::time::Instant::now);
 
+    // How many health ticks have elapsed. Used to throttle the INFO heartbeat
+    // log line -- we write it once every HEARTBEAT_LOG_CADENCE ticks so an
+    // idle daemon is silent most of the time but still proves liveness in the
+    // log file without spamming it.
+    let mut health_tick_count: u64 = 0;
+    const HEARTBEAT_LOG_CADENCE: u64 = 10;
+
+    let daemon_pid: u32 = std::process::id();
+    let daemon_version: &str = env!("CARGO_PKG_VERSION");
+
     loop {
         // Yield to tokio scheduler each iteration.
         tokio::time::sleep(std::time::Duration::from_secs(1)).await;
@@ -483,6 +493,25 @@ async fn run_watch_task(data_dir: &Path) {
                 Err(e) => {
                     eprintln!("[legion daemon] health sample error: {e}");
                 }
+            }
+
+            // Persist the liveness heartbeat so `legion watch status` can
+            // report alive/stale/absent without requiring ps or log inspection.
+            let repo_count: u32 = config.repos.len() as u32;
+            if let Err(e) =
+                db.upsert_watch_heartbeat(&host, daemon_pid, daemon_version, repo_count, None)
+            {
+                eprintln!("[legion daemon] heartbeat persist error: {e}");
+            }
+
+            // Emit a heartbeat INFO line on a longer cadence so the log file
+            // proves liveness without being flooded on a quiet daemon.
+            health_tick_count += 1;
+            if health_tick_count % HEARTBEAT_LOG_CADENCE == 1 {
+                eprintln!(
+                    "[legion daemon] heartbeat tick={} repos={} pid={}",
+                    health_tick_count, repo_count, daemon_pid
+                );
             }
 
             health_timer = tokio::time::Instant::now();

--- a/src/db.rs
+++ b/src/db.rs
@@ -1056,6 +1056,23 @@ impl Database {
             );",
         )?;
 
+        // Migration 24: watch heartbeat (#581).
+        //
+        // One row per host, keyed by hostname. The daemon upserts this row on
+        // every health_interval tick so an operator can run `legion watch status`
+        // and know whether the daemon is alive, stale, or has never written a beat.
+        // Singleton-per-host with no UUID id column; the primary key IS the host.
+        conn.execute_batch(
+            "CREATE TABLE IF NOT EXISTS watch_heartbeat (
+                host TEXT PRIMARY KEY,
+                pid INTEGER NOT NULL,
+                version TEXT NOT NULL,
+                repo_count INTEGER NOT NULL,
+                last_spawn_summary TEXT,
+                updated_at TEXT NOT NULL
+            );",
+        )?;
+
         Ok(())
     }
 
@@ -4904,6 +4921,133 @@ impl Database {
     }
 }
 
+// -- watch heartbeat (#581) --------------------------------------------------
+
+/// A persisted liveness record written by the watch daemon on each health tick.
+///
+/// One row per host, keyed by hostname. Reading this row tells an operator
+/// whether the daemon is alive (beat is recent), stale (beat is old), or
+/// absent (no row). The `version` field is the binary's CARGO_PKG_VERSION at
+/// the time the row was written, which may differ from a fresh `legion --version`
+/// invocation when the binary was replaced but the daemon process was not restarted.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct WatchHeartbeat {
+    /// Hostname that wrote this row (primary key).
+    pub host: String,
+    /// PID of the daemon process that wrote this row.
+    pub pid: u32,
+    /// `CARGO_PKG_VERSION` of the binary the daemon loaded at startup.
+    pub version: String,
+    /// Number of repos in watch.toml at the time of the beat.
+    pub repo_count: u32,
+    /// Optional human-readable summary of the most recent poll cycle's spawns.
+    pub last_spawn_summary: Option<String>,
+    /// ISO-8601 timestamp of the most recent upsert.
+    pub updated_at: String,
+}
+
+impl Database {
+    /// Upsert the heartbeat row for this host.
+    ///
+    /// Called by the daemon on every health_interval tick. The ON CONFLICT
+    /// clause updates every column so stale values never accumulate.
+    pub fn upsert_watch_heartbeat(
+        &self,
+        host: &str,
+        pid: u32,
+        version: &str,
+        repo_count: u32,
+        last_spawn_summary: Option<&str>,
+    ) -> Result<()> {
+        let now = Utc::now().to_rfc3339();
+        self.conn.execute(
+            "INSERT INTO watch_heartbeat \
+             (host, pid, version, repo_count, last_spawn_summary, updated_at) \
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6) \
+             ON CONFLICT(host) DO UPDATE SET \
+                 pid = excluded.pid, \
+                 version = excluded.version, \
+                 repo_count = excluded.repo_count, \
+                 last_spawn_summary = excluded.last_spawn_summary, \
+                 updated_at = excluded.updated_at",
+            rusqlite::params![
+                host,
+                pid as i64,
+                version,
+                repo_count as i64,
+                last_spawn_summary,
+                &now
+            ],
+        )?;
+        Ok(())
+    }
+
+    /// Read the heartbeat row for a specific host, or any host when `host` is `None`.
+    ///
+    /// When `host` is `None`, returns the most recently updated row across all hosts.
+    /// Returns `Ok(None)` when no heartbeat has ever been written.
+    pub fn get_watch_heartbeat(&self, host: Option<&str>) -> Result<Option<WatchHeartbeat>> {
+        let map_row = |row: &rusqlite::Row<'_>| -> rusqlite::Result<WatchHeartbeat> {
+            let pid_i64: i64 = row.get(1)?;
+            let repo_count_i64: i64 = row.get(3)?;
+            Ok(WatchHeartbeat {
+                host: row.get(0)?,
+                pid: pid_i64 as u32,
+                version: row.get(2)?,
+                repo_count: repo_count_i64 as u32,
+                last_spawn_summary: row.get(4)?,
+                updated_at: row.get(5)?,
+            })
+        };
+        match host {
+            Some(h) => self
+                .conn
+                .query_row(
+                    "SELECT host, pid, version, repo_count, last_spawn_summary, updated_at \
+                     FROM watch_heartbeat WHERE host = ?1",
+                    rusqlite::params![h],
+                    map_row,
+                )
+                .optional()
+                .map_err(LegionError::Database),
+            None => self
+                .conn
+                .query_row(
+                    "SELECT host, pid, version, repo_count, last_spawn_summary, updated_at \
+                     FROM watch_heartbeat ORDER BY updated_at DESC LIMIT 1",
+                    [],
+                    map_row,
+                )
+                .optional()
+                .map_err(LegionError::Database),
+        }
+    }
+
+    /// Return the N most recent wake_attempts rows, ordered newest-first.
+    ///
+    /// Used by `legion watch status` to show a terse wake activity summary.
+    /// All states are included (terminal and in-flight) so the operator sees
+    /// the full recent history, not just live wakes.
+    pub fn recent_wake_attempts(
+        &self,
+        limit: u32,
+    ) -> Result<Vec<crate::wake_attempts::WakeAttempt>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT attempt_id, persona_id, repo_name, signal_ids, state, \
+                    acquired_by_host, acquired_at, spawned_pid, spawned_at, \
+                    exit_observed_at, exited_at, exit_status, outcome, \
+                    deleted_at, updated_at \
+             FROM wake_attempts \
+             WHERE deleted_at IS NULL \
+             ORDER BY updated_at DESC \
+             LIMIT ?1",
+        )?;
+        Ok(stmt
+            .query_map(rusqlite::params![limit as i64], map_wake_attempt_row)?
+            .collect::<rusqlite::Result<Vec<_>>>()?)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -8482,5 +8626,126 @@ mod tests {
         assert!(db.apply_wake_attempt_delta(&tomb).unwrap());
         let row = db.get_wake_attempt("tomb-id").unwrap().expect("row");
         assert!(row.deleted_at.is_some());
+    }
+
+    // -- watch heartbeat tests (#581) -----------------------------------------
+
+    #[test]
+    fn upsert_and_get_watch_heartbeat_round_trips() {
+        let db = test_db();
+
+        // No heartbeat yet -- get returns None.
+        assert!(
+            db.get_watch_heartbeat(Some("host-a")).unwrap().is_none(),
+            "absent host -> None"
+        );
+        assert!(
+            db.get_watch_heartbeat(None).unwrap().is_none(),
+            "empty table -> None"
+        );
+
+        // Write a heartbeat.
+        db.upsert_watch_heartbeat("host-a", 1234, "0.16.4", 3, Some("spawned 1"))
+            .unwrap();
+
+        let beat = db
+            .get_watch_heartbeat(Some("host-a"))
+            .unwrap()
+            .expect("row should exist after upsert");
+        assert_eq!(beat.host, "host-a");
+        assert_eq!(beat.pid, 1234);
+        assert_eq!(beat.version, "0.16.4");
+        assert_eq!(beat.repo_count, 3);
+        assert_eq!(beat.last_spawn_summary.as_deref(), Some("spawned 1"));
+
+        // Timestamp is an ISO-8601 string.
+        assert!(beat.updated_at.contains('T'));
+
+        // get with None should return the same row.
+        let any = db
+            .get_watch_heartbeat(None)
+            .unwrap()
+            .expect("any-host query");
+        assert_eq!(any.host, "host-a");
+    }
+
+    #[test]
+    fn upsert_watch_heartbeat_updates_existing_row() {
+        let db = test_db();
+
+        db.upsert_watch_heartbeat("host-b", 100, "0.1.0", 2, None)
+            .unwrap();
+        // Small sleep to ensure updated_at changes.
+        std::thread::sleep(std::time::Duration::from_millis(5));
+        db.upsert_watch_heartbeat("host-b", 200, "0.2.0", 5, Some("summary"))
+            .unwrap();
+
+        let beat = db
+            .get_watch_heartbeat(Some("host-b"))
+            .unwrap()
+            .expect("row");
+        assert_eq!(beat.pid, 200, "pid should be updated");
+        assert_eq!(beat.version, "0.2.0", "version should be updated");
+        assert_eq!(beat.repo_count, 5, "repo_count should be updated");
+        assert_eq!(beat.last_spawn_summary.as_deref(), Some("summary"));
+
+        // Only one row for this host (upsert is not insert).
+        let count: i64 = db
+            .conn
+            .query_row(
+                "SELECT COUNT(*) FROM watch_heartbeat WHERE host = 'host-b'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(count, 1, "upsert must not insert a duplicate row");
+    }
+
+    #[test]
+    fn get_watch_heartbeat_none_returns_latest_when_multiple_hosts() {
+        let db = test_db();
+
+        db.upsert_watch_heartbeat("host-x", 1, "0.1.0", 1, None)
+            .unwrap();
+        std::thread::sleep(std::time::Duration::from_millis(5));
+        db.upsert_watch_heartbeat("host-y", 2, "0.2.0", 2, None)
+            .unwrap();
+
+        // host-y was written last, so get(None) should return host-y.
+        let beat = db
+            .get_watch_heartbeat(None)
+            .unwrap()
+            .expect("row from multi-host table");
+        assert_eq!(
+            beat.host, "host-y",
+            "None should return the most recently updated host"
+        );
+    }
+
+    #[test]
+    fn recent_wake_attempts_returns_latest_first() {
+        let db = test_db();
+
+        // Seed three wake attempts with different updated_at values.
+        let now = chrono::Utc::now();
+        let ts1 = (now - chrono::Duration::minutes(10)).to_rfc3339();
+        let ts2 = (now - chrono::Duration::minutes(5)).to_rfc3339();
+        let ts3 = now.to_rfc3339();
+
+        for (id, ts) in [("att-a", &ts1), ("att-b", &ts2), ("att-c", &ts3)] {
+            db.conn
+                .execute(
+                    "INSERT INTO wake_attempts \
+                     (attempt_id, persona_id, repo_name, signal_ids, state, updated_at) \
+                     VALUES (?1, 'p', 'r', '[]', 'queued', ?2)",
+                    rusqlite::params![id, ts],
+                )
+                .unwrap();
+        }
+
+        let recent = db.recent_wake_attempts(2).unwrap();
+        assert_eq!(recent.len(), 2, "limit=2 returns 2 rows");
+        assert_eq!(recent[0].attempt_id, "att-c", "newest first");
+        assert_eq!(recent[1].attempt_id, "att-b");
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2148,6 +2148,28 @@ enum WatchAction {
         #[arg(long)]
         attempt_id: String,
     },
+
+    /// Show whether the watch daemon is alive, stale, or absent (#581).
+    ///
+    /// Reads the heartbeat row the daemon writes on each health tick and
+    /// prints one of:
+    ///   alive  -- beat is newer than two poll intervals
+    ///   stale  -- beat exists but is older than that threshold
+    ///   absent -- no heartbeat has ever been written
+    ///
+    /// Also prints the daemon version, watched repo count, and the most
+    /// recent wake attempts so the operator can verify the daemon is not
+    /// just alive but also doing work.
+    Status {
+        /// Number of recent wake attempts to show (default 5).
+        #[arg(long, default_value = "5")]
+        recent: u32,
+
+        /// Staleness threshold in seconds. A beat older than this is
+        /// reported as stale. Defaults to twice the poll interval (120s).
+        #[arg(long, default_value = "120")]
+        stale_after_secs: u64,
+    },
 }
 
 #[derive(Subcommand, Debug)]
@@ -3585,6 +3607,99 @@ fn no_index_found(repo: Option<&str>, lang: Option<&str>) {
         (None, None) => "(any repo)".to_string(),
     };
     eprintln!("[legion] no index found for {scope}; run `legion index <repo>` first");
+}
+
+/// Render the `legion watch status` output.
+///
+/// Classifies the watch daemon as alive, stale, or absent by comparing
+/// the heartbeat's `updated_at` against `now - stale_after_secs`. Also
+/// prints the daemon version, repo count, and recent wake attempts so
+/// the operator can confirm that the daemon is not just alive but working.
+fn run_watch_status(db: &db::Database, recent: u32, stale_after_secs: u64) -> error::Result<()> {
+    use std::io::Write;
+
+    let stdout = std::io::stdout();
+    let mut out = stdout.lock();
+
+    let beat = db.get_watch_heartbeat(None)?;
+
+    match beat {
+        None => {
+            writeln!(out, "status:  absent")?;
+            writeln!(
+                out,
+                "         no heartbeat row found -- daemon has never run or DB is fresh"
+            )?;
+        }
+        Some(ref hb) => {
+            let now = chrono::Utc::now();
+            let threshold = std::time::Duration::from_secs(stale_after_secs);
+
+            // Parse updated_at to compute age. If the timestamp is
+            // unparseable (should not happen in practice), treat it as
+            // stale so we fail safely visible.
+            let age_secs: i64 = chrono::DateTime::parse_from_rfc3339(&hb.updated_at)
+                .ok()
+                .map(|ts| (now - ts.with_timezone(&chrono::Utc)).num_seconds())
+                .unwrap_or(i64::MAX);
+
+            let is_alive = age_secs >= 0 && (age_secs as u64) < threshold.as_secs();
+
+            if is_alive {
+                writeln!(out, "status:  alive")?;
+            } else {
+                let age_display = if age_secs < 0 {
+                    "clock skew (future timestamp)".to_string()
+                } else if age_secs < 60 {
+                    format!("{age_secs}s ago")
+                } else if age_secs < 3600 {
+                    format!("{}m ago", age_secs / 60)
+                } else {
+                    format!("{}h ago", age_secs / 3600)
+                };
+                writeln!(out, "status:  stale  (last beat: {age_display})")?;
+            }
+
+            writeln!(out, "host:    {}", hb.host)?;
+            writeln!(out, "pid:     {}", hb.pid)?;
+            writeln!(out, "version: {}", hb.version)?;
+            writeln!(out, "repos:   {}", hb.repo_count)?;
+            writeln!(out, "beat:    {}", hb.updated_at)?;
+
+            if let Some(ref summary) = hb.last_spawn_summary {
+                writeln!(out, "last:    {summary}")?;
+            }
+        }
+    }
+
+    // Recent wake attempts.
+    let attempts = db.recent_wake_attempts(recent)?;
+    if attempts.is_empty() {
+        writeln!(out, "\nwake attempts: none recorded")?;
+    } else {
+        writeln!(out, "\nrecent wake attempts ({}):", attempts.len())?;
+        writeln!(
+            out,
+            "  {:<38} {:<12} {:<12} updated_at",
+            "attempt_id", "persona", "state"
+        )?;
+        for a in &attempts {
+            // Truncate attempt_id to first 8 chars of the UUID for brevity.
+            let id_short: String = a.attempt_id.chars().take(8).collect();
+            let persona_short: String = a.persona_id.chars().take(12).collect();
+            writeln!(
+                out,
+                "  {:<38} {:<12} {:<12} {}",
+                id_short,
+                persona_short,
+                a.state.as_str(),
+                db::format_date(&a.updated_at),
+            )?;
+        }
+    }
+
+    out.flush()?;
+    Ok(())
 }
 
 fn main() -> error::Result<()> {
@@ -6780,6 +6895,14 @@ fn run() -> error::Result<()> {
                     let db_path = base.join("legion.db");
                     let db = db::Database::open(&db_path)?;
                     watch::record_session_end(&db, &attempt_id, &base)?;
+                }
+                Some(WatchAction::Status {
+                    recent,
+                    stale_after_secs,
+                }) => {
+                    let db_path = base.join("legion.db");
+                    let db = db::Database::open(&db_path)?;
+                    run_watch_status(&db, recent, stale_after_secs)?;
                 }
             }
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3609,6 +3609,57 @@ fn no_index_found(repo: Option<&str>, lang: Option<&str>) {
     eprintln!("[legion] no index found for {scope}; run `legion index <repo>` first");
 }
 
+/// Liveness of a heartbeat row, factored out of [`run_watch_status`] so the
+/// alive/stale boundary is unit-testable without going through stdout or the
+/// wall clock. `Absent` (no row at all) is handled by the caller; this only
+/// classifies an existing beat's `updated_at`.
+#[derive(Debug, PartialEq, Eq)]
+enum BeatLiveness {
+    /// Beat is newer than the stale threshold.
+    Alive,
+    /// Beat is older than the threshold by `age_secs` seconds.
+    Stale { age_secs: i64 },
+    /// Beat timestamp is in the future relative to `now` (clock skew or an
+    /// unparseable timestamp coerced to `i64::MAX`). Treated as not-alive so
+    /// the failure is visible rather than silently passing as healthy.
+    ClockSkew { age_secs: i64 },
+}
+
+/// Classify a heartbeat's `updated_at` against `now` and the stale window.
+///
+/// An unparseable timestamp coerces to `i64::MAX` age, which lands in `Stale`
+/// -- a corrupt beat reads as dead, never alive.
+fn classify_beat(
+    updated_at: &str,
+    now: chrono::DateTime<chrono::Utc>,
+    stale_after_secs: u64,
+) -> BeatLiveness {
+    let age_secs: i64 = chrono::DateTime::parse_from_rfc3339(updated_at)
+        .ok()
+        .map(|ts| (now - ts.with_timezone(&chrono::Utc)).num_seconds())
+        .unwrap_or(i64::MAX);
+
+    if age_secs < 0 {
+        BeatLiveness::ClockSkew { age_secs }
+    } else if (age_secs as u64) < stale_after_secs {
+        BeatLiveness::Alive
+    } else {
+        BeatLiveness::Stale { age_secs }
+    }
+}
+
+/// Human-friendly age for a non-negative second count: `42s ago`, `5m ago`,
+/// `3h ago`.
+fn humanize_age(age_secs: i64) -> String {
+    if age_secs < 60 {
+        format!("{age_secs}s ago")
+    } else if age_secs < 3600 {
+        format!("{}m ago", age_secs / 60)
+    } else {
+        format!("{}h ago", age_secs / 3600)
+    }
+}
+
 /// Render the `legion watch status` output.
 ///
 /// Classifies the watch daemon as alive, stale, or absent by comparing
@@ -3633,31 +3684,23 @@ fn run_watch_status(db: &db::Database, recent: u32, stale_after_secs: u64) -> er
         }
         Some(ref hb) => {
             let now = chrono::Utc::now();
-            let threshold = std::time::Duration::from_secs(stale_after_secs);
-
-            // Parse updated_at to compute age. If the timestamp is
-            // unparseable (should not happen in practice), treat it as
-            // stale so we fail safely visible.
-            let age_secs: i64 = chrono::DateTime::parse_from_rfc3339(&hb.updated_at)
-                .ok()
-                .map(|ts| (now - ts.with_timezone(&chrono::Utc)).num_seconds())
-                .unwrap_or(i64::MAX);
-
-            let is_alive = age_secs >= 0 && (age_secs as u64) < threshold.as_secs();
-
-            if is_alive {
-                writeln!(out, "status:  alive")?;
-            } else {
-                let age_display = if age_secs < 0 {
-                    "clock skew (future timestamp)".to_string()
-                } else if age_secs < 60 {
-                    format!("{age_secs}s ago")
-                } else if age_secs < 3600 {
-                    format!("{}m ago", age_secs / 60)
-                } else {
-                    format!("{}h ago", age_secs / 3600)
-                };
-                writeln!(out, "status:  stale  (last beat: {age_display})")?;
+            match classify_beat(&hb.updated_at, now, stale_after_secs) {
+                BeatLiveness::Alive => {
+                    writeln!(out, "status:  alive")?;
+                }
+                BeatLiveness::ClockSkew { .. } => {
+                    writeln!(
+                        out,
+                        "status:  stale  (last beat: clock skew (future timestamp))"
+                    )?;
+                }
+                BeatLiveness::Stale { age_secs } => {
+                    writeln!(
+                        out,
+                        "status:  stale  (last beat: {})",
+                        humanize_age(age_secs)
+                    )?;
+                }
             }
 
             writeln!(out, "host:    {}", hb.host)?;
@@ -7979,5 +8022,58 @@ mod index_banner_tests {
             now,
         );
         assert!(banner.contains("1h ago"));
+    }
+}
+
+#[cfg(test)]
+mod watch_status_tests {
+    use super::*;
+    use chrono::{TimeZone, Utc};
+
+    fn now() -> chrono::DateTime<chrono::Utc> {
+        Utc.with_ymd_and_hms(2026, 5, 7, 12, 0, 0).unwrap()
+    }
+
+    #[test]
+    fn classify_beat_alive_within_threshold() {
+        // 20s old, 90s window -> alive.
+        let beat = "2026-05-07T11:59:40Z";
+        assert_eq!(classify_beat(beat, now(), 90), BeatLiveness::Alive);
+    }
+
+    #[test]
+    fn classify_beat_stale_past_threshold() {
+        // 5 minutes old, 90s window -> stale, age 300s.
+        let beat = "2026-05-07T11:55:00Z";
+        assert_eq!(
+            classify_beat(beat, now(), 90),
+            BeatLiveness::Stale { age_secs: 300 }
+        );
+    }
+
+    #[test]
+    fn classify_beat_future_timestamp_is_clock_skew() {
+        // 10s in the future -> clock skew, never alive.
+        let beat = "2026-05-07T12:00:10Z";
+        assert!(matches!(
+            classify_beat(beat, now(), 90),
+            BeatLiveness::ClockSkew { .. }
+        ));
+    }
+
+    #[test]
+    fn classify_beat_unparseable_reads_as_stale() {
+        // A corrupt beat must read as dead, never alive.
+        assert!(matches!(
+            classify_beat("not-a-timestamp", now(), 90),
+            BeatLiveness::Stale { .. }
+        ));
+    }
+
+    #[test]
+    fn humanize_age_picks_unit() {
+        assert_eq!(humanize_age(42), "42s ago");
+        assert_eq!(humanize_age(300), "5m ago");
+        assert_eq!(humanize_age(7200), "2h ago");
     }
 }


### PR DESCRIPTION
## Summary

The watch daemon only logged on spawn or error, so an idle daemon produced no output and read as wedged -- this session a healthy daemon was misdiagnosed from a frozen `daemon.log` and needlessly restarted. This change gives watch a persisted liveness heartbeat and an operator-facing `legion watch status` command, so "is watch alive?" is answerable in one command without reading raw logs or running `ps`. Migration 24 adds a `watch_heartbeat` table; the daemon upserts a beat each health tick; the new subcommand classifies the daemon and prints recent wake activity and the running version.

## Acceptance criteria mapping

### 1. `legion watch status` distinguishes alive / stale / absent and prints recent wakes + running version

The new `WatchAction::Status` subcommand (src/main.rs) opens the DB and calls `run_watch_status`, which reads the heartbeat via `Database::get_watch_heartbeat`. A missing row is reported as `absent` (the daemon never ran); an existing row is classified by `classify_beat`, a pure helper that compares the beat's `updated_at` against `now` and the stale window and returns `Alive`, `Stale { age_secs }`, or `ClockSkew`. A future-dated or unparseable timestamp deliberately lands in not-alive so a corrupt beat reads as dead rather than silently healthy. The command then prints the daemon's `version` field (the binary version captured at the time of the beat, which surfaces the daemon-vs-installed drift that confused this session), the watched repo count, and the last K rows from `wake_attempts` via `Database::recent_wake_attempts` (which reuses the existing `map_wake_attempt_row` mapper rather than re-rolling the row decode).
Evidence: `watch_status_tests::classify_beat_alive_within_threshold`, `classify_beat_stale_past_threshold`, `classify_beat_future_timestamp_is_clock_skew`, `classify_beat_unparseable_reads_as_stale` (src/main.rs); `db::tests::recent_wake_attempts_returns_latest_first`. Observed live: `./target/debug/legion watch status` printed `status: absent` plus the 5 most recent real wake attempts (including the smugglr wake probe `019eae4c`).

### 2. Heartbeat persisted each poll tick; periodic INFO liveness log line

`run_watch_task` (src/daemon.rs) upserts the heartbeat on every health tick through `Database::upsert_watch_heartbeat`, writing host, pid (`std::process::id()`), version (`env!("CARGO_PKG_VERSION")`), and repo count. The upsert is keyed on `host` (`ON CONFLICT(host) DO UPDATE`) so the row is a singleton per host and stale columns never accumulate. To prove liveness in the log without flooding a quiet daemon, an INFO line is emitted on a throttled cadence (`health_tick_count % HEARTBEAT_LOG_CADENCE == 1`, i.e. every 10th tick) rather than on every tick.
Evidence: `db::tests::upsert_and_get_watch_heartbeat_round_trips`, `db::tests::upsert_watch_heartbeat_updates_existing_row` (asserts the upsert updates in place and does not insert a duplicate row), `db::tests::get_watch_heartbeat_none_returns_latest_when_multiple_hosts`; heartbeat write + throttled log in src/daemon.rs `run_watch_task`.

### 3. All tests pass; simplify + review done; PR linked

`cargo test` is green (917 bin unit tests + 156 integration, 0 failed), `cargo clippy -- -D warnings` clean, `cargo fmt -- --check` clean. The simplify gate was recorded clean for HEAD (`legion quality-gate record`, gate `019eaecd`). This PR references and closes #581; automated `/review-pr` and team review follow on the open PR per the workflow.
Evidence: gate row `019eaecd-ff03-7290-ab19-6ba913eb10a3`; test run output (917 passed / 0 failed bin, 156 passed / 0 failed integration).

## Not done

Auto-restart of the daemon when the installed binary is upgraded is out of scope (issue notes it as a possible follow-up); `legion watch status` surfaces the running version so the drift is visible, but acting on it is not implemented here. Broadcast and verb-gate changes are tracked separately (#585, #586). The heartbeat is written on the health-tick cadence rather than literally every 1s poll iteration -- the health tick is the daemon's existing periodic seam and the 120s default stale threshold (twice that cadence) is set accordingly.