### PR TITLE
feat(#586): correct wake-verb canon + send-time non-waking feedback

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -4349,6 +4349,19 @@ fn run() -> error::Result<()> {
                     info!("[legion] embedded {} signals", n);
                 }
             }
+
+            // #586: tell the sender when a directed signal will not wake its
+            // recipient -- a non-wake-worthy verb delivers to a live session but
+            // never pages an asleep agent, so surface it at send time.
+            if watch::directed_verb_will_not_wake(&to, &verb) {
+                eprintln!(
+                    "[legion] note: verb '{}' will not wake {} -- it delivers to a live \
+                     session but does not page an asleep agent. Wake-worthy verbs: {}.",
+                    verb,
+                    to,
+                    watch::WAKE_WORTHY_VERBS.join(", ")
+                );
+            }
         }
         Commands::PendingReplies { repo } => {
             let base = data_dir()?;

--- a/src/watch.rs
+++ b/src/watch.rs
@@ -792,17 +792,49 @@ pub fn find_pending_signals(
 
 // -- Agent Spawning ----------------------------------------------------------
 
-/// Verbs whose presence in a directed signal triggers a watch wake (#404).
+/// Verbs whose presence in a directed signal triggers a watch wake (#404, #586).
 ///
 /// `--verb` was designed to express intent; this set is the subsection of
 /// intents that warrant spawning an asleep recipient. Other verbs
 /// (`announce`, `ack`, `info`, `answer`, bare `review`) deliver to live
 /// sessions via the channel push but do not page an asleep agent.
 ///
+/// The canon (#586) is the set of verbs that actually mean "I need you to act":
+/// `question`, `request`, `handoff`, `correction`, `proposal`, `decision`,
+/// `rfc`, `routing`. The original #404 set carried `help` and `blocker`, but
+/// those are *statuses* (`request:help`, `review:blocker`), not bare verbs --
+/// they decorated the status slot, never the verb slot, so they never matched a
+/// real signal's verb and only crowded the wake set. The verbs added here are
+/// the ones bullpen mining shows the team actually uses to page each other.
+///
 /// Posts (text without a leading `@recipient`) never wake -- posts are
 /// broadcasts; the `legion signal --to <agent> --verb <wake-worthy>`
 /// primitive is the agent equivalent of a tweet at someone.
-pub const WAKE_WORTHY_VERBS: &[&str] = &["question", "request", "help", "blocker"];
+pub const WAKE_WORTHY_VERBS: &[&str] = &[
+    "question",
+    "request",
+    "handoff",
+    "correction",
+    "proposal",
+    "decision",
+    "rfc",
+    "routing",
+];
+
+/// Whether a directed `legion signal --to <to> --verb <verb>` will fail to wake
+/// its recipient, so the sender can be warned at send time (#586).
+///
+/// True when the target is a specific agent (not the `@all`/`@everyone`
+/// broadcast, which is never a directed page) AND the verb is outside
+/// [`WAKE_WORTHY_VERBS`]. Such a signal still delivers to a live session via the
+/// channel push, but it does not page an asleep agent -- surfacing that avoids
+/// the silent "I signaled but nobody woke" trap. Reserved broadcast names are
+/// matched case-insensitively.
+pub fn directed_verb_will_not_wake(to: &str, verb: &str) -> bool {
+    let to_normalized = to.trim().to_ascii_lowercase();
+    let is_broadcast = matches!(to_normalized.as_str(), "all" | "everyone");
+    !is_broadcast && !WAKE_WORTHY_VERBS.contains(&verb)
+}
 
 /// Whether a signal text triggers a wake under the verb-driven gate.
 ///
@@ -2503,8 +2535,9 @@ workdir = "/tmp"
         // The pre-#404 fallback that treated `status=request` or `status=help`
         // on any verb as reply-required was a workaround for the broken
         // text-prefix wake gate. Senders who want a reply now use a
-        // wake-worthy verb directly: `--verb request`, `--verb help`,
-        // `--verb question`, `--verb blocker`.
+        // wake-worthy verb directly: `--verb request`, `--verb handoff`,
+        // `--verb question`, `--verb decision` (#586 canon -- `help` and
+        // `blocker` are statuses, not wake verbs).
         let signals = vec![
             (
                 "id-rev-req".to_string(),
@@ -2512,8 +2545,8 @@ workdir = "/tmp"
                 "smugglr".to_string(),
             ),
             (
-                "id-help-verb".to_string(),
-                "@platform help -- need a hand on the rfc".to_string(),
+                "id-handoff-verb".to_string(),
+                "@platform handoff -- taking the rfc over to you".to_string(),
                 "kelex".to_string(),
             ),
             (
@@ -2536,8 +2569,8 @@ workdir = "/tmp"
             [prompt.find("REQUIRES A REPLY").unwrap()..prompt.find("INFORMATIONAL").unwrap()];
 
         assert!(
-            reply_section.contains("id-help-verb"),
-            "verb=help must require reply"
+            reply_section.contains("id-handoff-verb"),
+            "verb=handoff must require reply"
         );
         assert!(
             reply_section.contains("id-request-verb"),
@@ -2566,7 +2599,12 @@ workdir = "/tmp"
 
     #[test]
     fn is_wake_worthy_rejects_informational_verbs() {
-        for verb in ["announce", "ack", "info", "answer", "review"] {
+        // `help` and `blocker` are included here deliberately (#586): they are
+        // statuses (`request:help`, `review:blocker`), not bare wake verbs, and
+        // must not wake when used in the verb slot.
+        for verb in [
+            "announce", "ack", "info", "answer", "review", "help", "blocker",
+        ] {
             let text = format!("@kessel {verb} -- fyi");
             assert!(
                 !is_wake_worthy(&text),
@@ -2593,6 +2631,34 @@ workdir = "/tmp"
             is_wake_worthy("@platform request:help -- pls"),
             "verb=request stays wake-worthy regardless of status"
         );
+    }
+
+    #[test]
+    fn directed_non_wake_verb_warns() {
+        // A directed signal with an informational verb should warn.
+        assert!(directed_verb_will_not_wake("kessel", "announce"));
+        assert!(directed_verb_will_not_wake("kessel", "ack"));
+        // `help`/`blocker` are statuses, not wake verbs (#586) -- they warn too.
+        assert!(directed_verb_will_not_wake("kessel", "help"));
+        assert!(directed_verb_will_not_wake("kessel", "blocker"));
+    }
+
+    #[test]
+    fn directed_wake_verb_does_not_warn() {
+        for verb in WAKE_WORTHY_VERBS {
+            assert!(
+                !directed_verb_will_not_wake("kessel", verb),
+                "wake-worthy verb `{verb}` must not warn"
+            );
+        }
+    }
+
+    #[test]
+    fn broadcast_target_never_warns() {
+        // @all / @everyone are not directed pages, so no warning regardless of verb.
+        assert!(!directed_verb_will_not_wake("all", "announce"));
+        assert!(!directed_verb_will_not_wake("everyone", "announce"));
+        assert!(!directed_verb_will_not_wake("All", "ack")); // case-insensitive
     }
 
     #[test]


### PR DESCRIPTION
## Summary

The watch wake gate keyed on `WAKE_WORTHY_VERBS = {question, request, help, blocker}` (#404), but `help` and `blocker` are statuses (`request:help`, `review:blocker`), not bare verbs -- they only ever decorated the status slot, so they never matched a real signal's verb and merely crowded the set while the verbs the team actually pages with were absent. This change replaces the set with the data-true canon and adds a send-time note when a directed signal uses a verb that will not wake its recipient, so the silent "I signaled but nobody woke" trap (hit this session with an `announce` broadcast) is visible at the moment of sending.

## Acceptance criteria mapping

### 1. A `question`/`request`/`handoff`/etc. directed at a sleeping watched repo wakes it

`WAKE_WORTHY_VERBS` is now `{question, request, handoff, correction, proposal, decision, rfc, routing}` -- the verbs bullpen mining shows the team uses to page each other. `is_wake_worthy` (and therefore the watch wake decision and the REQUIRES A REPLY routing, which share this one cut) accept any of them; `help` and `blocker` are dropped because they are statuses. The wake path itself is unchanged -- only the membership of the set it consults.
Evidence: `watch::tests::is_wake_worthy_recognizes_designated_verbs` (iterates the canon and asserts each wakes); `is_wake_worthy_rejects_informational_verbs` now also asserts `help` and `blocker` do not wake; the `build_wake_prompt_routes_by_verb_only` test was moved off the retired `help` verb onto `handoff` and still asserts a wake-worthy verb routes to the reply section.

### 2. An `announce` does not wake and the sender is told so at send time

`directed_verb_will_not_wake(to, verb)` is a pure predicate: true when the target is a specific agent (not the `@all`/`@everyone` broadcast) and the verb is outside the canon. The `legion signal` command calls it after sending and, when true, prints a `[legion] note: verb '<v>' will not wake <to> ...` line listing the wake-worthy verbs. The signal is still sent (the verb may be intentionally informational and will reach a live session via the channel push); the note is advisory, surfaced on stderr so it never corrupts machine-readable output.
Evidence: `watch::tests::directed_non_wake_verb_warns` (announce/ack/help/blocker warn), `directed_wake_verb_does_not_warn` (every canon verb is silent), `broadcast_target_never_warns` (`@all`/`@everyone`, case-insensitive, never warn); the `eprintln!` guarded by `directed_verb_will_not_wake` in the `Commands::Signal` handler.

### 3. All tests pass; simplify + review done; PR linked

`cargo test` green (929 bin unit tests + 156 integration, 0 failed), `cargo clippy -- -D warnings` clean, `cargo fmt -- --check` clean. The warning condition was extracted into the testable `directed_verb_will_not_wake` predicate rather than inlined in the command handler (the same pattern used for #581's `classify_beat`), so the boundary is unit-tested without invoking the CLI. Simplify gate recorded clean for HEAD. This PR references and closes #586; `/review-pr` and team review follow on the open PR. It also lays the default canon that #587's verb-plugin manifest will reproduce.
Evidence: test output (929 + 156 passed, 0 failed); simplify gate row `019eaf52-dfd7-7653-9075-cc2eaa62f88c`.

## Not done

The canon is still a hard-coded `const` here -- making it data-driven via TOML verb manifests is #587, which will reproduce exactly this set as its default. Required-field enforcement per verb (e.g. `rfc` requires a budget) is also #587. The send-time note does not block or alter the send (an informational verb is a legitimate choice); it only informs. This branch is based on main (includes #581-#584) and is independent of the open #585 broadcast PR -- they touch different regions of watch.rs (the verb set vs. the recipient matching) and merge independently.