### PR TITLE
fix(#536): cluster sync runs under the daemon and actually transfers data

### DIFF
--- a/src/cluster.rs
+++ b/src/cluster.rs
@@ -4,6 +4,14 @@
 //! and synchronize reflections, cards, and schedules using delta packets.
 //! All traffic is encrypted with XChaCha20-Poly1305 using a pre-shared key.
 //!
+//! Trust model: the PSK is the entire boundary. Schedules sync across the
+//! cluster and the schedule runner executes their commands, so possession
+//! of the secret (or compromise of any one node) is command execution on
+//! every node. Share the key accordingly. Discovery announcements are
+//! unauthenticated by design (availability only -- delta payloads stay
+//! AEAD-sealed); an on-LAN spoofer can misdirect traffic but not read or
+//! forge it.
+//!
 //! Configuration is stored in `<data_dir>/cluster.toml`:
 //! ```toml
 //! enabled = true

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -486,6 +486,12 @@ async fn run_watch_task(data_dir: &Path) {
 
     let host = watch::resolve_host_id();
 
+    // Spawn the cluster sync actor when enabled (#536 defect 1: this task
+    // previously never loaded cluster.toml, so sync only ran under the
+    // deprecated foreground `legion watch`). The handle lives for the
+    // lifetime of this task; sync is optional and never fatal.
+    let _sync_handle = crate::sync_actor::spawn_sync_if_enabled(data_dir, "[legion daemon]");
+
     // Timer intervals are read before `config` moves into the WatchLoop.
     let poll_interval = std::time::Duration::from_secs(config.poll_interval_secs);
     let health_interval = std::time::Duration::from_secs(config.health_poll_secs);

--- a/src/db.rs
+++ b/src/db.rs
@@ -4025,6 +4025,262 @@ impl Database {
         tx.commit()?;
         Ok(late_loser)
     }
+
+    /// Apply a peer's reflection delta with last-write-wins merge (#536).
+    ///
+    /// No local row: INSERT (embedding stays NULL -- each node computes its
+    /// own embeddings, see the ReflectionDelta doc). Local row exists: the
+    /// delta wins only when its effective timestamp (max of updated_at /
+    /// deleted_at, falling back to created_at) is strictly newer than the
+    /// local row's. Tombstones ride the same comparison.
+    pub fn apply_reflection_delta(&self, delta: &crate::sync::ReflectionDelta) -> Result<()> {
+        let tx = self.conn.unchecked_transaction()?;
+
+        let local: Option<(String, Option<String>, Option<String>)> = tx
+            .query_row(
+                "SELECT created_at, updated_at, deleted_at FROM reflections WHERE id = ?1",
+                rusqlite::params![&delta.id],
+                |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)),
+            )
+            .optional()?;
+
+        let delta_ts = effective_sync_ts(&delta.created_at, &delta.updated_at, &delta.deleted_at);
+        match local {
+            None => {
+                tx.execute(
+                    "INSERT INTO reflections \
+                     (id, repo, text, created_at, updated_at, deleted_at, audience, \
+                      domain, tags, recall_count, last_recalled_at, parent_id) \
+                     VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)",
+                    rusqlite::params![
+                        &delta.id,
+                        &delta.repo,
+                        &delta.text,
+                        &delta.created_at,
+                        &delta.updated_at,
+                        &delta.deleted_at,
+                        &delta.audience,
+                        &delta.domain,
+                        &delta.tags,
+                        &delta.recall_count,
+                        &delta.last_recalled_at,
+                        &delta.parent_id,
+                    ],
+                )?;
+            }
+            Some((local_created, local_updated, local_deleted)) => {
+                let local_ts = effective_sync_ts(&local_created, &local_updated, &local_deleted);
+                if delta_ts > local_ts {
+                    tx.execute(
+                        "UPDATE reflections SET repo = ?2, text = ?3, created_at = ?4, \
+                         updated_at = ?5, deleted_at = ?6, audience = ?7, domain = ?8, \
+                         tags = ?9, recall_count = ?10, last_recalled_at = ?11, parent_id = ?12 \
+                         WHERE id = ?1",
+                        rusqlite::params![
+                            &delta.id,
+                            &delta.repo,
+                            &delta.text,
+                            &delta.created_at,
+                            &delta.updated_at,
+                            &delta.deleted_at,
+                            &delta.audience,
+                            &delta.domain,
+                            &delta.tags,
+                            &delta.recall_count,
+                            &delta.last_recalled_at,
+                            &delta.parent_id,
+                        ],
+                    )?;
+                }
+            }
+        }
+        tx.commit()?;
+        Ok(())
+    }
+
+    /// Apply a peer's card delta with last-write-wins merge (#536). Same
+    /// LWW rule as [`Self::apply_reflection_delta`].
+    pub fn apply_card_delta(&self, delta: &crate::sync::CardDelta) -> Result<()> {
+        let tx = self.conn.unchecked_transaction()?;
+
+        let local: Option<(String, Option<String>, Option<String>)> = tx
+            .query_row(
+                "SELECT created_at, updated_at, deleted_at FROM tasks WHERE id = ?1",
+                rusqlite::params![&delta.id],
+                |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)),
+            )
+            .optional()?;
+
+        let updated = Some(delta.updated_at.clone());
+        let delta_ts = effective_sync_ts(&delta.created_at, &updated, &delta.deleted_at);
+        match local {
+            None => {
+                tx.execute(
+                    "INSERT INTO tasks \
+                     (id, from_repo, to_repo, text, context, priority, status, note, labels, \
+                      parent_card_id, source_url, source_type, sort_order, created_at, \
+                      updated_at, deleted_at, assigned_at, started_at, completed_at, \
+                      problem, solution, acceptance) \
+                     VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, \
+                             ?15, ?16, ?17, ?18, ?19, ?20, ?21, ?22)",
+                    rusqlite::params![
+                        &delta.id,
+                        &delta.from_repo,
+                        &delta.to_repo,
+                        &delta.text,
+                        &delta.context,
+                        &delta.priority,
+                        &delta.status,
+                        &delta.note,
+                        &delta.labels,
+                        &delta.parent_card_id,
+                        &delta.source_url,
+                        &delta.source_type,
+                        &delta.sort_order,
+                        &delta.created_at,
+                        &delta.updated_at,
+                        &delta.deleted_at,
+                        &delta.assigned_at,
+                        &delta.started_at,
+                        &delta.completed_at,
+                        &delta.problem,
+                        &delta.solution,
+                        &delta.acceptance,
+                    ],
+                )?;
+            }
+            Some((local_created, local_updated, local_deleted)) => {
+                let local_ts = effective_sync_ts(&local_created, &local_updated, &local_deleted);
+                if delta_ts > local_ts {
+                    tx.execute(
+                        "UPDATE tasks SET from_repo = ?2, to_repo = ?3, text = ?4, context = ?5, \
+                         priority = ?6, status = ?7, note = ?8, labels = ?9, parent_card_id = ?10, \
+                         source_url = ?11, source_type = ?12, sort_order = ?13, created_at = ?14, \
+                         updated_at = ?15, deleted_at = ?16, assigned_at = ?17, started_at = ?18, \
+                         completed_at = ?19, problem = ?20, solution = ?21, acceptance = ?22 \
+                         WHERE id = ?1",
+                        rusqlite::params![
+                            &delta.id,
+                            &delta.from_repo,
+                            &delta.to_repo,
+                            &delta.text,
+                            &delta.context,
+                            &delta.priority,
+                            &delta.status,
+                            &delta.note,
+                            &delta.labels,
+                            &delta.parent_card_id,
+                            &delta.source_url,
+                            &delta.source_type,
+                            &delta.sort_order,
+                            &delta.created_at,
+                            &delta.updated_at,
+                            &delta.deleted_at,
+                            &delta.assigned_at,
+                            &delta.started_at,
+                            &delta.completed_at,
+                            &delta.problem,
+                            &delta.solution,
+                            &delta.acceptance,
+                        ],
+                    )?;
+                }
+            }
+        }
+        tx.commit()?;
+        Ok(())
+    }
+
+    /// Apply a peer's schedule delta with last-write-wins merge (#536). Same
+    /// LWW rule as [`Self::apply_reflection_delta`].
+    pub fn apply_schedule_delta(&self, delta: &crate::sync::ScheduleDelta) -> Result<()> {
+        let tx = self.conn.unchecked_transaction()?;
+
+        let local: Option<(String, Option<String>, Option<String>)> = tx
+            .query_row(
+                "SELECT created_at, updated_at, deleted_at FROM schedules WHERE id = ?1",
+                rusqlite::params![&delta.id],
+                |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)),
+            )
+            .optional()?;
+
+        let delta_ts = effective_sync_ts(&delta.created_at, &delta.updated_at, &delta.deleted_at);
+        match local {
+            None => {
+                tx.execute(
+                    "INSERT INTO schedules \
+                     (id, name, cron, command, repo, enabled, last_run, next_run, created_at, \
+                      updated_at, deleted_at, active_start, active_end) \
+                     VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)",
+                    rusqlite::params![
+                        &delta.id,
+                        &delta.name,
+                        &delta.cron,
+                        &delta.command,
+                        &delta.repo,
+                        &delta.enabled,
+                        &delta.last_run,
+                        &delta.next_run,
+                        &delta.created_at,
+                        &delta.updated_at,
+                        &delta.deleted_at,
+                        &delta.active_start,
+                        &delta.active_end,
+                    ],
+                )?;
+            }
+            Some((local_created, local_updated, local_deleted)) => {
+                let local_ts = effective_sync_ts(&local_created, &local_updated, &local_deleted);
+                if delta_ts > local_ts {
+                    tx.execute(
+                        "UPDATE schedules SET name = ?2, cron = ?3, command = ?4, repo = ?5, \
+                         enabled = ?6, last_run = ?7, next_run = ?8, created_at = ?9, \
+                         updated_at = ?10, deleted_at = ?11, active_start = ?12, active_end = ?13 \
+                         WHERE id = ?1",
+                        rusqlite::params![
+                            &delta.id,
+                            &delta.name,
+                            &delta.cron,
+                            &delta.command,
+                            &delta.repo,
+                            &delta.enabled,
+                            &delta.last_run,
+                            &delta.next_run,
+                            &delta.created_at,
+                            &delta.updated_at,
+                            &delta.deleted_at,
+                            &delta.active_start,
+                            &delta.active_end,
+                        ],
+                    )?;
+                }
+            }
+        }
+        tx.commit()?;
+        Ok(())
+    }
+}
+
+/// Effective timestamp for sync LWW comparisons (#536): the latest of
+/// updated_at / deleted_at, falling back to created_at when neither is set.
+/// RFC3339 strings compare lexicographically in time order.
+fn effective_sync_ts<'a>(
+    created_at: &'a str,
+    updated_at: &'a Option<String>,
+    deleted_at: &'a Option<String>,
+) -> &'a str {
+    let mut best = created_at;
+    if let Some(u) = updated_at.as_deref()
+        && u > best
+    {
+        best = u;
+    }
+    if let Some(d) = deleted_at.as_deref()
+        && d > best
+    {
+        best = d;
+    }
+    best
 }
 
 // -- wake_attempts (#487, part of #495) --------------------------------------
@@ -7460,6 +7716,193 @@ mod tests {
         assert!(
             listed.is_empty(),
             "incoming tombstone with newer updated_at must eclipse local live lease"
+        );
+    }
+
+    // -- apply_*_delta LWW (#536) ------------------------------------------
+
+    fn reflection_delta(id: &str, text: &str, updated_at: &str) -> crate::sync::ReflectionDelta {
+        crate::sync::ReflectionDelta {
+            id: id.into(),
+            repo: "legion".into(),
+            text: text.into(),
+            created_at: "2026-06-01T00:00:00Z".into(),
+            updated_at: Some(updated_at.into()),
+            deleted_at: None,
+            audience: "self".into(),
+            domain: None,
+            tags: None,
+            recall_count: 0,
+            last_recalled_at: None,
+            parent_id: None,
+        }
+    }
+
+    fn read_reflection_text(db: &Database, id: &str) -> Option<String> {
+        db.conn
+            .query_row("SELECT text FROM reflections WHERE id = ?1", [id], |r| {
+                r.get(0)
+            })
+            .optional()
+            .unwrap()
+    }
+
+    #[test]
+    fn apply_reflection_delta_inserts_when_missing() {
+        let db = test_db();
+        db.apply_reflection_delta(&reflection_delta(
+            "r-1",
+            "from peer",
+            "2026-06-02T00:00:00Z",
+        ))
+        .unwrap();
+        assert_eq!(
+            read_reflection_text(&db, "r-1").as_deref(),
+            Some("from peer")
+        );
+    }
+
+    #[test]
+    fn apply_reflection_delta_newer_overwrites_older_is_noop() {
+        let db = test_db();
+        db.apply_reflection_delta(&reflection_delta("r-2", "v1", "2026-06-02T00:00:00Z"))
+            .unwrap();
+        // Newer delta wins.
+        db.apply_reflection_delta(&reflection_delta("r-2", "v2", "2026-06-03T00:00:00Z"))
+            .unwrap();
+        assert_eq!(read_reflection_text(&db, "r-2").as_deref(), Some("v2"));
+        // Older delta is a no-op.
+        db.apply_reflection_delta(&reflection_delta("r-2", "stale", "2026-06-01T00:00:00Z"))
+            .unwrap();
+        assert_eq!(read_reflection_text(&db, "r-2").as_deref(), Some("v2"));
+    }
+
+    #[test]
+    fn apply_reflection_delta_tombstone_wins_by_lww() {
+        let db = test_db();
+        db.apply_reflection_delta(&reflection_delta("r-3", "alive", "2026-06-02T00:00:00Z"))
+            .unwrap();
+        let mut tomb = reflection_delta("r-3", "alive", "2026-06-02T00:00:00Z");
+        tomb.deleted_at = Some("2026-06-04T00:00:00Z".into());
+        db.apply_reflection_delta(&tomb).unwrap();
+        let deleted: Option<String> = db
+            .conn
+            .query_row(
+                "SELECT deleted_at FROM reflections WHERE id = ?1",
+                ["r-3"],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(deleted.as_deref(), Some("2026-06-04T00:00:00Z"));
+    }
+
+    #[test]
+    fn apply_card_delta_insert_then_lww() {
+        let db = test_db();
+        let mut delta = crate::sync::CardDelta {
+            id: "c-1".into(),
+            from_repo: "legion".into(),
+            to_repo: "legion".into(),
+            text: "card v1".into(),
+            context: None,
+            priority: "med".into(),
+            status: "pending".into(),
+            note: None,
+            labels: None,
+            parent_card_id: None,
+            source_url: None,
+            source_type: None,
+            sort_order: 0,
+            created_at: "2026-06-01T00:00:00Z".into(),
+            updated_at: "2026-06-02T00:00:00Z".into(),
+            deleted_at: None,
+            assigned_at: None,
+            started_at: None,
+            completed_at: None,
+            problem: None,
+            solution: None,
+            acceptance: None,
+        };
+        db.apply_card_delta(&delta).unwrap();
+
+        delta.text = "card v2".into();
+        delta.updated_at = "2026-06-03T00:00:00Z".into();
+        db.apply_card_delta(&delta).unwrap();
+
+        // Stale write loses.
+        delta.text = "card stale".into();
+        delta.updated_at = "2026-06-01T12:00:00Z".into();
+        db.apply_card_delta(&delta).unwrap();
+
+        let text: String = db
+            .conn
+            .query_row("SELECT text FROM tasks WHERE id = ?1", ["c-1"], |r| {
+                r.get(0)
+            })
+            .unwrap();
+        assert_eq!(text, "card v2");
+    }
+
+    #[test]
+    fn apply_schedule_delta_insert_then_lww() {
+        let db = test_db();
+        let mut delta = crate::sync::ScheduleDelta {
+            id: "s-1".into(),
+            name: "nightly".into(),
+            cron: "0 2 * * *".into(),
+            command: "echo one".into(),
+            repo: "legion".into(),
+            enabled: true,
+            last_run: None,
+            next_run: "2026-06-02T02:00:00Z".into(),
+            created_at: "2026-06-01T00:00:00Z".into(),
+            updated_at: Some("2026-06-02T00:00:00Z".into()),
+            deleted_at: None,
+            active_start: None,
+            active_end: None,
+        };
+        db.apply_schedule_delta(&delta).unwrap();
+
+        delta.command = "echo two".into();
+        delta.updated_at = Some("2026-06-03T00:00:00Z".into());
+        db.apply_schedule_delta(&delta).unwrap();
+
+        delta.command = "echo stale".into();
+        delta.updated_at = Some("2026-06-01T06:00:00Z".into());
+        db.apply_schedule_delta(&delta).unwrap();
+
+        let cmd: String = db
+            .conn
+            .query_row(
+                "SELECT command FROM schedules WHERE id = ?1",
+                ["s-1"],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(cmd, "echo two");
+    }
+
+    #[test]
+    fn effective_sync_ts_picks_latest_of_three() {
+        assert_eq!(
+            effective_sync_ts("2026-01-01T00:00:00Z", &None, &None),
+            "2026-01-01T00:00:00Z"
+        );
+        assert_eq!(
+            effective_sync_ts(
+                "2026-01-01T00:00:00Z",
+                &Some("2026-02-01T00:00:00Z".into()),
+                &None
+            ),
+            "2026-02-01T00:00:00Z"
+        );
+        assert_eq!(
+            effective_sync_ts(
+                "2026-01-01T00:00:00Z",
+                &Some("2026-02-01T00:00:00Z".into()),
+                &Some("2026-03-01T00:00:00Z".into())
+            ),
+            "2026-03-01T00:00:00Z"
         );
     }
 

--- a/src/db.rs
+++ b/src/db.rs
@@ -4263,7 +4263,14 @@ impl Database {
 
 /// Effective timestamp for sync LWW comparisons (#536): the latest of
 /// updated_at / deleted_at, falling back to created_at when neither is set.
-/// RFC3339 strings compare lexicographically in time order.
+///
+/// Precondition: all compared timestamps share legion's uniform format
+/// (`Utc::now().to_rfc3339()`, +00:00 offset, fixed precision), under which
+/// lexicographic order equals time order. Mixed formats (e.g. a 'Z' suffix)
+/// would misorder; every writer in the sync path is legion itself.
+/// Exact ties keep the local row (strict >): no flip-flop, but concurrent
+/// same-instant writes on two nodes stay divergent -- changing that
+/// tiebreaker is a conflict-policy change, out of #536's scope.
 fn effective_sync_ts<'a>(
     created_at: &'a str,
     updated_at: &'a Option<String>,

--- a/src/sync_actor.rs
+++ b/src/sync_actor.rs
@@ -144,11 +144,28 @@ async fn run_sync_loop(
         }
     };
 
-    let key = config.encryption_key().map_err(|e| {
-        crate::error::LegionError::Config(format!("sync actor key derivation failed: {e}"))
-    })?;
+    // Hard requirement, not Option: without a key, maybe_decrypt would pass
+    // unauthenticated plaintext from 0.0.0.0 straight into the DB. The spawn
+    // gate already filters secretless configs; this is the defense in depth
+    // for any future caller of SyncHandle::spawn.
+    let key = config
+        .encryption_key()
+        .map_err(|e| {
+            crate::error::LegionError::Config(format!("sync actor key derivation failed: {e}"))
+        })?
+        .ok_or_else(|| {
+            crate::error::LegionError::Config(
+                "sync requires a cluster secret; refusing to run unencrypted".into(),
+            )
+        })?;
+    let key = Some(key);
 
-    let data_port = config.port + DATA_PORT_OFFSET;
+    let data_port = config.port.checked_add(DATA_PORT_OFFSET).ok_or_else(|| {
+        crate::error::LegionError::Config(format!(
+            "cluster port {} leaves no room for the data port (port + {DATA_PORT_OFFSET} overflows); pick a lower port",
+            config.port
+        ))
+    })?;
     let data_socket = UdpSocket::bind(("0.0.0.0", data_port)).await.map_err(|e| {
         crate::error::LegionError::Config(format!("sync actor bind data port {data_port}: {e}"))
     })?;
@@ -179,7 +196,12 @@ async fn run_sync_loop(
         .unwrap_or_else(|| chrono::Utc::now().to_rfc3339());
     let sync_interval = Duration::from_secs(config.interval_secs);
     let source_id = discovery.instance_id().to_string();
-    let mut seq: u64 = 0;
+    // Seed seq above any value peers may remember for this instance_id:
+    // their ReplayGuards live as long as their receive loops, so a restart
+    // that re-started from 0 would be rejected as replay until it caught up
+    // (silently losing every cycle in between). Epoch-millis is monotonic
+    // across restarts at any realistic cycle rate.
+    let mut seq: u64 = u64::try_from(chrono::Utc::now().timestamp_millis()).unwrap_or(0);
 
     loop {
         // Check for stop signal (non-blocking)
@@ -211,55 +233,56 @@ async fn run_sync_loop(
             eprintln!("[legion sync] {} peer(s) online", peers.len());
 
             let cycle_start = chrono::Utc::now().to_rfc3339();
-            if let Ok(db) = Database::open(&db_path) {
-                let packets = match build_delta_packets(&db, &last_sync, &source_id, &mut seq) {
-                    Ok(p) => p,
-                    Err(e) => {
-                        eprintln!("[legion sync] delta build failed: {e}");
-                        Vec::new()
-                    }
-                };
+            match Database::open(&db_path) {
+                Err(e) => eprintln!("[legion sync] db open for send cycle failed: {e}"),
+                Ok(db) => {
+                    let packets = match build_delta_packets(&db, &last_sync, &source_id, &mut seq) {
+                        Ok(p) => p,
+                        Err(e) => {
+                            eprintln!("[legion sync] delta build failed: {e}");
+                            Vec::new()
+                        }
+                    };
 
-                if !packets.is_empty() {
-                    let upsert_total: usize = packets.iter().map(|p| p.upserts.len()).sum();
-                    eprintln!(
-                        "[legion sync] broadcasting {} delta row(s) in {} packet(s) to {} peer(s)",
-                        upsert_total,
-                        packets.len(),
-                        peers.len()
-                    );
+                    if !packets.is_empty() {
+                        let upsert_total: usize = packets.iter().map(|p| p.upserts.len()).sum();
+                        eprintln!(
+                            "[legion sync] broadcasting {} delta row(s) in {} packet(s) to {} peer(s)",
+                            upsert_total,
+                            packets.len(),
+                            peers.len()
+                        );
 
-                    let mut all_sent = true;
-                    for packet in &packets {
-                        let bytes = match packet.to_bytes().and_then(|b| maybe_encrypt(&b, &key)) {
-                            Ok(b) => b,
-                            Err(e) => {
-                                eprintln!("[legion sync] packet seal failed: {e}");
-                                all_sent = false;
-                                continue;
-                            }
-                        };
-                        for peer in &peers {
-                            let target = std::net::SocketAddr::new(
-                                peer.addr.ip(),
-                                config.port + DATA_PORT_OFFSET,
-                            );
-                            if let Err(e) = data_socket.send_to(&bytes, target).await {
-                                eprintln!(
-                                    "[legion sync] send to {} ({}) failed: {e}",
-                                    peer.instance_id, target
-                                );
-                                all_sent = false;
+                        let mut all_sent = true;
+                        for packet in &packets {
+                            let bytes =
+                                match packet.to_bytes().and_then(|b| maybe_encrypt(&b, &key)) {
+                                    Ok(b) => b,
+                                    Err(e) => {
+                                        eprintln!("[legion sync] packet seal failed: {e}");
+                                        all_sent = false;
+                                        continue;
+                                    }
+                                };
+                            for peer in &peers {
+                                let target = std::net::SocketAddr::new(peer.addr.ip(), data_port);
+                                if let Err(e) = data_socket.send_to(&bytes, target).await {
+                                    eprintln!(
+                                        "[legion sync] send to {} ({}) failed: {e}",
+                                        peer.instance_id, target
+                                    );
+                                    all_sent = false;
+                                }
                             }
                         }
-                    }
 
-                    // Advance and persist last_sync only after a fully
-                    // successful cycle (#536 defects 2+3); a failed peer
-                    // retries the same window next cycle.
-                    if all_sent {
-                        last_sync = cycle_start;
-                        persist_last_sync(data_dir, &last_sync);
+                        // Advance and persist last_sync only after a fully
+                        // successful cycle (#536 defects 2+3); a failed peer
+                        // retries the same window next cycle.
+                        if all_sent {
+                            last_sync = cycle_start;
+                            persist_last_sync(data_dir, &last_sync);
+                        }
                     }
                 }
             }
@@ -331,10 +354,19 @@ fn pack_table<T: serde::Serialize>(
         })
         .collect::<Result<Vec<_>>>()?;
 
-    let split = split_delta(source_id, *seq, table, upserts, Vec::new(), SEAL_RESERVE)
+    let mut split = split_delta(source_id, *seq, table, upserts, Vec::new(), SEAL_RESERVE)
         .map_err(|e| crate::error::LegionError::Config(format!("delta split ({table}): {e}")))?;
-    // split_delta emits parts sharing one seq; bump once per table batch.
-    *seq += 1;
+    // split_delta stamps every part with the seq it was given, but the
+    // receiver's ReplayGuard drops repeated seqs as duplicates -- so re-stamp
+    // each part as an independent single-part packet with its own seq (the
+    // same scheme smugglr-core's own multicast engine uses). Each part
+    // carries complete rows, so independent application is sound.
+    for p in &mut split {
+        p.seq = *seq;
+        *seq += 1;
+        p.part = 0;
+        p.total_parts = 1;
+    }
     packets.extend(split);
     Ok(())
 }
@@ -349,11 +381,17 @@ async fn receive_loop(
 ) {
     let mut guard = ReplayGuard::new();
     let mut buf = vec![0u8; 65_536];
+    // One connection for the loop's lifetime, lazily (re)opened on failure --
+    // not per packet. busy_timeout keeps concurrent watch-loop writes from
+    // surfacing as immediate SQLITE_BUSY row drops.
+    let mut db: Option<Database> = None;
     loop {
         let (len, from) = match socket.recv_from(&mut buf).await {
             Ok(v) => v,
             Err(e) => {
                 eprintln!("[legion sync] recv error: {e}");
+                // Backoff so a persistent socket error cannot hot-spin.
+                tokio::time::sleep(Duration::from_millis(100)).await;
                 continue;
             }
         };
@@ -378,18 +416,28 @@ async fn receive_loop(
         if !guard.check(&packet.source_id, packet.seq) {
             continue; // replay or out-of-order duplicate
         }
-        match Database::open(&db_path) {
-            Ok(db) => {
-                let applied = apply_packet(&db, &packet);
-                eprintln!(
-                    "[legion sync] applied {applied}/{} row(s) from {} (table: {})",
-                    packet.upserts.len(),
-                    packet.source_id,
-                    packet.table
-                );
+        if db.is_none() {
+            match Database::open(&db_path) {
+                Ok(opened) => {
+                    if let Err(e) = opened.conn.busy_timeout(Duration::from_secs(2)) {
+                        eprintln!("[legion sync] busy_timeout not set: {e}");
+                    }
+                    db = Some(opened);
+                }
+                Err(e) => {
+                    eprintln!("[legion sync] db open for apply failed: {e}");
+                    continue;
+                }
             }
-            Err(e) => eprintln!("[legion sync] db open for apply failed: {e}"),
         }
+        let Some(ref open_db) = db else { continue };
+        let applied = apply_packet(open_db, &packet);
+        eprintln!(
+            "[legion sync] applied {applied}/{} row(s) from {} (table: {})",
+            packet.upserts.len(),
+            packet.source_id,
+            packet.table
+        );
     }
 }
 
@@ -541,6 +589,54 @@ mod tests {
             )
             .expect("read back");
         assert_eq!(text, "synced from peer");
+    }
+
+    #[test]
+    fn multipart_batches_pass_a_fresh_replay_guard() {
+        // Regression for the review-caught data-loss bug: split_delta stamps
+        // all parts of a batch with one seq, and ReplayGuard drops repeated
+        // seqs -- so pack_table must re-stamp each part with its own seq.
+        let big_text = "x".repeat(900);
+        let rows: Vec<ReflectionDelta> = (0..8)
+            .map(|i| ReflectionDelta {
+                id: format!("r-big-{i}"),
+                repo: "legion".into(),
+                text: big_text.clone(),
+                created_at: "2026-06-10T00:00:00Z".into(),
+                updated_at: Some("2026-06-10T01:00:00Z".into()),
+                deleted_at: None,
+                audience: "self".into(),
+                domain: None,
+                tags: None,
+                recall_count: 0,
+                last_recalled_at: None,
+                parent_id: None,
+            })
+            .collect();
+
+        let mut seq = 1_000;
+        let mut packets = Vec::new();
+        pack_table(&mut packets, "node-mp", &mut seq, TABLE_REFLECTIONS, &rows).expect("pack");
+        assert!(
+            packets.len() > 1,
+            "test must force a multi-part split, got {} packet(s)",
+            packets.len()
+        );
+
+        // Every packet must clear a fresh ReplayGuard exactly as receive_loop
+        // checks them -- and carry every row exactly once.
+        let mut guard = ReplayGuard::new();
+        let mut total_rows = 0;
+        for p in &packets {
+            assert!(
+                guard.check(&p.source_id, p.seq),
+                "packet seq {} rejected as replay -- parts share a seq",
+                p.seq
+            );
+            total_rows += p.upserts.len();
+        }
+        assert_eq!(total_rows, rows.len());
+        assert_eq!(seq, 1_000 + packets.len() as u64);
     }
 
     #[test]

--- a/src/sync_actor.rs
+++ b/src/sync_actor.rs
@@ -1,26 +1,51 @@
-//! Sync actor for multi-node delta replication.
+//! Sync actor for multi-node delta replication (#536).
 //!
 //! Runs in a background thread with its own tokio runtime, handling:
-//! - Peer discovery via UDP broadcast
-//! - Delta serialization and transmission
+//! - Peer discovery via UDP broadcast (smugglr-core `PeerDiscovery`)
+//! - Delta serialization, encryption, and unicast transmission to peers
 //! - Receiving and applying deltas with LWW merge
 //!
-//! The actor communicates with the main watch loop via channels.
+//! Transport convention: discovery announcements broadcast on the configured
+//! `port`; delta data flows over a second UDP socket on `port + 1`
+//! ([`DATA_PORT_OFFSET`]). Every node in a cluster shares one `cluster.toml`
+//! shape (same port, same secret), so the data port is derivable without
+//! carrying it in the announcement. All delta traffic is sealed with
+//! XChaCha20-Poly1305 via smugglr-core's `maybe_encrypt`/`maybe_decrypt`.
+//!
+//! `last_sync` advances and persists to `cluster.toml` only after a cycle in
+//! which every computed packet was handed to the socket without error, so
+//! `legion cluster status` reflects reality and a failed cycle retries the
+//! same window.
 
-use std::collections::HashMap;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::mpsc;
 use std::thread;
 use std::time::Duration;
 
-use serde_json::Value;
-use smugglr_core::broadcast::{BroadcastConfig, PeerDiscovery, hash_db_path};
+use smugglr_core::broadcast::{
+    BroadcastConfig, DeltaPacket, PeerDiscovery, ReplayGuard, hash_db_path, maybe_decrypt,
+    maybe_encrypt, split_delta,
+};
+use tokio::net::UdpSocket;
 use tokio::runtime::Runtime;
 
 use crate::cluster::ClusterConfig;
 use crate::db::Database;
 use crate::error::Result;
-use crate::sync::{CardDelta, ReflectionDelta, ScheduleDelta};
+use crate::sync::{CardDelta, PersonaWakeLeaseDelta, ReflectionDelta, ScheduleDelta};
+
+/// Delta data flows on `discovery port + DATA_PORT_OFFSET`.
+const DATA_PORT_OFFSET: u16 = 1;
+
+/// Wire-envelope headroom passed to `split_delta`: XChaCha20-Poly1305 adds a
+/// 24-byte nonce and 16-byte tag; the rest is margin for base overhead.
+const SEAL_RESERVE: usize = 64;
+
+/// Table names on the wire. The receive path matches on these exactly.
+const TABLE_REFLECTIONS: &str = "reflections";
+const TABLE_CARDS: &str = "cards";
+const TABLE_SCHEDULES: &str = "schedules";
+const TABLE_LEASES: &str = "persona_wake_leases";
 
 /// Handle for communicating with the sync actor.
 pub struct SyncHandle {
@@ -28,6 +53,36 @@ pub struct SyncHandle {
     _stop_tx: mpsc::Sender<()>,
     /// Thread handle for joining.
     _thread: thread::JoinHandle<()>,
+}
+
+/// Load `cluster.toml` and spawn the sync actor when sync is enabled and a
+/// secret is configured. The single spawn gate shared by `legion watch` and
+/// the daemon's watch task (#536 defect 1: the daemon previously had no spawn
+/// at all). Sync is optional and never fatal: config errors and spawn
+/// failures log under `log_prefix` and return None so the caller's loop runs
+/// regardless.
+pub fn spawn_sync_if_enabled(data_dir: &Path, log_prefix: &str) -> Option<SyncHandle> {
+    match ClusterConfig::load(data_dir) {
+        Ok(cc) if cc.enabled && cc.secret.is_some() => {
+            eprintln!(
+                "{log_prefix} cluster sync enabled on port {} (instance: {})",
+                cc.port,
+                cc.resolve_instance_id()
+            );
+            match SyncHandle::spawn(data_dir, cc) {
+                Ok(handle) => Some(handle),
+                Err(e) => {
+                    eprintln!("{log_prefix} failed to start sync actor: {e}");
+                    None
+                }
+            }
+        }
+        Ok(_) => None,
+        Err(e) => {
+            eprintln!("{log_prefix} cluster config error (sync disabled): {e}");
+            None
+        }
+    }
 }
 
 impl SyncHandle {
@@ -49,7 +104,13 @@ impl SyncHandle {
         let data_dir = data_dir.to_path_buf();
 
         let thread = thread::spawn(move || {
-            let rt = Runtime::new().expect("failed to create tokio runtime");
+            let rt = match Runtime::new() {
+                Ok(rt) => rt,
+                Err(e) => {
+                    eprintln!("[legion sync] failed to create tokio runtime: {e}");
+                    return;
+                }
+            };
             rt.block_on(async {
                 if let Err(e) =
                     run_sync_loop(&data_dir, broadcast_config, db_path_hash, stop_rx).await
@@ -83,15 +144,42 @@ async fn run_sync_loop(
         }
     };
 
+    let key = config.encryption_key().map_err(|e| {
+        crate::error::LegionError::Config(format!("sync actor key derivation failed: {e}"))
+    })?;
+
+    let data_port = config.port + DATA_PORT_OFFSET;
+    let data_socket = UdpSocket::bind(("0.0.0.0", data_port)).await.map_err(|e| {
+        crate::error::LegionError::Config(format!("sync actor bind data port {data_port}: {e}"))
+    })?;
+    let data_socket = std::sync::Arc::new(data_socket);
+
     eprintln!(
-        "[legion sync] actor started (instance: {}, port: {})",
+        "[legion sync] actor started (instance: {}, discovery port: {}, data port: {})",
         discovery.instance_id(),
-        config.port
+        config.port,
+        data_port
     );
 
+    // Receive side: own task, shared socket. Applies sealed DeltaPackets to
+    // the local DB with replay protection. Never crashes the actor: every
+    // failure logs and the loop continues.
+    let recv_db_path = data_dir.join("legion.db");
+    let recv_socket = data_socket.clone();
+    let recv_key = key;
+    let recv_self_id = discovery.instance_id().to_string();
+    tokio::spawn(async move {
+        receive_loop(recv_socket, recv_key, recv_self_id, recv_db_path).await;
+    });
+
     let db_path = data_dir.join("legion.db");
-    let mut last_sync = chrono::Utc::now().to_rfc3339();
+    let mut last_sync = ClusterConfig::load(data_dir)
+        .ok()
+        .and_then(|cc| cc.last_sync)
+        .unwrap_or_else(|| chrono::Utc::now().to_rfc3339());
     let sync_interval = Duration::from_secs(config.interval_secs);
+    let source_id = discovery.instance_id().to_string();
+    let mut seq: u64 = 0;
 
     loop {
         // Check for stop signal (non-blocking)
@@ -122,53 +210,57 @@ async fn run_sync_loop(
         if !peers.is_empty() {
             eprintln!("[legion sync] {} peer(s) online", peers.len());
 
-            // Open DB and check for local changes
+            let cycle_start = chrono::Utc::now().to_rfc3339();
             if let Ok(db) = Database::open(&db_path) {
-                // Get deltas since last sync
-                let reflection_deltas =
-                    db.get_reflection_deltas_since(&last_sync)
-                        .unwrap_or_else(|e| {
-                            eprintln!("[legion sync] reflection delta query failed: {}", e);
-                            Vec::new()
-                        });
-                let card_deltas = db.get_card_deltas_since(&last_sync).unwrap_or_else(|e| {
-                    eprintln!("[legion sync] card delta query failed: {}", e);
-                    Vec::new()
-                });
-                let schedule_deltas =
-                    db.get_schedule_deltas_since(&last_sync)
-                        .unwrap_or_else(|e| {
-                            eprintln!("[legion sync] schedule delta query failed: {}", e);
-                            Vec::new()
-                        });
-                let lease_deltas = db
-                    .get_persona_wake_lease_deltas_since(&last_sync)
-                    .unwrap_or_else(|e| {
-                        eprintln!("[legion sync] lease delta query failed: {}", e);
+                let packets = match build_delta_packets(&db, &last_sync, &source_id, &mut seq) {
+                    Ok(p) => p,
+                    Err(e) => {
+                        eprintln!("[legion sync] delta build failed: {e}");
                         Vec::new()
-                    });
+                    }
+                };
 
-                let total = reflection_deltas.len()
-                    + card_deltas.len()
-                    + schedule_deltas.len()
-                    + lease_deltas.len();
-                if total > 0 {
+                if !packets.is_empty() {
+                    let upsert_total: usize = packets.iter().map(|p| p.upserts.len()).sum();
                     eprintln!(
-                        "[legion sync] broadcasting {} delta(s) ({} reflections, {} cards, {} schedules, {} leases)",
-                        total,
-                        reflection_deltas.len(),
-                        card_deltas.len(),
-                        schedule_deltas.len(),
-                        lease_deltas.len()
+                        "[legion sync] broadcasting {} delta row(s) in {} packet(s) to {} peer(s)",
+                        upsert_total,
+                        packets.len(),
+                        peers.len()
                     );
 
-                    // TODO: Actually broadcast the deltas to peers
-                    // For now, just log that we would send them
-                    // The wire protocol uses DeltaPacket with upserts/deletes
-                    //
-                    // IMPORTANT: Only advance last_sync AFTER successful transmission.
-                    // Moving it here now so we don't forget when implementing the wire protocol.
-                    last_sync = chrono::Utc::now().to_rfc3339();
+                    let mut all_sent = true;
+                    for packet in &packets {
+                        let bytes = match packet.to_bytes().and_then(|b| maybe_encrypt(&b, &key)) {
+                            Ok(b) => b,
+                            Err(e) => {
+                                eprintln!("[legion sync] packet seal failed: {e}");
+                                all_sent = false;
+                                continue;
+                            }
+                        };
+                        for peer in &peers {
+                            let target = std::net::SocketAddr::new(
+                                peer.addr.ip(),
+                                config.port + DATA_PORT_OFFSET,
+                            );
+                            if let Err(e) = data_socket.send_to(&bytes, target).await {
+                                eprintln!(
+                                    "[legion sync] send to {} ({}) failed: {e}",
+                                    peer.instance_id, target
+                                );
+                                all_sent = false;
+                            }
+                        }
+                    }
+
+                    // Advance and persist last_sync only after a fully
+                    // successful cycle (#536 defects 2+3); a failed peer
+                    // retries the same window next cycle.
+                    if all_sent {
+                        last_sync = cycle_start;
+                        persist_last_sync(data_dir, &last_sync);
+                    }
                 }
             }
         }
@@ -180,102 +272,351 @@ async fn run_sync_loop(
     Ok(())
 }
 
-/// Convert a ReflectionDelta to a HashMap for DeltaPacket.
-#[allow(dead_code)]
-fn reflection_to_map(r: &ReflectionDelta) -> HashMap<String, Value> {
-    let mut m = HashMap::new();
-    m.insert("id".into(), Value::String(r.id.clone()));
-    m.insert("repo".into(), Value::String(r.repo.clone()));
-    m.insert("text".into(), Value::String(r.text.clone()));
-    m.insert("created_at".into(), Value::String(r.created_at.clone()));
-    if let Some(ref v) = r.updated_at {
-        m.insert("updated_at".into(), Value::String(v.clone()));
-    }
-    if let Some(ref v) = r.deleted_at {
-        m.insert("deleted_at".into(), Value::String(v.clone()));
-    }
-    m.insert("audience".into(), Value::String(r.audience.clone()));
-    if let Some(ref v) = r.domain {
-        m.insert("domain".into(), Value::String(v.clone()));
-    }
-    if let Some(ref v) = r.tags {
-        m.insert("tags".into(), Value::String(v.clone()));
-    }
-    m.insert("recall_count".into(), Value::Number(r.recall_count.into()));
-    if let Some(ref v) = r.last_recalled_at {
-        m.insert("last_recalled_at".into(), Value::String(v.clone()));
-    }
-    if let Some(ref v) = r.parent_id {
-        m.insert("parent_id".into(), Value::String(v.clone()));
-    }
-    m
+/// Compute per-table deltas since `last_sync` and pack them into
+/// datagram-sized `DeltaPacket`s. Rows travel as their serde maps; tombstones
+/// ride in `upserts` with `deleted_at` set (the LWW apply handles them), so
+/// `deletes` stays empty.
+fn build_delta_packets(
+    db: &Database,
+    last_sync: &str,
+    source_id: &str,
+    seq: &mut u64,
+) -> Result<Vec<DeltaPacket>> {
+    let mut packets = Vec::new();
+
+    let reflections = db.get_reflection_deltas_since(last_sync)?;
+    pack_table(
+        &mut packets,
+        source_id,
+        seq,
+        TABLE_REFLECTIONS,
+        &reflections,
+    )?;
+    let cards = db.get_card_deltas_since(last_sync)?;
+    pack_table(&mut packets, source_id, seq, TABLE_CARDS, &cards)?;
+    let schedules = db.get_schedule_deltas_since(last_sync)?;
+    pack_table(&mut packets, source_id, seq, TABLE_SCHEDULES, &schedules)?;
+    let leases = db.get_persona_wake_lease_deltas_since(last_sync)?;
+    pack_table(&mut packets, source_id, seq, TABLE_LEASES, &leases)?;
+
+    Ok(packets)
 }
 
-/// Convert a CardDelta to a HashMap for DeltaPacket.
-#[allow(dead_code)]
-fn card_to_map(c: &CardDelta) -> HashMap<String, Value> {
-    let mut m = HashMap::new();
-    m.insert("id".into(), Value::String(c.id.clone()));
-    m.insert("from_repo".into(), Value::String(c.from_repo.clone()));
-    m.insert("to_repo".into(), Value::String(c.to_repo.clone()));
-    m.insert("text".into(), Value::String(c.text.clone()));
-    if let Some(ref v) = c.context {
-        m.insert("context".into(), Value::String(v.clone()));
+/// Serialize one table's delta rows into MTU-sized packets, advancing `seq`
+/// per packet so the receiver's `ReplayGuard` sees a strictly increasing
+/// sequence per source.
+fn pack_table<T: serde::Serialize>(
+    packets: &mut Vec<DeltaPacket>,
+    source_id: &str,
+    seq: &mut u64,
+    table: &str,
+    rows: &[T],
+) -> Result<()> {
+    if rows.is_empty() {
+        return Ok(());
     }
-    m.insert("priority".into(), Value::String(c.priority.clone()));
-    m.insert("status".into(), Value::String(c.status.clone()));
-    m.insert("created_at".into(), Value::String(c.created_at.clone()));
-    m.insert("updated_at".into(), Value::String(c.updated_at.clone()));
-    if let Some(ref v) = c.deleted_at {
-        m.insert("deleted_at".into(), Value::String(v.clone()));
-    }
-    // ... more fields as needed
-    m
+    let upserts = rows
+        .iter()
+        .map(|r| {
+            serde_json::to_value(r)
+                .map_err(|e| {
+                    crate::error::LegionError::Config(format!("delta serialize ({table}): {e}"))
+                })
+                .and_then(|v| match v {
+                    serde_json::Value::Object(m) => Ok(m.into_iter().collect()),
+                    other => Err(crate::error::LegionError::Config(format!(
+                        "delta row for {table} is not an object: {other}"
+                    ))),
+                })
+        })
+        .collect::<Result<Vec<_>>>()?;
+
+    let split = split_delta(source_id, *seq, table, upserts, Vec::new(), SEAL_RESERVE)
+        .map_err(|e| crate::error::LegionError::Config(format!("delta split ({table}): {e}")))?;
+    // split_delta emits parts sharing one seq; bump once per table batch.
+    *seq += 1;
+    packets.extend(split);
+    Ok(())
 }
 
-/// Convert a ScheduleDelta to a HashMap for DeltaPacket.
-#[allow(dead_code)]
-fn schedule_to_map(s: &ScheduleDelta) -> HashMap<String, Value> {
-    let mut m = HashMap::new();
-    m.insert("id".into(), Value::String(s.id.clone()));
-    m.insert("name".into(), Value::String(s.name.clone()));
-    m.insert("cron".into(), Value::String(s.cron.clone()));
-    m.insert("command".into(), Value::String(s.command.clone()));
-    m.insert("repo".into(), Value::String(s.repo.clone()));
-    m.insert("enabled".into(), Value::Bool(s.enabled));
-    m.insert("created_at".into(), Value::String(s.created_at.clone()));
-    if let Some(ref v) = s.updated_at {
-        m.insert("updated_at".into(), Value::String(v.clone()));
+/// Receive sealed DeltaPackets and apply them to the local DB. Runs for the
+/// actor's lifetime; every failure path logs and continues.
+async fn receive_loop(
+    socket: std::sync::Arc<UdpSocket>,
+    key: Option<[u8; 32]>,
+    self_id: String,
+    db_path: PathBuf,
+) {
+    let mut guard = ReplayGuard::new();
+    let mut buf = vec![0u8; 65_536];
+    loop {
+        let (len, from) = match socket.recv_from(&mut buf).await {
+            Ok(v) => v,
+            Err(e) => {
+                eprintln!("[legion sync] recv error: {e}");
+                continue;
+            }
+        };
+        let plaintext = match maybe_decrypt(&buf[..len], &key) {
+            Ok(Some(p)) => p,
+            Ok(None) => continue, // not for us / not decryptable with our key
+            Err(e) => {
+                eprintln!("[legion sync] decrypt error from {from}: {e}");
+                continue;
+            }
+        };
+        let packet = match DeltaPacket::from_bytes(&plaintext) {
+            Ok(p) => p,
+            Err(e) => {
+                eprintln!("[legion sync] bad packet from {from}: {e}");
+                continue;
+            }
+        };
+        if packet.source_id == self_id {
+            continue; // our own broadcast reflected back
+        }
+        if !guard.check(&packet.source_id, packet.seq) {
+            continue; // replay or out-of-order duplicate
+        }
+        match Database::open(&db_path) {
+            Ok(db) => {
+                let applied = apply_packet(&db, &packet);
+                eprintln!(
+                    "[legion sync] applied {applied}/{} row(s) from {} (table: {})",
+                    packet.upserts.len(),
+                    packet.source_id,
+                    packet.table
+                );
+            }
+            Err(e) => eprintln!("[legion sync] db open for apply failed: {e}"),
+        }
     }
-    if let Some(ref v) = s.deleted_at {
-        m.insert("deleted_at".into(), Value::String(v.clone()));
+}
+
+/// Apply one packet's rows to the local DB via the per-table LWW apply
+/// methods. Returns the number of rows applied without error; per-row
+/// failures log and do not abort the packet.
+fn apply_packet(db: &Database, packet: &DeltaPacket) -> usize {
+    let mut applied = 0;
+    for row in &packet.upserts {
+        let value = serde_json::Value::Object(row.clone().into_iter().collect());
+        let result = match packet.table.as_str() {
+            TABLE_REFLECTIONS => serde_json::from_value::<ReflectionDelta>(value)
+                .map_err(|e| e.to_string())
+                .and_then(|d| db.apply_reflection_delta(&d).map_err(|e| e.to_string())),
+            TABLE_CARDS => serde_json::from_value::<CardDelta>(value)
+                .map_err(|e| e.to_string())
+                .and_then(|d| db.apply_card_delta(&d).map_err(|e| e.to_string())),
+            TABLE_SCHEDULES => serde_json::from_value::<ScheduleDelta>(value)
+                .map_err(|e| e.to_string())
+                .and_then(|d| db.apply_schedule_delta(&d).map_err(|e| e.to_string())),
+            TABLE_LEASES => serde_json::from_value::<PersonaWakeLeaseDelta>(value)
+                .map_err(|e| e.to_string())
+                .and_then(|d| {
+                    db.apply_persona_wake_lease_delta(&d)
+                        .map(|_| ())
+                        .map_err(|e| e.to_string())
+                }),
+            other => Err(format!("unknown table '{other}'")),
+        };
+        match result {
+            Ok(()) => applied += 1,
+            Err(e) => eprintln!("[legion sync] apply failed (table: {}): {e}", packet.table),
+        }
     }
-    m
+    applied
+}
+
+/// Persist `last_sync` to cluster.toml so `legion cluster status` reflects
+/// reality (#536 defect 3). Best-effort: a write failure logs and the
+/// in-memory cursor still advances.
+fn persist_last_sync(data_dir: &Path, ts: &str) {
+    match ClusterConfig::load(data_dir) {
+        Ok(mut cc) => {
+            cc.last_sync = Some(ts.to_string());
+            if let Err(e) = cc.save(data_dir) {
+                eprintln!("[legion sync] failed to persist last_sync: {e}");
+            }
+        }
+        Err(e) => eprintln!("[legion sync] failed to reload cluster.toml: {e}"),
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::db::ReflectionMeta;
+
+    fn temp_data_dir() -> PathBuf {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().to_path_buf();
+        std::mem::forget(dir);
+        path
+    }
 
     #[test]
-    fn reflection_to_map_basic_fields() {
-        let r = ReflectionDelta {
-            id: "test-id".into(),
-            repo: "test-repo".into(),
-            text: "test text".into(),
-            created_at: "2026-04-15T00:00:00Z".into(),
-            updated_at: Some("2026-04-15T01:00:00Z".into()),
+    fn spawn_gate_none_when_disabled_or_secretless() {
+        let dir = temp_data_dir();
+        // No cluster.toml at all -> default config -> disabled -> None.
+        assert!(spawn_sync_if_enabled(&dir, "[test]").is_none());
+
+        // Enabled but no secret -> None.
+        let cc = ClusterConfig {
+            enabled: true,
+            secret: None,
+            ..Default::default()
+        };
+        cc.save(&dir).expect("save");
+        assert!(spawn_sync_if_enabled(&dir, "[test]").is_none());
+    }
+
+    #[test]
+    fn packet_seal_unseal_round_trip() {
+        let key = Some([7u8; 32]);
+        let mut seq = 0;
+        let mut packets = Vec::new();
+        let rows = vec![ReflectionDelta {
+            id: "r-1".into(),
+            repo: "legion".into(),
+            text: "hello".into(),
+            created_at: "2026-06-10T00:00:00Z".into(),
+            updated_at: Some("2026-06-10T01:00:00Z".into()),
+            deleted_at: None,
+            audience: "self".into(),
+            domain: None,
+            tags: None,
+            recall_count: 0,
+            last_recalled_at: None,
+            parent_id: None,
+        }];
+        pack_table(&mut packets, "node-a", &mut seq, TABLE_REFLECTIONS, &rows).expect("pack");
+        assert_eq!(packets.len(), 1);
+        assert_eq!(seq, 1);
+
+        let sealed = maybe_encrypt(&packets[0].to_bytes().expect("bytes"), &key).expect("seal");
+        let opened = maybe_decrypt(&sealed, &key).expect("unseal").expect("some");
+        let packet = DeltaPacket::from_bytes(&opened).expect("parse");
+        assert_eq!(packet.table, TABLE_REFLECTIONS);
+        assert_eq!(packet.upserts.len(), 1);
+        assert_eq!(
+            packet.upserts[0].get("id").and_then(|v| v.as_str()),
+            Some("r-1")
+        );
+    }
+
+    #[test]
+    fn apply_packet_round_trips_reflection_into_db() {
+        let dir = temp_data_dir();
+        let db = Database::open(&dir.join("legion.db")).expect("open");
+
+        let rows = vec![ReflectionDelta {
+            id: "0190a000-0000-7000-8000-000000000001".into(),
+            repo: "legion".into(),
+            text: "synced from peer".into(),
+            created_at: "2026-06-10T00:00:00Z".into(),
+            updated_at: Some("2026-06-10T01:00:00Z".into()),
             deleted_at: None,
             audience: "self".into(),
             domain: Some("test".into()),
             tags: None,
-            recall_count: 5,
+            recall_count: 0,
             last_recalled_at: None,
             parent_id: None,
-        };
+        }];
+        let mut seq = 0;
+        let mut packets = Vec::new();
+        pack_table(&mut packets, "node-b", &mut seq, TABLE_REFLECTIONS, &rows).expect("pack");
 
-        let m = reflection_to_map(&r);
-        assert_eq!(m.get("id").unwrap(), &Value::String("test-id".into()));
-        assert_eq!(m.get("recall_count").unwrap(), &Value::Number(5.into()));
+        let applied = apply_packet(&db, &packets[0]);
+        assert_eq!(applied, 1);
+
+        // Read back via a direct row query (get_reflections_by_ids carries a
+        // known column-shift bug being fixed separately under #606).
+        let text: String = db
+            .conn
+            .query_row(
+                "SELECT text FROM reflections WHERE id = ?1",
+                ["0190a000-0000-7000-8000-000000000001"],
+                |r| r.get(0),
+            )
+            .expect("read back");
+        assert_eq!(text, "synced from peer");
+    }
+
+    #[test]
+    fn apply_packet_unknown_table_applies_zero() {
+        let dir = temp_data_dir();
+        let db = Database::open(&dir.join("legion.db")).expect("open");
+        let mut packet = DeltaPacket::new("node-c".into(), 0, "no_such_table".into());
+        packet.upserts.push(std::collections::HashMap::from([(
+            "id".to_string(),
+            serde_json::Value::String("x".into()),
+        )]));
+        assert_eq!(apply_packet(&db, &packet), 0);
+    }
+
+    #[test]
+    fn persist_last_sync_survives_reload() {
+        let dir = temp_data_dir();
+        let cc = ClusterConfig {
+            enabled: true,
+            secret: Some("ab".repeat(32)),
+            ..Default::default()
+        };
+        cc.save(&dir).expect("save");
+
+        persist_last_sync(&dir, "2026-06-10T12:00:00Z");
+        let reloaded = ClusterConfig::load(&dir).expect("reload");
+        assert_eq!(reloaded.last_sync.as_deref(), Some("2026-06-10T12:00:00Z"));
+        // Other fields survive the round-trip.
+        assert!(reloaded.enabled);
+        assert_eq!(reloaded.secret.as_deref(), Some("ab".repeat(32).as_str()));
+    }
+
+    // ReflectionMeta imported for the receive-side test below.
+    #[test]
+    fn apply_packet_lww_does_not_clobber_newer_local() {
+        let dir = temp_data_dir();
+        let db = Database::open(&dir.join("legion.db")).expect("open");
+
+        // Local row written now (fresh updated_at).
+        let local = db
+            .insert_reflection_with_meta(
+                "legion",
+                "local newer text",
+                "self",
+                &ReflectionMeta::default(),
+            )
+            .expect("insert");
+
+        // Peer delta carrying an OLDER updated_at must not overwrite.
+        let rows = vec![ReflectionDelta {
+            id: local.id.clone(),
+            repo: "legion".into(),
+            text: "stale peer text".into(),
+            created_at: "2020-01-01T00:00:00Z".into(),
+            updated_at: Some("2020-01-01T00:00:00Z".into()),
+            deleted_at: None,
+            audience: "self".into(),
+            domain: None,
+            tags: None,
+            recall_count: 0,
+            last_recalled_at: None,
+            parent_id: None,
+        }];
+        let mut seq = 0;
+        let mut packets = Vec::new();
+        pack_table(&mut packets, "node-d", &mut seq, TABLE_REFLECTIONS, &rows).expect("pack");
+        apply_packet(&db, &packets[0]);
+
+        let text: String = db
+            .conn
+            .query_row(
+                "SELECT text FROM reflections WHERE id = ?1",
+                [local.id.as_str()],
+                |r| r.get(0),
+            )
+            .expect("read back");
+        assert_eq!(text, "local newer text");
     }
 }

--- a/src/watch.rs
+++ b/src/watch.rs
@@ -2286,26 +2286,9 @@ pub fn run(data_dir: &Path) -> Result<()> {
             .join(", ")
     );
 
-    // Check cluster sync config and spawn sync actor if enabled.
-    // This stays in watch::run (not in WatchLoop) because the daemon does not
-    // use sync_actor -- it has its own wiring.
-    let _sync_handle = match crate::cluster::ClusterConfig::load(data_dir) {
-        Ok(cc) if cc.enabled && cc.secret.is_some() => {
-            eprintln!(
-                "[legion watch] cluster sync enabled on port {} (instance: {})",
-                cc.port,
-                cc.resolve_instance_id()
-            );
-            match crate::sync_actor::SyncHandle::spawn(data_dir, cc) {
-                Ok(handle) => Some(handle),
-                Err(e) => {
-                    eprintln!("[legion watch] failed to start sync actor: {}", e);
-                    None
-                }
-            }
-        }
-        _ => None,
-    };
+    // Spawn the cluster sync actor when enabled. Shared gate with the
+    // daemon's watch task (#536: the daemon previously never spawned it).
+    let _sync_handle = crate::sync_actor::spawn_sync_if_enabled(data_dir, "[legion watch]");
 
     // Move config and db into the shared loop state via the same constructor
     // the daemon uses, so the field wiring lives in exactly one place.


### PR DESCRIPTION
## Summary

Cluster sync now actually syncs (#536). Three defects, one cause-chain: the daemon never spawned the sync actor (only the deprecated foreground watch did), the actor computed deltas but transmission was a TODO, and last_sync lived in memory so cluster status always read "never". The fix switches transmission onto smugglr-core 0.4.0 primitives (DeltaPacket/split_delta, XChaCha20 maybe_encrypt/maybe_decrypt, ReplayGuard), adds the missing receive-side LWW apply methods for reflections/cards/schedules, unifies the spawn behind one shared gate both drivers call, and persists last_sync to cluster.toml only after fully-successful cycles.

## Acceptance criteria mapping

### 1. All tests pass

979 unit + 161 integration tests green locally (cargo test), clippy --all-targets -D warnings clean, fmt clean. New coverage: 6 apply-LWW tests in src/db.rs (insert-when-missing, newer-overwrites/older-noop, tombstone-wins for reflections; insert-then-LWW for cards and schedules; effective_sync_ts picks latest of created/updated/deleted), and 6 actor tests in src/sync_actor.rs (spawn gate returns None when disabled or secretless, packet seal/unseal round trip through real encryption, apply_packet round-trips a reflection into the DB, unknown table applies zero, LWW does not clobber newer local rows, persist_last_sync survives ClusterConfig reload).
Evidence: src/db.rs tests apply_reflection_delta_inserts_when_missing through effective_sync_ts_picks_latest_of_three; src/sync_actor.rs tests spawn_gate_none_when_disabled_or_secretless through apply_packet_lww_does_not_clobber_newer_local

### 2. Simplify pass completed

Recorded clean on HEAD. Substantive call made during the pass: the three apply_*_delta bodies stay parallel rather than unified -- the 2026-06 audit adversarially verdicted the equivalent delta-getter shape as coincidence-not-duplicate, and unifying them requires a column-driven query builder (explicit operator constraint). What IS one invariant got extracted: effective_sync_ts (the LWW comparison, one fn + test), pack_table (generic over any serde delta), spawn_sync_if_enabled (one gate, two callers). The three hand-rolled *_to_map converter fns and their test were deleted outright -- the delta structs already derive Serialize, so serde_json::to_value replaces 148 lines.
Evidence: quality gate row on HEAD f65d03d; diff shows reflection_to_map/card_to_map/schedule_to_map deleted

### 3. Review pass completed and issues fixed

Self-review against the issue's error-handling requirements: config errors and spawn failures log and return None so the watch loop always runs (spawn_sync_if_enabled error arms); send failures mark the cycle unsuccessful so last_sync does not advance and the window retries (all_sent flag); a failed peer logs and the loop continues; receive-side failures (bad decrypt, bad packet, db open, per-row apply) each log and continue -- nothing crashes the actor. The expect() on Runtime::new in the old code was also replaced with a log-and-return (no-panic discipline). Team review requested via signals on this PR.
Evidence: src/sync_actor.rs spawn_sync_if_enabled error arms, all_sent gating in run_sync_loop, receive_loop error arms

### 4. PR created and linked to this issue

This PR, branch fix/536-cluster-sync, linked to issue #536 and kanban card 019e7617-33b9-7f92-a0d6-6995eb21edb1.
Evidence: PR metadata; pr create --task linkage

## Not done

- Gossip-stack adoption: smugglr-core's multicast::Gossip is coupled to smugglr's own LocalDb/Config; modeling legion tables as a smugglr datasource is a redesign, not this bug fix. The broadcast primitives were the right cut.
- Syncing the remaining delta types (rate-limit/usage samples, uncertainty, wake_attempts) over this transport: the issue scopes transmission to reflections/cards/schedules/leases; the other deltas keep their existing paths and can join the packet loop in a follow-up by adding pack_table lines.
- Tantivy/embedding refresh for peer-applied reflections: applied rows have no embedding (by design, each node computes its own) and are not in the search index until reindex/backfill runs; surfaced previously as closed #250, re-file if live clusters show recall gaps.
- Cross-subnet discovery (LAN broadcast only, per issue out-of-scope) and un-deprecating foreground watch.
- A live two-node integration test: needs two daemons and UDP broadcast in CI; the loopback-free unit seam (pack -> seal -> unseal -> apply) covers the protocol path deterministically instead.