### PR TITLE
fix(#599): port preflight -- daemon spawn/restart fail loud instead of start-then-die

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -69,6 +69,31 @@ pub fn spawn_detached(data_dir: &Path, port: u16) -> Result<()> {
         }
     }
 
+    // Port preflight (#599). The pidfile check above already returned for a
+    // live daemon we own, so if the port is bound now it is held by a FOREIGN
+    // process: a stray `legion serve` (which shares this port and writes the
+    // same daemon.pid), or an orphaned daemon the pidfile lost track of.
+    // Spawning anyway forks a child that dies on bind ("Address already in
+    // use") while we falsely report "daemon started (pid N)" and leave the
+    // pidfile pointing at a corpse. Fail loud and name the holder instead.
+    if !port_available(port) {
+        let holders = port_listener_pids(port);
+        let (who, hint) = match holders.first() {
+            Some(pid) => (
+                format!("pid {pid}"),
+                format!("stop it first (e.g. `kill {pid}`), then retry"),
+            ),
+            None => (
+                "another process".to_string(),
+                "stop it first, then retry".to_string(),
+            ),
+        };
+        return Err(LegionError::DaemonPortInUse(format!(
+            "port {port} is already held by {who}; not starting a second daemon. \
+             If this is a stray `legion serve` or an orphaned daemon, {hint}."
+        )));
+    }
+
     // Resolve the current binary path so the child runs the same binary.
     let binary = std::env::current_exe().map_err(LegionError::Io)?;
 
@@ -134,6 +159,41 @@ fn is_process_alive(pid: u32) -> bool {
     {
         let _ = pid;
         false
+    }
+}
+
+/// Whether `port` can be bound right now (i.e. it is free).
+///
+/// Binds and immediately drops a listener on `0.0.0.0:port`. A momentary
+/// TOCTOU gap exists between this probe and the daemon child's own bind, but it
+/// converts the common "another process already owns the port" case from a
+/// silent fork-then-die into a clear up-front error. The same race already
+/// existed before this check, so it adds safety without removing any.
+fn port_available(port: u16) -> bool {
+    std::net::TcpListener::bind(("0.0.0.0", port)).is_ok()
+}
+
+/// Best-effort: the PID(s) listening on `port`, for naming the holder in the
+/// port-conflict error. Unix-only via `lsof`; returns empty on other platforms
+/// or when `lsof` is unavailable -- the caller degrades to a generic message.
+fn port_listener_pids(port: u16) -> Vec<u32> {
+    #[cfg(unix)]
+    {
+        let output = std::process::Command::new("lsof")
+            .args(["-nP", &format!("-iTCP:{port}"), "-sTCP:LISTEN", "-t"])
+            .output();
+        match output {
+            Ok(out) => String::from_utf8_lossy(&out.stdout)
+                .lines()
+                .filter_map(|l| l.trim().parse::<u32>().ok())
+                .collect(),
+            Err(_) => Vec::new(),
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = port;
+        Vec::new()
     }
 }
 
@@ -544,6 +604,36 @@ mod tests {
             "stale (dead) pid -> nothing stopped"
         );
         assert!(!pid_path.exists(), "stale pidfile should be removed");
+    }
+
+    #[test]
+    fn port_available_false_for_bound_port() {
+        let listener = std::net::TcpListener::bind(("0.0.0.0", 0)).expect("bind ephemeral");
+        let port = listener.local_addr().expect("addr").port();
+        assert!(
+            !port_available(port),
+            "a held port must read as unavailable"
+        );
+    }
+
+    #[test]
+    fn spawn_detached_refuses_when_port_held() {
+        // Hold the port the way a stray `legion serve` or orphaned daemon would.
+        let listener = std::net::TcpListener::bind(("0.0.0.0", 0)).expect("bind ephemeral");
+        let port = listener.local_addr().expect("addr").port();
+        let dir = tempfile::tempdir().expect("tempdir");
+
+        let err = spawn_detached(dir.path(), port).expect_err("must refuse a held port");
+        assert!(
+            matches!(err, LegionError::DaemonPortInUse(_)),
+            "expected DaemonPortInUse, got {err:?}"
+        );
+        // The preflight returns before forking, so no doomed child is spawned
+        // and no pidfile is left pointing at a corpse.
+        assert!(
+            !dir.path().join(DAEMON_PID_FILE).exists(),
+            "no pidfile should be written when the port is held"
+        );
     }
 
     #[tokio::test]

--- a/src/error.rs
+++ b/src/error.rs
@@ -30,6 +30,9 @@ pub enum LegionError {
     #[error("daemon did not stop: {0}")]
     DaemonStopFailed(String),
 
+    #[error("daemon port in use: {0}")]
+    DaemonPortInUse(String),
+
     #[error("embedding error: {0}")]
     Embedding(String),
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -4273,13 +4273,26 @@ fn daemon_auto_spawn_clears_stale_pid() {
     let data_dir = tempfile::tempdir().unwrap();
     let pid_file = data_dir.path().join("daemon.pid");
 
+    // Use a free ephemeral port rather than the default 3131. The #599 port
+    // preflight now refuses to spawn onto an occupied port, and a dev box
+    // commonly already runs a daemon on 3131 -- binding port 0 and dropping the
+    // listener hands us a port that is free at this instant so the spawn path
+    // (and the stale-pid clearing it exercises) is what gets tested, not the
+    // collision guard.
+    // Bind 0.0.0.0:0 to mirror the production `port_available` probe exactly.
+    let port = std::net::TcpListener::bind(("0.0.0.0", 0))
+        .unwrap()
+        .local_addr()
+        .unwrap()
+        .port();
+
     // Write a stale PID: use 2^31 - 1, the maximum valid POSIX PID, which is
     // almost never a live process on any real system.
     let stale_pid: u32 = (i32::MAX) as u32;
     std::fs::write(&pid_file, stale_pid.to_string()).unwrap();
 
     let output = legion_cmd(data_dir.path())
-        .args(["daemon-spawn"])
+        .args(["daemon-spawn", "--port", &port.to_string()])
         .output()
         .unwrap();
 


### PR DESCRIPTION
## Summary

`spawn_detached` consulted only the `daemon.pid` file, never the port. When a foreign process held the daemon port -- a stray `legion serve` (which shares the port and the same `daemon.pid`) or an orphaned daemon the pidfile lost track of -- it forked a child that died on bind ("Address already in use") while printing "daemon started (pid N)" and leaving the pidfile pointing at a corpse. `daemon-restart` inherited this: it stopped the tracked daemon, then start-then-died against the squatter. This change adds a port preflight after the pidfile already-running check, so spawn/restart fail loud and name the holder instead of forking a doomed child. The deeper serve/daemon port-and-pidfile unification is split into #601.

## Acceptance criteria mapping

### 1. spawn_detached detects an already-held port (after the pidfile short-circuit) and returns a clear error naming the holder instead of forking a child that dies on bind
The preflight is placed deliberately after the existing pidfile check that returns early for a live daemon we own -- so a normal "already running" case still short-circuits exactly as before and the new path only fires when no tracked daemon explains the bound port. At that point a bound port means a foreign holder, so `port_available(port)` (a bind-and-drop probe on `0.0.0.0:port`) gates the spawn: if it cannot bind, the function returns `LegionError::DaemonPortInUse` whose message names the holder pid (best-effort via `lsof`, degrading to "another process" when `lsof` is unavailable) and suggests `kill <pid>`. No child is forked.
Evidence: preflight block in `spawn_detached` (src/daemon.rs, immediately before `std::env::current_exe()`); helpers `port_available` and `port_listener_pids`; new `LegionError::DaemonPortInUse` variant in src/error.rs; test `spawn_detached_refuses_when_port_held` asserts the `Err(DaemonPortInUse)`.

### 2. No pidfile is written when the spawn is refused for a held port
The preflight returns `Err` before the function reaches `std::fs::write(&pid_path, ...)`, which only runs after a successful fork further down. So a refused spawn cannot leave a stale or wrong pid in `daemon.pid` -- the corpse-pointer that made the original incident hard to diagnose. The test asserts the pidfile does not exist after a refused spawn against a held port.
Evidence: `spawn_detached_refuses_when_port_held` asserts `!dir.path().join(DAEMON_PID_FILE).exists()` after the refusal; the `std::fs::write(&pid_path, ...)` call sits below the preflight in src/daemon.rs.

### 3. Regression coverage for the "port already bound" startup path
Two unit tests plus an updated integration test lock the behavior. `port_available_false_for_bound_port` binds an ephemeral port and asserts the probe reports it unavailable. `spawn_detached_refuses_when_port_held` exercises the full refusal path (error variant + no pidfile). The integration test `daemon_auto_spawn_clears_stale_pid` previously passed only because `daemon-spawn` lied about success on the default port; it now binds an ephemeral free port and passes `--port`, so it deterministically exercises the stale-pid-clear path through the honest preflight regardless of whether a real daemon already holds 3131 on the host.
Evidence: `port_available_false_for_bound_port` and `spawn_detached_refuses_when_port_held` in src/daemon.rs tests; the ephemeral-port change in `daemon_auto_spawn_clears_stale_pid` in tests/integration.rs.

## Not done

- Unifying serve/daemon ownership of :3131 and the shared `daemon.pid` file, and tracing/gating the #321 supervisor auto-start so a daemon kill cannot spawn an orphan `legion serve` on the daemon port -- deliberately deferred to #601. This PR makes the collision safe (fail loud) but does not remove the collision itself; getting the ownership model right needs design work I did not want to rush.
- The bind-and-drop probe has an inherent TOCTOU gap between the check and the child's own bind. That race already existed before this change (the daemon always bound after the fork); the preflight only adds an up-front guard for the common case, so it is strictly safer, not a new hazard.