### PR TITLE
feat(#587): verb-plugin shapes -- data-driven wake via TOML manifests

### DIFF
--- a/plugin/verbs/default.toml
+++ b/plugin/verbs/default.toml
@@ -1,0 +1,68 @@
+# Default verb manifest for legion.
+#
+# This file encodes the canonical verb set introduced in #586. Agents and
+# operators can overlay additional verbs (or override existing ones) by
+# placing *.toml files in the verbs directory pointed to by LEGION_VERBS_DIR
+# or ${CLAUDE_PLUGIN_ROOT}/verbs.
+#
+# Schema: each verb is a section under [verbs.<name>].
+#
+#   [verbs.<name>]
+#   shape = "wake" | "record" | "fuckoff" | "maybe-close"
+#   required_fields = ["field1", "field2"]   # optional; defaults to []
+#
+# Shapes:
+#   wake        -- wakes an asleep recipient; agent MUST reply or decline.
+#   record      -- informational; delivered to live sessions only, no wake.
+#   fuckoff     -- discard; useful for machine-generated noise.
+#   maybe-close -- may resolve a pending ask when status matches a resolution.
+#
+# The wake set below exactly reproduces the #586 canon. Do not add verbs here
+# without updating watch::WAKE_WORTHY_VERBS in src/watch.rs, and vice versa.
+# The shipped_default_toml_wake_set_matches_builtin_default test enforces
+# this invariant at CI time.
+
+# ---------------------------------------------------------------------------
+# Wake verbs (#586 canon)
+# ---------------------------------------------------------------------------
+
+[verbs.question]
+shape = "wake"
+
+[verbs.request]
+shape = "wake"
+
+[verbs.handoff]
+shape = "wake"
+
+[verbs.correction]
+shape = "wake"
+
+[verbs.proposal]
+shape = "wake"
+
+[verbs.decision]
+shape = "wake"
+
+[verbs.rfc]
+shape = "wake"
+required_fields = ["budget"]
+
+[verbs.routing]
+shape = "wake"
+
+# ---------------------------------------------------------------------------
+# Informational verbs (Record shape -- never wake)
+# ---------------------------------------------------------------------------
+
+[verbs.announce]
+shape = "record"
+
+[verbs.ack]
+shape = "record"
+
+[verbs.info]
+shape = "record"
+
+[verbs.answer]
+shape = "record"

--- a/src/error.rs
+++ b/src/error.rs
@@ -91,6 +91,16 @@ pub enum LegionError {
     #[error("watch already running (pid {0})")]
     WatchAlreadyRunning(u32),
 
+    #[error(
+        "signal verb '{verb}' requires the following detail field(s) that are missing: {missing}. \
+         Pass them via --details '{missing_example}:value'"
+    )]
+    SignalMissingRequiredFields {
+        verb: String,
+        missing: String,
+        missing_example: String,
+    },
+
     #[error("TOML parse error: {0}")]
     Toml(#[from] toml::de::Error),
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,6 +37,7 @@ mod telemetry;
 mod testutil;
 mod uncertainty;
 mod usage;
+mod verbs;
 mod verify;
 mod wake_attempts;
 mod watch;
@@ -4312,6 +4313,25 @@ fn run() -> error::Result<()> {
                 })
                 .unwrap_or_default();
 
+            // #587: check required fields for this verb before sending.
+            let provided_keys: std::collections::HashSet<&str> =
+                detail_pairs.iter().map(|(k, _)| k.as_str()).collect();
+            let required: &[String] = verbs::active_manifest().required_fields(&verb);
+            let missing: Vec<&str> = required
+                .iter()
+                .filter(|f| !provided_keys.contains(f.as_str()))
+                .map(|f| f.as_str())
+                .collect();
+            if !missing.is_empty() {
+                let missing_str = missing.join(", ");
+                let example = missing[0];
+                return Err(error::LegionError::SignalMissingRequiredFields {
+                    verb: verb.clone(),
+                    missing: missing_str,
+                    missing_example: example.to_string(),
+                });
+            }
+
             if let Some(ref n) = note {
                 signal::validate_note(n)?;
             }
@@ -4354,12 +4374,13 @@ fn run() -> error::Result<()> {
             // recipient -- a non-wake-worthy verb delivers to a live session but
             // never pages an asleep agent, so surface it at send time.
             if watch::directed_verb_will_not_wake(&to, &verb) {
+                let wake_verbs: Vec<&str> = verbs::active_manifest().wake_verb_names();
                 eprintln!(
                     "[legion] note: verb '{}' will not wake {} -- it delivers to a live \
                      session but does not page an asleep agent. Wake-worthy verbs: {}.",
                     verb,
                     to,
-                    watch::WAKE_WORTHY_VERBS.join(", ")
+                    wake_verbs.join(", ")
                 );
             }
         }

--- a/src/verbs.rs
+++ b/src/verbs.rs
@@ -1,0 +1,540 @@
+use std::collections::HashMap;
+use std::path::Path;
+use std::sync::OnceLock;
+
+use serde::{Deserialize, Serialize};
+
+use crate::watch::WAKE_WORTHY_VERBS;
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/// Behavioral shape of a verb -- governs wake-gate and reply routing.
+///
+/// Only `Wake` is load-bearing for the wake gate: a signal whose verb maps to
+/// this shape will page an asleep recipient. The remaining shapes are modeled
+/// for future downstream routing; today they all mean "does not wake".
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum VerbShape {
+    /// Wakes an asleep recipient. The agent MUST reply (or explicitly decline).
+    Wake,
+    /// Informational delivery -- no wake, silence is acknowledgment.
+    Record,
+    /// Explicitly discard / no-op; useful for machine-generated noise.
+    #[serde(rename = "fuckoff")]
+    Fuckoff,
+    /// May close a pending ask when the status matches a resolution pattern.
+    #[serde(rename = "maybe-close")]
+    MaybeClose,
+}
+
+/// Per-verb specification: shape plus any field constraints.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct VerbSpec {
+    /// Behavioral shape controlling wake and routing decisions.
+    pub shape: VerbShape,
+
+    /// Detail keys that MUST be present in a signal carrying this verb.
+    ///
+    /// An absent required field is a send-time error, not a warning.
+    #[serde(default)]
+    pub required_fields: Vec<String>,
+}
+
+// ---------------------------------------------------------------------------
+// TOML manifest schema
+//
+// Each manifest file uses a top-level [verbs] table:
+//
+//   [verbs.rfc]
+//   shape = "wake"
+//   required_fields = ["budget"]
+//
+//   [verbs.announce]
+//   shape = "record"
+//
+// Multiple files in the verbs dir are loaded and merged; later files override
+// earlier ones (sorted by filename for determinism).
+// ---------------------------------------------------------------------------
+
+/// Wire-format for a single manifest file: a [verbs] table.
+#[derive(Debug, Deserialize)]
+struct ManifestFile {
+    #[serde(default)]
+    verbs: HashMap<String, VerbSpec>,
+}
+
+/// Complete verb manifest: maps verb names to their `VerbSpec`.
+///
+/// Use `builtin_default()` for the canonical embedded manifest, or `load(dir)`
+/// to merge user-supplied overrides on top of it. `active_manifest()` returns
+/// the process-lifetime singleton, resolving from env vars or the embedded
+/// default.
+#[derive(Debug, Clone)]
+pub struct VerbManifest {
+    verbs: HashMap<String, VerbSpec>,
+}
+
+impl VerbManifest {
+    /// Return the embedded default manifest.
+    ///
+    /// The Wake set is derived directly from `WAKE_WORTHY_VERBS` (watch.rs) so
+    /// the two sources cannot drift without a compile error.  Informational
+    /// verbs (`announce`, `ack`, `info`, `answer`) are `Record`.  `rfc` carries
+    /// `required_fields = ["budget"]` as the canonical example of a structured
+    /// wake verb.
+    pub fn builtin_default() -> Self {
+        let mut verbs: HashMap<String, VerbSpec> = HashMap::new();
+
+        // Wake set -- derived from the watch.rs const so drift is impossible.
+        for &verb in WAKE_WORTHY_VERBS {
+            verbs.insert(
+                verb.to_string(),
+                VerbSpec {
+                    shape: VerbShape::Wake,
+                    required_fields: Vec::new(),
+                },
+            );
+        }
+
+        // rfc overrides its entry with a required "budget" field.
+        verbs.insert(
+            "rfc".to_string(),
+            VerbSpec {
+                shape: VerbShape::Wake,
+                required_fields: vec!["budget".to_string()],
+            },
+        );
+
+        // Informational verbs: deliver to live sessions, never wake.
+        for verb in ["announce", "ack", "info", "answer"] {
+            verbs.insert(
+                verb.to_string(),
+                VerbSpec {
+                    shape: VerbShape::Record,
+                    required_fields: Vec::new(),
+                },
+            );
+        }
+
+        Self { verbs }
+    }
+
+    /// Load a manifest from a directory of `*.toml` files, overlaying them
+    /// onto `builtin_default()`.
+    ///
+    /// Files are processed in sorted (lexicographic) order so the merge is
+    /// deterministic.  A missing or empty directory silently returns
+    /// `builtin_default()`.  A malformed TOML file logs to stderr and is
+    /// skipped (fail-open: a broken manifest must never brick the wake gate).
+    pub fn load(dir: &Path) -> Self {
+        let mut manifest = Self::builtin_default();
+
+        let read_dir = match std::fs::read_dir(dir) {
+            Ok(rd) => rd,
+            Err(_) => return manifest, // dir absent or unreadable -> embedded default
+        };
+
+        let mut paths: Vec<std::path::PathBuf> = read_dir
+            .filter_map(|entry| {
+                let entry = entry.ok()?;
+                let path = entry.path();
+                if path.extension().and_then(|e| e.to_str()) == Some("toml") {
+                    Some(path)
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        paths.sort();
+
+        for path in &paths {
+            let src = match std::fs::read_to_string(path) {
+                Ok(s) => s,
+                Err(e) => {
+                    eprintln!(
+                        "[legion verbs] failed to read {:?}: {} -- skipping",
+                        path, e
+                    );
+                    continue;
+                }
+            };
+
+            let parsed: ManifestFile = match toml::from_str(&src) {
+                Ok(m) => m,
+                Err(e) => {
+                    eprintln!(
+                        "[legion verbs] malformed TOML in {:?}: {} -- skipping",
+                        path, e
+                    );
+                    continue;
+                }
+            };
+
+            for (verb, spec) in parsed.verbs {
+                manifest.verbs.insert(verb, spec);
+            }
+        }
+
+        manifest
+    }
+
+    /// Returns `true` iff `verb` maps to `VerbShape::Wake` in this manifest.
+    ///
+    /// Unknown verbs return `false` -- an unlisted verb does not wake.
+    pub fn is_wake_worthy(&self, verb: &str) -> bool {
+        matches!(
+            self.verbs.get(verb),
+            Some(VerbSpec {
+                shape: VerbShape::Wake,
+                ..
+            })
+        )
+    }
+
+    /// Returns the required detail-field names for `verb`.
+    ///
+    /// Returns an empty slice for unknown verbs or verbs with no requirements.
+    pub fn required_fields(&self, verb: &str) -> &[String] {
+        self.verbs
+            .get(verb)
+            .map(|s| s.required_fields.as_slice())
+            .unwrap_or(&[])
+    }
+
+    /// The complete set of wake-worthy verb names in this manifest.
+    ///
+    /// Returned in sorted order for stable display.
+    pub fn wake_verb_names(&self) -> Vec<&str> {
+        let mut names: Vec<&str> = self
+            .verbs
+            .iter()
+            .filter(|(_, spec)| spec.shape == VerbShape::Wake)
+            .map(|(name, _)| name.as_str())
+            .collect();
+        names.sort_unstable();
+        names
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Process-lifetime singleton
+// ---------------------------------------------------------------------------
+
+static ACTIVE_MANIFEST: OnceLock<VerbManifest> = OnceLock::new();
+
+/// Return the process-lifetime active verb manifest.
+///
+/// Resolution order (first match wins):
+/// 1. `LEGION_VERBS_DIR` env var -- explicit override for tests and operators.
+/// 2. `${CLAUDE_PLUGIN_ROOT}/verbs` -- conventional plugin dir when the plugin
+///    root is configured.
+/// 3. Embedded `builtin_default()` -- always available, no filesystem required.
+///
+/// The result is cached for the process lifetime via `OnceLock`. Tests that
+/// need a different manifest should call `VerbManifest::load()` directly
+/// rather than relying on this singleton.
+pub fn active_manifest() -> &'static VerbManifest {
+    ACTIVE_MANIFEST.get_or_init(|| {
+        if let Ok(dir) = std::env::var("LEGION_VERBS_DIR") {
+            let path = Path::new(&dir);
+            if path.exists() {
+                return VerbManifest::load(path);
+            }
+        }
+
+        if let Ok(root) = std::env::var("CLAUDE_PLUGIN_ROOT") {
+            let path = Path::new(&root).join("verbs");
+            if path.exists() {
+                return VerbManifest::load(&path);
+            }
+        }
+
+        VerbManifest::builtin_default()
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Helper: write a toml string to a tempdir file and return the dir.
+    fn write_toml(dir: &tempfile::TempDir, name: &str, content: &str) {
+        let path = dir.path().join(name);
+        std::fs::write(path, content).expect("failed to write test toml");
+    }
+
+    // ---------------------------------------------------------------------------
+    // builtin_default correctness
+    // ---------------------------------------------------------------------------
+
+    #[test]
+    fn builtin_default_marks_all_wake_worthy_verbs_as_wake() {
+        let m = VerbManifest::builtin_default();
+        for verb in WAKE_WORTHY_VERBS {
+            assert!(
+                m.is_wake_worthy(verb),
+                "WAKE_WORTHY_VERBS entry '{}' must be Wake shape in builtin_default",
+                verb
+            );
+        }
+    }
+
+    #[test]
+    fn builtin_default_marks_informational_verbs_as_not_wake() {
+        let m = VerbManifest::builtin_default();
+        for verb in ["announce", "ack", "info", "answer"] {
+            assert!(
+                !m.is_wake_worthy(verb),
+                "informational verb '{}' must not be wake-worthy",
+                verb
+            );
+        }
+    }
+
+    #[test]
+    fn builtin_default_rfc_has_required_budget_field() {
+        let m = VerbManifest::builtin_default();
+        let fields = m.required_fields("rfc");
+        assert!(
+            fields.contains(&"budget".to_string()),
+            "rfc must have required_fields = [\"budget\"] in builtin_default"
+        );
+    }
+
+    #[test]
+    fn builtin_default_unknown_verb_is_not_wake_worthy() {
+        let m = VerbManifest::builtin_default();
+        assert!(!m.is_wake_worthy("escalation"));
+        assert!(!m.is_wake_worthy(""));
+    }
+
+    // ---------------------------------------------------------------------------
+    // load: absent / empty dir returns builtin_default
+    // ---------------------------------------------------------------------------
+
+    #[test]
+    fn load_absent_dir_returns_builtin_default() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        // Use a nonexistent subpath.
+        let absent = dir.path().join("no_such_dir");
+        let m = VerbManifest::load(&absent);
+        // Must have the same wake set as builtin_default.
+        let default = VerbManifest::builtin_default();
+        for verb in WAKE_WORTHY_VERBS {
+            assert_eq!(
+                m.is_wake_worthy(verb),
+                default.is_wake_worthy(verb),
+                "verb '{}' wake status differs from builtin_default",
+                verb
+            );
+        }
+    }
+
+    #[test]
+    fn load_empty_dir_returns_builtin_default() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let m = VerbManifest::load(dir.path());
+        let default = VerbManifest::builtin_default();
+        for verb in WAKE_WORTHY_VERBS {
+            assert_eq!(m.is_wake_worthy(verb), default.is_wake_worthy(verb));
+        }
+        for verb in ["announce", "ack", "info", "answer"] {
+            assert_eq!(m.is_wake_worthy(verb), default.is_wake_worthy(verb));
+        }
+    }
+
+    // ---------------------------------------------------------------------------
+    // load: adding a new verb without touching Rust source
+    // ---------------------------------------------------------------------------
+
+    #[test]
+    fn load_adds_new_wake_verb_from_toml_without_recompile() {
+        // This is the "no recompile" criterion from the issue:
+        // writing a TOML file and loading it makes a new verb wake-worthy.
+        let dir = tempfile::tempdir().expect("tempdir");
+        write_toml(
+            &dir,
+            "custom.toml",
+            r#"
+[verbs.escalation]
+shape = "wake"
+"#,
+        );
+        let m = VerbManifest::load(dir.path());
+        assert!(
+            m.is_wake_worthy("escalation"),
+            "escalation must be wake-worthy after loading custom.toml"
+        );
+        // Existing wake verbs must still work.
+        assert!(m.is_wake_worthy("question"));
+    }
+
+    // ---------------------------------------------------------------------------
+    // load: overriding an existing verb's shape
+    // ---------------------------------------------------------------------------
+
+    #[test]
+    fn load_can_override_existing_verb_shape() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write_toml(
+            &dir,
+            "override.toml",
+            r#"
+[verbs.question]
+shape = "record"
+"#,
+        );
+        let m = VerbManifest::load(dir.path());
+        assert!(
+            !m.is_wake_worthy("question"),
+            "overriding question to record must make it non-wake"
+        );
+        // Other wake verbs must be unaffected.
+        assert!(m.is_wake_worthy("request"));
+    }
+
+    // ---------------------------------------------------------------------------
+    // load: malformed TOML is fail-open
+    // ---------------------------------------------------------------------------
+
+    #[test]
+    fn load_malformed_toml_is_fail_open() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write_toml(&dir, "bad.toml", "this is not valid toml }{{{");
+        // Must not panic; must return a usable manifest.
+        let m = VerbManifest::load(dir.path());
+        // The builtin wake set must still be intact.
+        assert!(m.is_wake_worthy("question"));
+        assert!(!m.is_wake_worthy("announce"));
+    }
+
+    #[test]
+    fn load_good_file_processed_after_bad_file() {
+        // Sorted by filename: "a_bad.toml" < "b_good.toml".
+        // The good file must still be applied even if the bad one is skipped.
+        let dir = tempfile::tempdir().expect("tempdir");
+        write_toml(&dir, "a_bad.toml", "not valid { toml");
+        write_toml(
+            &dir,
+            "b_good.toml",
+            r#"
+[verbs.escalation]
+shape = "wake"
+"#,
+        );
+        let m = VerbManifest::load(dir.path());
+        assert!(m.is_wake_worthy("escalation"));
+    }
+
+    // ---------------------------------------------------------------------------
+    // required_fields
+    // ---------------------------------------------------------------------------
+
+    #[test]
+    fn required_fields_returns_empty_for_unknown_verb() {
+        let m = VerbManifest::builtin_default();
+        assert!(m.required_fields("nonexistent").is_empty());
+    }
+
+    #[test]
+    fn required_fields_returns_empty_for_question() {
+        let m = VerbManifest::builtin_default();
+        assert!(m.required_fields("question").is_empty());
+    }
+
+    // ---------------------------------------------------------------------------
+    // shipped default.toml wake set matches builtin_default
+    // ---------------------------------------------------------------------------
+
+    #[test]
+    fn shipped_default_toml_wake_set_matches_builtin_default() {
+        // Locate plugin/verbs/default.toml relative to CARGO_MANIFEST_DIR.
+        let manifest_dir = env!("CARGO_MANIFEST_DIR");
+        let toml_path = std::path::Path::new(manifest_dir)
+            .join("plugin")
+            .join("verbs")
+            .join("default.toml");
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        // Copy the shipped file into a fresh temp dir so load() picks it up.
+        let dest = dir.path().join("default.toml");
+        std::fs::copy(&toml_path, &dest)
+            .unwrap_or_else(|e| panic!("failed to copy {:?}: {}", toml_path, e));
+
+        let loaded = VerbManifest::load(dir.path());
+        let builtin = VerbManifest::builtin_default();
+
+        // Every builtin wake verb must be wake in the shipped file.
+        for verb in WAKE_WORTHY_VERBS {
+            assert_eq!(
+                loaded.is_wake_worthy(verb),
+                builtin.is_wake_worthy(verb),
+                "shipped default.toml and builtin_default disagree on wake status for '{}'",
+                verb
+            );
+        }
+
+        // Informational verbs must not be wake in the shipped file either.
+        for verb in ["announce", "ack", "info", "answer"] {
+            assert!(
+                !loaded.is_wake_worthy(verb),
+                "shipped default.toml marks '{}' as wake; it should be record",
+                verb
+            );
+        }
+    }
+
+    // ---------------------------------------------------------------------------
+    // regression: is_wake_worthy via manifest == #586 canon
+    // ---------------------------------------------------------------------------
+
+    #[test]
+    fn manifest_wake_gate_is_behavior_identical_to_586_canon() {
+        let m = VerbManifest::builtin_default();
+
+        // Canon wake verbs from #586 -- every one must wake.
+        let canon_wake = [
+            "question",
+            "request",
+            "handoff",
+            "correction",
+            "proposal",
+            "decision",
+            "rfc",
+            "routing",
+        ];
+        for verb in canon_wake {
+            assert!(
+                m.is_wake_worthy(verb),
+                "#586 canon wake verb '{}' must be wake-worthy",
+                verb
+            );
+        }
+
+        // Dropped verbs (old #404 set, not canon per #586) must NOT wake.
+        for verb in ["help", "blocker"] {
+            assert!(
+                !m.is_wake_worthy(verb),
+                "status-slot verb '{}' must not be wake-worthy (dropped in #586)",
+                verb
+            );
+        }
+
+        // Informational verbs must not wake.
+        for verb in ["announce", "ack", "info", "answer", "review"] {
+            assert!(
+                !m.is_wake_worthy(verb),
+                "informational verb '{}' must not be wake-worthy",
+                verb
+            );
+        }
+    }
+}

--- a/src/watch.rs
+++ b/src/watch.rs
@@ -941,25 +941,29 @@ pub const WAKE_WORTHY_VERBS: &[&str] = &[
 /// its recipient, so the sender can be warned at send time (#586).
 ///
 /// True when the target is a specific agent (not the `@all`/`@everyone`
-/// broadcast, which is never a directed page) AND the verb is outside
-/// [`WAKE_WORTHY_VERBS`]. Such a signal still delivers to a live session via the
-/// channel push, but it does not page an asleep agent -- surfacing that avoids
-/// the silent "I signaled but nobody woke" trap. Reserved broadcast names are
-/// matched case-insensitively.
+/// broadcast, which is never a directed page) AND the verb is not wake-worthy
+/// in the active manifest. Such a signal still delivers to a live session via
+/// the channel push, but it does not page an asleep agent -- surfacing that
+/// avoids the silent "I signaled but nobody woke" trap. Reserved broadcast
+/// names are matched case-insensitively.
 pub fn directed_verb_will_not_wake(to: &str, verb: &str) -> bool {
     let to_normalized = to.trim().to_ascii_lowercase();
     let is_broadcast = matches!(to_normalized.as_str(), "all" | "everyone");
-    !is_broadcast && !WAKE_WORTHY_VERBS.contains(&verb)
+    !is_broadcast && !crate::verbs::active_manifest().is_wake_worthy(verb)
 }
 
 /// Whether a signal text triggers a wake under the verb-driven gate.
 ///
-/// Returns `false` for posts, malformed signals, and signals whose verb is
-/// outside [`WAKE_WORTHY_VERBS`]. The decision is verb-only -- status is
+/// Returns `false` for posts, malformed signals, and signals whose verb is not
+/// wake-worthy in the active manifest. The decision is verb-only -- status is
 /// decoration that downstream tools may use, but the wake gate ignores it.
+///
+/// The active manifest defaults to `builtin_default()`, which reproduces the
+/// #586 canon exactly. Operators can overlay additional verbs via TOML files
+/// in the verbs directory without a legion release.
 pub fn is_wake_worthy(text: &str) -> bool {
     match signal::parse_signal(text) {
-        Some(sig) => WAKE_WORTHY_VERBS.contains(&sig.verb.as_str()),
+        Some(sig) => crate::verbs::active_manifest().is_wake_worthy(&sig.verb),
         None => false,
     }
 }


### PR DESCRIPTION
## Summary

The wake decision was a hard-coded `WAKE_WORTHY_VERBS` const (#586), so evolving the team's coordination vocabulary meant a code change and a legion release. This change makes the wake model data-driven: a new `src/verbs.rs` defines verb shapes (`wake`/`record`/`fuckoff`/`maybe-close`) and a `VerbManifest` loaded from TOML files under `plugin/verbs/`, with `is_wake_worthy` consulting the active manifest instead of the const. Behavior is identical by default -- the built-in default manifest is derived from `WAKE_WORTHY_VERBS` so it reproduces the #586 canon exactly -- and dropping a TOML file can add or override a verb with no recompile. Verbs may declare required fields (e.g. `rfc` requires a `budget`), enforced at signal-create.

## Acceptance criteria mapping

### 1. Wake behavior is driven by `plugin/verbs/` manifests, not a hard-coded set

`watch::is_wake_worthy` and `directed_verb_will_not_wake` now call `verbs::active_manifest().is_wake_worthy(&verb)`, where `active_manifest()` is a process-lifetime `OnceLock` resolving the verbs directory from `LEGION_VERBS_DIR`, then `${CLAUDE_PLUGIN_ROOT}/verbs`, then the embedded default. Only the `Wake` shape pages an asleep agent; `Record`/`Fuckoff`/`MaybeClose` do not wake (their richer downstream behavior is deliberately out of scope here -- they are modeled and parsed, not yet acted on beyond not-waking). The hot-path signature `is_wake_worthy(text: &str) -> bool` is unchanged, so no caller had to thread state.
Evidence: the rewired `is_wake_worthy`/`directed_verb_will_not_wake` in src/watch.rs; `verbs::active_manifest` (src/verbs.rs); `verbs::tests::manifest_wake_gate_is_behavior_identical_to_586_canon`.

### 2. Default manifest reproduces #586 canon

`VerbManifest::builtin_default()` builds its `Wake` set by iterating `watch::WAKE_WORTHY_VERBS` itself, so the manifest and the const cannot drift; it adds the informational verbs (`announce`/`ack`/`info`/`answer`) as `Record` and gives `rfc` a required `budget` field. The shipped `plugin/verbs/default.toml` encodes the same canon, and a test asserts the shipped file's wake set equals `builtin_default()`'s -- so the embedded default and the on-disk default can never silently diverge.
Evidence: `verbs::tests::builtin_default_marks_all_wake_worthy_verbs_as_wake`, `builtin_default_marks_informational_verbs_as_not_wake`, `builtin_default_rfc_has_required_budget_field`, `shipped_default_toml_wake_set_matches_builtin_default`; the unchanged `watch::tests::is_wake_worthy_recognizes_designated_verbs`/`rejects_informational_verbs`.

### 3. Adding a verb manifest changes behavior with no recompile

`VerbManifest::load(dir)` reads every `*.toml` in the directory (sorted for determinism) and overlays its entries onto the built-in default, so a manifest file can add a brand-new verb or override an existing verb's shape. A malformed or unreadable file logs to stderr and is skipped (fail-open: a broken manifest must never brick the wake gate). The "no recompile" property is proven by a test that writes a TOML file declaring a new `escalation -> wake` verb and asserts it becomes wake-worthy purely through `load`, with no source change.
Evidence: `verbs::tests::load_adds_new_wake_verb_from_toml_without_recompile`, `load_can_override_existing_verb_shape`, `load_absent_dir_returns_builtin_default`, `load_empty_dir_returns_builtin_default`, `load_malformed_toml_is_fail_open`, `load_good_file_processed_after_bad_file`.

### 4. Required-fields enforced at signal-create

The `Commands::Signal` handler looks up `active_manifest().required_fields(&verb)` and, before building or sending the signal, returns `LegionError::SignalMissingRequiredFields` (naming the verb, the missing field(s), and an example) when a required key is absent from the `--details` set. Verbs with no requirements (the common case) are unaffected.
Evidence: the validation block in src/main.rs `Commands::Signal` (runs before `format_signal`/send); `verbs::tests::builtin_default_rfc_has_required_budget_field`, `required_fields_returns_empty_for_question`, `required_fields_returns_empty_for_unknown_verb`.

### 5. All tests pass; simplify + review done; PR linked

`cargo test` green (952 bin unit tests + 156 integration, 0 failed), `cargo clippy -- -D warnings` clean, `cargo fmt -- --check` clean. All 16 verb tests use `tempfile::tempdir()` (no hardcoded `/tmp`, after the #585 Windows lesson), so they are cross-platform. Simplify gate recorded clean for HEAD. This PR references and closes #587.
Evidence: test output (952 + 156 passed, 0 failed); simplify gate row `019eaf72-7dff-72a2-b03b-7f872fb7956e`.

## Not done

The `Fuckoff` and `MaybeClose` shapes are modeled, parsed, and documented in `default.toml`, but their behavior beyond "does not wake" is intentionally future work -- this issue makes the wake gate data-driven, not the full verb-shape dispatch the checkpoint envisions. The `active_manifest()` singleton is resolved once per process via `OnceLock`; tests that need a different manifest call `VerbManifest::load()` directly rather than mutating the global (documented on the function). Required-field validation keys on the `--details` set; a field supplied only in free-text note is not counted (details are the structured slot). No changes to the #586 canon membership itself -- this PR consumes it as the default, it does not alter it.