### PR TITLE
fix(#621): pr merge defers to repo review policy instead of hardcoding APPROVED

### DIFF
--- a/plugin/worksources/github
+++ b/plugin/worksources/github
@@ -346,12 +346,21 @@ case "${1:-}" in
       echo '{"error":"gh CLI not found"}' >&2
       exit 1
     fi
-    # Check review status before merging
+    # Review gate defers to the repo's own policy (#621): reviewDecision is
+    # empty when the repo has no required-review branch protection, so only
+    # an explicit negative decision blocks here. gh pr merge still fails if
+    # any actual branch protection is unmet.
     REVIEW_STATUS=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json reviewDecision -q '.reviewDecision' 2>/dev/null)
-    if [ "$REVIEW_STATUS" != "APPROVED" ]; then
-      echo "{\"error\":\"PR #${PR_NUMBER} not approved (status: ${REVIEW_STATUS:-NONE})\"}" >&2
-      exit 1
-    fi
+    case "$REVIEW_STATUS" in
+      CHANGES_REQUESTED)
+        echo "{\"error\":\"PR #${PR_NUMBER} has changes requested -- address the review before merging\"}" >&2
+        exit 1
+        ;;
+      REVIEW_REQUIRED)
+        echo "{\"error\":\"PR #${PR_NUMBER} requires a review per branch protection and has none\"}" >&2
+        exit 1
+        ;;
+    esac
     ARGS=(pr merge "$PR_NUMBER" --repo "$REPO")
     case "$STRATEGY" in
       squash) ARGS+=(--squash) ;;


### PR DESCRIPTION
## Summary

legion pr merge refused every merge on runlegion/legion with "not approved (status: NONE)" after the operator removed required reviews from the repo. Root cause: plugin/worksources/github:349-354 hardcoded reviewDecision == APPROVED, but GitHub's reviewDecision is empty precisely when a repo has no required-review branch protection -- the plugin was enforcing a policy the repo does not have. Surfaced live blocking release PR #620. The gate now defers to the repo: explicit negative decisions block, absence of a policy does not.

## Acceptance criteria mapping

### 1. merge proceeds when reviewDecision is empty (no required-review protection)

The unconditional `!= APPROVED` rejection is replaced by a case statement over REVIEW_STATUS that only matches the two negative decisions; an empty string falls through both patterns and execution continues to `gh pr merge`, which itself still fail-closes if any real branch protection is unmet. Observable behavior: PR #620 (reviewDecision empty on this repo) merges through this path where it previously errored.
Evidence: plugin/worksources/github:349-364 (case statement); merge of #620 via the fixed plugin

### 2. merge proceeds when reviewDecision is APPROVED

APPROVED matches neither CHANGES_REQUESTED nor REVIEW_REQUIRED in the case statement, so it falls through to the gh pr merge invocation exactly as the empty case does -- approved PRs keep working unchanged.
Evidence: plugin/worksources/github:355-364 (no APPROVED arm; fallthrough to merge)

### 3. merge refuses with the decision named when reviewDecision is CHANGES_REQUESTED or REVIEW_REQUIRED

Each negative decision has its own case arm emitting a JSON error and exit 1, preserving the fail-closed behavior for repos that DO configure review requirements.
Evidence: plugin/worksources/github:351-358 (two explicit refusal arms)

### 4. error message distinguishes 'changes requested' from 'review required'

The CHANGES_REQUESTED arm says "has changes requested -- address the review before merging"; the REVIEW_REQUIRED arm says "requires a review per branch protection and has none". An agent hitting either knows which remedy applies (fix findings vs obtain a review).
Evidence: plugin/worksources/github:352-357 (distinct messages per arm)

## Not done

- No change to the review-submission path (the APPROVE event arm) -- GitHub still forbids self-approval and that is GitHub's policy to keep.
- No repo-settings introspection (querying branch protection directly): reviewDecision already encodes the repo's effective policy, which is the cheaper and equivalent signal.
- The cached plugin copies in ~/.claude/plugins update on the next release; until then the fixed worksource resolves via CLAUDE_PLUGIN_ROOT.