### PR TITLE
fix(#583): write interactive session lock to close awake-detection gap

### DIFF
--- a/plugin/hooks/session-start.sh
+++ b/plugin/hooks/session-start.sh
@@ -44,6 +44,12 @@ rm -f "/tmp/legion-work-${CWD_HASH}" 2>/dev/null
 # the curl probe or the legion serve spawn handshake.
 (bash "${CLAUDE_PLUGIN_ROOT}/hooks/_legion-daemon-supervisor.sh" >/dev/null 2>&1 < /dev/null &)
 
+# Write an interactive-session lock so watch does not spawn a duplicate
+# agent while this session is open (#583). $PPID is the Claude session
+# process -- the long-lived pid the lock must track. Non-blocking; never
+# allowed to add latency or fail the hook.
+("$LEGION" watch session-start --repo "$REPO" --pid "$PPID" >/dev/null 2>&1 &)
+
 # Sync GitHub issues into kanban (5-second timeout, opt-out via LEGION_NO_SYNC=1)
 if [ "${LEGION_NO_SYNC:-}" != "1" ]; then
   if command -v gtimeout >/dev/null 2>&1; then

--- a/src/main.rs
+++ b/src/main.rs
@@ -2138,6 +2138,25 @@ enum WatchAction {
         action: LeaseAction,
     },
 
+    /// Record an interactive (human-started) session lock for a repo (#583).
+    ///
+    /// Called from the SessionStart hook with the Claude session PID so watch
+    /// does not spawn a duplicate agent while an interactive session is open.
+    /// Uses a separate `.session` lock file; the gate is PID-liveness alone
+    /// (no TTL) because an idle interactive session must still hold the gate.
+    /// Non-fatal and fast -- hook failure never blocks Claude Code startup.
+    SessionStart {
+        /// Repo name to lock (basename of the working directory).
+        #[arg(long)]
+        repo: String,
+
+        /// PID of the interactive session process to track. When omitted,
+        /// falls back to the current process id -- prefer supplying $PPID
+        /// from the hook so the tracked pid is the long-lived session process.
+        #[arg(long)]
+        pid: Option<u32>,
+    },
+
     /// Optimistic stop-hook handoff for the watch reaper (#493). Writes
     /// `exit_observed_at` on the wake_attempts row so the reaper can
     /// skip a poll cycle. PTY EOF + PID-poll remain authoritative; this
@@ -6932,6 +6951,22 @@ fn run() -> error::Result<()> {
                                 );
                             }
                         }
+                    }
+                }
+                Some(WatchAction::SessionStart { repo, pid }) => {
+                    let effective_pid: u32 = pid.unwrap_or_else(std::process::id);
+                    // TTL only affects the `.lock` gate; the `.session` file is
+                    // PID-liveness only. Using the default avoids reading watch.toml
+                    // on every SessionStart hook call (matches record_session_end).
+                    let locks = watch::SessionLockTracker::new(
+                        &base,
+                        watch::default_session_lock_ttl_secs(),
+                    );
+                    if let Err(e) = locks.record_interactive(&repo, effective_pid) {
+                        eprintln!(
+                            "[legion watch] session-start: failed to write interactive lock for {}: {}",
+                            repo, e
+                        );
                     }
                 }
                 Some(WatchAction::SessionEnd { attempt_id }) => {

--- a/src/watch.rs
+++ b/src/watch.rs
@@ -252,7 +252,12 @@ fn default_retention_days() -> u64 {
     7
 }
 
-fn default_session_lock_ttl_secs() -> u64 {
+/// Default TTL for the watch-spawn `.lock` files.
+///
+/// Exposed so callers that construct `SessionLockTracker` outside of the
+/// watch daemon (e.g. `legion watch session-start`) can use the same
+/// default without reading watch.toml.
+pub fn default_session_lock_ttl_secs() -> u64 {
     3600
 }
 
@@ -586,22 +591,65 @@ impl SessionLockTracker {
         self.lock_dir.join(format!("{}.lock", repo))
     }
 
-    /// Returns the holding PID when a prior spawn's lockfile is still considered
-    /// live (fresh mtime AND a running PID). Returns `None` on any parse error,
-    /// missing file, or staleness -- callers can safely proceed to spawn in all
-    /// `None` cases. The PID is surfaced so skip-log messages can identify the
-    /// session holding the gate.
+    /// Path for the interactive-session lock file.
+    ///
+    /// Distinct from the TTL-gated `.lock` path used by watch-spawned children.
+    /// Interactive sessions write their pid here; the gate is PID-liveness alone
+    /// (no TTL) because an idle-but-open interactive session must still hold the
+    /// gate -- a live process IS the authoritative signal.
+    fn session_path(&self, repo: &str) -> PathBuf {
+        self.lock_dir.join(format!("{}.session", repo))
+    }
+
+    /// Returns the holding PID when any live session (watch-spawned or interactive)
+    /// holds the gate. Returns `None` when no live holder exists in either lock
+    /// file; callers can safely spawn in all `None` cases.
+    ///
+    /// Two independent sources are checked:
+    ///
+    /// 1. `<repo>.lock` -- watch-spawned children. Held when BOTH mtime is within
+    ///    `ttl` AND the PID is alive. The TTL guards against PID-reuse on
+    ///    un-released locks from crashed spawns.
+    ///
+    /// 2. `<repo>.session` -- interactive (human-started) sessions. Held when
+    ///    the PID is alive, regardless of mtime. No TTL is applied because a
+    ///    live interactive session may be idle for hours and must still gate.
+    ///    When the PID is dead the stale file is deleted opportunistically.
+    ///
+    /// The `.lock` holder is preferred when both sources report a live pid.
+    /// The existing `.lock` mtime-TTL semantics are unchanged.
     pub fn active_pid(&self, repo: &str) -> Option<u32> {
-        let path = self.lock_path(repo);
-        let meta = std::fs::metadata(&path).ok()?;
-        let mtime = meta.modified().ok()?;
-        let age = mtime.elapsed().unwrap_or(Duration::ZERO);
-        if age > self.ttl {
-            return None;
-        }
-        let contents = std::fs::read_to_string(&path).ok()?;
-        let pid = contents.trim().parse::<u32>().ok()?;
-        if process_alive(pid) { Some(pid) } else { None }
+        // -- .lock path (watch-spawned; TTL-gated) ----------------------------
+        let lock_pid: Option<u32> = (|| {
+            let path = self.lock_path(repo);
+            let meta = std::fs::metadata(&path).ok()?;
+            let mtime = meta.modified().ok()?;
+            let age = mtime.elapsed().unwrap_or(Duration::ZERO);
+            if age > self.ttl {
+                return None;
+            }
+            let contents = std::fs::read_to_string(&path).ok()?;
+            let pid = contents.trim().parse::<u32>().ok()?;
+            if process_alive(pid) { Some(pid) } else { None }
+        })();
+
+        // -- .session path (interactive; PID-liveness only) -------------------
+        let session_pid: Option<u32> = (|| {
+            let path = self.session_path(repo);
+            let contents = std::fs::read_to_string(&path).ok()?;
+            let pid = contents.trim().parse::<u32>().ok()?;
+            if process_alive(pid) {
+                Some(pid)
+            } else {
+                // Opportunistically clean up the stale file so it does not
+                // accumulate after the interactive session exits.
+                let _ = std::fs::remove_file(&path);
+                None
+            }
+        })();
+
+        // Prefer .lock if both are held; fall back to .session.
+        lock_pid.or(session_pid)
     }
 
     /// Write or overwrite the lockfile for `repo` with `pid`. Creates the
@@ -611,6 +659,36 @@ impl SessionLockTracker {
         std::fs::create_dir_all(&self.lock_dir)?;
         std::fs::write(self.lock_path(repo), pid.to_string())?;
         Ok(())
+    }
+
+    /// Write or overwrite the interactive-session lock for `repo` with `pid`.
+    ///
+    /// Called from the `legion watch session-start` subcommand, which the
+    /// SessionStart hook invokes with `$PPID` (the Claude session process).
+    /// Unlike `record_spawn`, there is no TTL -- `active_pid` checks the
+    /// written PID for liveness directly, so the lock is released only when
+    /// the process exits (or when `release_interactive` is called explicitly).
+    pub fn record_interactive(&self, repo: &str, pid: u32) -> Result<()> {
+        std::fs::create_dir_all(&self.lock_dir)?;
+        std::fs::write(self.session_path(repo), pid.to_string())?;
+        Ok(())
+    }
+
+    /// Delete the interactive-session lock for `repo`.
+    ///
+    /// Idempotent: a missing file is not an error. Removes only the
+    /// `.session` file; the `.lock` file (watch-spawned) is untouched.
+    ///
+    /// Available for explicit cleanup; the passive path is `active_pid`
+    /// deleting stale files opportunistically when it reads a dead PID.
+    #[allow(dead_code)] // public API completion -- no production call site yet
+    pub fn release_interactive(&self, repo: &str) -> Result<()> {
+        let path = self.session_path(repo);
+        match std::fs::remove_file(&path) {
+            Ok(()) => Ok(()),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(e) => Err(LegionError::Io(e)),
+        }
     }
 
     /// Delete the lockfile for `repo`, freeing the per-repo wake gate so
@@ -2575,6 +2653,132 @@ workdir = "/tmp"
             result.is_ok(),
             "release of a missing lockfile must return Ok, got {:?}",
             result
+        );
+    }
+
+    // -- record_interactive / release_interactive / active_pid (.session) ----
+
+    /// A .session file written with the test process's (live) PID makes
+    /// active_pid return Some, even with no .lock file present.
+    #[cfg(unix)]
+    #[test]
+    fn interactive_lock_active_for_live_pid() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let locks = SessionLockTracker::new(dir.path(), 3600);
+        locks
+            .record_interactive("myrepo", std::process::id())
+            .expect("record_interactive");
+        let held = locks.active_pid("myrepo");
+        assert!(
+            held.is_some(),
+            "a .session with a live pid must make active_pid return Some"
+        );
+        assert_eq!(
+            held,
+            Some(std::process::id()),
+            "active_pid must return the pid from the .session file"
+        );
+    }
+
+    /// A .session file with a dead PID returns None.
+    #[test]
+    fn interactive_lock_inactive_for_dead_pid() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let locks = SessionLockTracker::new(dir.path(), 3600);
+        locks
+            .record_interactive("myrepo", dead_pid())
+            .expect("record_interactive");
+        assert!(
+            locks.active_pid("myrepo").is_none(),
+            "a .session with a dead pid must return None"
+        );
+    }
+
+    /// A .session with a live PID gates even when mtime is not fresh (no TTL
+    /// applied). This is the key property: an idle interactive session must
+    /// still hold the gate regardless of how old the file is.
+    /// We cannot easily age the mtime in a test, so we assert that a freshly
+    /// written .session with a live pid -- and no .lock file present -- gates.
+    /// The absence of a TTL check in active_pid for the .session path is the
+    /// structural guarantee; this test confirms the live-pid gate works.
+    #[cfg(unix)]
+    #[test]
+    fn interactive_lock_gates_without_lock_file() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        // TTL=1s so any .lock would expire quickly; .session must still hold.
+        let locks = SessionLockTracker::new(dir.path(), 1);
+        locks
+            .record_interactive("myrepo", std::process::id())
+            .expect("record_interactive");
+        // No .lock file written; gate must still be held via .session alone.
+        assert!(
+            locks.active_pid("myrepo").is_some(),
+            "live .session with no .lock must still gate (no TTL on .session)"
+        );
+    }
+
+    /// release_interactive removes only the .session file; the .lock is untouched.
+    #[cfg(unix)]
+    #[test]
+    fn interactive_lock_release_removes_only_session_file() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let locks = SessionLockTracker::new(dir.path(), 3600);
+        // Write both a .lock and a .session for the same repo.
+        locks
+            .record_spawn("myrepo", std::process::id())
+            .expect("record_spawn");
+        locks
+            .record_interactive("myrepo", std::process::id())
+            .expect("record_interactive");
+        assert!(
+            locks.active_pid("myrepo").is_some(),
+            "precondition: both locks active"
+        );
+
+        // release_interactive only.
+        locks
+            .release_interactive("myrepo")
+            .expect("release_interactive");
+
+        // The .lock must still hold the gate.
+        assert!(
+            locks.active_pid("myrepo").is_some(),
+            ".lock must still gate after release_interactive"
+        );
+
+        // The .session file must be gone.
+        assert!(
+            !locks.session_path("myrepo").exists(),
+            ".session file must be deleted by release_interactive"
+        );
+    }
+
+    /// release_interactive on a missing .session file is idempotent.
+    #[test]
+    fn interactive_lock_release_of_missing_session_is_ok() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let locks = SessionLockTracker::new(dir.path(), 3600);
+        let result = locks.release_interactive("nonexistent-repo");
+        assert!(
+            result.is_ok(),
+            "release_interactive on missing .session must return Ok, got {:?}",
+            result
+        );
+    }
+
+    /// Coexistence: a live .lock and no .session still gates (existing behavior
+    /// preserved by the refactored active_pid).
+    #[cfg(unix)]
+    #[test]
+    fn lock_file_alone_still_gates_after_active_pid_refactor() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let locks = SessionLockTracker::new(dir.path(), 3600);
+        locks
+            .record_spawn("myrepo", std::process::id())
+            .expect("record_spawn");
+        assert!(
+            locks.active_pid("myrepo").is_some(),
+            "a live .lock with no .session must still gate (existing semantics preserved)"
         );
     }
 


### PR DESCRIPTION
## Summary

The watch daemon decides whether to spawn an agent for a repo by reading a per-repo session lock, but only watch-spawned children ever wrote that lock (`record_spawn`). A human-started interactive session was therefore invisible to watch, which would spawn a duplicate agent on top of it (the #406 write-side gap). This change lets an interactive session register itself at SessionStart via a separate `.session` lock gated on PID-liveness alone, so a live operator session holds the wake gate without a duplicate spawn. The existing TTL-gated `.lock` path for watch-spawned children is preserved unchanged.

## Acceptance criteria mapping

### 1. Interactive session in a watched repo prevents a duplicate watch spawn

A new `SessionLockTracker::record_interactive` writes the session PID to `<data_dir>/sessions/<repo>.session`, and `active_pid` now reports the repo as held if EITHER the existing `.lock` is live (mtime within TTL and PID alive) OR the `.session` PID is alive. The `.session` path deliberately applies no TTL: an interactive session can sit idle for hours (longer than the 1h lock TTL) and must still gate, and there is no reliable session-end hook (Stop fires per turn), so a live PID is the authoritative signal -- a live process holds the gate, and the conservative failure mode is a missed wake, never a wrong one. Registration is wired into the SessionStart hook as a backgrounded `legion watch session-start --repo "$REPO" --pid "$PPID"` call (`$PPID` is the long-lived Claude session process), so it adds no latency and cannot fail the hook.
Evidence: `watch::tests::interactive_lock_active_for_live_pid`, `interactive_lock_gates_without_lock_file` (a live `.session` gates with no `.lock` present); the new `WatchAction::SessionStart` arm in src/main.rs; the hook line in plugin/hooks/session-start.sh.

### 2. Dead-PID locks self-heal

`active_pid` returns `None` for a `.session` whose PID is dead, and additionally deletes the stale file opportunistically on that read, so a session that exited never holds the gate and its lock does not accumulate. The existing `.lock` dead-PID self-heal (PID-alive check via `process_alive`) is unchanged, and `release_interactive` provides explicit cleanup that removes only the `.session` file.
Evidence: `watch::tests::interactive_lock_inactive_for_dead_pid`, `interactive_lock_release_removes_only_session_file`, `interactive_lock_release_of_missing_session_is_ok`, `session_lock_release_clears_active_pid`.

### 3. All tests pass; simplify + review done; PR linked

`cargo test` green (923 bin unit tests + 156 integration, 0 failed), `cargo clippy -- -D warnings` clean, `cargo fmt -- --check` clean. The `active_pid` refactor preserves the existing `.lock` logic byte-for-byte (it is wrapped verbatim in a closure), confirmed by `lock_file_alone_still_gates_after_active_pid_refactor`. The simplify gate is recorded clean for HEAD. This PR references and closes #583 and extends #406; `/review-pr` and team review follow on the open PR per the batched-review plan.
Evidence: simplify gate row `019eaf17-a61e-7842-997f-0f76e114b50f`; test output (923 + 156 passed, 0 failed); regression-guard test `lock_file_alone_still_gates_after_active_pid_refactor`.

## Not done

This relies on the SessionStart hook's `$PPID` being the long-lived Claude session process; if a given harness wraps the hook in a transient shell, the tracked PID could be short-lived and the lock would self-clear early -- acceptable because the failure mode is a missed gate (a possible duplicate spawn), never a wrong wake, and it self-heals. No periodic refresh is added (the PID-liveness gate makes mtime irrelevant for `.session`, so none is needed). No changes to the wake decision, broadcast routing, or verb gate (separate issues). This branch is based on main and does not include the unmerged #582 loop unification; the two touch different regions of watch.rs and merge independently.