### PR TITLE
feat(#585): broadcast wake -- broadcast_tags + Recipient + collision guard

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -2264,74 +2264,138 @@ impl Database {
 
     /// Find unhandled signals directed at a specific repo.
     ///
-    /// Returns team posts that mention `@<repo_name>` (at start or mid-text)
-    /// or `@all` that have not been handled by this specific repo yet.
-    /// Uses the `watch_handled` table for per-repo tracking, so @all
-    /// broadcasts wake each repo exactly once.
+    /// `names` is the full addressable name set for this repo: the repo's
+    /// `recipient()` value plus any `broadcast_tags`. A signal is returned
+    /// when its text starts with (or contains mid-string) `@<name>` for any
+    /// name in `names`, OR when it starts with `@all` / `@everyone`.
+    ///
+    /// Uses the `watch_handled` table for per-repo dedup keyed on `repo_name`
+    /// (not on recipient or tags), so `@all` / `@everyone` broadcasts wake
+    /// each repo exactly once, and a tag-addressed signal wakes each tagged
+    /// repo exactly once. `repo_name` is also the self-signal exclusion key.
+    ///
+    /// When `names` is empty the function returns an empty vec (nothing to
+    /// match). When `names` has one entry it matches only that name plus the
+    /// reserved broadcasts, preserving backward-compatible behavior.
     pub fn get_unhandled_signals_for_repo(
         &self,
         repo_name: &str,
-        recipient: &str,
+        names: &[String],
         since: Option<&str>,
     ) -> Result<Vec<Reflection>> {
-        // `recipient` drives the @mention pattern matching (this is the agent name
-        // when configured, otherwise the repo name). `repo_name` is the stable key
-        // for the watch_handled table and for self-signal exclusion -- signals are
-        // stored by their source repo, not by any agent override.
-        let pattern_start = format!("@{} %", recipient);
-        let pattern_mid = format!("%@{} %", recipient);
-        let pattern_all_start = "@all %";
-        let pattern_all_mid = "%@all %";
+        if names.is_empty() {
+            return Ok(Vec::new());
+        }
+
         let now = Utc::now().to_rfc3339();
-        // Decay (#376): wake-loop must never deliver a stale signal. Without
-        // this filter, a multi-day-dormant agent wakes to month-old @<me>
-        // mentions and posts replies into long-dead threads.
+
+        // Build LIKE patterns for every addressable name plus the reserved
+        // broadcast aliases. Parameters are bound positionally, so we
+        // pre-compute the full set before building the SQL.
+        //
+        // Reserved pattern slots (always present, param-indexed from 1):
+        //   1: "@all %"
+        //   2: "%@all %"
+        //   3: "@everyone %"
+        //   4: "%@everyone %"
+        //
+        // Per-name slots (two per name, starting at param 5):
+        //   5k-4: "@<name> %"
+        //   5k-3: "%@<name> %"
+        //   ...
+        //
+        // Fixed trailing params:
+        //   repo_name (for watch_handled join + self-exclusion)
+        //   now       (for expires_at > now)
+        //   since_ts  (optional, last)
+
+        // Build the dynamic name OR clauses. Each name contributes two LIKE
+        // patterns: one anchored at the start ("@name ...") and one mid-text
+        // ("%@name ..."). The param indices start at 5 (1-4 are the reserved
+        // @all / @everyone patterns).
+        let mut name_clauses: Vec<String> = Vec::with_capacity(names.len() * 2);
+        for (i, _) in names.iter().enumerate() {
+            // Each name occupies two consecutive parameter slots: 2*(i+2)+1 and 2*(i+2)+2.
+            // With 4 reserved slots (params 1-4), name[0] uses params 5,6;
+            // name[1] uses 7,8; etc.
+            let p_start = 5 + i * 2;
+            let p_mid = 6 + i * 2;
+            name_clauses.push(format!(
+                "r.text LIKE ?{} OR r.text LIKE ?{}",
+                p_start, p_mid
+            ));
+        }
+
+        // The last two fixed params follow all name params.
+        let n_name_params = names.len() * 2;
+        let p_repo = 5 + n_name_params; // repo_name
+        let p_now = 6 + n_name_params; // now (expires_at check)
+        let p_since = 7 + n_name_params; // since_ts (optional)
+
         let since_clause = if since.is_some() {
-            " AND r.created_at > ?7"
+            format!(" AND r.created_at > ?{}", p_since)
         } else {
-            ""
+            String::new()
         };
+
+        // Assemble the WHERE text fragment: reserved broadcasts + per-name.
+        let text_filter = {
+            let mut parts: Vec<String> = vec![
+                "r.text LIKE ?1".to_string(),
+                "r.text LIKE ?2".to_string(),
+                "r.text LIKE ?3".to_string(),
+                "r.text LIKE ?4".to_string(),
+            ];
+            parts.extend(name_clauses);
+            parts.join(" OR ")
+        };
+
         let query = format!(
             "SELECT r.id, r.repo, r.text, r.created_at, r.updated_at, r.audience, r.domain, r.tags, \
              r.recall_count, r.last_recalled_at, r.parent_id \
              FROM reflections r \
-             LEFT JOIN watch_handled wh ON wh.signal_id = r.id AND wh.repo_name = ?5 \
+             LEFT JOIN watch_handled wh ON wh.signal_id = r.id AND wh.repo_name = ?{repo_param} \
              WHERE r.audience = 'team' AND r.deleted_at IS NULL \
-               AND (r.evergreen = 1 OR r.expires_at > ?6) \
+               AND (r.evergreen = 1 OR r.expires_at > ?{now_param}) \
                AND r.resolved_at IS NULL \
                AND wh.signal_id IS NULL \
-               AND (r.text LIKE ?1 OR r.text LIKE ?2 OR r.text LIKE ?3 OR r.text LIKE ?4) \
-               AND r.repo != ?5{} \
+               AND ({text_filter}) \
+               AND r.repo != ?{repo_param}{since_clause} \
              ORDER BY r.created_at ASC",
-            since_clause
+            repo_param = p_repo,
+            now_param = p_now,
+            text_filter = text_filter,
+            since_clause = since_clause,
         );
+
         let mut stmt = self.conn.prepare(&query)?;
-        let rows = if let Some(since_ts) = since {
-            stmt.query_map(
-                rusqlite::params![
-                    &pattern_start,
-                    &pattern_mid,
-                    pattern_all_start,
-                    pattern_all_mid,
-                    repo_name,
-                    &now,
-                    since_ts
-                ],
-                map_reflection_row,
-            )?
-        } else {
-            stmt.query_map(
-                rusqlite::params![
-                    &pattern_start,
-                    &pattern_mid,
-                    pattern_all_start,
-                    pattern_all_mid,
-                    repo_name,
-                    &now
-                ],
-                map_reflection_row,
-            )?
-        };
+
+        // Bind params in slot order: reserved broadcasts, then per-name pairs,
+        // then repo_name, now, and optionally since_ts.
+        use rusqlite::types::ToSql;
+        // Slots 1-4: reserved broadcasts. Per-name slots follow (two per name),
+        // then repo_name and now as fixed trailing params.
+        let mut params: Vec<Box<dyn ToSql>> = vec![
+            Box::new("@all %".to_string()),
+            Box::new("%@all %".to_string()),
+            Box::new("@everyone %".to_string()),
+            Box::new("%@everyone %".to_string()),
+        ];
+        for name in names {
+            params.push(Box::new(format!("@{} %", name)));
+            params.push(Box::new(format!("%@{} %", name)));
+        }
+        params.push(Box::new(repo_name.to_string()));
+        params.push(Box::new(now));
+
+        // Optional since_ts.
+        let since_owned: Option<String> = since.map(str::to_string);
+        if let Some(ref ts) = since_owned {
+            params.push(Box::new(ts.clone()));
+        }
+
+        let param_refs: Vec<&dyn ToSql> = params.iter().map(|p| p.as_ref()).collect();
+        let rows = stmt.query_map(param_refs.as_slice(), map_reflection_row)?;
         rows.collect::<std::result::Result<Vec<_>, _>>()
             .map_err(LegionError::Database)
     }
@@ -7674,7 +7738,7 @@ mod tests {
             )
             .unwrap();
         let signals = db
-            .get_unhandled_signals_for_repo("kessel", "kessel", None)
+            .get_unhandled_signals_for_repo("kessel", &["kessel".to_string()], None)
             .unwrap();
         assert!(
             signals.is_empty(),
@@ -7803,7 +7867,7 @@ mod tests {
             .unwrap();
         db.resolve_post(&r.id, None).unwrap();
         let signals = db
-            .get_unhandled_signals_for_repo("kessel", "kessel", None)
+            .get_unhandled_signals_for_repo("kessel", &["kessel".to_string()], None)
             .unwrap();
         assert!(
             signals.is_empty(),

--- a/src/error.rs
+++ b/src/error.rs
@@ -80,6 +80,14 @@ pub enum LegionError {
     #[error("watch config error: {0}")]
     WatchConfig(String),
 
+    /// A watch.toml repo name set violates the signal-routing uniqueness
+    /// invariants. Either multiple repos share a recipient (which causes
+    /// silent multi-wake on directed signals), or an agent name equals a
+    /// `broadcast_tags` entry (which makes tag vs. direct-address
+    /// indistinguishable at match time).
+    #[error("watch config collision: {0}")]
+    WatchConfigCollision(String),
+
     #[error("watch already running (pid {0})")]
     WatchAlreadyRunning(u32),
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -4354,19 +4354,22 @@ fn run() -> error::Result<()> {
             let base = data_dir()?;
             let database = db::Database::open(&base.join("legion.db"))?;
 
-            // Recipient is the agent name when configured via watch.toml,
-            // else the repo name. Fall back to repo for un-watched callers.
-            let recipient = watch::load_config(&base.join("watch.toml"))
+            // Build the full addressable name set for this repo: the repo's
+            // recipient() plus any broadcast_tags. Fall back to [repo] for
+            // un-watched callers (no watch.toml, or repo not in it).
+            let names: Vec<String> = watch::load_config(&base.join("watch.toml"))
                 .ok()
                 .and_then(|cfg| {
-                    cfg.repos
-                        .iter()
-                        .find(|r| r.name == repo)
-                        .map(|r| r.recipient().to_string())
+                    cfg.repos.into_iter().find(|r| r.name == repo).map(|r| {
+                        let mut ns: Vec<String> = Vec::with_capacity(1 + r.broadcast_tags.len());
+                        ns.push(r.recipient().to_string());
+                        ns.extend(r.broadcast_tags);
+                        ns
+                    })
                 })
-                .unwrap_or_else(|| repo.clone());
+                .unwrap_or_else(|| vec![repo.clone()]);
 
-            let signals = watch::find_pending_signals(&database, &repo, &recipient, None)?;
+            let signals = watch::find_pending_signals(&database, &repo, &names, None)?;
             let reply_required: Vec<(String, String, String)> = signals
                 .into_iter()
                 .filter(|(_, text, _)| watch::signal_requires_reply(text))

--- a/src/watch.rs
+++ b/src/watch.rs
@@ -4586,19 +4586,16 @@ broadcast_tags = ["eng-team", "backend"]
         // error -- the hard gate supersedes the soft `watch list` warning.
         let dir = tempfile::tempdir().expect("tempdir");
         let config_path = dir.path().join("watch.toml");
+        // workdir must be a real directory on every platform (the workdir-exists
+        // check runs before the collision check), and a TOML literal string
+        // ('...') avoids escaping Windows backslashes.
+        let wd = dir.path().display().to_string();
         std::fs::write(
             &config_path,
-            r#"
-[[repos]]
-name = "alpha"
-workdir = "/tmp"
-agent = "platform"
-
-[[repos]]
-name = "beta"
-workdir = "/tmp"
-agent = "platform"
-"#,
+            format!(
+                "[[repos]]\nname = \"alpha\"\nworkdir = '{wd}'\nagent = \"platform\"\n\n\
+                 [[repos]]\nname = \"beta\"\nworkdir = '{wd}'\nagent = \"platform\"\n"
+            ),
         )
         .expect("write");
 
@@ -4624,19 +4621,13 @@ agent = "platform"
         // A tag that equals any repo's recipient() must be refused.
         let dir = tempfile::tempdir().expect("tempdir");
         let config_path = dir.path().join("watch.toml");
+        let wd = dir.path().display().to_string();
         std::fs::write(
             &config_path,
-            r#"
-[[repos]]
-name = "alpha"
-workdir = "/tmp"
-agent = "platform"
-
-[[repos]]
-name = "beta"
-workdir = "/tmp"
-broadcast_tags = ["platform"]
-"#,
+            format!(
+                "[[repos]]\nname = \"alpha\"\nworkdir = '{wd}'\nagent = \"platform\"\n\n\
+                 [[repos]]\nname = \"beta\"\nworkdir = '{wd}'\nbroadcast_tags = [\"platform\"]\n"
+            ),
         )
         .expect("write");
 
@@ -4658,21 +4649,15 @@ broadcast_tags = ["platform"]
         // A valid config with unique recipients and non-colliding tags must load cleanly.
         let dir = tempfile::tempdir().expect("tempdir");
         let config_path = dir.path().join("watch.toml");
+        let wd = dir.path().display().to_string();
         std::fs::write(
             &config_path,
-            r#"
-[[repos]]
-name = "alpha"
-workdir = "/tmp"
-agent = "agent-a"
-broadcast_tags = ["eng-team"]
-
-[[repos]]
-name = "beta"
-workdir = "/tmp"
-agent = "agent-b"
-broadcast_tags = ["eng-team", "backend"]
-"#,
+            format!(
+                "[[repos]]\nname = \"alpha\"\nworkdir = '{wd}'\nagent = \"agent-a\"\n\
+                 broadcast_tags = [\"eng-team\"]\n\n\
+                 [[repos]]\nname = \"beta\"\nworkdir = '{wd}'\nagent = \"agent-b\"\n\
+                 broadcast_tags = [\"eng-team\", \"backend\"]\n"
+            ),
         )
         .expect("write");
 

--- a/src/watch.rs
+++ b/src/watch.rs
@@ -26,6 +26,17 @@ pub struct WatchRepoConfig {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub agent: Option<String>,
 
+    /// Group tags this repo subscribes to. A signal addressed to `@<tag>` wakes
+    /// every repo that lists `<tag>` in `broadcast_tags`. Tags complement the
+    /// reserved `@all` / `@everyone` broadcasts: they let an operator fan out
+    /// to a named subset of repos without waking the entire mesh. An empty vec
+    /// (the default) means this repo subscribes to no tags.
+    ///
+    /// No tag may equal any repo's `recipient()` value -- `load_config` rejects
+    /// that collision so the match layer never confuses a tag with a direct address.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub broadcast_tags: Vec<String>,
+
     /// Any additional per-repo fields the struct does not model explicitly
     /// (e.g., `github`, `worksource`, `review`). These survive a read-modify-write
     /// cycle so CRUD on one entry never strips integration config on another.
@@ -44,6 +55,54 @@ impl WatchRepoConfig {
             .map(str::trim)
             .filter(|s| !s.is_empty())
             .unwrap_or(&self.name)
+    }
+}
+
+/// A signal recipient parsed from a raw address string.
+///
+/// The reserved names `all` and `everyone` (case-insensitive, with or without
+/// a leading `@`) map to `Broadcast(All)`. Everything else is treated as a
+/// direct `Agent` address. Tag resolution is NOT done here -- the caller must
+/// compare the address against each repo's `broadcast_tags` at match time.
+///
+/// This type is part of the public API for #585. Production call sites that
+/// consume `Recipient` are in #586 (wake-verb canon) and the future
+/// signal-routing layer; it is defined here as a stable contract.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[allow(dead_code)] // public API foundation for #585/#586; callers ship in follow-on issues
+pub enum Recipient {
+    /// Directly addressed to a named agent or repo.
+    Agent(String),
+    /// Addressed to a broadcast group.
+    Broadcast(BroadcastTarget),
+}
+
+/// The target of a broadcast signal.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[allow(dead_code)] // public API foundation for #585; Tag variant consumed by routing layer in #586
+pub enum BroadcastTarget {
+    /// The reserved `@all` / `@everyone` group -- wakes every watcher.
+    All,
+    /// A named tag group -- wakes only repos whose `broadcast_tags` include
+    /// this name.
+    Tag(String),
+}
+
+impl Recipient {
+    /// Parse a raw signal address into a typed `Recipient`.
+    ///
+    /// Strips a leading `@` if present before comparing. The reserved set
+    /// {`all`, `everyone`} (case-insensitive) maps to `Broadcast(All)`;
+    /// all other values become `Agent(name)`. Tag-vs-agent disambiguation
+    /// is NOT done here -- the caller resolves tags against each repo's
+    /// `broadcast_tags` at match time.
+    #[allow(dead_code)] // public API foundation for #585/#586; callers ship in follow-on issues
+    pub fn parse(raw: &str) -> Self {
+        let stripped = raw.strip_prefix('@').unwrap_or(raw);
+        match stripped.to_ascii_lowercase().as_str() {
+            "all" | "everyone" => Self::Broadcast(BroadcastTarget::All),
+            _ => Self::Agent(stripped.to_string()),
+        }
     }
 }
 
@@ -432,6 +491,7 @@ pub fn add_repo_to_config(
         name: name.to_string(),
         workdir: canonical_str,
         agent: normalized_agent,
+        broadcast_tags: Vec::new(),
         extra: toml::Table::new(),
     });
 
@@ -491,6 +551,56 @@ pub fn load_config(path: &Path) -> Result<WatchConfig> {
                 "workdir does not exist for repo '{}': {}",
                 repo.name, repo.workdir
             )));
+        }
+    }
+
+    // Collision guard: two repos sharing the same recipient causes silent
+    // multi-wake on directed signals. Refuse startup so the operator
+    // fixes the config rather than chasing mystery double-wakes.
+    //
+    // This supersedes the soft WARNING that `legion watch list` emits for
+    // manually-edited configs. The list command warning is LEFT in place so
+    // operators who load the file with a read-only tool still see it, but
+    // `load_config` is now the hard gate.
+    {
+        let mut recipient_map: std::collections::HashMap<&str, Vec<&str>> =
+            std::collections::HashMap::new();
+        for repo in &config.repos {
+            recipient_map
+                .entry(repo.recipient())
+                .or_default()
+                .push(&repo.name);
+        }
+        for (recipient, names) in &recipient_map {
+            if names.len() > 1 {
+                return Err(LegionError::WatchConfigCollision(format!(
+                    "recipient '{}' is shared by {} repos: {}. \
+                     Each watched repo requires a unique signal-routing identity \
+                     (its `agent` field, or its `name` when `agent` is unset). \
+                     Give each repo a distinct `agent` value, or model the shared \
+                     grouping as a `broadcast_tags` entry.",
+                    recipient,
+                    names.len(),
+                    names.join(", ")
+                )));
+            }
+        }
+
+        // Tag/recipient collision: a tag name that equals any repo's recipient()
+        // makes direct-address vs. tag-address indistinguishable at match time.
+        for repo in &config.repos {
+            for tag in &repo.broadcast_tags {
+                if let Some(names) = recipient_map.get(tag.as_str()) {
+                    return Err(LegionError::WatchConfigCollision(format!(
+                        "broadcast tag '{}' in repo '{}' collides with the recipient of repo(s): {}. \
+                         Tag names must not equal any repo's recipient() value -- \
+                         rename the tag or change the agent override on the conflicting repo.",
+                        tag,
+                        repo.name,
+                        names.join(", ")
+                    )));
+                }
+            }
         }
     }
 
@@ -770,15 +880,21 @@ impl CooldownTracker {
 
 /// Find unhandled signals targeting a specific repo.
 ///
+/// `names` is the full addressable name set for this repo: the repo's
+/// `recipient()` value plus any `broadcast_tags`. Signals addressed to any
+/// name in this set are returned, along with reserved `@all` / `@everyone`
+/// broadcasts. The DB handles per-repo dedup via `watch_handled` so each
+/// broadcast wakes a repo exactly once regardless of which names it carries.
+///
 /// Returns signal reflection IDs and their text, filtered to only actual
 /// signals (text starts with @).
 pub fn find_pending_signals(
     db: &Database,
     repo_name: &str,
-    recipient: &str,
+    names: &[String],
     since: Option<&str>,
 ) -> Result<Vec<(String, String, String)>> {
-    let reflections = db.get_unhandled_signals_for_repo(repo_name, recipient, since)?;
+    let reflections = db.get_unhandled_signals_for_repo(repo_name, names, since)?;
 
     let mut signals: Vec<(String, String, String)> = Vec::new();
     for r in reflections {
@@ -1492,7 +1608,10 @@ pub fn poll_cycle(
 
     // Check for auto-unblock opportunities from recent signals
     for repo in &config.repos {
-        match find_pending_signals(db, &repo.name, repo.recipient(), since) {
+        let mut names: Vec<String> = Vec::with_capacity(1 + repo.broadcast_tags.len());
+        names.push(repo.recipient().to_string());
+        names.extend(repo.broadcast_tags.iter().cloned());
+        match find_pending_signals(db, &repo.name, &names, since) {
             Ok(signals) => {
                 check_auto_unblock(db, &signals);
             }
@@ -1519,7 +1638,10 @@ pub fn poll_cycle(
         }
 
         let recipient = repo.recipient();
-        let signals = find_pending_signals(db, &repo.name, recipient, since)?;
+        let mut names: Vec<String> = Vec::with_capacity(1 + repo.broadcast_tags.len());
+        names.push(recipient.to_string());
+        names.extend(repo.broadcast_tags.iter().cloned());
+        let signals = find_pending_signals(db, &repo.name, &names, since)?;
         if signals.is_empty() {
             continue;
         }
@@ -2307,7 +2429,8 @@ workdir = "/tmp"
         db.insert_reflection("rafters", "@all announce: shipped", "team")
             .expect("insert broadcast");
 
-        let signals = find_pending_signals(&db, "legion", "legion", None).expect("find signals");
+        let signals = find_pending_signals(&db, "legion", &["legion".to_string()], None)
+            .expect("find signals");
         assert_eq!(signals.len(), 2);
 
         // Verify the targeted signal is found
@@ -2337,9 +2460,10 @@ workdir = "/tmp"
         .expect("insert multi-recipient");
 
         // Both shingle and huttspawn should see it
-        let shingle = find_pending_signals(&db, "shingle", "shingle", None).expect("shingle");
-        let huttspawn =
-            find_pending_signals(&db, "huttspawn", "huttspawn", None).expect("huttspawn");
+        let shingle =
+            find_pending_signals(&db, "shingle", &["shingle".to_string()], None).expect("shingle");
+        let huttspawn = find_pending_signals(&db, "huttspawn", &["huttspawn".to_string()], None)
+            .expect("huttspawn");
         assert_eq!(
             shingle.len(),
             1,
@@ -2352,11 +2476,13 @@ workdir = "/tmp"
         );
 
         // legion (sender) should NOT see it
-        let legion = find_pending_signals(&db, "legion", "legion", None).expect("legion");
+        let legion =
+            find_pending_signals(&db, "legion", &["legion".to_string()], None).expect("legion");
         assert!(legion.is_empty(), "sender should not see own signal");
 
         // unrelated repo should NOT see it
-        let kelex = find_pending_signals(&db, "kelex", "kelex", None).expect("kelex");
+        let kelex =
+            find_pending_signals(&db, "kelex", &["kelex".to_string()], None).expect("kelex");
         assert!(kelex.is_empty(), "unmentioned repo should not see signal");
     }
 
@@ -2368,7 +2494,8 @@ workdir = "/tmp"
         db.insert_reflection("legion", "@legion review:approved", "team")
             .expect("insert self-signal");
 
-        let signals = find_pending_signals(&db, "legion", "legion", None).expect("find signals");
+        let signals = find_pending_signals(&db, "legion", &["legion".to_string()], None)
+            .expect("find signals");
         assert!(signals.is_empty(), "self-signals should be excluded");
     }
 
@@ -2383,7 +2510,8 @@ workdir = "/tmp"
         db.insert_reflection("ledger", "@platform review:approved", "team")
             .expect("insert self-signal");
 
-        let signals = find_pending_signals(&db, "ledger", "platform", None).expect("find signals");
+        let signals = find_pending_signals(&db, "ledger", &["platform".to_string()], None)
+            .expect("find signals");
         assert!(
             signals.is_empty(),
             "self-signals must be excluded by repo_name, not by recipient"
@@ -2397,7 +2525,8 @@ workdir = "/tmp"
         db.insert_reflection("kelex", "@platform review:approved", "team")
             .expect("insert external signal");
 
-        let signals = find_pending_signals(&db, "ledger", "platform", None).expect("find signals");
+        let signals = find_pending_signals(&db, "ledger", &["platform".to_string()], None)
+            .expect("find signals");
         assert_eq!(signals.len(), 1, "external signal to agent should be found");
     }
 
@@ -2408,7 +2537,8 @@ workdir = "/tmp"
         db.insert_reflection("kelex", "@legion review:approved", "team")
             .expect("insert signal");
 
-        let signals = find_pending_signals(&db, "legion", "legion", None).expect("first poll");
+        let signals =
+            find_pending_signals(&db, "legion", &["legion".to_string()], None).expect("first poll");
         assert_eq!(signals.len(), 1);
 
         // Mark as handled for legion
@@ -2417,7 +2547,8 @@ workdir = "/tmp"
             .expect("mark handled");
 
         // Should not appear again for legion
-        let signals = find_pending_signals(&db, "legion", "legion", None).expect("second poll");
+        let signals = find_pending_signals(&db, "legion", &["legion".to_string()], None)
+            .expect("second poll");
         assert!(signals.is_empty());
     }
 
@@ -3086,6 +3217,7 @@ workdir = "/tmp"
                 name: "legion".to_string(),
                 workdir: "/tmp".to_string(),
                 agent: None,
+                broadcast_tags: Vec::new(),
                 extra: toml::Table::new(),
             }],
             ..WatchConfig::default()
@@ -3130,6 +3262,7 @@ workdir = "/tmp"
                 name: "legion".to_string(),
                 workdir: "/tmp".to_string(),
                 agent: None,
+                broadcast_tags: Vec::new(),
                 extra: toml::Table::new(),
             }],
             ..WatchConfig::default()
@@ -3184,6 +3317,7 @@ workdir = "/tmp"
                 name: "legion".to_string(),
                 workdir: "/tmp".to_string(),
                 agent: None,
+                broadcast_tags: Vec::new(),
                 extra: toml::Table::new(),
             }],
             ..WatchConfig::default()
@@ -3221,9 +3355,10 @@ workdir = "/tmp"
             .expect("insert broadcast");
 
         // Both legion and rafters should see it
-        let legion_signals = find_pending_signals(&db, "legion", "legion", None).expect("legion");
+        let legion_signals =
+            find_pending_signals(&db, "legion", &["legion".to_string()], None).expect("legion");
         let rafters_signals =
-            find_pending_signals(&db, "rafters", "rafters", None).expect("rafters");
+            find_pending_signals(&db, "rafters", &["rafters".to_string()], None).expect("rafters");
         assert_eq!(legion_signals.len(), 1);
         assert_eq!(rafters_signals.len(), 1);
 
@@ -3234,16 +3369,16 @@ workdir = "/tmp"
         }
 
         // legion should NOT see it anymore
-        let legion_after =
-            find_pending_signals(&db, "legion", "legion", None).expect("legion after");
+        let legion_after = find_pending_signals(&db, "legion", &["legion".to_string()], None)
+            .expect("legion after");
         assert!(
             legion_after.is_empty(),
             "legion should not see broadcast after handling"
         );
 
         // rafters should STILL see the broadcast
-        let rafters_after =
-            find_pending_signals(&db, "rafters", "rafters", None).expect("rafters after");
+        let rafters_after = find_pending_signals(&db, "rafters", &["rafters".to_string()], None)
+            .expect("rafters after");
         assert_eq!(
             rafters_after.len(),
             1,
@@ -3257,8 +3392,8 @@ workdir = "/tmp"
         }
 
         // Now rafters should not see it either
-        let rafters_final =
-            find_pending_signals(&db, "rafters", "rafters", None).expect("rafters final");
+        let rafters_final = find_pending_signals(&db, "rafters", &["rafters".to_string()], None)
+            .expect("rafters final");
         assert!(
             rafters_final.is_empty(),
             "rafters should not see broadcast after handling"
@@ -3477,6 +3612,7 @@ workdir = "/nonexistent/path/that/does/not/exist"
             name: "ledger".to_string(),
             workdir: "/tmp".to_string(),
             agent: Some("platform".to_string()),
+            broadcast_tags: Vec::new(),
             extra: toml::Table::new(),
         };
         assert_eq!(repo_with_agent.recipient(), "platform");
@@ -3485,6 +3621,7 @@ workdir = "/nonexistent/path/that/does/not/exist"
             name: "legion".to_string(),
             workdir: "/tmp".to_string(),
             agent: None,
+            broadcast_tags: Vec::new(),
             extra: toml::Table::new(),
         };
         assert_eq!(repo_without_agent.recipient(), "legion");
@@ -3498,6 +3635,7 @@ workdir = "/nonexistent/path/that/does/not/exist"
             name: "fallback".to_string(),
             workdir: "/tmp".to_string(),
             agent: Some("".to_string()),
+            broadcast_tags: Vec::new(),
             extra: toml::Table::new(),
         };
         assert_eq!(empty.recipient(), "fallback");
@@ -3506,6 +3644,7 @@ workdir = "/nonexistent/path/that/does/not/exist"
             name: "fallback".to_string(),
             workdir: "/tmp".to_string(),
             agent: Some("   ".to_string()),
+            broadcast_tags: Vec::new(),
             extra: toml::Table::new(),
         };
         assert_eq!(whitespace.recipient(), "fallback");
@@ -4133,6 +4272,7 @@ secret = "0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF"
                 name: "test-repo".to_string(),
                 workdir: "/tmp".to_string(),
                 agent: None,
+                broadcast_tags: Vec::new(),
                 extra: toml::Table::new(),
             }],
             ..WatchConfig::default()
@@ -4186,15 +4326,15 @@ secret = "0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF"
         let mut state = test_watch_loop(db, "[legion test]");
 
         // Before the tick: signal should be pending.
-        let before =
-            find_pending_signals(&state.db, "test-repo", "test-repo", None).expect("find pending");
+        let before = find_pending_signals(&state.db, "test-repo", &["test-repo".to_string()], None)
+            .expect("find pending");
         assert!(!before.is_empty(), "signal should be pending before tick");
 
         state.tick_poll();
 
         // After the tick: poll_cycle ran (Proceed gate), marked the
         // non-wake-worthy signal as handled, so the pending list is empty.
-        let after = find_pending_signals(&state.db, "test-repo", "test-repo", None)
+        let after = find_pending_signals(&state.db, "test-repo", &["test-repo".to_string()], None)
             .expect("find pending after");
         assert!(
             after.is_empty(),
@@ -4228,8 +4368,9 @@ secret = "0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF"
         state.tick_poll();
 
         // Signal must still be pending: poll_cycle was skipped due to QuotaPanic.
-        let pending = find_pending_signals(&state.db, "test-repo", "test-repo", None)
-            .expect("find pending after quota panic tick");
+        let pending =
+            find_pending_signals(&state.db, "test-repo", &["test-repo".to_string()], None)
+                .expect("find pending after quota panic tick");
         assert!(
             !pending.is_empty(),
             "signal must remain pending when quota panic gate fires (poll_cycle must not run)"
@@ -4259,11 +4400,283 @@ secret = "0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF"
         state.tick_poll();
 
         // Signal must still be pending: poll_cycle was skipped due to Pressure.
-        let pending = find_pending_signals(&state.db, "test-repo", "test-repo", None)
-            .expect("find pending after pressure gate tick");
+        let pending =
+            find_pending_signals(&state.db, "test-repo", &["test-repo".to_string()], None)
+                .expect("find pending after pressure gate tick");
         assert!(
             !pending.is_empty(),
             "signal must remain pending when pressure gate fires (poll_cycle must not run)"
         );
+    }
+
+    // -- Broadcast tags + Recipient enum (#585) ----------------------------------
+
+    #[test]
+    fn recipient_parse_all_variants_map_to_broadcast_all() {
+        // Case-insensitive reserved words "all" and "everyone" must parse as
+        // Broadcast(All) whether or not they carry a leading @.
+        assert_eq!(
+            Recipient::parse("all"),
+            Recipient::Broadcast(BroadcastTarget::All)
+        );
+        assert_eq!(
+            Recipient::parse("ALL"),
+            Recipient::Broadcast(BroadcastTarget::All)
+        );
+        assert_eq!(
+            Recipient::parse("@all"),
+            Recipient::Broadcast(BroadcastTarget::All)
+        );
+        assert_eq!(
+            Recipient::parse("everyone"),
+            Recipient::Broadcast(BroadcastTarget::All)
+        );
+        assert_eq!(
+            Recipient::parse("Everyone"),
+            Recipient::Broadcast(BroadcastTarget::All)
+        );
+        assert_eq!(
+            Recipient::parse("@everyone"),
+            Recipient::Broadcast(BroadcastTarget::All)
+        );
+    }
+
+    #[test]
+    fn recipient_parse_named_becomes_agent() {
+        // Anything that is not a reserved broadcast maps to Agent, with the
+        // leading @ stripped.
+        assert_eq!(
+            Recipient::parse("platform"),
+            Recipient::Agent("platform".to_string())
+        );
+        assert_eq!(
+            Recipient::parse("@platform"),
+            Recipient::Agent("platform".to_string())
+        );
+        assert_eq!(
+            Recipient::parse("legion"),
+            Recipient::Agent("legion".to_string())
+        );
+    }
+
+    #[test]
+    fn at_everyone_wakes_repo_same_as_at_all() {
+        // @everyone must behave identically to @all: both repos should see the
+        // broadcast, each exactly once. This is the regression guard for the
+        // new reserved word.
+        let (db, _index, _dir) = test_storage();
+
+        db.insert_reflection("kelex", "@everyone RFC:help -- discover proposal", "team")
+            .expect("insert @everyone broadcast");
+
+        let legion_signals =
+            find_pending_signals(&db, "legion", &["legion".to_string()], None).expect("legion");
+        let rafters_signals =
+            find_pending_signals(&db, "rafters", &["rafters".to_string()], None).expect("rafters");
+
+        assert_eq!(
+            legion_signals.len(),
+            1,
+            "@everyone must wake legion just like @all"
+        );
+        assert_eq!(
+            rafters_signals.len(),
+            1,
+            "@everyone must wake rafters just like @all"
+        );
+
+        // Mark handled for legion; rafters must still see it.
+        for (id, _, _) in &legion_signals {
+            db.mark_signal_handled_for_repo(id, "legion")
+                .expect("mark legion handled");
+        }
+
+        let rafters_after = find_pending_signals(&db, "rafters", &["rafters".to_string()], None)
+            .expect("rafters after legion handled");
+        assert_eq!(
+            rafters_after.len(),
+            1,
+            "@everyone dedup must be per-repo: rafters must still see the signal"
+        );
+    }
+
+    #[test]
+    fn broadcast_tag_signal_wakes_only_tagged_repos() {
+        // A signal addressed @eng-team should wake repos whose broadcast_tags
+        // includes "eng-team", but NOT repos that do not carry that tag.
+        let (db, _index, _dir) = test_storage();
+
+        // tagged: subscribes to "eng-team"
+        let tagged_names: Vec<String> = vec!["tagged".to_string(), "eng-team".to_string()];
+        // untagged: no broadcast_tags
+        let untagged_names: Vec<String> = vec!["untagged".to_string()];
+
+        db.insert_reflection("other", "@eng-team question:help -- need input", "team")
+            .expect("insert tag signal");
+
+        let tagged_sigs = find_pending_signals(&db, "tagged", &tagged_names, None).expect("tagged");
+        let untagged_sigs =
+            find_pending_signals(&db, "untagged", &untagged_names, None).expect("untagged");
+
+        assert_eq!(
+            tagged_sigs.len(),
+            1,
+            "repo with matching broadcast_tag must see the @eng-team signal"
+        );
+        assert!(
+            untagged_sigs.is_empty(),
+            "repo without the tag must NOT see the @eng-team signal"
+        );
+    }
+
+    #[test]
+    fn directed_signal_wakes_only_target_repo() {
+        // A @<name> signal wakes only the repo whose recipient() equals name,
+        // not repos that happen to share a tag.
+        let (db, _index, _dir) = test_storage();
+
+        db.insert_reflection("other", "@direct question:help -- for you only", "team")
+            .expect("insert directed signal");
+
+        let direct_sigs =
+            find_pending_signals(&db, "direct", &["direct".to_string()], None).expect("direct");
+        let bystander_sigs =
+            find_pending_signals(&db, "bystander", &["bystander".to_string()], None)
+                .expect("bystander");
+
+        assert_eq!(direct_sigs.len(), 1, "target repo must see directed signal");
+        assert!(
+            bystander_sigs.is_empty(),
+            "unaddressed repo must not see directed signal"
+        );
+    }
+
+    #[test]
+    fn broadcast_tags_deserialize_from_toml() {
+        // Backward-compat: a config without broadcast_tags parses cleanly;
+        // a config with broadcast_tags round-trips.
+        let without = r#"
+[[repos]]
+name = "legion"
+workdir = "/tmp"
+"#;
+        let cfg: WatchConfig = toml::from_str(without).expect("parse without tags");
+        assert!(
+            cfg.repos[0].broadcast_tags.is_empty(),
+            "missing broadcast_tags field must default to empty vec"
+        );
+
+        let with_tags = r#"
+[[repos]]
+name = "legion"
+workdir = "/tmp"
+broadcast_tags = ["eng-team", "backend"]
+"#;
+        let cfg2: WatchConfig = toml::from_str(with_tags).expect("parse with tags");
+        assert_eq!(
+            cfg2.repos[0].broadcast_tags,
+            vec!["eng-team", "backend"],
+            "broadcast_tags must round-trip through TOML"
+        );
+    }
+
+    #[test]
+    fn load_config_rejects_duplicate_recipients() {
+        // Two repos sharing a recipient must cause load_config to return an
+        // error -- the hard gate supersedes the soft `watch list` warning.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let config_path = dir.path().join("watch.toml");
+        std::fs::write(
+            &config_path,
+            r#"
+[[repos]]
+name = "alpha"
+workdir = "/tmp"
+agent = "platform"
+
+[[repos]]
+name = "beta"
+workdir = "/tmp"
+agent = "platform"
+"#,
+        )
+        .expect("write");
+
+        let err = load_config(&config_path).unwrap_err();
+        assert!(
+            matches!(err, crate::error::LegionError::WatchConfigCollision(_)),
+            "expected WatchConfigCollision, got: {:?}",
+            err
+        );
+        let msg = err.to_string();
+        assert!(
+            msg.contains("platform"),
+            "error must name the offending recipient"
+        );
+        assert!(
+            msg.contains("alpha") && msg.contains("beta"),
+            "error must list the offending repos"
+        );
+    }
+
+    #[test]
+    fn load_config_rejects_agent_name_equal_to_broadcast_tag() {
+        // A tag that equals any repo's recipient() must be refused.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let config_path = dir.path().join("watch.toml");
+        std::fs::write(
+            &config_path,
+            r#"
+[[repos]]
+name = "alpha"
+workdir = "/tmp"
+agent = "platform"
+
+[[repos]]
+name = "beta"
+workdir = "/tmp"
+broadcast_tags = ["platform"]
+"#,
+        )
+        .expect("write");
+
+        let err = load_config(&config_path).unwrap_err();
+        assert!(
+            matches!(err, crate::error::LegionError::WatchConfigCollision(_)),
+            "expected WatchConfigCollision for tag/recipient collision, got: {:?}",
+            err
+        );
+        let msg = err.to_string();
+        assert!(
+            msg.contains("platform"),
+            "error must name the offending tag/recipient"
+        );
+    }
+
+    #[test]
+    fn load_config_accepts_valid_config_with_unique_recipients_and_tags() {
+        // A valid config with unique recipients and non-colliding tags must load cleanly.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let config_path = dir.path().join("watch.toml");
+        std::fs::write(
+            &config_path,
+            r#"
+[[repos]]
+name = "alpha"
+workdir = "/tmp"
+agent = "agent-a"
+broadcast_tags = ["eng-team"]
+
+[[repos]]
+name = "beta"
+workdir = "/tmp"
+agent = "agent-b"
+broadcast_tags = ["eng-team", "backend"]
+"#,
+        )
+        .expect("write");
+
+        let cfg = load_config(&config_path).expect("valid config must load cleanly");
+        assert_eq!(cfg.repos.len(), 2);
     }
 }


### PR DESCRIPTION
## Summary

`@all` broadcasts already fanned out correctly (per-repo `watch_handled` dedup), but tags did not exist and several repos sharing one `agent` name all woke on a directed `@name` -- the silent multi-wake (the live config has `platform` on five repos). This change adds per-repo `broadcast_tags` subscriptions, a typed `Recipient`/`BroadcastTarget` model, the `@everyone` alias, and a hard collision guard at config load so a shared routing identity becomes a startup error instead of a silent multi-wake. Each fan-out target still rides the existing per-repo poll loop, so cooldown/health/session-lock/quota gates apply unchanged.

## Acceptance criteria mapping

### 1. `@all` wakes each watched repo exactly once through per-repo gates

`@all` (and the new `@everyone` alias) are matched in `get_unhandled_signals_for_repo` as reserved patterns present for every repo, while the `watch_handled` LEFT JOIN keyed on `repo_name` (not on recipient or tag) ensures a given broadcast signal is returned to each repo only until that repo marks it handled. The fan-out is just the existing per-repo `poll_cycle` loop iterating watched repos, so every repo's spawn still passes its own cooldown, health-pressure, session-lock, and quota-panic gates -- no new spawn path was added.
Evidence: `watch::tests::broadcast_signals_visible_to_all_repos` (asserts `@all`/`@everyone` reach each repo and dedup once); the unchanged per-repo loop in `poll_cycle`.

### 2. A tag wakes only its members

`WatchRepoConfig` gains `broadcast_tags: Vec<String>`. `poll_cycle` now passes each repo's full addressable name set -- its `recipient()` plus its `broadcast_tags` -- through `find_pending_signals` into `get_unhandled_signals_for_repo(repo_name, names, since)`, which builds a bound LIKE pattern per name. A `@<tag>` signal therefore matches only repos that carry that tag; a repo without the tag in its set has no pattern that matches it and stays asleep. A directed `@<agent>` matches only the repo whose recipient is that agent.
Evidence: `watch::tests::broadcast_tag_signal_wakes_only_tagged_repos` (tagged repos wake, untagged do not), `broadcast_tags_deserialize_from_toml`.

### 3. Agent/tag name collision fails fast with a clear error

`load_config` validates after parse and returns a typed `LegionError::WatchConfigCollision` when (a) the same `recipient()` is used by more than one repo -- naming the value and the repos and telling the operator to give each a unique `agent` or model the grouping as `broadcast_tags` -- or (b) any repo's `recipient()` equals any `broadcast_tags` entry (which would make direct-address and tag-address indistinguishable). The daemon already surfaces load errors as `watch not started: {e}`, so startup now refuses rather than silently multi-waking. The soft `legion watch list` warning is left in place for read-only inspection; `load_config` is the hard gate.
Evidence: `watch::tests::load_config_rejects_agent_name_equal_to_broadcast_tag`; the shared-recipient rejection in `load_config`; `Recipient::parse` mapped by `recipient_parse_all_variants_map_to_broadcast_all` / `recipient_parse_named_becomes_agent`.

### 4. All tests pass; simplify + review done; PR linked

`cargo test` green (935 bin unit tests + 156 integration, 0 failed), `cargo clippy -- -D warnings` clean, `cargo fmt -- --check` clean. The generalized query builds its OR-clauses dynamically but binds every LIKE pattern value as a positional parameter (only integer indices are formatted into the SQL), so it is injection-safe. Simplify gate recorded clean for HEAD. This PR references and closes #585; `/review-pr` and team review follow on the open PR.
Evidence: test output (935 + 156 passed, 0 failed); simplify gate row `019eaf4c-a746-7512-9e99-5d75f8567bc5`.

## Not done

**Operator action required before deploying:** the collision guard will refuse to load the current `watch.toml`, which has `agent = "platform"` on five repos (platform, astro-data, ledger, astro-meta, better-auth-paseto). After this merges and the daemon restarts on the new binary, `legion watch` will error until those five get distinct `agent` values or are modeled with `broadcast_tags`. That is the intended fix for the silent multi-wake, but it is a required config edit, not automatic.

Backward compatibility otherwise holds: a config with no `broadcast_tags` and unique agents loads unchanged. The `Recipient` enum intentionally resolves only the reserved-broadcast case (`all`/`everyone`); agent-vs-tag is disambiguated at the match layer via the names set, because a bare name cannot be classified without the config. LIKE-wildcard characters (`%`, `_`) in a tag/agent name are not escaped -- the same property the prior single-recipient query had; names are alphanumeric/hyphen by convention. No verb-gate changes (that is #586) and no verb-plugin work (#587).