### PR TITLE
chore(release): 0.17.2

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
     {
       "name": "legion",
       "description": "Agent memory layer with recall, reflect, consult, bullpen, and cross-agent coordination. Includes health monitoring and auto-wake. Hooks wire legion into every session automatically.",
-      "version": "0.17.1",
+      "version": "0.17.2",
       "author": {
         "name": "Sean Silvius",
         "email": "sean@silvius.me"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1473,7 +1473,7 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "legion"
-version = "0.17.1"
+version = "0.17.2"
 dependencies = [
  "async-stream",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "legion"
-version = "0.17.1"
+version = "0.17.2"
 edition = "2024"
 description = "Agent specialization through deliberate practice"
 

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "legion",
-  "version": "0.17.1",
+  "version": "0.17.2",
   "description": "Institutional memory for Claude Code agents with real-time team channel.",
   "author": {
     "name": "Sean Silvius",

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Legion Changelog
 
-## Unreleased
+## 0.17.2
+
+The quality pipeline completes and the definition layer lands. The plugin now ships every stage of the work pipeline -- explore, simplify, pr-write, review, verify -- and the substrate holds its first real schemas. Patch release: additive features within existing surfaces, no schema migration, no wire-format change.
 
 ### New
 


### PR DESCRIPTION
## 0.17.2 -- the pipeline completes, the definition layer lands

All features already merged to main; this PR is the version cut.

- **#604 (PR #605)** -- legion-explore agent: sym/recall-first exploration replacing grep-based harness Explore on every legion-equipped repo. Four-lane routing, deterministic escalation, telemetry-logged fallback.
- **#526 (PR #618)** -- schemas as documents: requirement + five service-design schemas in the substrate (doc_type=schema), structurally gated at create, recallable via --domain schema pointer reflections, plus legion document validate (dependency-free subset validator). 6/6 vault instances pass.
- **#617 (PR #619)** -- legion-review agent + skill: the review gate between pr-write and verify, repo-generic, with dimension fan-out, adversarial refutation of findings, and a HEAD-keyed legion-review quality gate. Absorbs #532/#177. First live run reviewed its own PR and caught a namespacing bug that would have failed on every plugin install.

Patch release: additive features within existing surfaces, no schema migration, no wire-format change. Version synced across Cargo.toml, Cargo.lock, plugin.json, marketplace.json (sync-version hook did not fire in this clone; synced manually and verified). CHANGELOG header matches Cargo.toml.

Releasing puts legion-explore and legion-review in the fleet's plugin caches -- the operator's ask: the reviewer exists so other agents can review while legion works.