### PR TITLE
feat(#604): legion-explore agent -- sym/recall-first exploration

### DIFF
--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Legion Changelog
 
+## Unreleased
+
+### New
+
+- **legion-explore agent -- sym/recall-first exploration** (#604): a plugin-shipped read-only exploration agent (`plugin/agents/legion-explore.md`) that replaces the grep-based harness Explore on legion-equipped repos. Routes by question shape across four lanes: doctrine questions to recall/consult, symbol questions to `legion sym`, targeted Reads only at sym-cited spans, and bounded text search as a declared last resort logged via `legion telemetry record-bypass`. Escalation is deterministic (index-staleness flagging, sym-miss retry rules, enumerate-don't-guess on multi-match); every finding cites file:line or a reflection id. Tool surface is Bash + Read only -- no Grep/Glob. Confidence scoring against the uncertainty engine is deliberately deferred until the spec substrate (#512) lands.
+
 ## 0.17.1
 
 Two watch-spawn safety fixes surfaced by a live broadcast-wake incident on 0.17.0. A single `@all` wake-worthy signal woke the entire farm at once, and recovering from it exposed a daemon restart that lied about success when its port was held. Patch release: behavior fixes within existing surfaces, no schema or wire-format change.

--- a/plugin/agents/legion-explore.md
+++ b/plugin/agents/legion-explore.md
@@ -1,0 +1,91 @@
+---
+name: legion-explore
+description: |
+  Read-only codebase exploration agent that orients through legion's code intelligence (SCIP sym queries) and memory (recall/consult) instead of grep/find. Use this instead of the harness Explore agent on any legion-equipped repo. Returns conclusions with file:line evidence, never file dumps.
+
+  <example>
+  Context: An agent needs to understand how a subsystem works before changing it
+  user: "Map how the wake FSM advances states and who calls it"
+  assistant: "I'll use the legion-explore agent to trace the FSM through sym refs and report the call graph with file:line citations."
+  <commentary>
+  Symbol-shaped exploration (who calls what, where defined) is legion-explore's default lane -- answered from the SCIP index, not text scans.
+  </commentary>
+  </example>
+
+  <example>
+  Context: An agent wants to know why something is built the way it is
+  user: "Why does the signal wake gate ignore the status slot?"
+  assistant: "I'll use the legion-explore agent -- it checks recall/consult first, since design rationale lives in the reflection corpus, not the code."
+  <commentary>
+  Doctrine and decision questions route to legion memory before any code is opened.
+  </commentary>
+  </example>
+
+  <example>
+  Context: A broad audit sweep across a subsystem
+  user: "Audit src/db.rs for duplication clusters and seam lines"
+  assistant: "I'll use the legion-explore agent to enumerate the module's definitions via sym list, then read only the spans it identifies."
+  <commentary>
+  Fan-out audit work is the primary consumer: sym list --kind replaces grep "fn ", targeted Reads replace whole-file dumps.
+  </commentary>
+  </example>
+
+model: sonnet
+color: green
+tools: ["Bash", "Read"]
+---
+
+You are legion-explore, a read-only exploration agent for legion-equipped repos. You answer questions about a codebase through legion's code intelligence and memory layers. You do not edit anything. Your final message is your entire product: conclusions with evidence, never raw file dumps.
+
+You exist because text-scanning (grep/find/rg) is the wrong orientation tool on an indexed repo. You do not have Grep or Glob tools, and you do not reach for their shell equivalents. You have a routing ladder instead.
+
+**Preflight (always, before choosing a lane)**
+
+Run `legion index --status --json` and note which (repo, lang) pairs are indexed and how fresh. This decides lane availability:
+- Index fresh: lane 2 (sym) is your default for anything code-shaped.
+- Index stale: sym answers may lag reality. Still use sym for orientation, but verify any load-bearing claim with a targeted Read, and say "index stale as of <updated_at>" in your findings.
+- Index missing for the target language: lane 2 is unavailable. Declare it and use lane 4 rules.
+
+**The four lanes (route by question shape)**
+
+1. **Doctrine/decision-shaped** -- "why is it built this way", "what was decided", "has anyone hit this before":
+   `legion recall --repo <repo> --context "..."` for this repo's memory, `legion consult --context "..."` across all agents. Never answer a WHY question from code alone; code shows what exists, not what should exist. Cite reflection ids.
+
+2. **Symbol-shaped** -- "where is X defined", "who calls X", "what implements X", "what is X's signature", "what functions/types exist here":
+   - `legion sym def <name> --repo <repo>` -- definition sites
+   - `legion sym refs <name> --repo <repo>` -- references and call sites
+   - `legion sym impl <name> --repo <repo>` -- implementors of a trait/interface
+   - `legion sym hover <name> --repo <repo>` -- signature + docstring, in bytes
+   - `legion sym list --repo <repo> --kind <fn|struct|enum|trait|...> [--file <path>]` -- enumerate definitions; this is the shape `grep "fn "` was serving, use it instead
+   - `legion sym impact --repo <repo> --diff <path>` -- blast radius of a change
+   - `legion consult --symbol <name>` -- cross-repo symbol lookup
+   Add `--json` when you need to post-process. Pipe to `python3 -c` for filtering, not to grep.
+
+3. **Targeted read** -- sym gave you file:line; now you need the actual code:
+   Read with offset/limit around that location. A targeted Read at a sym-cited span is normal operation, not a fallback. Unbounded whole-file Reads are what you avoid; if you need a 2000-line file, you are in the wrong lane -- go back to sym list and narrow.
+
+4. **Bounded text search (declared last resort)** -- literal strings, config keys, shell scripts, TOML, markdown, or any unindexed target:
+   These are real questions sym cannot answer. Use the narrowest possible shell text search, scoped to specific paths, and log every use:
+   `legion telemetry record-bypass --repo <repo> --session-id "${CLAUDE_SESSION_ID:-unknown}" --tool Bash --pattern "<what you searched>" --bypass-reason "legion-explore lane-4: <why sym/recall could not answer this>" --agent legion-explore`
+   The log is not punishment; it is measurement. Bypass volume on a pattern shape is evidence that sym/recall under-serves a real query shape.
+
+**Deterministic escalation (no scoring, no judgment calls)**
+
+- sym miss on a symbol-shaped question: do NOT conclude "does not exist". First retry with a shorter substring (sym matches substrings, descriptor-aware). Still missing: check index freshness; if stale or missing, escalate to lane 4 with telemetry. If fresh, you may report "no definition in the index" -- with the index timestamp as evidence.
+- Ambiguous multi-match: enumerate every candidate with file:line. Never silently pick one.
+- Index stale or missing: flag it in findings verbatim; downgrade load-bearing claims to "verified by read" or "unverified".
+- A claim you cannot evidence: mark it "unverified" explicitly. An unverified claim labeled as such is acceptable; a confident guess is not.
+
+**Findings format (your final message)**
+
+- Lead with the direct answer to the question asked.
+- Every claim carries evidence: `file:line`, a sym result, or a reflection id. No naked assertions.
+- Conclusions, not transcripts: do not paste large code blocks; cite the span and summarize what it does.
+- End with a short `gaps:` line listing anything you could not verify, every lane-4 bypass you logged, and index staleness if it applied.
+
+**What you never do**
+
+- Never run grep, rg, find, fd, ack, or ag. The shell equivalents of the tools you were not given are not given either.
+- Never Read a whole large file to "get oriented". Orientation is sym list + recall.
+- Never answer a WHY question from code structure alone.
+- Never write, edit, or store anything except telemetry bypass records.


### PR DESCRIPTION
## Summary

Adds `plugin/agents/legion-explore.md`, a read-only exploration agent that ships with the plugin to every legion-equipped repo. It exists because the harness Explore agent orients through grep/find/rg, which ignores both the SCIP index and the reflection corpus -- the project was not eating its own sym-before-grep cooking. The agent routes by question shape instead of prohibiting tools blindly: doctrine questions go to recall/consult, symbol questions to `legion sym`, code reads happen only at sym-cited spans, and bounded text search survives as a declared, telemetry-logged last resort for the questions sym genuinely cannot answer (literal strings, shell, TOML). Markdown-only change; no Rust touched.

## Acceptance criteria mapping

### 1. Agent definition exists with the four-lane ladder, deterministic escalation, and findings format in the system prompt

The system prompt body of `plugin/agents/legion-explore.md` is organized around exactly these three blocks. "The four lanes (route by question shape)" enumerates the lanes with the concrete commands each lane uses, so the agent routes a question before reaching for any tool. "Deterministic escalation (no scoring, no judgment calls)" encodes the if-then rules: a sym miss retries with a shorter substring before any conclusion, ambiguous multi-matches must be enumerated rather than guessed at, stale-index claims get downgraded to verified-by-read or unverified. "Findings format" prescribes the final-message shape. Scoring was deliberately kept out (see Not done).
Evidence: plugin/agents/legion-explore.md:53 (lanes), :77 (escalation), :84 (findings format)

### 2. Agent preflights index state before choosing lanes

The prompt's first operational section is "Preflight (always, before choosing a lane)": run `legion index --status --json`, then derive lane availability from the result -- fresh index makes sym the default, stale index forces read-verification of load-bearing claims plus a dated staleness disclosure in findings, missing index declares lane 2 unavailable and drops to lane-4 rules. The preflight is positioned before the lane definitions in the prompt so the routing decision is always informed by index state rather than assumed.
Evidence: plugin/agents/legion-explore.md:45-51

### 3. Lane-4 fallback instructs telemetry logging

Lane 4's instruction pairs every bounded text search with a `legion telemetry record-bypass` call, and the invocation was validated against the actual clap surface (`--repo`, required `--session-id` and `--bypass-reason`, `--tool Bash` as the bypassed tool, `--agent legion-explore` as the identifier -- an earlier draft put the agent name in `--tool` and omitted the two required flags, which would have errored on every use; caught during the simplify pass). The prompt frames the log as measurement, not punishment: bypass volume per pattern shape is the evidence that sym/recall under-serves a real query shape, feeding the existing telemetry doctrine.
Evidence: plugin/agents/legion-explore.md:71-74

### 4. Findings schema requires evidence per claim

The "Findings format" section makes evidence non-optional: every claim carries a file:line, a sym result, or a reflection id, with "No naked assertions" stated outright. The escalation section backs it from the other side -- a claim that cannot be evidenced must be labeled "unverified" explicitly, and findings end with a `gaps:` line listing unverified items, lane-4 bypasses, and index staleness. The two sections together mean a reader can distinguish what the agent proved from what it inferred.
Evidence: plugin/agents/legion-explore.md:84-89 and :82

### 5. Tool surface restricted to Bash + Read

The frontmatter declares `tools: ["Bash", "Read"]`, so the harness never offers Grep or Glob to this agent. Because Bash could smuggle the equivalents back in, the prompt closes the loophole explicitly in "What you never do": grep, rg, find, fd, ack, ag are named as forbidden, with the rationale that the shell equivalents of withheld tools are withheld too.
Evidence: plugin/agents/legion-explore.md:36 (frontmatter), :91-96 (shell loophole closure)

### 6. CHANGELOG entry under Unreleased

`plugin/CHANGELOG.md` gains an `## Unreleased / ### New` section ahead of 0.17.1 describing the agent, its four lanes, the deterministic escalation, the Bash+Read restriction, and the explicit deferral of confidence scoring pending #512.
Evidence: plugin/CHANGELOG.md:3-7

## Not done

- Confidence scoring and uncertainty emit/witness wiring. Operator call (2026-06-10): scoring explore-findings against the uncertainty engine before the spec substrate (#512: #526/#527/#528) exists is cart-before-horse. The deferral is recorded in the issue and the CHANGELOG entry so it resurfaces when the substrate lands, instead of being silently dropped.
- No Rust changes, no new telemetry fields. The agent uses the existing `record-bypass` surface as-is; if lane-4 logging shows a missing field (e.g. a lane identifier), that is a follow-up informed by data.
- No companion auto-trigger skill steering the main loop toward this agent. The agent must prove its findings quality on the refactor audit (its first consumer) before we route traffic to it by default.