### PR TITLE
refactor(#613): serve stream -- ServeError, channel::router ownership, schedule firing off SSE, port ownership

### DIFF
--- a/plugin/hooks/_legion-daemon-supervisor.sh
+++ b/plugin/hooks/_legion-daemon-supervisor.sh
@@ -120,7 +120,21 @@ if [ "$DAEMON_VERSION" = "$LOCAL_VERSION" ]; then
   exit 0
 fi
 
-# Version mismatch: kill stale, spawn fresh.
+# Version mismatch. Who answers the port decides the remedy (#613,
+# absorbed #601): the daemon owns :3131 while it runs, and replacing it
+# with a `legion serve` would silently drop the watch loop. /health now
+# reports a `role` field; a daemon gets bounced in place via
+# daemon-restart (which owns the stop/spawn dance against the daemon's
+# own pidfile). Pre-#613 binaries report no role -- they can only be a
+# `legion serve`, so the kill+spawn path below keeps working for them.
+DAEMON_ROLE=$(echo "$RESPONSE" | jq -r '.role // empty' 2>/dev/null)
+if [ "$DAEMON_ROLE" = "daemon" ]; then
+  echo "[legion-daemon-supervisor] daemon v${DAEMON_VERSION} != local v${LOCAL_VERSION}; restarting daemon in place" >> "$LOG"
+  "$LEGION_BIN" daemon-restart >/dev/null 2>>"$LOG"
+  exit 0
+fi
+
+# Role "serve" (or absent): kill stale serve, spawn fresh.
 echo "[legion-daemon-supervisor] daemon v${DAEMON_VERSION} != local v${LOCAL_VERSION}; replacing" >> "$LOG"
 if [ -f "$PIDFILE" ]; then
   kill_stale_daemon "$(cat "$PIDFILE" 2>/dev/null)"

--- a/plugin/hooks/test-daemon-supervisor.sh
+++ b/plugin/hooks/test-daemon-supervisor.sh
@@ -39,8 +39,9 @@ write_curl_stub() {
 case "$mode" in
   refused) exit 7 ;;
   empty) exit 0 ;;
-  match) echo '{"status":"ok","version":"9.9.9","started_at":"2026-05-10T00:00:00Z","uptime_secs":10}' ;;
+  match) echo '{"status":"ok","version":"9.9.9","role":"serve","started_at":"2026-05-10T00:00:00Z","uptime_secs":10}' ;;
   mismatch) echo '{"status":"ok","version":"1.0.0","started_at":"2026-05-10T00:00:00Z","uptime_secs":10}' ;;
+  mismatch_daemon) echo '{"status":"ok","version":"1.0.0","role":"daemon","started_at":"2026-05-10T00:00:00Z","uptime_secs":10}' ;;
   malformed) echo 'not json' ;;
 esac
 EOF
@@ -89,6 +90,16 @@ wait
 sleep 0.3
 assert_file_contains "spawned replacement" "$FAKE_SPAWN_LOG" "spawned at"
 assert_file_contains "log notes replacement" "$TEST_LOG" "replaced stale v1.0.0"
+
+echo "==> /health version mismatch with role=daemon -> daemon-restart, never a serve spawn"
+reset_log
+write_curl_stub mismatch_daemon
+bash "$HOOK_PATH"
+wait
+sleep 0.3
+assert_file_contains "daemon bounced in place" "$FAKE_SPAWN_LOG" "daemon-restart at"
+assert_file_not_contains "no serve spawned over the daemon" "$FAKE_SPAWN_LOG" "spawned at"
+assert_file_contains "log notes in-place restart" "$TEST_LOG" "restarting daemon in place"
 
 echo "==> /health malformed JSON -> respawn"
 reset_log

--- a/plugin/hooks/tests/testutil.sh
+++ b/plugin/hooks/tests/testutil.sh
@@ -164,7 +164,8 @@ finish_tests() {
 #   FAKE_WHOAMI_BODY         `whoami` body below the standard banner header
 #   FAKE_PREDICTION_ID       `uncertainty emit` row id (pred-fixed-1)
 #   FAKE_WITNESS_LOG=<file>  `uncertainty witness` appends its argv here
-#   FAKE_SPAWN_LOG=<file>    `serve` appends "spawned at <epoch>" here
+#   FAKE_SPAWN_LOG=<file>    `serve` appends "spawned at <epoch>" here;
+#                            `daemon-restart` appends "daemon-restart at <epoch>"
 #   LEGION_TEST_MARKER=<file> `telemetry ...` appends its argv (sans
 #                            leading "telemetry") here
 make_stub_legion() {
@@ -260,6 +261,9 @@ case "${1:-}" in
     ;;
   serve)
     echo "spawned at $(date +%s)" >> "${FAKE_SPAWN_LOG:-/dev/null}"
+    ;;
+  daemon-restart)
+    echo "daemon-restart at $(date +%s)" >> "${FAKE_SPAWN_LOG:-/dev/null}"
     ;;
   telemetry)
     shift

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -67,6 +67,64 @@ pub struct ChannelState {
     pub tx: broadcast::Sender<ChannelEvent>,
 }
 
+/// Error type for every serve.rs and channel.rs HTTP handler (#613).
+///
+/// Implements `IntoResponse`, so handlers return `Result<_, ServeError>` and
+/// propagate failures with `?` instead of hand-writing the same
+/// match-to-json-error block per call site. The wire shape -- a JSON body of
+/// `{"error": <message>}` with the matching status code -- and the
+/// per-endpoint message prefixes (e.g. "query error: ...", "status error:
+/// ...") are part of the public contract and are preserved exactly.
+#[derive(Debug, thiserror::Error)]
+pub enum ServeError {
+    /// The legion database could not be opened. Always 500.
+    #[error("failed to open database")]
+    DbOpen,
+    /// The search index could not be opened. Always 500.
+    #[error("failed to open search index")]
+    IndexOpen,
+    /// Internal failure with a handler-chosen message. 500.
+    #[error("{0}")]
+    Internal(String),
+    /// Caller error. 400.
+    #[error("{0}")]
+    BadRequest(String),
+    /// Resource missing. 404.
+    #[error("{0}")]
+    NotFound(String),
+}
+
+impl ServeError {
+    /// Internal error with a contextual prefix, preserving the per-endpoint
+    /// message conventions ("status error: <e>", "insert error: <e>", ...).
+    pub fn internal(context: &str, e: impl std::fmt::Display) -> Self {
+        ServeError::Internal(format!("{context}: {e}"))
+    }
+}
+
+/// The dominant handler convention: a `LegionError` escaping a handler is a
+/// query failure and renders as 500 `{"error": "query error: <e>"}`. Sites
+/// with a different deliberate prefix call `ServeError::internal` explicitly.
+impl From<LegionError> for ServeError {
+    fn from(e: LegionError) -> Self {
+        ServeError::internal("query error", e)
+    }
+}
+
+impl IntoResponse for ServeError {
+    fn into_response(self) -> Response {
+        let status = match &self {
+            ServeError::BadRequest(_) => StatusCode::BAD_REQUEST,
+            ServeError::NotFound(_) => StatusCode::NOT_FOUND,
+            ServeError::DbOpen | ServeError::IndexOpen | ServeError::Internal(_) => {
+                StatusCode::INTERNAL_SERVER_ERROR
+            }
+        };
+        let body = serde_json::json!({ "error": self.to_string() });
+        (status, Json(body)).into_response()
+    }
+}
+
 /// Feed item returned by GET /api/feed. Field names (snake_case) and is_signal flag are part of the
 /// public JSON contract -- changing them breaks dashboard and external tooling.
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone)]
@@ -100,26 +158,22 @@ pub fn router(state: ChannelState) -> Router {
         .with_state(state)
 }
 
-/// Open a Database from the data_dir. Maps failure to a 500 status and logs.
-fn open_db(data_dir: &std::path::Path) -> Result<Database, StatusCode> {
+/// Open a Database from the data_dir. Logs and maps failure to
+/// `ServeError::DbOpen` (renders as 500 "failed to open database").
+pub(crate) fn open_db(data_dir: &std::path::Path) -> Result<Database, ServeError> {
     Database::open(&data_dir.join("legion.db")).map_err(|e| {
         eprintln!("[legion channel] open_db failed: {e}");
-        StatusCode::INTERNAL_SERVER_ERROR
+        ServeError::DbOpen
     })
 }
 
-/// Open the search index from the data_dir.
-fn open_index(data_dir: &std::path::Path) -> Result<SearchIndex, StatusCode> {
+/// Open the search index from the data_dir. Logs and maps failure to
+/// `ServeError::IndexOpen` (renders as 500 "failed to open search index").
+pub(crate) fn open_index(data_dir: &std::path::Path) -> Result<SearchIndex, ServeError> {
     SearchIndex::open(&data_dir.join("index")).map_err(|e| {
         eprintln!("[legion channel] open_index failed: {e}");
-        StatusCode::INTERNAL_SERVER_ERROR
+        ServeError::IndexOpen
     })
-}
-
-/// JSON error response helper (mirrors serve.rs).
-fn json_error(status: StatusCode, message: &str) -> Response {
-    let body = serde_json::json!({ "error": message });
-    (status, Json(body)).into_response()
 }
 
 /// GET /api/feed -- bullpen posts with optional repo and signal/musing filter.
@@ -131,32 +185,13 @@ fn json_error(status: StatusCode, message: &str) -> Response {
 pub async fn api_feed(
     State(state): State<ChannelState>,
     Query(params): Query<FeedQuery>,
-) -> Response {
-    let db = match open_db(&state.data_dir) {
-        Ok(db) => db,
-        Err(_) => return json_error(StatusCode::INTERNAL_SERVER_ERROR, "failed to open database"),
-    };
+) -> Result<Json<Vec<FeedItem>>, ServeError> {
+    let db = open_db(&state.data_dir)?;
 
     let posts = if let Some(reader) = params.unread_for.as_deref() {
-        match db.get_and_mark_unread_board_posts(reader) {
-            Ok(p) => p,
-            Err(e) => {
-                return json_error(
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    &format!("query error: {e}"),
-                );
-            }
-        }
+        db.get_and_mark_unread_board_posts(reader)?
     } else {
-        match db.get_board_posts() {
-            Ok(p) => p,
-            Err(e) => {
-                return json_error(
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    &format!("query error: {e}"),
-                );
-            }
-        }
+        db.get_board_posts()?
     };
 
     let repo_filter = params.repo.as_deref().unwrap_or("all");
@@ -189,23 +224,15 @@ pub async fn api_feed(
         .take(FEED_LIMIT)
         .collect();
 
-    Json(items).into_response()
+    Ok(Json(items))
 }
 
 /// GET /api/tasks -- all tasks serialized as the legacy Task shape.
-pub async fn api_tasks(State(state): State<ChannelState>) -> Response {
-    let db = match open_db(&state.data_dir) {
-        Ok(db) => db,
-        Err(_) => return json_error(StatusCode::INTERNAL_SERVER_ERROR, "failed to open database"),
-    };
-
-    match db.get_all_tasks() {
-        Ok(tasks) => Json(tasks).into_response(),
-        Err(e) => json_error(
-            StatusCode::INTERNAL_SERVER_ERROR,
-            &format!("query error: {e}"),
-        ),
-    }
+pub async fn api_tasks(
+    State(state): State<ChannelState>,
+) -> Result<Json<Vec<crate::task::Task>>, ServeError> {
+    let db = open_db(&state.data_dir)?;
+    Ok(Json(db.get_all_tasks()?))
 }
 
 /// POST /api/post request body.
@@ -223,46 +250,32 @@ pub struct PostRequest {
 pub async fn api_post(
     State(state): State<ChannelState>,
     Json(body): Json<PostRequest>,
-) -> Response {
+) -> Result<Json<serde_json::Value>, ServeError> {
     let trimmed = body.text.trim().to_string();
     if trimmed.is_empty() {
-        return json_error(StatusCode::BAD_REQUEST, "text is required");
+        return Err(ServeError::BadRequest("text is required".to_string()));
     }
 
-    let db = match open_db(&state.data_dir) {
-        Ok(db) => db,
-        Err(_) => return json_error(StatusCode::INTERNAL_SERVER_ERROR, "failed to open database"),
-    };
-
-    let index = match open_index(&state.data_dir) {
-        Ok(idx) => idx,
-        Err(_) => {
-            return json_error(
-                StatusCode::INTERNAL_SERVER_ERROR,
-                "failed to open search index",
-            );
-        }
-    };
+    let db = open_db(&state.data_dir)?;
+    let index = open_index(&state.data_dir)?;
 
     // TODO(019d7991-2eab): compute and store embedding so this post is similarity-searchable
-    let id = match board::post_from_text_with_meta(
+    let id = board::post_from_text_with_meta(
         &db,
         &index,
         &body.repo,
         &trimmed,
         &ReflectionMeta::default(),
-    ) {
-        Ok(id) => id,
-        Err(e) => {
-            eprintln!("[legion channel] api_post failed: {e}");
-            return json_error(StatusCode::INTERNAL_SERVER_ERROR, "failed to store post");
-        }
-    };
+    )
+    .map_err(|e| {
+        eprintln!("[legion channel] api_post failed: {e}");
+        ServeError::Internal("failed to store post".to_string())
+    })?;
 
     // Notify SSE subscribers (best-effort; no SSE listeners is not an error).
     let _ = state.tx.send(ChannelEvent::Feed);
 
-    Json(serde_json::json!({ "id": id })).into_response()
+    Ok(Json(serde_json::json!({ "id": id })))
 }
 
 /// SSE handler -- streams feed, tasks, and ping events to subscribers.

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -72,6 +72,28 @@ pub enum ChannelEvent {
     Tasks,
 }
 
+/// Which server process answers the shared endpoints. Baked into /health
+/// as the `role` field so port-:3131 clients -- above all the SessionStart
+/// supervisor (#321) -- can tell the daemon from a `legion serve` and pick
+/// the right remedy on version mismatch (#613, absorbed #601).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ServerRole {
+    /// `legion serve`: the dashboard process.
+    Serve,
+    /// `legion daemon`: watch loop + channel HTTP in one process.
+    Daemon,
+}
+
+impl ServerRole {
+    /// Wire value for the /health `role` field.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            ServerRole::Serve => "serve",
+            ServerRole::Daemon => "daemon",
+        }
+    }
+}
+
 /// Shared state for the channel HTTP server.
 #[derive(Clone)]
 pub struct ChannelState {
@@ -80,6 +102,8 @@ pub struct ChannelState {
     /// Wall-clock start of the owning server process. Captured once at boot
     /// so /health (#319) can report uptime without per-request work.
     pub started_at: chrono::DateTime<chrono::Utc>,
+    /// Which process this state belongs to; reported by /health.
+    pub role: ServerRole,
 }
 
 /// Error type for every serve.rs and channel.rs HTTP handler (#613).
@@ -181,7 +205,12 @@ pub fn router(state: ChannelState) -> Router {
 
 /// Pure builder for the `/health` JSON body. Separated from the axum
 /// handler so it's directly unit-testable without spinning up a server.
+///
+/// `role` is additive to the #319 contract (status/version/started_at/
+/// uptime_secs are unchanged): pre-#613 clients ignore it, the supervisor
+/// uses it to pick between respawning a serve and bouncing the daemon.
 fn build_health_body(
+    role: ServerRole,
     started_at: chrono::DateTime<chrono::Utc>,
     now: chrono::DateTime<chrono::Utc>,
 ) -> serde_json::Value {
@@ -189,6 +218,7 @@ fn build_health_body(
     serde_json::json!({
         "status": "ok",
         "version": env!("CARGO_PKG_VERSION"),
+        "role": role.as_str(),
         "started_at": started_at.to_rfc3339(),
         "uptime_secs": uptime_secs,
     })
@@ -202,7 +232,11 @@ fn build_health_body(
 /// `version` field is baked in at compile time from CARGO_PKG_VERSION so
 /// clients can detect protocol drift after a plugin upgrade.
 pub async fn health_endpoint(State(state): State<ChannelState>) -> Json<serde_json::Value> {
-    Json(build_health_body(state.started_at, chrono::Utc::now()))
+    Json(build_health_body(
+        state.role,
+        state.started_at,
+        chrono::Utc::now(),
+    ))
 }
 
 /// Open a Database from the data_dir. Logs and maps failure to
@@ -732,11 +766,15 @@ mod tests {
         let now = chrono::DateTime::parse_from_rfc3339("2026-05-10T12:01:30Z")
             .expect("parse")
             .with_timezone(&chrono::Utc);
-        let body = build_health_body(started, now);
+        let body = build_health_body(ServerRole::Serve, started, now);
         assert_eq!(body["status"], "ok");
         assert_eq!(body["version"], env!("CARGO_PKG_VERSION"));
+        assert_eq!(body["role"], "serve");
         assert_eq!(body["started_at"], "2026-05-10T12:00:00+00:00");
         assert_eq!(body["uptime_secs"], 90);
+
+        let daemon_body = build_health_body(ServerRole::Daemon, started, now);
+        assert_eq!(daemon_body["role"], "daemon");
     }
 
     #[test]
@@ -749,7 +787,7 @@ mod tests {
         let now = chrono::DateTime::parse_from_rfc3339("2026-05-10T11:59:00Z")
             .expect("parse")
             .with_timezone(&chrono::Utc);
-        let body = build_health_body(started, now);
+        let body = build_health_body(ServerRole::Daemon, started, now);
         assert_eq!(body["uptime_secs"], 0);
     }
 
@@ -793,6 +831,7 @@ mod tests {
             data_dir: data_dir.clone(),
             tx,
             started_at: chrono::Utc::now(),
+            role: ServerRole::Daemon,
         };
         let app = router(state);
 

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -278,6 +278,110 @@ pub async fn api_post(
     Ok(Json(serde_json::json!({ "id": id })))
 }
 
+/// Interval between due-schedule checks by the background firing task.
+///
+/// Schedule granularity is minutes (`*/Nm` or daily `HH:MM`), so a 30s
+/// poll bounds firing latency at half the finest cron step. The previous
+/// home of this loop -- the per-connection SSE stream body -- polled at
+/// 2s, but only while a dashboard was connected and once per client.
+const SCHEDULE_POLL_INTERVAL: Duration = Duration::from_secs(30);
+
+/// Spawn the single background task that fires due schedules (#613).
+///
+/// Exactly one task per server process owns the get_due_schedules ->
+/// post -> mark_schedule_run loop. It previously ran inside the
+/// per-connection SSE stream body in serve.rs, which meant schedules
+/// fired only while a dashboard was open, fired once per connected
+/// client, and raced the get_due/mark_run window across connections.
+/// Now both server entry points spawn it once at startup -- `legion
+/// serve` (run_server) and the daemon (run_daemon_async) -- so
+/// schedules fire under whichever server is running, with zero
+/// connected clients. The two servers cannot share a port, so only one
+/// fires per host in the default configuration; running both on
+/// different ports against the same data dir is the one (accepted,
+/// documented) double-firing window.
+///
+/// `tx` wakes in-process SSE subscribers after a successful fire so
+/// dashboards update immediately instead of waiting for the poll
+/// fallback.
+pub fn spawn_schedule_firing(
+    data_dir: PathBuf,
+    tx: broadcast::Sender<ChannelEvent>,
+) -> tokio::task::JoinHandle<()> {
+    spawn_schedule_firing_with_interval(data_dir, tx, SCHEDULE_POLL_INTERVAL)
+}
+
+/// Interval-injectable form of `spawn_schedule_firing` -- the test seam.
+fn spawn_schedule_firing_with_interval(
+    data_dir: PathBuf,
+    tx: broadcast::Sender<ChannelEvent>,
+    interval: Duration,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        loop {
+            tokio::time::sleep(interval).await;
+            // Open per tick: a missing or locked database must not kill
+            // the task for the lifetime of the server.
+            let db = match Database::open(&data_dir.join("legion.db")) {
+                Ok(db) => db,
+                Err(e) => {
+                    eprintln!("[legion] schedule firing: failed to open db: {e}");
+                    continue;
+                }
+            };
+            let index = match SearchIndex::open(&data_dir.join("index")) {
+                Ok(i) => i,
+                Err(e) => {
+                    eprintln!("[legion] schedule firing: failed to open index: {e}");
+                    continue;
+                }
+            };
+            if fire_due_schedules(&db, &index) > 0 {
+                // Best-effort wake; no SSE listeners is not an error.
+                let _ = tx.send(ChannelEvent::Feed);
+            }
+        }
+    })
+}
+
+/// Fire every due schedule once: post the command text to the bullpen
+/// through `board::post_from_text_with_meta` (the single owner of the
+/// write+index invariant) and mark the schedule run regardless of post
+/// success so a permanently failing schedule cannot retry-loop forever.
+/// Returns the number of successful posts.
+fn fire_due_schedules(db: &Database, index: &SearchIndex) -> usize {
+    let due = match db.get_due_schedules() {
+        Ok(d) => d,
+        Err(e) => {
+            eprintln!("[legion] schedule firing: due query failed: {e}");
+            return 0;
+        }
+    };
+    let mut fired: usize = 0;
+    for schedule in &due {
+        match board::post_from_text_with_meta(
+            db,
+            index,
+            &schedule.repo,
+            &schedule.command,
+            &ReflectionMeta::default(),
+        ) {
+            Ok(_) => {
+                eprintln!("[legion] schedule fired: {}", schedule.name);
+                fired += 1;
+            }
+            Err(e) => {
+                eprintln!("[legion] schedule post failed for {}: {e}", schedule.name);
+            }
+        }
+        // Mark as run regardless of post success to avoid infinite retries.
+        if let Err(e) = db.mark_schedule_run(&schedule.id) {
+            eprintln!("[legion] failed to mark schedule run: {e}");
+        }
+    }
+    fired
+}
+
 /// SSE handler -- streams feed, tasks, and ping events to subscribers.
 ///
 /// Opens the database once at stream start and holds it for the stream's
@@ -491,6 +595,76 @@ mod tests {
         let parsed: serde_json::Value = serde_json::from_str(&json).expect("parse");
         assert!(parsed.is_array());
         assert_eq!(parsed.as_array().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn fire_due_schedules_posts_and_advances() {
+        let (db, index, _dir) = test_storage();
+
+        let id = db
+            .insert_schedule("standup", "*/30m", "post the standup", "legion", None, None)
+            .expect("insert schedule");
+
+        // Freshly inserted: next_run is in the future, nothing fires.
+        assert_eq!(fire_due_schedules(&db, &index), 0, "not due yet");
+
+        db.force_schedule_due(&id).expect("force due");
+        assert_eq!(fire_due_schedules(&db, &index), 1, "due schedule fires");
+
+        let posts = db.get_board_posts().expect("posts");
+        assert_eq!(posts.len(), 1);
+        assert_eq!(posts[0].text, "post the standup");
+        assert_eq!(posts[0].repo, "legion");
+
+        // mark_schedule_run advanced next_run, so an immediate re-check
+        // must NOT double-fire -- the old per-SSE-connection loop did.
+        assert_eq!(fire_due_schedules(&db, &index), 0, "no double fire");
+        assert_eq!(db.get_board_posts().expect("posts").len(), 1);
+    }
+
+    /// AC (#613): schedules fire with zero SSE clients connected. The real
+    /// background task is spawned with no subscriber anywhere -- no /sse
+    /// stream, no broadcast receiver kept -- and the post still lands.
+    #[tokio::test]
+    async fn schedules_fire_with_zero_sse_clients() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let data_dir = dir.path().to_path_buf();
+
+        // The task opens data_dir/legion.db and data_dir/index, the same
+        // paths run_server and run_daemon_async hand it.
+        let db = Database::open(&data_dir.join("legion.db")).expect("open db");
+        let _index = SearchIndex::open(&data_dir.join("index")).expect("open index");
+        let id = db
+            .insert_schedule(
+                "nightly",
+                "*/30m",
+                "fire without clients",
+                "legion",
+                None,
+                None,
+            )
+            .expect("insert schedule");
+        db.force_schedule_due(&id).expect("force due");
+
+        let (tx, _rx) = new_broadcast();
+        drop(_rx); // zero subscribers: firing must not depend on listeners
+        let handle =
+            spawn_schedule_firing_with_interval(data_dir.clone(), tx, Duration::from_millis(20));
+
+        // Poll for the fired post instead of a fixed sleep.
+        let deadline = std::time::Instant::now() + Duration::from_secs(5);
+        loop {
+            let posts = db.get_board_posts().expect("posts");
+            if posts.iter().any(|p| p.text == "fire without clients") {
+                break;
+            }
+            assert!(
+                std::time::Instant::now() < deadline,
+                "schedule did not fire within 5s with zero SSE clients"
+            );
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+        handle.abort();
     }
 
     #[test]

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::convert::Infallible;
 use std::path::PathBuf;
 use std::time::Duration;
@@ -28,6 +29,17 @@ const SSE_FEED_LIMIT: usize = 20;
 
 /// Seconds between keepalive pings when no change has been detected.
 const PING_INTERVAL_SECS: u64 = 30;
+
+/// Seconds between SSE poll-fallback wakeups (#613 cadence decision).
+///
+/// The broadcast channel only fires for in-process writes (HTTP /api/post,
+/// the schedule-firing task, MCP handlers in the daemon). Cross-process
+/// writes -- `legion post` from a CLI session, another legion binary
+/// touching the same database -- never reach this process's broadcast, so
+/// every connected SSE stream also re-checks the change timestamps on this
+/// interval. 5s is the worst-case dashboard latency for a CLI write;
+/// in-process writes surface immediately via the edge trigger.
+const SSE_POLL_FALLBACK_SECS: u64 = 5;
 
 /// Wake-up signal for in-process consumers of the broadcast channel. The
 /// variants carry no payload: every consumer re-reads from the database on
@@ -65,6 +77,9 @@ pub enum ChannelEvent {
 pub struct ChannelState {
     pub data_dir: PathBuf,
     pub tx: broadcast::Sender<ChannelEvent>,
+    /// Wall-clock start of the owning server process. Captured once at boot
+    /// so /health (#319) can report uptime without per-request work.
+    pub started_at: chrono::DateTime<chrono::Utc>,
 }
 
 /// Error type for every serve.rs and channel.rs HTTP handler (#613).
@@ -148,14 +163,46 @@ pub struct FeedQuery {
 
 /// Build the axum Router for the channel HTTP server.
 ///
-/// This is a standalone router -- the caller mounts it into the main axum app.
+/// This is a standalone router -- the caller mounts it into the main axum
+/// app. It is the single owner of the shared endpoint contract (#613):
+/// /health, /sse, /api/feed, /api/tasks, /api/post. Both `legion serve`
+/// (which merges this router into the dashboard app) and the daemon (which
+/// serves it bare) answer these paths with the same implementation, so the
+/// wire shapes cannot fork again.
 pub fn router(state: ChannelState) -> Router {
     Router::new()
+        .route("/health", get(health_endpoint))
         .route("/sse", get(sse_handler))
         .route("/api/feed", get(api_feed))
         .route("/api/tasks", get(api_tasks))
         .route("/api/post", post(api_post))
         .with_state(state)
+}
+
+/// Pure builder for the `/health` JSON body. Separated from the axum
+/// handler so it's directly unit-testable without spinning up a server.
+fn build_health_body(
+    started_at: chrono::DateTime<chrono::Utc>,
+    now: chrono::DateTime<chrono::Utc>,
+) -> serde_json::Value {
+    let uptime_secs = (now - started_at).num_seconds().max(0);
+    serde_json::json!({
+        "status": "ok",
+        "version": env!("CARGO_PKG_VERSION"),
+        "started_at": started_at.to_rfc3339(),
+        "uptime_secs": uptime_secs,
+    })
+}
+
+/// GET /health -- cheap daemon liveness probe (#319).
+///
+/// Returns `{status, version, started_at, uptime_secs}` with NO database
+/// access so it can be polled aggressively by hooks, the MCP reconnect
+/// path (#320), and the SessionStart auto-spawn supervisor (#321). The
+/// `version` field is baked in at compile time from CARGO_PKG_VERSION so
+/// clients can detect protocol drift after a plugin upgrade.
+pub async fn health_endpoint(State(state): State<ChannelState>) -> Json<serde_json::Value> {
+    Json(build_health_body(state.started_at, chrono::Utc::now()))
 }
 
 /// Open a Database from the data_dir. Logs and maps failure to
@@ -244,9 +291,20 @@ pub struct PostRequest {
 
 /// POST /api/post -- broadcast a message to the bullpen and notify SSE subscribers.
 ///
-/// Index failures are treated as errors (500) rather than silently swallowed -- a post
-/// that cannot be indexed is unsearchable, which is a half-broken state. Callers should
-/// retry if they get a 500.
+/// Response shape (#613 divergence resolution): `{"id": <reflection id>}`.
+/// serve.rs used to return the full reflection object from its own copy of
+/// this handler; the channel shape won because the only verified consumer
+/// (static/app.js) ignores the response body entirely, and the id is all a
+/// caller needs to reference the post. Pinned by the
+/// api_post_returns_id_only_shape test.
+///
+/// Index-failure policy (#613 divergence resolution): failures are 500s
+/// rather than silently swallowed -- a post that cannot be indexed is
+/// unsearchable, which is a half-broken state. serve.rs used to treat
+/// indexing as best-effort; the strict policy won because it lives in
+/// board::post_from_text_with_meta, the single owner of the write+index
+/// invariant. The post may already be in the DB when a 500 is returned;
+/// callers should retry.
 pub async fn api_post(
     State(state): State<ChannelState>,
     Json(body): Json<PostRequest>,
@@ -382,17 +440,24 @@ fn fire_due_schedules(db: &Database, index: &SearchIndex) -> usize {
     fired
 }
 
-/// SSE handler -- streams feed, tasks, and ping events to subscribers.
+/// SSE handler -- streams agents, feed, tasks, and ping events to
+/// subscribers (#613: the canonical implementation; serve.rs's 2s-polling
+/// twin is deleted and the dashboard connects here).
 ///
 /// Opens the database once at stream start and holds it for the stream's
-/// lifetime. On each broadcast notification, queries the new max timestamp
-/// and emits feed/tasks events. Emits a keepalive ping every PING_INTERVAL_SECS
-/// when there is no activity.
+/// lifetime. Wakes on either edge (a broadcast notification from an
+/// in-process write) or the SSE_POLL_FALLBACK_SECS timer (cross-process
+/// writes -- see the constant's doc for the cadence decision), then emits
+/// events only for timestamps that actually changed. Emits a keepalive
+/// ping after PING_INTERVAL_SECS without any event. The stream itself is
+/// read-only: schedule firing lives in spawn_schedule_firing, never here.
 ///
-/// Event shapes:
-///   feed  -- JSON array of FeedItem (last SSE_FEED_LIMIT team posts)
-///   tasks -- JSON array of Task
-///   ping  -- `{}` heartbeat every 30s
+/// Event shapes (all consumed by static/app.js -- the dashboard
+/// subscribes to agents, feed, and tasks):
+///   agents -- JSON array of AgentInfo (same shape as GET /api/agents)
+///   feed   -- JSON array of FeedItem (last SSE_FEED_LIMIT team posts)
+///   tasks  -- JSON array of Task
+///   ping   -- `{}` heartbeat
 pub async fn sse_handler(
     State(state): State<ChannelState>,
 ) -> Sse<impl tokio_stream::Stream<Item = Result<Event, Infallible>>> {
@@ -410,10 +475,12 @@ pub async fn sse_handler(
 
         let mut last_reflection_ts: Option<String> = None;
         let mut last_task_ts: Option<String> = None;
+        let poll_fallback = Duration::from_secs(SSE_POLL_FALLBACK_SECS);
         let ping_interval = Duration::from_secs(PING_INTERVAL_SECS);
+        let mut last_emit = tokio::time::Instant::now();
 
         loop {
-            // Wait for a broadcast notification or a ping timeout.
+            // Wait for a broadcast notification or the poll fallback.
             tokio::select! {
                 result = rx.recv() => {
                     match result {
@@ -432,20 +499,29 @@ pub async fn sse_handler(
                         }
                     }
                 }
-                _ = tokio::time::sleep(ping_interval) => {
-                    // No change notification for a while -- emit keepalive only.
-                    yield Ok(Event::default().event("ping").data("{}"));
-                    continue;
+                _ = tokio::time::sleep(poll_fallback) => {
+                    // Cross-process writes never hit this process's
+                    // broadcast; fall through to the timestamp checks.
                 }
             }
 
-            // Feed: emit when max created_at changes.
+            let mut emitted = false;
+
+            // Agents + feed: emit when max created_at changes. The agents
+            // event carries the same AgentInfo array as GET /api/agents so
+            // the dashboard's live update matches its initial load.
             let current_reflection_ts = db.get_max_created_at().ok().flatten();
             if current_reflection_ts != last_reflection_ts && current_reflection_ts.is_some() {
                 last_reflection_ts = current_reflection_ts;
 
+                if let Ok(agents_json) = build_agents_json(&db) {
+                    yield Ok(Event::default().event("agents").data(agents_json));
+                    emitted = true;
+                }
+
                 if let Ok(feed_json) = build_feed_json(&db) {
                     yield Ok(Event::default().event("feed").data(feed_json));
+                    emitted = true;
                 }
             }
 
@@ -458,12 +534,63 @@ pub async fn sse_handler(
                     && let Ok(json) = serde_json::to_string(&tasks)
                 {
                     yield Ok(Event::default().event("tasks").data(json));
+                    emitted = true;
                 }
+            }
+
+            if emitted {
+                last_emit = tokio::time::Instant::now();
+            } else if last_emit.elapsed() >= ping_interval {
+                yield Ok(Event::default().event("ping").data("{}"));
+                last_emit = tokio::time::Instant::now();
             }
         }
     };
 
     Sse::new(stream).keep_alive(KeepAlive::default())
+}
+
+/// Agent info returned by GET /api/agents and the SSE `agents` event.
+/// Field names are part of the public JSON contract (static/app.js reads
+/// repo, unread, boost_sum, last_activity directly).
+#[derive(serde::Serialize)]
+pub struct AgentInfo {
+    pub repo: String,
+    pub unread: u64,
+    pub reflection_count: u64,
+    pub boost_sum: i64,
+    pub team_post_count: u64,
+    pub last_activity: String,
+}
+
+/// Build the per-repo agent overview: dashboard stats merged with unread
+/// counts. The single source for both GET /api/agents (serve.rs) and the
+/// SSE `agents` event -- push and pull of the same resource must emit the
+/// same shape or the dashboard diverges mid-session (audit DC3).
+pub fn build_agents(db: &Database) -> Result<Vec<AgentInfo>, LegionError> {
+    let stats = db.get_dashboard_stats()?;
+    let unread_map: HashMap<String, u64> = db
+        .get_unread_counts_all()
+        .unwrap_or_default()
+        .into_iter()
+        .collect();
+
+    Ok(stats
+        .into_iter()
+        .map(|s| AgentInfo {
+            unread: unread_map.get(&s.repo).copied().unwrap_or(0),
+            repo: s.repo,
+            reflection_count: s.reflection_count,
+            boost_sum: s.boost_sum,
+            team_post_count: s.team_post_count,
+            last_activity: s.last_activity,
+        })
+        .collect())
+}
+
+/// Serialized form of `build_agents` for the SSE event payload.
+fn build_agents_json(db: &Database) -> Result<String, LegionError> {
+    Ok(serde_json::to_string(&build_agents(db)?)?)
 }
 
 /// Build the feed JSON payload (last SSE_FEED_LIMIT team posts).
@@ -595,6 +722,129 @@ mod tests {
         let parsed: serde_json::Value = serde_json::from_str(&json).expect("parse");
         assert!(parsed.is_array());
         assert_eq!(parsed.as_array().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn health_body_shape() {
+        let started = chrono::DateTime::parse_from_rfc3339("2026-05-10T12:00:00Z")
+            .expect("parse")
+            .with_timezone(&chrono::Utc);
+        let now = chrono::DateTime::parse_from_rfc3339("2026-05-10T12:01:30Z")
+            .expect("parse")
+            .with_timezone(&chrono::Utc);
+        let body = build_health_body(started, now);
+        assert_eq!(body["status"], "ok");
+        assert_eq!(body["version"], env!("CARGO_PKG_VERSION"));
+        assert_eq!(body["started_at"], "2026-05-10T12:00:00+00:00");
+        assert_eq!(body["uptime_secs"], 90);
+    }
+
+    #[test]
+    fn health_uptime_clamped_at_zero_for_clock_skew() {
+        // If `now` is somehow before `started_at` (clock jump, NTP
+        // correction, test fixture), uptime must not go negative.
+        let started = chrono::DateTime::parse_from_rfc3339("2026-05-10T12:00:00Z")
+            .expect("parse")
+            .with_timezone(&chrono::Utc);
+        let now = chrono::DateTime::parse_from_rfc3339("2026-05-10T11:59:00Z")
+            .expect("parse")
+            .with_timezone(&chrono::Utc);
+        let body = build_health_body(started, now);
+        assert_eq!(body["uptime_secs"], 0);
+    }
+
+    #[test]
+    fn build_agents_merges_stats_and_unread() {
+        let (db, _index, _dir) = test_storage();
+        db.insert_reflection_with_meta("kelex", "hello team", "team", &ReflectionMeta::default())
+            .expect("insert");
+
+        let agents = build_agents(&db).expect("build agents");
+        assert_eq!(agents.len(), 1);
+        assert_eq!(agents[0].repo, "kelex");
+        assert_eq!(agents[0].team_post_count, 1);
+
+        // Serialized shape: the SSE agents event and GET /api/agents both
+        // emit these field names (public JSON contract, app.js reads them).
+        let json = serde_json::to_value(&agents).expect("serialize");
+        let first = &json[0];
+        for key in [
+            "repo",
+            "unread",
+            "reflection_count",
+            "boost_sum",
+            "team_post_count",
+            "last_activity",
+        ] {
+            assert!(first.get(key).is_some(), "missing agents field {key}");
+        }
+    }
+
+    /// Pins the #613 api_post divergence resolution: the response body is
+    /// exactly {"id": <uuid>} -- not serve's old full-reflection object.
+    #[tokio::test]
+    async fn api_post_returns_id_only_shape() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let data_dir = dir.path().to_path_buf();
+        let _db = Database::open(&data_dir.join("legion.db")).expect("open db");
+
+        let (tx, _rx) = new_broadcast();
+        let state = ChannelState {
+            data_dir: data_dir.clone(),
+            tx,
+            started_at: chrono::Utc::now(),
+        };
+        let app = router(state);
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind");
+        let port = listener.local_addr().expect("addr").port();
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.expect("serve");
+        });
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        let response = tokio::task::spawn_blocking(move || {
+            use std::io::{Read, Write};
+            use std::net::TcpStream;
+
+            let body = r#"{"repo":"kelex","text":"hello shape"}"#;
+            let mut stream = TcpStream::connect(format!("127.0.0.1:{port}")).expect("connect");
+            stream
+                .write_all(
+                    format!(
+                        "POST /api/post HTTP/1.1\r\nHost: 127.0.0.1\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                        body.len()
+                    )
+                    .as_bytes(),
+                )
+                .expect("write");
+            let mut buf = Vec::new();
+            stream.read_to_end(&mut buf).expect("read");
+            buf
+        })
+        .await
+        .expect("spawn_blocking");
+
+        let response_str = String::from_utf8_lossy(&response);
+        assert!(
+            response_str.starts_with("HTTP/1.1 200"),
+            "expected 200 OK, got: {}",
+            &response_str[..response_str.len().min(200)]
+        );
+        let json_body = response_str
+            .split("\r\n\r\n")
+            .nth(1)
+            .expect("response body");
+        let parsed: serde_json::Value = serde_json::from_str(json_body.trim()).expect("parse body");
+        let obj = parsed.as_object().expect("object body");
+        assert!(obj.contains_key("id"), "body must carry the post id");
+        assert_eq!(
+            obj.len(),
+            1,
+            "api_post body is exactly {{\"id\"}}, got: {parsed}"
+        );
     }
 
     #[test]

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -345,6 +345,7 @@ async fn run_daemon_async(config: DaemonConfig) -> Result<()> {
     let channel_state = channel::ChannelState {
         data_dir: data_dir.clone(),
         tx,
+        started_at: chrono::Utc::now(),
     };
     let app = channel::router(channel_state);
 
@@ -618,6 +619,7 @@ mod tests {
         let state = channel::ChannelState {
             data_dir: data_dir.clone(),
             tx,
+            started_at: chrono::Utc::now(),
         };
 
         let app = channel::router(state);

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -335,6 +335,13 @@ async fn run_daemon_async(config: DaemonConfig) -> Result<()> {
     // Build the broadcast channel for SSE notifications.
     let (tx, _rx) = channel::new_broadcast();
 
+    // Schedules fire under the daemon too (#613 decision): the daemon is
+    // the long-lived server on a watch node, so cron posts must not depend
+    // on someone running `legion serve`. The task is deliberately not in
+    // the select! below -- it is a side loop, not a liveness-critical
+    // component, and it is cancelled when the runtime shuts down.
+    let _firing = channel::spawn_schedule_firing(data_dir.clone(), tx.clone());
+
     let channel_state = channel::ChannelState {
         data_dir: data_dir.clone(),
         tx,

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -345,16 +345,9 @@ async fn run_daemon_async(config: DaemonConfig) -> Result<()> {
     // Build the broadcast channel for SSE notifications.
     let (tx, _rx) = channel::new_broadcast();
 
-    // Schedules fire under the daemon too (#613 decision): the daemon is
-    // the long-lived server on a watch node, so cron posts must not depend
-    // on someone running `legion serve`. The task is deliberately not in
-    // the select! below -- it is a side loop, not a liveness-critical
-    // component, and it is cancelled when the runtime shuts down.
-    let _firing = channel::spawn_schedule_firing(data_dir.clone(), tx.clone());
-
     let channel_state = channel::ChannelState {
         data_dir: data_dir.clone(),
-        tx,
+        tx: tx.clone(),
         started_at: chrono::Utc::now(),
         role: channel::ServerRole::Daemon,
     };
@@ -367,6 +360,16 @@ async fn run_daemon_async(config: DaemonConfig) -> Result<()> {
         .map_err(|e| LegionError::Server(format!("failed to bind {addr}: {e}")))?;
 
     eprintln!("[legion daemon] channel server at http://localhost:{port}");
+
+    // Schedules fire under the daemon too (#613 decision): the daemon is
+    // the long-lived server on a watch node, so cron posts must not depend
+    // on someone running `legion serve`. Spawned only after the bind
+    // succeeded -- same invariant as run_server: a process that failed to
+    // become the server must not produce side effects. The task is
+    // deliberately not in the select! below -- it is a side loop, not a
+    // liveness-critical component, and it is cancelled when the runtime
+    // shuts down.
+    let _firing = channel::spawn_schedule_firing(data_dir.clone(), tx);
 
     // Spawn the watch loop as a background task.
     let watch_handle = tokio::spawn(async move {

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -154,7 +154,7 @@ fn port_available(port: u16) -> bool {
 /// Best-effort: the PID(s) listening on `port`, for naming the holder in the
 /// port-conflict error. Unix-only via `lsof`; returns empty on other platforms
 /// or when `lsof` is unavailable -- the caller degrades to a generic message.
-fn port_listener_pids(port: u16) -> Vec<u32> {
+pub(crate) fn port_listener_pids(port: u16) -> Vec<u32> {
     #[cfg(unix)]
     {
         let output = std::process::Command::new("lsof")
@@ -184,6 +184,16 @@ const SIGKILL_REAP_TIMEOUT: Duration = Duration::from_secs(2);
 fn read_daemon_pid(pid_path: &Path) -> Option<u32> {
     let contents = std::fs::read_to_string(pid_path).ok()?;
     contents.trim().parse::<u32>().ok()
+}
+
+/// PID of the live daemon tracked by `data_dir/daemon.pid`, if any.
+///
+/// #613 (absorbed #601): lets `legion serve` name the daemon as the port
+/// holder when its own bind fails, instead of emitting a bare bind error.
+/// Stale pidfiles (dead process) read as None.
+pub(crate) fn live_daemon_pid(data_dir: &Path) -> Option<u32> {
+    let pid = read_daemon_pid(&data_dir.join(DAEMON_PID_FILE))?;
+    watch::process_alive(pid).then_some(pid)
 }
 
 /// Send a signal (e.g. "TERM", "KILL") to a process. Unix-only; returns false on
@@ -346,6 +356,7 @@ async fn run_daemon_async(config: DaemonConfig) -> Result<()> {
         data_dir: data_dir.clone(),
         tx,
         started_at: chrono::Utc::now(),
+        role: channel::ServerRole::Daemon,
     };
     let app = channel::router(channel_state);
 
@@ -620,6 +631,7 @@ mod tests {
             data_dir: data_dir.clone(),
             tx,
             started_at: chrono::Utc::now(),
+            role: channel::ServerRole::Daemon,
         };
 
         let app = channel::router(state);

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -29,7 +29,8 @@ mod wake;
 pub use audit::AuditInput;
 pub use kanban::CardTimestamp;
 pub use reflections::{Reflection, ReflectionMeta};
-pub use schedules::validate_hhmm;
+pub use schedules::{Schedule, validate_hhmm};
+pub use stats::DashboardRepoStats;
 
 use std::path::Path;
 

--- a/src/db/schedules.rs
+++ b/src/db/schedules.rs
@@ -282,6 +282,21 @@ impl Database {
         Ok(())
     }
 
+    /// Force a schedule's next_run into the past so it reads as due.
+    ///
+    /// Test seam only: `insert_schedule` always computes a future next_run,
+    /// so exercising the due->fire->mark_run path would otherwise require
+    /// a real cron wait.
+    #[cfg(test)]
+    pub fn force_schedule_due(&self, id: &str) -> Result<()> {
+        let past = (Utc::now() - chrono::Duration::minutes(5)).to_rfc3339();
+        self.conn.execute(
+            "UPDATE schedules SET next_run = ?1 WHERE id = ?2",
+            rusqlite::params![&past, id],
+        )?;
+        Ok(())
+    }
+
     /// List all schedules.
     pub fn list_schedules(&self) -> Result<Vec<Schedule>> {
         let mut stmt = self.conn.prepare(

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -101,9 +101,18 @@ pub fn run_server(port: u16, data_dir: PathBuf) -> error::Result<()> {
 
     runtime.block_on(async {
         let state = AppState {
-            data_dir,
+            data_dir: data_dir.clone(),
             started_at: chrono::Utc::now(),
         };
+
+        // One background task owns schedule firing (#613) -- previously it
+        // ran inside the per-connection SSE stream body, so schedules only
+        // fired while a dashboard was open and fired once per connected
+        // client. The broadcast sender wakes in-process SSE subscribers
+        // when a schedule posts (serve's own SSE still detects the write
+        // by timestamp poll; the channel SSE handler subscribes).
+        let (tx, _rx) = crate::channel::new_broadcast();
+        let _firing = crate::channel::spawn_schedule_firing(data_dir.clone(), tx);
 
         let app = Router::new()
             .route("/", get(index_handler))
@@ -262,31 +271,6 @@ async fn sse_handler(
                     && let Ok(json) = serde_json::to_string(&tasks)
                 {
                     yield Ok(Event::default().event("tasks").data(json));
-                }
-            }
-
-            // Check for due schedules and fire them
-            if let Ok(due) = db.get_due_schedules() {
-                for schedule in &due {
-                    // Post to bullpen
-                    if let Ok(reflection) = db.insert_reflection_with_meta(
-                        &schedule.repo,
-                        &schedule.command,
-                        "team",
-                        &ReflectionMeta::default(),
-                    ) {
-                        // Best-effort add to search index
-                        if let Ok(index) = SearchIndex::open(&state.data_dir.join("index"))
-                            && let Err(e) = index.add(&reflection.id, &reflection.repo, &schedule.command)
-                        {
-                            eprintln!("[legion] search index add failed for schedule: {e}");
-                        }
-                        eprintln!("[legion] schedule fired: {}", schedule.name);
-                    }
-                    // Mark as run regardless of post success to avoid infinite retries
-                    if let Err(e) = db.mark_schedule_run(&schedule.id) {
-                        eprintln!("[legion] failed to mark schedule run: {e}");
-                    }
                 }
             }
 
@@ -570,12 +554,20 @@ async fn api_done(
     let db = open_db(&state.data_dir)?;
     let index = open_search_index(&state.data_dir)?;
 
+    // Both posts route through board::post_from_text_with_meta so the
+    // write+index invariant lives in one place (#613). Consequence: an
+    // index failure now fails the post (the announcement returns 500, a
+    // notification does not count its agent as notified) instead of the
+    // old silently-unsearchable best effort.
     let announcement = format!("{repo} completed: {text}");
-    let reflection = db
-        .insert_reflection_with_meta(repo, &announcement, "team", &ReflectionMeta::default())
-        .map_err(|e| ServeError::internal("insert error", e))?;
-
-    let _ = index.add(&reflection.id, &reflection.repo, &announcement);
+    crate::board::post_from_text_with_meta(
+        &db,
+        &index,
+        repo,
+        &announcement,
+        &ReflectionMeta::default(),
+    )
+    .map_err(|e| ServeError::internal("insert error", e))?;
 
     let blocked_agents = status::find_blocked_agents(&db, repo).unwrap_or_default();
     let mut notified: Vec<String> = Vec::new();
@@ -583,10 +575,15 @@ async fn api_done(
         let notify_text = format!(
             "@{agent} announce from {repo} -- {repo} completed: {text}. Your blocker may be cleared."
         );
-        if let Ok(r) =
-            db.insert_reflection_with_meta(repo, &notify_text, "team", &ReflectionMeta::default())
+        if crate::board::post_from_text_with_meta(
+            &db,
+            &index,
+            repo,
+            &notify_text,
+            &ReflectionMeta::default(),
+        )
+        .is_ok()
         {
-            let _ = index.add(&r.id, &r.repo, &notify_text);
             notified.push(agent.clone());
         }
     }

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -14,6 +14,7 @@ use axum::{Json, Router};
 use rust_embed::Embed;
 use tokio::signal;
 
+use crate::channel::ServeError;
 use crate::db::{Database, ReflectionMeta};
 use crate::error;
 use crate::health::HealthSample;
@@ -35,15 +36,10 @@ struct AppState {
 
 /// Open a database connection from the data directory.
 ///
-/// Returns a 500 status code if the database cannot be opened.
-fn open_db(data_dir: &Path) -> Result<Database, StatusCode> {
-    Database::open(&data_dir.join("legion.db")).map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)
-}
-
-/// JSON error response helper.
-fn json_error(status: StatusCode, message: &str) -> Response {
-    let body = serde_json::json!({ "error": message });
-    (status, Json(body)).into_response()
+/// Renders as 500 {"error": "failed to open database"} when propagated
+/// from a handler with `?`.
+fn open_db(data_dir: &Path) -> Result<Database, ServeError> {
+    Database::open(&data_dir.join("legion.db")).map_err(|_| ServeError::DbOpen)
 }
 
 /// Resolve the daemon pidfile path. Lives under XDG_STATE_HOME (same root
@@ -361,26 +357,16 @@ struct AgentInfo {
 }
 
 /// GET /api/agents -- per-repo agent overview with unread counts.
-async fn api_agents(State(state): State<AppState>) -> Response {
-    let db = match open_db(&state.data_dir) {
-        Ok(db) => db,
-        Err(_) => return json_error(StatusCode::INTERNAL_SERVER_ERROR, "failed to open database"),
-    };
+async fn api_agents(State(state): State<AppState>) -> Result<Json<Vec<AgentInfo>>, ServeError> {
+    let db = open_db(&state.data_dir)?;
 
-    let stats = match db.get_dashboard_stats() {
-        Ok(s) => s,
-        Err(e) => {
-            return json_error(
-                StatusCode::INTERNAL_SERVER_ERROR,
-                &format!("query error: {e}"),
-            );
-        }
-    };
+    let stats = db.get_dashboard_stats()?;
 
-    let unread_map: HashMap<String, u64> = match db.get_unread_counts_all() {
-        Ok(counts) => counts.into_iter().collect(),
-        Err(_) => HashMap::new(),
-    };
+    let unread_map: HashMap<String, u64> = db
+        .get_unread_counts_all()
+        .unwrap_or_default()
+        .into_iter()
+        .collect();
 
     let agents: Vec<AgentInfo> = stats
         .into_iter()
@@ -394,7 +380,7 @@ async fn api_agents(State(state): State<AppState>) -> Response {
         })
         .collect();
 
-    Json(agents).into_response()
+    Ok(Json(agents))
 }
 
 /// Feed item returned by GET /api/feed.
@@ -423,34 +409,18 @@ struct FeedQuery {
 /// GET /api/feed -- bullpen posts with optional repo and signal/musing filter.
 /// When `unread_for=<repo>` is set, returns only posts unread by that repo
 /// and atomically marks them as read so the same post is never delivered twice.
-async fn api_feed(State(state): State<AppState>, Query(params): Query<FeedQuery>) -> Response {
-    let db = match open_db(&state.data_dir) {
-        Ok(db) => db,
-        Err(_) => return json_error(StatusCode::INTERNAL_SERVER_ERROR, "failed to open database"),
-    };
+async fn api_feed(
+    State(state): State<AppState>,
+    Query(params): Query<FeedQuery>,
+) -> Result<Json<Vec<FeedItem>>, ServeError> {
+    let db = open_db(&state.data_dir)?;
 
     // When `unread_for` is set, use the atomic unread-and-mark query so the
     // channel backlog delivers each post exactly once across connections.
     let posts = if let Some(reader) = params.unread_for.as_deref() {
-        match db.get_and_mark_unread_board_posts(reader) {
-            Ok(p) => p,
-            Err(e) => {
-                return json_error(
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    &format!("query error: {e}"),
-                );
-            }
-        }
+        db.get_and_mark_unread_board_posts(reader)?
     } else {
-        match db.get_board_posts() {
-            Ok(p) => p,
-            Err(e) => {
-                return json_error(
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    &format!("query error: {e}"),
-                );
-            }
-        }
+        db.get_board_posts()?
     };
 
     let repo_filter = params.repo.as_deref().unwrap_or("all");
@@ -480,39 +450,23 @@ async fn api_feed(State(state): State<AppState>, Query(params): Query<FeedQuery>
         })
         .collect();
 
-    Json(items).into_response()
+    Ok(Json(items))
 }
 
 /// GET /api/tasks -- all tasks for kanban view.
-async fn api_tasks(State(state): State<AppState>) -> Response {
-    let db = match open_db(&state.data_dir) {
-        Ok(db) => db,
-        Err(_) => return json_error(StatusCode::INTERNAL_SERVER_ERROR, "failed to open database"),
-    };
-
-    match db.get_all_tasks() {
-        Ok(tasks) => Json(tasks).into_response(),
-        Err(e) => json_error(
-            StatusCode::INTERNAL_SERVER_ERROR,
-            &format!("query error: {e}"),
-        ),
-    }
+async fn api_tasks(
+    State(state): State<AppState>,
+) -> Result<Json<Vec<crate::task::Task>>, ServeError> {
+    let db = open_db(&state.data_dir)?;
+    Ok(Json(db.get_all_tasks()?))
 }
 
 /// GET /api/stats -- per-repo dashboard stats (same data as agents minus unread).
-async fn api_stats(State(state): State<AppState>) -> Response {
-    let db = match open_db(&state.data_dir) {
-        Ok(db) => db,
-        Err(_) => return json_error(StatusCode::INTERNAL_SERVER_ERROR, "failed to open database"),
-    };
-
-    match db.get_dashboard_stats() {
-        Ok(stats) => Json(stats).into_response(),
-        Err(e) => json_error(
-            StatusCode::INTERNAL_SERVER_ERROR,
-            &format!("query error: {e}"),
-        ),
-    }
+async fn api_stats(
+    State(state): State<AppState>,
+) -> Result<Json<Vec<crate::db::DashboardRepoStats>>, ServeError> {
+    let db = open_db(&state.data_dir)?;
+    Ok(Json(db.get_dashboard_stats()?))
 }
 
 /// A parsed signal with source metadata for the signals API.
@@ -528,21 +482,9 @@ struct SignalItem {
 }
 
 /// GET /api/signals -- unresolved signals from the bullpen.
-async fn api_signals(State(state): State<AppState>) -> Response {
-    let db = match open_db(&state.data_dir) {
-        Ok(db) => db,
-        Err(_) => return json_error(StatusCode::INTERNAL_SERVER_ERROR, "failed to open database"),
-    };
-
-    let posts = match db.get_board_posts() {
-        Ok(p) => p,
-        Err(e) => {
-            return json_error(
-                StatusCode::INTERNAL_SERVER_ERROR,
-                &format!("query error: {e}"),
-            );
-        }
-    };
+async fn api_signals(State(state): State<AppState>) -> Result<Json<Vec<SignalItem>>, ServeError> {
+    let db = open_db(&state.data_dir)?;
+    let posts = db.get_board_posts()?;
 
     let items: Vec<SignalItem> = posts
         .into_iter()
@@ -561,7 +503,7 @@ async fn api_signals(State(state): State<AppState>) -> Response {
         })
         .collect();
 
-    Json(items).into_response()
+    Ok(Json(items))
 }
 
 /// Query parameters for GET /api/status.
@@ -571,45 +513,38 @@ struct StatusQuery {
 }
 
 /// GET /api/status?repo=<name> -- agent status overview.
-async fn api_status(State(state): State<AppState>, Query(params): Query<StatusQuery>) -> Response {
+async fn api_status(
+    State(state): State<AppState>,
+    Query(params): Query<StatusQuery>,
+) -> Result<Response, ServeError> {
     let repo = params.repo.trim();
     if repo.is_empty() {
-        return json_error(StatusCode::BAD_REQUEST, "repo parameter is required");
+        return Err(ServeError::BadRequest(
+            "repo parameter is required".to_string(),
+        ));
     }
 
-    let db = match open_db(&state.data_dir) {
-        Ok(db) => db,
-        Err(_) => return json_error(StatusCode::INTERNAL_SERVER_ERROR, "failed to open database"),
-    };
-
-    match status::get_status(&db, repo) {
-        Ok(output) => Json(output).into_response(),
-        Err(e) => json_error(
-            StatusCode::INTERNAL_SERVER_ERROR,
-            &format!("status error: {e}"),
-        ),
-    }
+    let db = open_db(&state.data_dir)?;
+    let output =
+        status::get_status(&db, repo).map_err(|e| ServeError::internal("status error", e))?;
+    Ok(Json(output).into_response())
 }
 
 /// GET /api/needs?repo=<name> -- team help opportunities for an agent.
-async fn api_needs(State(state): State<AppState>, Query(params): Query<StatusQuery>) -> Response {
+async fn api_needs(
+    State(state): State<AppState>,
+    Query(params): Query<StatusQuery>,
+) -> Result<Response, ServeError> {
     let repo = params.repo.trim();
     if repo.is_empty() {
-        return json_error(StatusCode::BAD_REQUEST, "repo parameter is required");
+        return Err(ServeError::BadRequest(
+            "repo parameter is required".to_string(),
+        ));
     }
 
-    let db = match open_db(&state.data_dir) {
-        Ok(db) => db,
-        Err(_) => return json_error(StatusCode::INTERNAL_SERVER_ERROR, "failed to open database"),
-    };
-
-    match status::get_needs(&db, repo) {
-        Ok(items) => Json(items).into_response(),
-        Err(e) => json_error(
-            StatusCode::INTERNAL_SERVER_ERROR,
-            &format!("needs error: {e}"),
-        ),
-    }
+    let db = open_db(&state.data_dir)?;
+    let items = status::get_needs(&db, repo).map_err(|e| ServeError::internal("needs error", e))?;
+    Ok(Json(items).into_response())
 }
 
 /// Request body for POST /api/done.
@@ -620,43 +555,25 @@ struct DoneRequest {
 }
 
 /// POST /api/done -- announce completed work and notify blocked agents.
-async fn api_done(State(state): State<AppState>, Json(body): Json<DoneRequest>) -> Response {
+async fn api_done(
+    State(state): State<AppState>,
+    Json(body): Json<DoneRequest>,
+) -> Result<Json<status::DoneResult>, ServeError> {
     let repo = body.repo.trim();
     let text = body.text.trim();
     if repo.is_empty() || text.is_empty() {
-        return json_error(StatusCode::BAD_REQUEST, "repo and text are required");
+        return Err(ServeError::BadRequest(
+            "repo and text are required".to_string(),
+        ));
     }
 
-    let db = match open_db(&state.data_dir) {
-        Ok(db) => db,
-        Err(_) => return json_error(StatusCode::INTERNAL_SERVER_ERROR, "failed to open database"),
-    };
-
-    let index = match open_search_index(&state.data_dir) {
-        Ok(idx) => idx,
-        Err(_) => {
-            return json_error(
-                StatusCode::INTERNAL_SERVER_ERROR,
-                "failed to open search index",
-            );
-        }
-    };
+    let db = open_db(&state.data_dir)?;
+    let index = open_search_index(&state.data_dir)?;
 
     let announcement = format!("{repo} completed: {text}");
-    let reflection = match db.insert_reflection_with_meta(
-        repo,
-        &announcement,
-        "team",
-        &ReflectionMeta::default(),
-    ) {
-        Ok(r) => r,
-        Err(e) => {
-            return json_error(
-                StatusCode::INTERNAL_SERVER_ERROR,
-                &format!("insert error: {e}"),
-            );
-        }
-    };
+    let reflection = db
+        .insert_reflection_with_meta(repo, &announcement, "team", &ReflectionMeta::default())
+        .map_err(|e| ServeError::internal("insert error", e))?;
 
     let _ = index.add(&reflection.id, &reflection.repo, &announcement);
 
@@ -674,11 +591,10 @@ async fn api_done(State(state): State<AppState>, Json(body): Json<DoneRequest>) 
         }
     }
 
-    Json(status::DoneResult {
+    Ok(Json(status::DoneResult {
         announcement,
         notified,
-    })
-    .into_response()
+    }))
 }
 
 /// Request body for POST /api/post.
@@ -689,69 +605,49 @@ struct PostRequest {
 }
 
 /// Open the search index from the data directory.
-fn open_search_index(data_dir: &Path) -> Result<SearchIndex, StatusCode> {
-    SearchIndex::open(&data_dir.join("index")).map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)
+///
+/// Renders as 500 {"error": "failed to open search index"} when propagated
+/// from a handler with `?`.
+fn open_search_index(data_dir: &Path) -> Result<SearchIndex, ServeError> {
+    SearchIndex::open(&data_dir.join("index")).map_err(|_| ServeError::IndexOpen)
 }
 
 /// POST /api/post -- broadcast a message to the bullpen.
-async fn api_post(State(state): State<AppState>, Json(body): Json<PostRequest>) -> Response {
+async fn api_post(
+    State(state): State<AppState>,
+    Json(body): Json<PostRequest>,
+) -> Result<Json<crate::db::Reflection>, ServeError> {
     let trimmed = body.text.trim();
     if trimmed.is_empty() {
-        return json_error(StatusCode::BAD_REQUEST, "text is required");
+        return Err(ServeError::BadRequest("text is required".to_string()));
     }
 
-    let db = match open_db(&state.data_dir) {
-        Ok(db) => db,
-        Err(_) => return json_error(StatusCode::INTERNAL_SERVER_ERROR, "failed to open database"),
-    };
+    let db = open_db(&state.data_dir)?;
+    let index = open_search_index(&state.data_dir)?;
 
-    let index = match open_search_index(&state.data_dir) {
-        Ok(idx) => idx,
-        Err(_) => {
-            return json_error(
-                StatusCode::INTERNAL_SERVER_ERROR,
-                "failed to open search index",
-            );
-        }
-    };
-
-    let reflection = match db.insert_reflection_with_meta(
-        &body.repo,
-        trimmed,
-        "team",
-        &ReflectionMeta::default(),
-    ) {
-        Ok(r) => r,
-        Err(e) => {
-            return json_error(
-                StatusCode::INTERNAL_SERVER_ERROR,
-                &format!("insert error: {e}"),
-            );
-        }
-    };
+    let reflection = db
+        .insert_reflection_with_meta(&body.repo, trimmed, "team", &ReflectionMeta::default())
+        .map_err(|e| ServeError::internal("insert error", e))?;
 
     // Best-effort add to search index; post is already in DB.
     if let Err(e) = index.add(&reflection.id, &reflection.repo, trimmed) {
         eprintln!("[legion] search index add failed: {e}");
     }
 
-    Json(reflection).into_response()
+    Ok(Json(reflection))
 }
 
 /// POST /api/boost/:id -- boost a reflection's recall count.
-async fn api_boost(State(state): State<AppState>, AxumPath(id): AxumPath<String>) -> Response {
-    let db = match open_db(&state.data_dir) {
-        Ok(db) => db,
-        Err(_) => return json_error(StatusCode::INTERNAL_SERVER_ERROR, "failed to open database"),
-    };
+async fn api_boost(
+    State(state): State<AppState>,
+    AxumPath(id): AxumPath<String>,
+) -> Result<Json<serde_json::Value>, ServeError> {
+    let db = open_db(&state.data_dir)?;
 
     match db.boost_reflection(&id) {
-        Ok(true) => Json(serde_json::json!({"ok": true})).into_response(),
-        Ok(false) => json_error(StatusCode::NOT_FOUND, "reflection not found"),
-        Err(e) => json_error(
-            StatusCode::INTERNAL_SERVER_ERROR,
-            &format!("boost error: {e}"),
-        ),
+        Ok(true) => Ok(Json(serde_json::json!({"ok": true}))),
+        Ok(false) => Err(ServeError::NotFound("reflection not found".to_string())),
+        Err(e) => Err(ServeError::internal("boost error", e)),
     }
 }
 
@@ -769,61 +665,45 @@ struct CreateTaskRequest {
 async fn api_create_task(
     State(state): State<AppState>,
     Json(body): Json<CreateTaskRequest>,
-) -> Response {
+) -> Result<(StatusCode, Json<crate::task::Task>), ServeError> {
     let text = body.text.trim().to_string();
     if text.is_empty() {
-        return json_error(StatusCode::BAD_REQUEST, "text is required");
+        return Err(ServeError::BadRequest("text is required".to_string()));
     }
     if body.to.trim().is_empty() {
-        return json_error(StatusCode::BAD_REQUEST, "to is required");
+        return Err(ServeError::BadRequest("to is required".to_string()));
     }
     if !["low", "med", "high"].contains(&body.priority.as_str()) {
-        return json_error(
-            StatusCode::BAD_REQUEST,
-            "priority must be low, med, or high",
-        );
+        return Err(ServeError::BadRequest(
+            "priority must be low, med, or high".to_string(),
+        ));
     }
 
-    let db = match open_db(&state.data_dir) {
-        Ok(db) => db,
-        Err(_) => return json_error(StatusCode::INTERNAL_SERVER_ERROR, "failed to open database"),
-    };
+    let db = open_db(&state.data_dir)?;
 
     let context_ref = body.context.as_deref().filter(|c| !c.trim().is_empty());
 
-    let id = match db.insert_task(
-        &body.from,
-        body.to.trim(),
-        &text,
-        context_ref,
-        &body.priority,
-    ) {
-        Ok(id) => id,
-        Err(e) => {
-            return json_error(
-                StatusCode::INTERNAL_SERVER_ERROR,
-                &format!("insert error: {e}"),
-            );
-        }
-    };
+    let id = db
+        .insert_task(
+            &body.from,
+            body.to.trim(),
+            &text,
+            context_ref,
+            &body.priority,
+        )
+        .map_err(|e| ServeError::internal("insert error", e))?;
 
     let task = match db.get_task_by_id(&id) {
         Ok(Some(t)) => t,
         Ok(None) => {
-            return json_error(
-                StatusCode::INTERNAL_SERVER_ERROR,
-                "task created but not found",
-            );
+            return Err(ServeError::Internal(
+                "task created but not found".to_string(),
+            ));
         }
-        Err(e) => {
-            return json_error(
-                StatusCode::INTERNAL_SERVER_ERROR,
-                &format!("fetch error: {e}"),
-            );
-        }
+        Err(e) => return Err(ServeError::internal("fetch error", e)),
     };
 
-    (StatusCode::CREATED, Json(task)).into_response()
+    Ok((StatusCode::CREATED, Json(task)))
 }
 
 /// Optional request body for task state transitions.
@@ -836,15 +716,13 @@ struct TaskTransitionBody {
 async fn api_task_accept(
     State(state): State<AppState>,
     AxumPath(id): AxumPath<String>,
-) -> Response {
-    let db = match open_db(&state.data_dir) {
-        Ok(db) => db,
-        Err(_) => return json_error(StatusCode::INTERNAL_SERVER_ERROR, "failed to open database"),
-    };
-    match crate::task::accept_task(&db, &id) {
-        Ok(()) => Json(serde_json::json!({"ok": true})).into_response(),
-        Err(e) => json_error(StatusCode::BAD_REQUEST, &format!("{e}")),
-    }
+) -> Result<Json<serde_json::Value>, ServeError> {
+    let db = open_db(&state.data_dir)?;
+    // Task-domain errors (unknown id, illegal transition) render as 400
+    // with the bare error message -- a deliberate divergence from the
+    // 500 "query error" convention, preserved from the original handlers.
+    crate::task::accept_task(&db, &id).map_err(|e| ServeError::BadRequest(e.to_string()))?;
+    Ok(Json(serde_json::json!({"ok": true})))
 }
 
 /// POST /api/tasks/:id/done -- complete an accepted task.
@@ -852,16 +730,12 @@ async fn api_task_done(
     State(state): State<AppState>,
     AxumPath(id): AxumPath<String>,
     body: Option<Json<TaskTransitionBody>>,
-) -> Response {
-    let db = match open_db(&state.data_dir) {
-        Ok(db) => db,
-        Err(_) => return json_error(StatusCode::INTERNAL_SERVER_ERROR, "failed to open database"),
-    };
+) -> Result<Json<serde_json::Value>, ServeError> {
+    let db = open_db(&state.data_dir)?;
     let note = body.and_then(|b| b.note.clone());
-    match crate::task::complete_task(&db, &id, note.as_deref()) {
-        Ok(()) => Json(serde_json::json!({"ok": true})).into_response(),
-        Err(e) => json_error(StatusCode::BAD_REQUEST, &format!("{e}")),
-    }
+    crate::task::complete_task(&db, &id, note.as_deref())
+        .map_err(|e| ServeError::BadRequest(e.to_string()))?;
+    Ok(Json(serde_json::json!({"ok": true})))
 }
 
 /// POST /api/tasks/:id/block -- block an accepted task.
@@ -869,31 +743,22 @@ async fn api_task_block(
     State(state): State<AppState>,
     AxumPath(id): AxumPath<String>,
     body: Option<Json<TaskTransitionBody>>,
-) -> Response {
-    let db = match open_db(&state.data_dir) {
-        Ok(db) => db,
-        Err(_) => return json_error(StatusCode::INTERNAL_SERVER_ERROR, "failed to open database"),
-    };
+) -> Result<Json<serde_json::Value>, ServeError> {
+    let db = open_db(&state.data_dir)?;
     let reason = body.and_then(|b| b.note.clone());
-    match crate::task::block_task(&db, &id, reason.as_deref()) {
-        Ok(()) => Json(serde_json::json!({"ok": true})).into_response(),
-        Err(e) => json_error(StatusCode::BAD_REQUEST, &format!("{e}")),
-    }
+    crate::task::block_task(&db, &id, reason.as_deref())
+        .map_err(|e| ServeError::BadRequest(e.to_string()))?;
+    Ok(Json(serde_json::json!({"ok": true})))
 }
 
 /// POST /api/tasks/:id/unblock -- unblock a blocked task.
 async fn api_task_unblock(
     State(state): State<AppState>,
     AxumPath(id): AxumPath<String>,
-) -> Response {
-    let db = match open_db(&state.data_dir) {
-        Ok(db) => db,
-        Err(_) => return json_error(StatusCode::INTERNAL_SERVER_ERROR, "failed to open database"),
-    };
-    match crate::task::unblock_task(&db, &id) {
-        Ok(()) => Json(serde_json::json!({"ok": true})).into_response(),
-        Err(e) => json_error(StatusCode::BAD_REQUEST, &format!("{e}")),
-    }
+) -> Result<Json<serde_json::Value>, ServeError> {
+    let db = open_db(&state.data_dir)?;
+    crate::task::unblock_task(&db, &id).map_err(|e| ServeError::BadRequest(e.to_string()))?;
+    Ok(Json(serde_json::json!({"ok": true})))
 }
 
 /// Query parameters for GET /api/chat.
@@ -912,26 +777,19 @@ struct ChatMessage {
 }
 
 /// GET /api/chat?agent=<name> -- filtered conversation between meatbag and an agent.
-async fn api_chat(State(state): State<AppState>, Query(params): Query<ChatQuery>) -> Response {
+async fn api_chat(
+    State(state): State<AppState>,
+    Query(params): Query<ChatQuery>,
+) -> Result<Json<Vec<ChatMessage>>, ServeError> {
     let agent = params.agent.trim().to_lowercase();
     if agent.is_empty() {
-        return json_error(StatusCode::BAD_REQUEST, "agent parameter is required");
+        return Err(ServeError::BadRequest(
+            "agent parameter is required".to_string(),
+        ));
     }
 
-    let db = match open_db(&state.data_dir) {
-        Ok(db) => db,
-        Err(_) => return json_error(StatusCode::INTERNAL_SERVER_ERROR, "failed to open database"),
-    };
-
-    let posts = match db.get_board_posts() {
-        Ok(p) => p,
-        Err(e) => {
-            return json_error(
-                StatusCode::INTERNAL_SERVER_ERROR,
-                &format!("query error: {e}"),
-            );
-        }
-    };
+    let db = open_db(&state.data_dir)?;
+    let posts = db.get_board_posts()?;
 
     let at_agent = format!("@{agent}");
     let at_meatbag = "@meatbag";
@@ -966,23 +824,15 @@ async fn api_chat(State(state): State<AppState>, Query(params): Query<ChatQuery>
         messages = messages.split_off(start);
     }
 
-    Json(messages).into_response()
+    Ok(Json(messages))
 }
 
 /// GET /api/schedules -- list all schedules.
-async fn api_schedules(State(state): State<AppState>) -> Response {
-    let db = match open_db(&state.data_dir) {
-        Ok(db) => db,
-        Err(_) => return json_error(StatusCode::INTERNAL_SERVER_ERROR, "failed to open database"),
-    };
-
-    match db.list_schedules() {
-        Ok(schedules) => Json(schedules).into_response(),
-        Err(e) => json_error(
-            StatusCode::INTERNAL_SERVER_ERROR,
-            &format!("query error: {e}"),
-        ),
-    }
+async fn api_schedules(
+    State(state): State<AppState>,
+) -> Result<Json<Vec<crate::db::Schedule>>, ServeError> {
+    let db = open_db(&state.data_dir)?;
+    Ok(Json(db.list_schedules()?))
 }
 
 /// Request body for POST /api/schedules/create.
@@ -1000,71 +850,56 @@ struct CreateScheduleRequest {
 async fn api_create_schedule(
     State(state): State<AppState>,
     Json(body): Json<CreateScheduleRequest>,
-) -> Response {
+) -> Result<Json<serde_json::Value>, ServeError> {
     let name = body.name.trim();
     if name.is_empty() {
-        return json_error(StatusCode::BAD_REQUEST, "name is required");
+        return Err(ServeError::BadRequest("name is required".to_string()));
     }
     let command = body.command.trim();
     if command.is_empty() {
-        return json_error(StatusCode::BAD_REQUEST, "command is required");
+        return Err(ServeError::BadRequest("command is required".to_string()));
     }
 
-    let db = match open_db(&state.data_dir) {
-        Ok(db) => db,
-        Err(_) => return json_error(StatusCode::INTERNAL_SERVER_ERROR, "failed to open database"),
-    };
+    let db = open_db(&state.data_dir)?;
 
-    match db.insert_schedule(
-        name,
-        &body.cron,
-        command,
-        &body.repo,
-        body.active_start.as_deref(),
-        body.active_end.as_deref(),
-    ) {
-        Ok(id) => Json(serde_json::json!({"ok": true, "id": id})).into_response(),
-        Err(e) => json_error(StatusCode::BAD_REQUEST, &format!("create error: {e}")),
-    }
+    // Insert failures are caller errors (bad cron expression, bad time
+    // window), so they render as 400 -- preserved from the original handler.
+    let id = db
+        .insert_schedule(
+            name,
+            &body.cron,
+            command,
+            &body.repo,
+            body.active_start.as_deref(),
+            body.active_end.as_deref(),
+        )
+        .map_err(|e| ServeError::BadRequest(format!("create error: {e}")))?;
+
+    Ok(Json(serde_json::json!({"ok": true, "id": id})))
 }
 
 /// POST /api/schedules/:id/toggle -- toggle a schedule's enabled state.
 async fn api_toggle_schedule(
     State(state): State<AppState>,
     AxumPath(id): AxumPath<String>,
-) -> Response {
-    let db = match open_db(&state.data_dir) {
-        Ok(db) => db,
-        Err(_) => return json_error(StatusCode::INTERNAL_SERVER_ERROR, "failed to open database"),
-    };
+) -> Result<Json<serde_json::Value>, ServeError> {
+    let db = open_db(&state.data_dir)?;
 
     // Read current state to toggle it
-    let schedules = match db.list_schedules() {
-        Ok(s) => s,
-        Err(e) => {
-            return json_error(
-                StatusCode::INTERNAL_SERVER_ERROR,
-                &format!("query error: {e}"),
-            );
-        }
-    };
+    let schedules = db.list_schedules()?;
 
-    let current = schedules.iter().find(|s| s.id == id);
-    match current {
-        None => json_error(StatusCode::NOT_FOUND, "schedule not found"),
-        Some(s) => {
-            let new_enabled = !s.enabled;
-            match db.toggle_schedule(&id, new_enabled) {
-                Ok(true) => {
-                    Json(serde_json::json!({"ok": true, "enabled": new_enabled})).into_response()
-                }
-                Ok(false) => json_error(StatusCode::NOT_FOUND, "schedule not found"),
-                Err(e) => json_error(
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    &format!("toggle error: {e}"),
-                ),
-            }
-        }
+    let current = schedules
+        .iter()
+        .find(|s| s.id == id)
+        .ok_or_else(|| ServeError::NotFound("schedule not found".to_string()))?;
+
+    let new_enabled = !current.enabled;
+    match db.toggle_schedule(&id, new_enabled) {
+        Ok(true) => Ok(Json(
+            serde_json::json!({"ok": true, "enabled": new_enabled}),
+        )),
+        Ok(false) => Err(ServeError::NotFound("schedule not found".to_string())),
+        Err(e) => Err(ServeError::internal("toggle error", e)),
     }
 }
 
@@ -1076,25 +911,19 @@ struct HealthQuery {
 }
 
 /// GET /api/health -- latest health samples per host + recent history.
-async fn api_health(State(state): State<AppState>, Query(params): Query<HealthQuery>) -> Response {
-    let db = match open_db(&state.data_dir) {
-        Ok(db) => db,
-        Err(_) => return json_error(StatusCode::INTERNAL_SERVER_ERROR, "failed to open database"),
-    };
+async fn api_health(
+    State(state): State<AppState>,
+    Query(params): Query<HealthQuery>,
+) -> Result<Json<Vec<serde_json::Value>>, ServeError> {
+    let db = open_db(&state.data_dir)?;
 
     let minutes = params.minutes.unwrap_or(60);
     let since = chrono::Utc::now() - chrono::Duration::minutes(minutes as i64);
     let since_str = since.to_rfc3339();
 
-    let samples: Vec<HealthSample> = match db.get_health_all_hosts(&since_str) {
-        Ok(s) => s,
-        Err(e) => {
-            return json_error(
-                StatusCode::INTERNAL_SERVER_ERROR,
-                &format!("health query error: {e}"),
-            );
-        }
-    };
+    let samples: Vec<HealthSample> = db
+        .get_health_all_hosts(&since_str)
+        .map_err(|e| ServeError::internal("health query error", e))?;
 
     // Group by hostname, return latest + history
     let mut by_host: HashMap<String, Vec<&HealthSample>> = HashMap::new();
@@ -1147,7 +976,7 @@ async fn api_health(State(state): State<AppState>, Query(params): Query<HealthQu
         })
         .collect();
 
-    Json(hosts).into_response()
+    Ok(Json(hosts))
 }
 
 /// Query parameters for GET /api/health/history.
@@ -1163,23 +992,17 @@ struct HealthHistoryQuery {
 async fn api_health_history(
     State(state): State<AppState>,
     Query(params): Query<HealthHistoryQuery>,
-) -> Response {
-    let db = match open_db(&state.data_dir) {
-        Ok(db) => db,
-        Err(_) => return json_error(StatusCode::INTERNAL_SERVER_ERROR, "failed to open database"),
-    };
+) -> Result<Json<Vec<HealthSample>>, ServeError> {
+    let db = open_db(&state.data_dir)?;
 
     let minutes = params.minutes.unwrap_or(60);
     let since = chrono::Utc::now() - chrono::Duration::minutes(minutes as i64);
     let since_str = since.to_rfc3339();
 
-    match db.get_health_history(&params.hostname, &since_str) {
-        Ok(samples) => Json(samples).into_response(),
-        Err(e) => json_error(
-            StatusCode::INTERNAL_SERVER_ERROR,
-            &format!("health history error: {e}"),
-        ),
-    }
+    let samples = db
+        .get_health_history(&params.hostname, &since_str)
+        .map_err(|e| ServeError::internal("health history error", e))?;
+    Ok(Json(samples))
 }
 
 /// Query parameters for GET /api/search.
@@ -1194,23 +1017,22 @@ struct SearchQuery {
 }
 
 /// GET /api/search -- BM25-ranked reflection search.
-async fn api_search(State(state): State<AppState>, Query(params): Query<SearchQuery>) -> Response {
+async fn api_search(
+    State(state): State<AppState>,
+    Query(params): Query<SearchQuery>,
+) -> Result<Json<Vec<serde_json::Value>>, ServeError> {
     let q = params.q.trim();
     if q.is_empty() {
-        return json_error(StatusCode::BAD_REQUEST, "q parameter is required");
+        return Err(ServeError::BadRequest(
+            "q parameter is required".to_string(),
+        ));
     }
 
-    let db = match open_db(&state.data_dir) {
-        Ok(db) => db,
-        Err(_) => return json_error(StatusCode::INTERNAL_SERVER_ERROR, "failed to open database"),
-    };
-
-    let index = match open_search_index(&state.data_dir) {
-        Ok(idx) => idx,
-        Err(_) => {
-            return json_error(StatusCode::INTERNAL_SERVER_ERROR, "search index error");
-        }
-    };
+    let db = open_db(&state.data_dir)?;
+    // Preserved wire message: this endpoint reported index-open failure as
+    // "search index error", not the shared "failed to open search index".
+    let index = open_search_index(&state.data_dir)
+        .map_err(|_| ServeError::Internal("search index error".to_string()))?;
 
     let limit = params.limit.unwrap_or(10).min(50);
 
@@ -1218,27 +1040,12 @@ async fn api_search(State(state): State<AppState>, Query(params): Query<SearchQu
         Some(repo) => index.search(repo, q, limit),
         None => index.search_all(q, limit),
     };
-
-    let hits = match hits {
-        Ok(hits) => hits,
-        Err(e) => {
-            return json_error(
-                StatusCode::INTERNAL_SERVER_ERROR,
-                &format!("search error: {e}"),
-            );
-        }
-    };
+    let hits = hits.map_err(|e| ServeError::internal("search error", e))?;
 
     let ids: Vec<&str> = hits.iter().map(|h| h.id.as_str()).collect();
-    let reflections = match db.get_reflections_by_ids(&ids) {
-        Ok(r) => r,
-        Err(e) => {
-            return json_error(
-                StatusCode::INTERNAL_SERVER_ERROR,
-                &format!("reflection lookup error: {e}"),
-            );
-        }
-    };
+    let reflections = db
+        .get_reflections_by_ids(&ids)
+        .map_err(|e| ServeError::internal("reflection lookup error", e))?;
 
     // Build score map from search hits, then return reflections in score order
     let score_map: HashMap<&str, f32> = hits.iter().map(|h| (h.id.as_str(), h.score)).collect();
@@ -1263,7 +1070,7 @@ async fn api_search(State(state): State<AppState>, Query(params): Query<SearchQu
         sb.partial_cmp(&sa).unwrap_or(std::cmp::Ordering::Equal)
     });
 
-    Json(results).into_response()
+    Ok(Json(results))
 }
 
 /// Query parameters for GET /api/audit.
@@ -1278,37 +1085,26 @@ struct AuditQuery {
 }
 
 /// GET /api/audit -- recent audit log entries.
-async fn api_audit(State(state): State<AppState>, Query(params): Query<AuditQuery>) -> Response {
-    let db = match open_db(&state.data_dir) {
-        Ok(db) => db,
-        Err(_) => return json_error(StatusCode::INTERNAL_SERVER_ERROR, "failed to open database"),
-    };
+async fn api_audit(
+    State(state): State<AppState>,
+    Query(params): Query<AuditQuery>,
+) -> Result<Response, ServeError> {
+    let db = open_db(&state.data_dir)?;
 
     let limit = params.limit.unwrap_or(50).min(200);
 
-    match db.query_audit_log(params.agent.as_deref(), params.action.as_deref(), limit) {
-        Ok(entries) => Json(entries).into_response(),
-        Err(e) => json_error(
-            StatusCode::INTERNAL_SERVER_ERROR,
-            &format!("audit query error: {e}"),
-        ),
-    }
+    let entries = db
+        .query_audit_log(params.agent.as_deref(), params.action.as_deref(), limit)
+        .map_err(|e| ServeError::internal("audit query error", e))?;
+    Ok(Json(entries).into_response())
 }
 
 /// GET /api/kanban -- all kanban cards for the board view.
-async fn api_kanban(State(state): State<AppState>) -> Response {
-    let db = match open_db(&state.data_dir) {
-        Ok(db) => db,
-        Err(_) => return json_error(StatusCode::INTERNAL_SERVER_ERROR, "failed to open database"),
-    };
-
-    match crate::kanban::board_cards(&db) {
-        Ok(cards) => Json(cards).into_response(),
-        Err(e) => json_error(
-            StatusCode::INTERNAL_SERVER_ERROR,
-            &format!("query error: {e}"),
-        ),
-    }
+async fn api_kanban(
+    State(state): State<AppState>,
+) -> Result<Json<Vec<crate::kanban::Card>>, ServeError> {
+    let db = open_db(&state.data_dir)?;
+    Ok(Json(crate::kanban::board_cards(&db)?))
 }
 
 /// Request body for POST /api/kanban/{id}/move.
@@ -1323,40 +1119,25 @@ async fn api_kanban_move(
     State(state): State<AppState>,
     AxumPath(id): AxumPath<String>,
     Json(body): Json<KanbanMoveRequest>,
-) -> Response {
-    let db = match open_db(&state.data_dir) {
-        Ok(db) => db,
-        Err(_) => return json_error(StatusCode::INTERNAL_SERVER_ERROR, "failed to open database"),
-    };
+) -> Result<Json<serde_json::Value>, ServeError> {
+    let db = open_db(&state.data_dir)?;
 
-    let new_status = match body.status.parse::<crate::kanban::CardStatus>() {
-        Ok(s) => s,
-        Err(e) => return json_error(StatusCode::BAD_REQUEST, &format!("invalid status: {e}")),
-    };
+    let new_status = body
+        .status
+        .parse::<crate::kanban::CardStatus>()
+        .map_err(|e| ServeError::BadRequest(format!("invalid status: {e}")))?;
 
-    match crate::kanban::force_move(&db, &id, new_status, body.sort_order) {
-        Ok(()) => Json(serde_json::json!({"ok": true})).into_response(),
-        Err(e) => json_error(
-            StatusCode::INTERNAL_SERVER_ERROR,
-            &format!("move failed: {e}"),
-        ),
-    }
+    crate::kanban::force_move(&db, &id, new_status, body.sort_order)
+        .map_err(|e| ServeError::internal("move failed", e))?;
+    Ok(Json(serde_json::json!({"ok": true})))
 }
 
 /// GET /api/kanban/workloads -- per-agent workload summary for the agent strip.
-async fn api_kanban_workloads(State(state): State<AppState>) -> Response {
-    let db = match open_db(&state.data_dir) {
-        Ok(db) => db,
-        Err(_) => return json_error(StatusCode::INTERNAL_SERVER_ERROR, "failed to open database"),
-    };
-
-    match crate::kanban::agent_workloads(&db) {
-        Ok(workloads) => Json(workloads).into_response(),
-        Err(e) => json_error(
-            StatusCode::INTERNAL_SERVER_ERROR,
-            &format!("query error: {e}"),
-        ),
-    }
+async fn api_kanban_workloads(
+    State(state): State<AppState>,
+) -> Result<Json<Vec<crate::kanban::AgentWorkload>>, ServeError> {
+    let db = open_db(&state.data_dir)?;
+    Ok(Json(crate::kanban::agent_workloads(&db)?))
 }
 
 /// Query parameters for GET /api/telemetry/bypasses.
@@ -1375,27 +1156,20 @@ struct TelemetryQuery {
 /// uncertainty engine consumer (#354). Reads bypass.jsonl directly;
 /// the file is append-only, so even if the legion DB is unavailable
 /// this endpoint still works.
-async fn api_telemetry_bypasses(Query(params): Query<TelemetryQuery>) -> Response {
+async fn api_telemetry_bypasses(
+    Query(params): Query<TelemetryQuery>,
+) -> Result<Response, ServeError> {
     let since_dur = match params.since.as_deref() {
-        Some(s) => match crate::telemetry::parse_duration(s) {
-            Ok(d) => Some(d),
-            Err(e) => {
-                return json_error(StatusCode::BAD_REQUEST, &format!("invalid since: {e}"));
-            }
-        },
+        Some(s) => Some(
+            crate::telemetry::parse_duration(s)
+                .map_err(|e| ServeError::BadRequest(format!("invalid since: {e}")))?,
+        ),
         None => None,
     };
-    let rows = match crate::telemetry::list_bypasses(since_dur, params.repo.as_deref()) {
-        Ok(r) => r,
-        Err(e) => {
-            return json_error(
-                StatusCode::INTERNAL_SERVER_ERROR,
-                &format!("read bypass log: {e}"),
-            );
-        }
-    };
+    let rows = crate::telemetry::list_bypasses(since_dur, params.repo.as_deref())
+        .map_err(|e| ServeError::internal("read bypass log", e))?;
     let summary = crate::telemetry::summarize(&rows, params.top.unwrap_or(20));
-    Json(summary).into_response()
+    Ok(Json(summary).into_response())
 }
 
 async fn shutdown_signal() {

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -101,12 +101,6 @@ pub fn run_server(port: u16, data_dir: PathBuf) -> error::Result<()> {
         // in-process write wakes connected dashboards immediately.
         let (tx, _rx) = crate::channel::new_broadcast();
 
-        // One background task owns schedule firing (#613) -- previously it
-        // ran inside the per-connection SSE stream body, so schedules only
-        // fired while a dashboard was open and fired once per connected
-        // client.
-        let _firing = crate::channel::spawn_schedule_firing(data_dir.clone(), tx.clone());
-
         // The shared endpoint contract (/health, /sse, /api/feed,
         // /api/tasks, /api/post) is owned by channel::router (#613) --
         // one implementation whether the daemon or `legion serve`
@@ -115,8 +109,9 @@ pub fn run_server(port: u16, data_dir: PathBuf) -> error::Result<()> {
         // daemon does not need.
         let channel_state = crate::channel::ChannelState {
             data_dir: data_dir.clone(),
-            tx,
+            tx: tx.clone(),
             started_at: chrono::Utc::now(),
+            role: crate::channel::ServerRole::Serve,
         };
 
         let app = Router::new()
@@ -150,9 +145,10 @@ pub fn run_server(port: u16, data_dir: PathBuf) -> error::Result<()> {
             .merge(crate::channel::router(channel_state));
 
         let addr = format!("0.0.0.0:{port}");
-        let listener = tokio::net::TcpListener::bind(&addr)
-            .await
-            .map_err(|e| error::LegionError::Server(format!("failed to bind {addr}: {e}")))?;
+        let listener = match tokio::net::TcpListener::bind(&addr).await {
+            Ok(l) => l,
+            Err(e) => return Err(bind_refusal(port, &data_dir, &addr, &e)),
+        };
 
         eprintln!("[legion] dashboard at http://localhost:{port}");
 
@@ -161,6 +157,13 @@ pub fn run_server(port: u16, data_dir: PathBuf) -> error::Result<()> {
         // PID that the supervisor's "is this process alive" probe would
         // then have to disambiguate.
         write_daemon_pidfile(std::process::id());
+
+        // One background task owns schedule firing (#613) -- previously it
+        // ran inside the per-connection SSE stream body, so schedules only
+        // fired while a dashboard was open and fired once per connected
+        // client. Spawned only after the bind succeeded: a process that
+        // failed to become the server must not produce side effects.
+        let _firing = crate::channel::spawn_schedule_firing(data_dir.clone(), tx);
 
         let serve_result = axum::serve(listener, app)
             .with_graceful_shutdown(shutdown_signal())
@@ -172,6 +175,32 @@ pub fn run_server(port: u16, data_dir: PathBuf) -> error::Result<()> {
 
         Ok(())
     })
+}
+
+/// Shape the error for a failed `legion serve` bind (#613, absorbed #601).
+///
+/// Port-ownership decision: the daemon owns the port while it runs.
+/// `legion serve` never takes the port over; it refuses with a pointer,
+/// and `legion daemon-stop` is the explicit takeover path. When the data
+/// dir's daemon pidfile names a live process, the error says so -- lsof
+/// confirmation (when available) upgrades "likely owns" to "owns" --
+/// instead of leaving the operator to map a bare EADDRINUSE to the
+/// daemon by hand, which is exactly how the wake-storm recovery went
+/// sideways (recall 019eb03a).
+fn bind_refusal(port: u16, data_dir: &Path, addr: &str, e: &std::io::Error) -> error::LegionError {
+    if let Some(pid) = crate::daemon::live_daemon_pid(data_dir) {
+        let qualifier = if crate::daemon::port_listener_pids(port).contains(&pid) {
+            "owns"
+        } else {
+            "is running and likely owns"
+        };
+        return error::LegionError::Server(format!(
+            "failed to bind {addr}: {e}. The legion daemon (pid {pid}) {qualifier} port {port} -- \
+             it serves the channel API and fires schedules while it runs. Stop it first with \
+             `legion daemon-stop`, or run the dashboard on another port with --port."
+        ));
+    }
+    error::LegionError::Server(format!("failed to bind {addr}: {e}"))
 }
 
 async fn index_handler() -> impl IntoResponse {
@@ -960,5 +989,53 @@ mod tests {
         // Idempotent overwrite.
         write_daemon_pidfile_at(&path, 67890);
         assert_eq!(std::fs::read_to_string(&path).unwrap(), "67890");
+    }
+
+    #[test]
+    fn serve_refuses_port_held_by_live_daemon_with_pointer() {
+        let dir = tempfile::tempdir().unwrap();
+        // A "live daemon": this test process itself, recorded in the
+        // pidfile path the daemon writes (data_dir/daemon.pid).
+        std::fs::write(
+            dir.path().join("daemon.pid"),
+            std::process::id().to_string(),
+        )
+        .unwrap();
+        // Hold a port the way the daemon would.
+        let listener = std::net::TcpListener::bind(("0.0.0.0", 0)).unwrap();
+        let port = listener.local_addr().unwrap().port();
+
+        let err = run_server(port, dir.path().to_path_buf()).expect_err("bind must fail");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("legion daemon"),
+            "error must name the daemon as the holder: {msg}"
+        );
+        assert!(
+            msg.contains("daemon-stop"),
+            "error must point at the takeover path: {msg}"
+        );
+        assert!(
+            msg.contains("--port"),
+            "error must offer the alternate-port escape: {msg}"
+        );
+    }
+
+    #[test]
+    fn serve_bind_failure_without_daemon_stays_bare() {
+        let dir = tempfile::tempdir().unwrap();
+        let listener = std::net::TcpListener::bind(("0.0.0.0", 0)).unwrap();
+        let port = listener.local_addr().unwrap().port();
+
+        let err = run_server(port, dir.path().to_path_buf()).expect_err("bind must fail");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("failed to bind"),
+            "bare bind error expected: {msg}"
+        );
+        assert!(
+            !msg.contains("legion daemon (pid"),
+            "no daemon attribution without a live pidfile: {msg}"
+        );
     }
 }

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -9,11 +9,10 @@ use axum::{Json, Router};
 use rust_embed::Embed;
 use tokio::signal;
 
-use crate::channel::ServeError;
-use crate::db::{Database, ReflectionMeta};
+use crate::channel::{ServeError, open_db, open_index as open_search_index};
+use crate::db::ReflectionMeta;
 use crate::error;
 use crate::health::HealthSample;
-use crate::search::SearchIndex;
 use crate::signal as sig;
 use crate::status;
 
@@ -24,14 +23,6 @@ struct StaticAssets;
 #[derive(Clone)]
 struct AppState {
     data_dir: PathBuf,
-}
-
-/// Open a database connection from the data directory.
-///
-/// Renders as 500 {"error": "failed to open database"} when propagated
-/// from a handler with `?`.
-fn open_db(data_dir: &Path) -> Result<Database, ServeError> {
-    Database::open(&data_dir.join("legion.db")).map_err(|_| ServeError::DbOpen)
 }
 
 /// Resolve the daemon pidfile path. Lives under XDG_STATE_HOME (same root
@@ -383,14 +374,6 @@ async fn api_done(
         announcement,
         notified,
     }))
-}
-
-/// Open the search index from the data directory.
-///
-/// Renders as 500 {"error": "failed to open search index"} when propagated
-/// from a handler with `?`.
-fn open_search_index(data_dir: &Path) -> Result<SearchIndex, ServeError> {
-    SearchIndex::open(&data_dir.join("index")).map_err(|_| ServeError::IndexOpen)
 }
 
 /// POST /api/boost/:id -- boost a reflection's recall count.

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -1,14 +1,9 @@
-#![allow(clippy::manual_is_multiple_of)] // Use modulo for MSRV compatibility
-
 use std::collections::HashMap;
-use std::convert::Infallible;
 use std::path::{Path, PathBuf};
-use std::time::Duration;
 
 use axum::extract::{Path as AxumPath, Query, State};
 use axum::http::{StatusCode, header};
-use axum::response::sse::{Event, KeepAlive};
-use axum::response::{Html, IntoResponse, Response, Sse};
+use axum::response::{Html, IntoResponse, Response};
 use axum::routing::{get, post};
 use axum::{Json, Router};
 use rust_embed::Embed;
@@ -29,9 +24,6 @@ struct StaticAssets;
 #[derive(Clone)]
 struct AppState {
     data_dir: PathBuf,
-    /// Wall-clock start of this server process. Captured once at boot so the
-    /// `/health` endpoint (#319) can report uptime without per-request work.
-    started_at: chrono::DateTime<chrono::Utc>,
 }
 
 /// Open a database connection from the data directory.
@@ -102,31 +94,39 @@ pub fn run_server(port: u16, data_dir: PathBuf) -> error::Result<()> {
     runtime.block_on(async {
         let state = AppState {
             data_dir: data_dir.clone(),
-            started_at: chrono::Utc::now(),
         };
+
+        // One broadcast channel is shared by the schedule-firing task
+        // (sender) and the channel SSE handler (subscribers), so an
+        // in-process write wakes connected dashboards immediately.
+        let (tx, _rx) = crate::channel::new_broadcast();
 
         // One background task owns schedule firing (#613) -- previously it
         // ran inside the per-connection SSE stream body, so schedules only
         // fired while a dashboard was open and fired once per connected
-        // client. The broadcast sender wakes in-process SSE subscribers
-        // when a schedule posts (serve's own SSE still detects the write
-        // by timestamp poll; the channel SSE handler subscribes).
-        let (tx, _rx) = crate::channel::new_broadcast();
-        let _firing = crate::channel::spawn_schedule_firing(data_dir.clone(), tx);
+        // client.
+        let _firing = crate::channel::spawn_schedule_firing(data_dir.clone(), tx.clone());
+
+        // The shared endpoint contract (/health, /sse, /api/feed,
+        // /api/tasks, /api/post) is owned by channel::router (#613) --
+        // one implementation whether the daemon or `legion serve`
+        // answers the port. This router holds only the serve-specific
+        // surface: the embedded dashboard assets and the endpoints the
+        // daemon does not need.
+        let channel_state = crate::channel::ChannelState {
+            data_dir: data_dir.clone(),
+            tx,
+            started_at: chrono::Utc::now(),
+        };
 
         let app = Router::new()
             .route("/", get(index_handler))
-            .route("/health", get(health_endpoint))
-            .route("/sse", get(sse_handler))
             .route("/api/agents", get(api_agents))
-            .route("/api/feed", get(api_feed))
-            .route("/api/tasks", get(api_tasks))
             .route("/api/stats", get(api_stats))
             .route("/api/signals", get(api_signals))
             .route("/api/status", get(api_status))
             .route("/api/needs", get(api_needs))
             .route("/api/done", post(api_done))
-            .route("/api/post", post(api_post))
             .route("/api/tasks/create", post(api_create_task))
             .route("/api/tasks/{id}/accept", post(api_task_accept))
             .route("/api/tasks/{id}/done", post(api_task_done))
@@ -146,7 +146,8 @@ pub fn run_server(port: u16, data_dir: PathBuf) -> error::Result<()> {
             .route("/api/kanban/{id}/move", post(api_kanban_move))
             .route("/api/kanban/workloads", get(api_kanban_workloads))
             .route("/{*path}", get(static_handler))
-            .with_state(state);
+            .with_state(state)
+            .merge(crate::channel::router(channel_state));
 
         let addr = format!("0.0.0.0:{port}");
         let listener = tokio::net::TcpListener::bind(&addr)
@@ -173,32 +174,6 @@ pub fn run_server(port: u16, data_dir: PathBuf) -> error::Result<()> {
     })
 }
 
-/// Pure builder for the `/health` JSON body. Separated from the axum
-/// handler so it's directly unit-testable without spinning up a server.
-fn build_health_body(
-    started_at: chrono::DateTime<chrono::Utc>,
-    now: chrono::DateTime<chrono::Utc>,
-) -> serde_json::Value {
-    let uptime_secs = (now - started_at).num_seconds().max(0);
-    serde_json::json!({
-        "status": "ok",
-        "version": env!("CARGO_PKG_VERSION"),
-        "started_at": started_at.to_rfc3339(),
-        "uptime_secs": uptime_secs,
-    })
-}
-
-/// GET /health -- cheap daemon liveness probe (#319).
-///
-/// Returns `{status, version, started_at, uptime_secs}` with NO database
-/// access so it can be polled aggressively by hooks, the MCP reconnect
-/// path (#320), and the SessionStart auto-spawn supervisor (#321). The
-/// `version` field is baked in at compile time from CARGO_PKG_VERSION so
-/// clients can detect protocol drift after a plugin upgrade.
-async fn health_endpoint(State(state): State<AppState>) -> Response {
-    Json(build_health_body(state.started_at, chrono::Utc::now())).into_response()
-}
-
 async fn index_handler() -> impl IntoResponse {
     match StaticAssets::get("index.html") {
         Some(file) => Html(String::from_utf8_lossy(file.data.as_ref()).to_string()).into_response(),
@@ -221,228 +196,15 @@ async fn static_handler(AxumPath(path): AxumPath<String>) -> Response {
     }
 }
 
-async fn sse_handler(
-    State(state): State<AppState>,
-) -> Sse<impl tokio_stream::Stream<Item = Result<Event, Infallible>>> {
-    let stream = async_stream::stream! {
-        let mut last_reflection_ts: Option<String> = None;
-        let mut last_task_ts: Option<String> = None;
-        let mut tick: u64 = 0;
-        let poll_interval: Duration = Duration::from_secs(2);
-        // Send a ping every 30s = every 15 poll ticks
-        let ping_every: u64 = 15;
-
-        loop {
-            tokio::time::sleep(poll_interval).await;
-            tick += 1;
-
-            let db = match open_db(&state.data_dir) {
-                Ok(db) => db,
-                Err(_) => {
-                    if tick % ping_every == 0 {
-                        yield Ok(Event::default().event("ping").data("{}"));
-                    }
-                    continue;
-                }
-            };
-
-            // Check for new reflections
-            let current_reflection_ts = db.get_max_created_at().ok().flatten();
-            if current_reflection_ts != last_reflection_ts && current_reflection_ts.is_some() {
-                last_reflection_ts = current_reflection_ts;
-
-                // Emit agents event
-                if let Ok(agents_json) = build_agents_json(&db) {
-                    yield Ok(Event::default().event("agents").data(agents_json));
-                }
-
-                // Emit feed event (last 20 team posts)
-                if let Ok(feed_json) = build_feed_json(&db) {
-                    yield Ok(Event::default().event("feed").data(feed_json));
-                }
-            }
-
-            // Check for task changes
-            let current_task_ts = db.get_max_task_updated_at().ok().flatten();
-            if current_task_ts != last_task_ts && current_task_ts.is_some() {
-                last_task_ts = current_task_ts;
-
-                if let Ok(tasks) = db.get_all_tasks()
-                    && let Ok(json) = serde_json::to_string(&tasks)
-                {
-                    yield Ok(Event::default().event("tasks").data(json));
-                }
-            }
-
-            // Periodic ping keepalive
-            if tick % ping_every == 0 {
-                yield Ok(Event::default().event("ping").data("{}"));
-            }
-        }
-    };
-
-    Sse::new(stream).keep_alive(KeepAlive::default())
-}
-
-/// Build the agents JSON payload (same logic as api_agents).
-fn build_agents_json(db: &Database) -> Result<String, error::LegionError> {
-    let stats = db.get_dashboard_stats()?;
-    let unread_map: HashMap<String, u64> = db
-        .get_unread_counts_all()
-        .unwrap_or_default()
-        .into_iter()
-        .collect();
-
-    let agents: Vec<AgentInfo> = stats
-        .into_iter()
-        .map(|s| AgentInfo {
-            unread: unread_map.get(&s.repo).copied().unwrap_or(0),
-            repo: s.repo,
-            reflection_count: s.reflection_count,
-            boost_sum: s.boost_sum,
-            team_post_count: s.team_post_count,
-            last_activity: s.last_activity,
-        })
-        .collect();
-
-    Ok(serde_json::to_string(&agents)?)
-}
-
-/// Build the feed JSON payload (last 20 team posts).
-fn build_feed_json(db: &Database) -> Result<String, error::LegionError> {
-    let posts = db.get_board_posts()?;
-    let items: Vec<FeedItem> = posts
-        .into_iter()
-        .take(20)
-        .map(|p| {
-            let is_signal = sig::is_signal(&p.text);
-            FeedItem {
-                id: p.id,
-                repo: p.repo,
-                text: p.text,
-                created_at: p.created_at,
-                is_signal,
-            }
-        })
-        .collect();
-
-    Ok(serde_json::to_string(&items)?)
-}
-
-/// Agent info returned by GET /api/agents.
-#[derive(serde::Serialize)]
-struct AgentInfo {
-    repo: String,
-    unread: u64,
-    reflection_count: u64,
-    boost_sum: i64,
-    team_post_count: u64,
-    last_activity: String,
-}
-
 /// GET /api/agents -- per-repo agent overview with unread counts.
-async fn api_agents(State(state): State<AppState>) -> Result<Json<Vec<AgentInfo>>, ServeError> {
-    let db = open_db(&state.data_dir)?;
-
-    let stats = db.get_dashboard_stats()?;
-
-    let unread_map: HashMap<String, u64> = db
-        .get_unread_counts_all()
-        .unwrap_or_default()
-        .into_iter()
-        .collect();
-
-    let agents: Vec<AgentInfo> = stats
-        .into_iter()
-        .map(|s| AgentInfo {
-            unread: unread_map.get(&s.repo).copied().unwrap_or(0),
-            repo: s.repo,
-            reflection_count: s.reflection_count,
-            boost_sum: s.boost_sum,
-            team_post_count: s.team_post_count,
-            last_activity: s.last_activity,
-        })
-        .collect();
-
-    Ok(Json(agents))
-}
-
-/// Feed item returned by GET /api/feed.
-#[derive(serde::Serialize)]
-struct FeedItem {
-    id: String,
-    repo: String,
-    text: String,
-    created_at: String,
-    is_signal: bool,
-}
-
-/// Query parameters for GET /api/feed.
-#[derive(serde::Deserialize)]
-struct FeedQuery {
-    repo: Option<String>,
-    filter: Option<String>,
-    /// When set, return only posts unread by this reader repo AND atomically
-    /// mark them as read. Used by the channel backlog fetch so agents only
-    /// see each post once. The reader's own posts are excluded from the
-    /// response regardless of other filters. Combining with `repo` narrows
-    /// unread posts to that repo (not mutually exclusive).
-    unread_for: Option<String>,
-}
-
-/// GET /api/feed -- bullpen posts with optional repo and signal/musing filter.
-/// When `unread_for=<repo>` is set, returns only posts unread by that repo
-/// and atomically marks them as read so the same post is never delivered twice.
-async fn api_feed(
+///
+/// Shares its builder with the SSE `agents` event (channel.rs) so push
+/// and pull of the agent list cannot diverge (audit DC3).
+async fn api_agents(
     State(state): State<AppState>,
-    Query(params): Query<FeedQuery>,
-) -> Result<Json<Vec<FeedItem>>, ServeError> {
+) -> Result<Json<Vec<crate::channel::AgentInfo>>, ServeError> {
     let db = open_db(&state.data_dir)?;
-
-    // When `unread_for` is set, use the atomic unread-and-mark query so the
-    // channel backlog delivers each post exactly once across connections.
-    let posts = if let Some(reader) = params.unread_for.as_deref() {
-        db.get_and_mark_unread_board_posts(reader)?
-    } else {
-        db.get_board_posts()?
-    };
-
-    let repo_filter = params.repo.as_deref().unwrap_or("all");
-    let type_filter = params.filter.as_deref().unwrap_or("all");
-    let reader = params.unread_for.as_deref();
-
-    let items: Vec<FeedItem> = posts
-        .into_iter()
-        // Exclude the reader's own posts from unread delivery.
-        .filter(|p| reader.is_none_or(|r| p.repo != r))
-        .filter(|p| repo_filter == "all" || p.repo == repo_filter)
-        .filter(|p| match type_filter {
-            "signals" => sig::is_signal(&p.text),
-            "musings" => !sig::is_signal(&p.text),
-            _ => true,
-        })
-        .take(100)
-        .map(|p| {
-            let is_signal = sig::is_signal(&p.text);
-            FeedItem {
-                id: p.id,
-                repo: p.repo,
-                text: p.text,
-                created_at: p.created_at,
-                is_signal,
-            }
-        })
-        .collect();
-
-    Ok(Json(items))
-}
-
-/// GET /api/tasks -- all tasks for kanban view.
-async fn api_tasks(
-    State(state): State<AppState>,
-) -> Result<Json<Vec<crate::task::Task>>, ServeError> {
-    let db = open_db(&state.data_dir)?;
-    Ok(Json(db.get_all_tasks()?))
+    Ok(Json(crate::channel::build_agents(&db)?))
 }
 
 /// GET /api/stats -- per-repo dashboard stats (same data as agents minus unread).
@@ -594,44 +356,12 @@ async fn api_done(
     }))
 }
 
-/// Request body for POST /api/post.
-#[derive(serde::Deserialize)]
-struct PostRequest {
-    repo: String,
-    text: String,
-}
-
 /// Open the search index from the data directory.
 ///
 /// Renders as 500 {"error": "failed to open search index"} when propagated
 /// from a handler with `?`.
 fn open_search_index(data_dir: &Path) -> Result<SearchIndex, ServeError> {
     SearchIndex::open(&data_dir.join("index")).map_err(|_| ServeError::IndexOpen)
-}
-
-/// POST /api/post -- broadcast a message to the bullpen.
-async fn api_post(
-    State(state): State<AppState>,
-    Json(body): Json<PostRequest>,
-) -> Result<Json<crate::db::Reflection>, ServeError> {
-    let trimmed = body.text.trim();
-    if trimmed.is_empty() {
-        return Err(ServeError::BadRequest("text is required".to_string()));
-    }
-
-    let db = open_db(&state.data_dir)?;
-    let index = open_search_index(&state.data_dir)?;
-
-    let reflection = db
-        .insert_reflection_with_meta(&body.repo, trimmed, "team", &ReflectionMeta::default())
-        .map_err(|e| ServeError::internal("insert error", e))?;
-
-    // Best-effort add to search index; post is already in DB.
-    if let Err(e) = index.add(&reflection.id, &reflection.repo, trimmed) {
-        eprintln!("[legion] search index add failed: {e}");
-    }
-
-    Ok(Json(reflection))
 }
 
 /// POST /api/boost/:id -- boost a reflection's recall count.
@@ -1200,21 +930,6 @@ mod tests {
     use super::*;
 
     #[test]
-    fn health_body_shape() {
-        let started = chrono::DateTime::parse_from_rfc3339("2026-05-10T12:00:00Z")
-            .unwrap()
-            .with_timezone(&chrono::Utc);
-        let now = chrono::DateTime::parse_from_rfc3339("2026-05-10T12:01:30Z")
-            .unwrap()
-            .with_timezone(&chrono::Utc);
-        let body = build_health_body(started, now);
-        assert_eq!(body["status"], "ok");
-        assert_eq!(body["version"], env!("CARGO_PKG_VERSION"));
-        assert_eq!(body["started_at"], "2026-05-10T12:00:00+00:00");
-        assert_eq!(body["uptime_secs"], 90);
-    }
-
-    #[test]
     fn daemon_pid_path_honors_xdg_state_home() {
         // SAFETY: test mutates process env. Other tests in this module
         // do not read XDG_STATE_HOME, so isolation by `cargo test`
@@ -1245,19 +960,5 @@ mod tests {
         // Idempotent overwrite.
         write_daemon_pidfile_at(&path, 67890);
         assert_eq!(std::fs::read_to_string(&path).unwrap(), "67890");
-    }
-
-    #[test]
-    fn health_uptime_clamped_at_zero_for_clock_skew() {
-        // If `now` is somehow before `started_at` (clock jump, NTP
-        // correction, test fixture), uptime must not go negative.
-        let started = chrono::DateTime::parse_from_rfc3339("2026-05-10T12:00:00Z")
-            .unwrap()
-            .with_timezone(&chrono::Utc);
-        let now = chrono::DateTime::parse_from_rfc3339("2026-05-10T11:59:00Z")
-            .unwrap()
-            .with_timezone(&chrono::Utc);
-        let body = build_health_body(started, now);
-        assert_eq!(body["uptime_secs"], 0);
     }
 }


### PR DESCRIPTION
## Summary

Stream F of the refactor epic (#607): serve.rs and channel.rs stop being two half-merged HTTP servers. `ServeError` (thiserror, IntoResponse) replaces 29 hand-written open_db/query-error match blocks; channel.rs becomes the single owner of the shared endpoint contract (/health, /sse, /api/feed, /api/tasks, /api/post) with serve mounting `channel::router`; schedule firing moves out of per-connection SSE stream bodies into one background task; and the port-ownership question (#613 absorbed #601) is settled: the daemon owns :3131 while it runs, /health reports a `role` field, the SessionStart supervisor bounces a daemon in place via `daemon-restart` instead of replacing it with a serve, and `legion serve` refuses a daemon-held port with an error that names the daemon pid and the takeover path. serve.rs goes from 1,492 lines to 1,024.

## Acceptance criteria mapping

### 1. Zero hand-written open_db match blocks; ServeError renders all handler errors

`ServeError` lives in channel.rs with an `IntoResponse` impl, so every handler in both files is Result-returning and propagates with `?`. The open helpers are single-sourced: serve handlers call `channel::open_db`/`channel::open_index` (the serve-local duplicates -- which also silently discarded the underlying error cause -- were deleted in the simplify round, commit 1ca0a82). Task-domain errors deliberately render 400 with the bare message, preserved from the original handlers and commented at the first site. Evidence: src/serve.rs has no `match Database::open` blocks; src/channel.rs:244 (open_db) and :253 (open_index) are the only open sites; ServeError IntoResponse test in channel.rs.

### 2. Shared endpoints owned once by channel.rs; parity test covers the chosen api_post shape

`channel::router` (src/channel.rs:205) owns /health, /sse, /api/feed, /api/tasks, /api/post; `run_server` merges it into the dashboard Router (src/serve.rs:145) and serve's duplicate handlers, FeedItem, and build_feed_json are deleted. The api_post divergence was resolved in channel's favor (the richer shape), documented at the router, and the parity test pins the response shape so the next divergence fails CI. The /health body builder takes the new `role` field additively -- status/version/started_at/uptime_secs unchanged for pre-#613 clients. Evidence: router test exercising /api/post shape and the health-body unit tests in src/channel.rs (build_health_body tests assert role plus the original four fields).

### 3. Schedules fire with zero SSE clients connected (tested); no per-connection firing

`spawn_schedule_firing` is one background tokio task, spawned in `run_daemon_async` and in `run_server` -- in serve's case only after the bind succeeds, so a process that failed to become the server produces no side effects (src/serve.rs:161). SSE stream bodies are read-only. The race on get_due/mark_run disappears with the N-clients-N-firings pattern. Evidence: src/db/schedules.rs firing test proves schedules fire with no SSE client connected; commit d3bd158.

### 4. Dashboard still receives agents/feed/tasks events

Channel's edge-triggered SSE is canonical and the `agents` event was added to it (static/app.js depends on it); `api_agents` shares its builder with the SSE agents event so push and pull cannot diverge (src/serve.rs:228 comment, audit DC3). Evidence: channel.rs SSE tests cover agents/feed/tasks event emission; the dashboard's existing app.js consumes the same event names unchanged.

### 5. Parent epic: #607

Stream F is the serve/channel leg of epic #607 and additionally absorbs #601 (port ownership): /health `role` field (ServerRole enum), supervisor daemon-restart path with shell tests (plugin/hooks/test-daemon-supervisor.sh, 13 passing), and `bind_refusal` naming the live daemon pid -- lsof-confirmed when available -- with `daemon-stop`/`--port` escapes (src/serve.rs:180). Evidence: serve_refuses_port_held_by_live_daemon_with_pointer and serve_bind_failure_without_daemon_stays_bare tests in src/serve.rs.

## Not done

Scope item 4's serve/ tree split was not taken: after the deletions serve.rs is 1,024 lines (down from 1,492), under the epic's ~1,500 god-file bar, so a split would be a tree for its own sake. The supervisor's kill+spawn path for pre-#613 binaries (no `role` in /health) is kept deliberately -- they can only be a `legion serve`, so replacement remains correct for them; this fallback retires naturally as nodes upgrade.