### PR TITLE
fix(#634): main compile break -- Priority::Med in watch/gates.rs test helper

### DIFF
--- a/src/watch/gates.rs
+++ b/src/watch/gates.rs
@@ -697,7 +697,7 @@ mod tests {
             "rafters",
             "do the thing",
             None,
-            "medium",
+            crate::kanban::Priority::Med,
             None,
             None,
             None,


### PR DESCRIPTION
## Summary

Main stopped compiling after #632 and #633 merged within minutes of each other: #632 carved watch.rs into the watch/ tree with a test helper calling `kanban::create_card(..., "medium")`, while #633 changed `create_card` to take the new `Priority` enum. Each PR was green against its own merge-base, so CI never saw the combination -- a semantic merge conflict with zero textual conflict. This PR is the one-token fix: the `blocked_card` test helper in src/watch/gates.rs now passes `crate::kanban::Priority::Med`. Incidentally, the enum migration caught a latent bug here: "medium" was never in the `Priority::from_str` set (low/med/high/critical), so the old string would have failed at the parse boundary anyway.

## Acceptance criteria mapping

### 1. cargo check --all-targets passes on the branch

The single hunk replaces the `&str` argument at the only call site the compiler flagged (src/watch/gates.rs:700) with the `Priority::Med` enum variant that the post-#633 signature of `kanban::create_card` requires. No other call site in the tree passes a string -- #633 migrated all of them; this helper was the one written concurrently in #632 and missed.
Evidence: `cargo check --all-targets` finishes clean in 4.6s on this branch; on main it fails with E0308 at src/watch/gates.rs:700.

### 2. cargo test passes

The fixed helper is test-only code (the `blocked_card` fixture inside `mod tests` for the check_auto_unblock suite), so the test run exercises the change directly -- the gates tests construct blocked cards through this exact path.
Evidence: `cargo test` on this branch: 170 passed, 0 failed, 2 ignored.

### 3. cargo clippy --all-targets -- -D warnings passes

The change introduces no new lint surface; clippy across all targets (which is what catches test-code issues like this one) runs clean.
Evidence: `cargo clippy --all-targets -- -D warnings` exits 0 on this branch.

### 4. cargo fmt -- --check passes

The replacement token sits within the existing multi-line argument list, already in rustfmt-normal form.
Evidence: `cargo fmt -- --check` exits 0 on this branch.

## Not done

No post-merge build check for the merge train -- the process gap that let two green PRs break main (per-PR CI tests against its own merge-base, never against sibling in-flight PRs) is not addressed here; that is a CI/process change worth its own issue. Also not done: rebasing the two stranded 2d branches (refactor/612-comms, refactor/613-serve), which each carry this same fix as their first commit -- they rebase and drop the duplicate once this lands.