### PR TITLE
fix(#584): stop the SubagentStop re-fire loop (loop guard + idempotency)

### DIFF
--- a/plugin/hooks/subagent-stop.sh
+++ b/plugin/hooks/subagent-stop.sh
@@ -33,6 +33,30 @@ if [ ! -x "$LEGION_BIN" ]; then
   exit 0
 fi
 
+# Loop guard + idempotency (#584). The additionalContext emitted below
+# continues the parent turn; without a guard a re-delivered SubagentStop event
+# re-reflects and re-injects context, looping and burning tokens (observed 3x,
+# ~337k tokens on one spurious fire). Two guards, mirroring stop.sh:
+#   1. stop_hook_active -- skip a continuation we ourselves caused.
+#   2. A per-event marker keyed on the subagent identity (its transcript path,
+#      else session_id + agent_type) so each subagent stop is processed once.
+STOP_ACTIVE=$(echo "$INPUT" | jq -r '.stop_hook_active // false' 2>/dev/null)
+if [ "$STOP_ACTIVE" = "true" ]; then
+  exit 0
+fi
+
+SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // empty' 2>/dev/null)
+DEDUP_SRC="${TRANSCRIPT:-${SESSION_ID}:${AGENT_TYPE}}"
+DEDUP_KEY=$(echo "$DEDUP_SRC" | md5 -q 2>/dev/null || echo "$DEDUP_SRC" | md5sum 2>/dev/null | cut -d' ' -f1)
+MARKER="${TMPDIR:-/tmp}/legion-subagent-stop-${DEDUP_KEY}"
+if [ -f "$MARKER" ]; then
+  # Already processed this subagent stop. Re-reflecting and re-injecting
+  # additionalContext is exactly what loops, so pass through silently.
+  exit 0
+fi
+# Claim the event before doing work so a fast re-delivery cannot double-fire.
+: > "$MARKER" 2>/dev/null || true
+
 # Scrape the subagent's final output from its transcript tail. Same extraction
 # shape as precompact.sh, with the alternate-format fallback. Bounded to the
 # last ~1500 chars to keep the reflection (and this hook) small.

--- a/plugin/hooks/test-subagent-stop.sh
+++ b/plugin/hooks/test-subagent-stop.sh
@@ -48,6 +48,10 @@ assert_empty() {
 WORK=$(mktemp -d)
 trap 'rm -rf "$WORK"' EXIT
 
+# Route the hook's dedup markers (#584) into $WORK so they are cleaned on EXIT
+# and cannot leak across test runs in the real /tmp.
+export TMPDIR="$WORK"
+
 mkdir -p "$WORK/plugin/bin" "$WORK/plugin/hooks"
 cp plugin/hooks/subagent-stop.sh "$WORK/plugin/hooks/"
 
@@ -99,6 +103,29 @@ echo "==> missing legion binary: exit 0, no output"
 out=$(echo "{\"cwd\":\"${CWD}\",\"agent_type\":\"Explore\",\"agent_transcript_path\":\"${TRANSCRIPT}\"}" \
   | CLAUDE_PLUGIN_ROOT="/no/such/plugin" bash "$HOOK")
 assert_empty "missing binary produces no output" "$out"
+
+echo "==> re-delivered SubagentStop is deduped: second fire silent, no double reflect (#584)"
+DEDUP_TRANSCRIPT="$WORK/dedup-transcript.jsonl"
+echo '{"type":"assistant","message":{"content":[{"type":"text","text":"Deduped subagent run summary."}]}}' > "$DEDUP_TRANSCRIPT"
+: > "$STUB_LOG"
+dedup_in="{\"cwd\":\"${CWD}\",\"agent_type\":\"Explore\",\"agent_transcript_path\":\"${DEDUP_TRANSCRIPT}\",\"session_id\":\"sess-1\"}"
+out1=$(echo "$dedup_in" | LEGION_STUB_LOG="$STUB_LOG" bash "$HOOK")
+out2=$(echo "$dedup_in" | LEGION_STUB_LOG="$STUB_LOG" bash "$HOOK")
+assert_contains "first fire informs the parent" "$out1" '"hookEventName": "SubagentStop"'
+assert_empty "second (re-delivered) fire is silent" "$out2"
+reflect_count=$(grep -c 'reflect' "$STUB_LOG" 2>/dev/null || echo 0)
+if [ "$reflect_count" = "1" ]; then
+  PASS=$((PASS + 1)); echo "  PASS: reflect called exactly once across two fires"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: reflect called $reflect_count times, expected 1" >&2
+fi
+
+echo "==> stop_hook_active=true short-circuits (loop guard, #584)"
+: > "$STUB_LOG"
+out=$(echo "{\"cwd\":\"${CWD}\",\"agent_type\":\"Explore\",\"agent_transcript_path\":\"${WORK}/guard.jsonl\",\"stop_hook_active\":true}" \
+  | LEGION_STUB_LOG="$STUB_LOG" bash "$HOOK")
+assert_empty "stop_hook_active produces no output" "$out"
+assert_not_contains "no reflect when stop_hook_active" "$(cat "$STUB_LOG")" 'reflect'
 
 echo
 echo "==> $PASS passed, $FAIL failed"


### PR DESCRIPTION
## Summary

The SubagentStop hook (added in #570) persisted a checkpoint reflection and emitted `hookSpecificOutput.additionalContext` on every delivery of a SubagentStop event. Because that `additionalContext` continues the parent turn, a re-delivered SubagentStop event re-reflected and re-injected context, looping and burning tokens -- observed this session firing 3 times with no new input, ~337k tokens on one spurious fire. This change gives the hook the same two guards `stop.sh` already has: a `stop_hook_active` loop-guard and a per-event idempotency marker, so each subagent stop is processed exactly once and a re-delivered event passes through silently.

## Acceptance criteria mapping

### 1. A subagent stop produces exactly one checkpoint + notify

Before doing any work the hook now derives a dedup key from the subagent's identity -- its `agent_transcript_path` when present, otherwise `session_id:agent_type` -- hashes it, and claims a marker file (`$TMPDIR/legion-subagent-stop-<key>`). If the marker already exists the hook exits 0 immediately, before the reflect and before emitting `additionalContext`. The marker is claimed (`: > "$MARKER"`) before the reflect runs, so even a fast re-delivery cannot slip a second fire through. The first fire still reflects and informs the parent exactly as before.
Evidence: `test-subagent-stop.sh` -> "reflect called exactly once across two fires" (two identical fires, `grep -c reflect` on the stub log == 1) and "second (re-delivered) fire is silent" (empty stdout, so no `additionalContext`).

### 2. No re-fire over several minutes with no new subagent activity

The loop was driven by `additionalContext` continuing the parent turn on each re-delivery. Suppressing both the reflect and the `additionalContext` on any delivery after the first breaks that continuation: a re-delivered event produces empty output, so there is nothing to continue the parent turn and nothing to re-trigger. The `stop_hook_active` short-circuit additionally drops any continuation the hook itself caused, the same loop-guard `stop.sh` relies on.
Evidence: `test-subagent-stop.sh` -> "second (re-delivered) fire is silent" and "stop_hook_active produces no output" / "no reflect when stop_hook_active".

### 3. No spurious token burn

The token burn was the repeated `additionalContext` injection (each continuation re-primed the parent). With at-most-once processing per subagent stop, only the first fire emits context; subsequent deliveries cost a marker stat and an exit 0. No reflect, no context, no continuation.
Evidence: the dedup + loop-guard tests above; the hook exits 0 on the marker-hit path before any `legion` invocation.

### 4. All tests pass; simplify + review done; PR linked

The hook test suite passes 15/15 (the 6 pre-existing cases plus the 3 new #584 cases), `shellcheck` is clean on both the hook and its test, and there are no Rust changes so `cargo` gates are unaffected. The test routes `TMPDIR` into its workdir so markers cannot leak across runs. The simplify gate is recorded clean for HEAD. This PR references and closes #584 (the re-fire bug in the #575/#570 hook); `/review-pr` and team review follow on the open PR per the batched-review plan.
Evidence: `bash plugin/hooks/test-subagent-stop.sh` -> "15 passed, 0 failed"; simplify gate row `019eaf1b-3084-7ee0-b48e-44d7e1715f70`.

## Not done

The fallback dedup key (`session_id:agent_type`, used only when a subagent has no transcript path) would collide if the same parent ran two transcript-less subagents of the same type in one session, suppressing the parent notice for the second -- accepted because subagents normally have a transcript path (the primary key is unique per invocation) and the failure mode is a missed one-line pointer, never a wrong action or a loop. Marker files are 0-byte and left in `$TMPDIR`; no periodic cleanup is added here (the markers are negligible and the SessionStart hook's existing /tmp marker hygiene can absorb them later). No changes to what the hook reflects or to the parent-pointer text.