### PR TITLE
refactor(#610): typed exits via ExitWith, GateResult enum, verify_gate_key single-source

### DIFF
--- a/src/cli/autonomy.rs
+++ b/src/cli/autonomy.rs
@@ -187,7 +187,7 @@ pub(crate) fn handle(action: AutonomyAction) -> error::Result<()> {
                          used (threshold {threshold_pct:.0}%). Self-directed work paused; \
                          operator-requested work still proceeds."
                     );
-                    std::process::exit(1);
+                    return Err(error::LegionError::ExitWith(1));
                 }
                 autonomy::BurnRateOutcome::Allowed { .. } => {
                     // Headroom is fine; fall through to work-unit budget check.
@@ -233,7 +233,7 @@ pub(crate) fn handle(action: AutonomyAction) -> error::Result<()> {
                          Operator-requested work still proceeds; self-directed work waits.",
                         budget.resets_at().format("%Y-%m-%d")
                     );
-                    std::process::exit(1);
+                    return Err(error::LegionError::ExitWith(1));
                 }
             }
         }

--- a/src/cli/index_cmd.rs
+++ b/src/cli/index_cmd.rs
@@ -170,7 +170,7 @@ fn run_sym_list(
                     "[legion] unknown --kind '{k}'. Supported: fn, struct, enum, trait, \
                      class, interface, mod, const, macro, type"
                 );
-                std::process::exit(2);
+                return Err(error::LegionError::ExitWith(2));
             }
         },
         None => None,
@@ -738,7 +738,7 @@ where
     let indexes = database.list_scip_indexes_filtered(repo.as_deref(), lang.as_deref())?;
     if indexes.is_empty() {
         no_index_found(repo.as_deref(), lang.as_deref());
-        std::process::exit(1);
+        return Err(error::LegionError::ExitWith(1));
     }
 
     // Skip non-rust indexes for `impl` queries (SCIP only models the
@@ -800,7 +800,7 @@ fn run_hover_query(
     let indexes = database.list_scip_indexes_filtered(repo.as_deref(), lang.as_deref())?;
     if indexes.is_empty() {
         no_index_found(repo.as_deref(), lang.as_deref());
-        std::process::exit(1);
+        return Err(error::LegionError::ExitWith(1));
     }
     let mut hover: Option<sym::HoverInfo> = None;
     for idx in &indexes {

--- a/src/cli/kanban.rs
+++ b/src/cli/kanban.rs
@@ -4,6 +4,7 @@
 use clap::Subcommand;
 
 use crate::cli::util::{audit, open_db, open_db_and_index};
+use crate::verify::GateResult;
 use crate::{db, error, kanban, status, verify, worksource};
 
 #[derive(Subcommand)]
@@ -493,23 +494,23 @@ pub(crate) fn handle_done(repo: String, text: String, id: Option<String>) -> err
         if let Some(card) = database.get_card_by_id(card_id)? {
             let acceptance = verify::acceptance_items(card.acceptance.as_deref());
             if !acceptance.is_empty() {
-                let skill = format!("legion-verify:{card_id}");
+                let skill = verify::verify_gate_key(card_id);
                 match database.get_latest_quality_gate_by_skill(&skill)? {
-                    Some(gate) if gate.result == "clean" => {}
+                    Some(gate) if gate.result == GateResult::Clean => {}
                     Some(_) => {
                         eprintln!(
                             "[legion] error: verify gate is not clean for card {card_id}. \
                              Resolve the failing/uncertain criteria and re-run verify \
                              before Done."
                         );
-                        std::process::exit(1);
+                        return Err(error::LegionError::ExitWith(1));
                     }
                     None => {
                         eprintln!(
                             "[legion] error: card {card_id} has acceptance criteria but no \
                              verify verdict. Run the verify skill before Done."
                         );
-                        std::process::exit(1);
+                        return Err(error::LegionError::ExitWith(1));
                     }
                 }
             }
@@ -635,7 +636,7 @@ pub(crate) fn handle(action: KanbanAction) -> error::Result<()> {
                 eprintln!(
                     "[legion] no fields to update: pass at least one of --text, --body, --priority, --labels, --add-labels, --remove-labels"
                 );
-                std::process::exit(1);
+                return Err(error::LegionError::ExitWith(1));
             }
             let params = kanban::CardUpdateParams {
                 text,

--- a/src/cli/memory.rs
+++ b/src/cli/memory.rs
@@ -468,7 +468,7 @@ pub(crate) fn handle_resolve(id: String, reflection: Option<String>) -> error::R
         info!("[legion] resolved {}", id);
     } else {
         eprintln!("[legion] post not found: {}", id);
-        std::process::exit(1);
+        return Err(error::LegionError::ExitWith(1));
     }
     Ok(())
 }

--- a/src/cli/ops.rs
+++ b/src/cli/ops.rs
@@ -821,7 +821,7 @@ pub(crate) fn handle_usage(
         // RFC3339-comparable prefix (timestamps sort lexicographically).
         if d.len() != 10 || !d.chars().all(|c| c.is_ascii_digit() || c == '-') {
             eprintln!("[legion] error: --since expects YYYY-MM-DD, got '{d}'");
-            std::process::exit(1);
+            return Err(error::LegionError::ExitWith(1));
         }
         Some(format!("{d}T00:00:00"))
     } else if session.is_none() {
@@ -840,7 +840,7 @@ pub(crate) fn handle_usage(
             "[legion] error: session not found: {}",
             session.as_deref().unwrap_or("")
         );
-        std::process::exit(1);
+        return Err(error::LegionError::ExitWith(1));
     }
 
     if json {

--- a/src/cli/pr.rs
+++ b/src/cli/pr.rs
@@ -4,6 +4,7 @@ use clap::Subcommand;
 
 use crate::cli::datadir::data_dir;
 use crate::cli::util::{audit, git_head_commit_and_branch, open_db, read_file_or_stdin};
+use crate::verify::GateResult;
 use crate::{board, card_parse, db, error, kanban, pr_view, pr_write, search, worksource};
 
 #[derive(Subcommand, Debug)]
@@ -286,15 +287,15 @@ pub(crate) fn handle(action: PrAction) -> error::Result<()> {
                                 "[legion] error: no clean {skill} gate on HEAD ({short_hash}). \
                                  Run {run_hint} before creating the PR."
                             );
-                            std::process::exit(1);
+                            return Err(error::LegionError::ExitWith(1));
                         }
-                        Some(gate) if gate.result != "clean" => {
+                        Some(gate) if gate.result != GateResult::Clean => {
                             eprintln!(
                                 "[legion] error: {skill} recorded issues on HEAD ({short_hash}), \
                                  {} findings. Fix them and re-run the skill before creating the PR.",
                                 gate.findings_count
                             );
-                            std::process::exit(1);
+                            return Err(error::LegionError::ExitWith(1));
                         }
                         Some(_) => {
                             // Gate is clean -- continue to the next.
@@ -509,7 +510,11 @@ pub(crate) fn handle(action: PrAction) -> error::Result<()> {
             // Record the gate on HEAD so `legion pr create` can gate on it,
             // exactly as it does for legion-simplify.
             let (commit_hash, branch) = git_head_commit_and_branch()?;
-            let result = if report.ok { "clean" } else { "issues" };
+            let gate_result = if report.ok {
+                GateResult::Clean
+            } else {
+                GateResult::Issues
+            };
             let details = serde_json::json!({
                 "skill": "legion-pr-write",
                 "issue": issue,
@@ -523,7 +528,7 @@ pub(crate) fn handle(action: PrAction) -> error::Result<()> {
                 &branch,
                 &commit_hash,
                 "legion-pr-write",
-                result,
+                gate_result,
                 report.findings.len() as u64,
                 Some(&details),
             )?;
@@ -547,7 +552,7 @@ pub(crate) fn handle(action: PrAction) -> error::Result<()> {
                      criterion, each citing evidence (a test, a file:line, an observable \
                      behavior) -- plus a 'Not done' section. Fix the body and re-run."
                 );
-                std::process::exit(1);
+                return Err(error::LegionError::ExitWith(1));
             }
         }
         PrAction::Comments { repo, number, json } => {

--- a/src/cli/verify.rs
+++ b/src/cli/verify.rs
@@ -1,8 +1,11 @@
 //! `legion verify` and `legion quality-gate` handlers (carved from main.rs, #610).
 
+use std::str::FromStr;
+
 use clap::Subcommand;
 
 use crate::cli::util::{git_head_commit_and_branch, open_db, read_file_or_stdin};
+use crate::verify::GateResult;
 use crate::{error, kanban, verify};
 
 #[derive(Subcommand, Debug)]
@@ -39,6 +42,7 @@ pub(crate) fn handle_quality_gate(action: QualityGateAction) -> error::Result<()
             findings_count,
             details_json,
         } => {
+            let gate_result = GateResult::from_str(&result)?;
             let (commit_hash, branch) = git_head_commit_and_branch()?;
 
             let database = open_db()?;
@@ -46,7 +50,7 @@ pub(crate) fn handle_quality_gate(action: QualityGateAction) -> error::Result<()
                 &branch,
                 &commit_hash,
                 &skill,
-                &result,
+                gate_result,
                 findings_count,
                 details_json.as_deref(),
             )?;
@@ -77,7 +81,7 @@ pub(crate) fn handle_verify(card: String, verdicts_file: Option<String>) -> erro
 
     // Record the verdict as a card-keyed gate so `legion done` can gate
     // on it regardless of which commit it runs on (e.g. post-merge).
-    let skill = format!("legion-verify:{card}");
+    let skill = verify::verify_gate_key(&card);
     let (commit_hash, branch) = git_head_commit_and_branch()?;
     let details = serde_json::json!({
         "skill": "legion-verify",
@@ -93,15 +97,16 @@ pub(crate) fn handle_verify(card: String, verdicts_file: Option<String>) -> erro
         verify::VerifyDecision::NoCheckableAc => 1,
         verify::VerifyDecision::Proceed => 0,
     };
+    let gate_result = if decision.allows_done() {
+        GateResult::Clean
+    } else {
+        GateResult::Issues
+    };
     database.record_quality_gate(
         &branch,
         &commit_hash,
         &skill,
-        if decision.allows_done() {
-            "clean"
-        } else {
-            "issues"
-        },
+        gate_result,
         findings,
         Some(&details),
     )?;
@@ -118,7 +123,7 @@ pub(crate) fn handle_verify(card: String, verdicts_file: Option<String>) -> erro
                 "[legion] verify BLOCKED for card {card}: no acceptance criteria to check. \
                  A card cannot reach Done without checkable criteria -- add them upstream."
             );
-            std::process::exit(1);
+            return Err(error::LegionError::ExitWith(1));
         }
         verify::VerifyDecision::Incomplete { unaddressed } => {
             eprintln!(
@@ -126,7 +131,7 @@ pub(crate) fn handle_verify(card: String, verdicts_file: Option<String>) -> erro
                  no verdict. Emit one verdict per criterion.",
                 acceptance.len()
             );
-            std::process::exit(1);
+            return Err(error::LegionError::ExitWith(1));
         }
         verify::VerifyDecision::Block { failed } => {
             eprintln!(
@@ -137,7 +142,7 @@ pub(crate) fn handle_verify(card: String, verdicts_file: Option<String>) -> erro
                 eprintln!("  - {c}");
             }
             eprintln!("\n->Done is blocked. Finish the work and re-verify.");
-            std::process::exit(1);
+            return Err(error::LegionError::ExitWith(1));
         }
         verify::VerifyDecision::NeedsInput { uncertain } => {
             eprintln!(
@@ -165,7 +170,7 @@ pub(crate) fn handle_verify(card: String, verdicts_file: Option<String>) -> erro
                      {e}; move it manually.)"
                 ),
             }
-            std::process::exit(1);
+            return Err(error::LegionError::ExitWith(1));
         }
     }
     Ok(())

--- a/src/db/quality_gates.rs
+++ b/src/db/quality_gates.rs
@@ -2,12 +2,15 @@
 //! `legion pr create` can verify a clean gate (#200). Owns the
 //! `quality_gates` DDL.
 
+use std::str::FromStr;
+
 use chrono::Utc;
 use rusqlite::Connection;
 use uuid::Uuid;
 
 use super::Database;
 use crate::error::{LegionError, Result};
+use crate::verify::GateResult;
 
 /// `quality_gates` table (#200).
 pub(super) fn create_tables(conn: &Connection) -> Result<()> {
@@ -42,10 +45,22 @@ pub struct QualityGateRow {
     pub branch: String,
     pub commit_hash: String,
     pub skill: String,
-    pub result: String,
+    pub result: GateResult,
     pub findings_count: u64,
     pub details: Option<String>,
     pub created_at: String,
+}
+
+/// Parse a `GateResult` from a DB string, mapping unknown values to a
+/// `LegionError::Database` so the error stays in the rusqlite query path.
+fn parse_result_from_db(s: String) -> std::result::Result<GateResult, rusqlite::Error> {
+    GateResult::from_str(&s).map_err(|e| {
+        rusqlite::Error::FromSqlConversionFailure(
+            4,
+            rusqlite::types::Type::Text,
+            Box::new(std::io::Error::other(e.to_string())),
+        )
+    })
 }
 
 impl Database {
@@ -59,12 +74,16 @@ impl Database {
         branch: &str,
         commit_hash: &str,
         skill: &str,
-        result: &str,
+        result: GateResult,
         findings_count: u64,
         details: Option<&str>,
     ) -> Result<QualityGateRow> {
         let id = Uuid::now_v7().to_string();
         let created_at = Utc::now().to_rfc3339();
+        let result_str: &str = match result {
+            GateResult::Clean => "clean",
+            GateResult::Issues => "issues",
+        };
         self.conn.execute(
             "INSERT INTO quality_gates \
              (id, branch, commit_hash, skill, result, findings_count, details, created_at) \
@@ -74,7 +93,7 @@ impl Database {
                 branch,
                 commit_hash,
                 skill,
-                result,
+                result_str,
                 findings_count as i64,
                 details,
                 &created_at,
@@ -85,7 +104,7 @@ impl Database {
             branch: branch.to_owned(),
             commit_hash: commit_hash.to_owned(),
             skill: skill.to_owned(),
-            result: result.to_owned(),
+            result,
             findings_count,
             details: details.map(str::to_owned),
             created_at,
@@ -109,13 +128,14 @@ impl Database {
              LIMIT 1",
         )?;
         let mut rows = stmt.query_map(rusqlite::params![commit_hash, skill], |row| {
+            let result_str: String = row.get(4)?;
             let findings_count_i64: i64 = row.get(5)?;
             Ok(QualityGateRow {
                 id: row.get(0)?,
                 branch: row.get(1)?,
                 commit_hash: row.get(2)?,
                 skill: row.get(3)?,
-                result: row.get(4)?,
+                result: parse_result_from_db(result_str)?,
                 findings_count: findings_count_i64.unsigned_abs(),
                 details: row.get(6)?,
                 created_at: row.get(7)?,
@@ -145,13 +165,14 @@ impl Database {
              LIMIT 1",
         )?;
         let mut rows = stmt.query_map(rusqlite::params![skill], |row| {
+            let result_str: String = row.get(4)?;
             let findings_count_i64: i64 = row.get(5)?;
             Ok(QualityGateRow {
                 id: row.get(0)?,
                 branch: row.get(1)?,
                 commit_hash: row.get(2)?,
                 skill: row.get(3)?,
-                result: row.get(4)?,
+                result: parse_result_from_db(result_str)?,
                 findings_count: findings_count_i64.unsigned_abs(),
                 details: row.get(6)?,
                 created_at: row.get(7)?,
@@ -168,6 +189,7 @@ impl Database {
 #[cfg(test)]
 mod tests {
     use crate::db::testutil::test_db;
+    use crate::verify::GateResult;
 
     #[test]
     fn quality_gate_insert_and_lookup() {
@@ -177,7 +199,7 @@ mod tests {
                 "feat/test-branch",
                 "abc1234def5678",
                 "legion-simplify",
-                "clean",
+                GateResult::Clean,
                 0,
                 None,
             )
@@ -186,7 +208,7 @@ mod tests {
         assert_eq!(row.branch, "feat/test-branch");
         assert_eq!(row.commit_hash, "abc1234def5678");
         assert_eq!(row.skill, "legion-simplify");
-        assert_eq!(row.result, "clean");
+        assert_eq!(row.result, GateResult::Clean);
         assert_eq!(row.findings_count, 0);
         assert!(row.details.is_none());
 
@@ -196,7 +218,7 @@ mod tests {
         assert!(fetched.is_some());
         let fetched = fetched.unwrap();
         assert_eq!(fetched.id, row.id);
-        assert_eq!(fetched.result, "clean");
+        assert_eq!(fetched.result, GateResult::Clean);
     }
 
     #[test]
@@ -211,8 +233,15 @@ mod tests {
     #[test]
     fn quality_gate_missing_skill_returns_none() {
         let db = test_db();
-        db.record_quality_gate("main", "abc1234", "legion-simplify", "clean", 0, None)
-            .unwrap();
+        db.record_quality_gate(
+            "main",
+            "abc1234",
+            "legion-simplify",
+            GateResult::Clean,
+            0,
+            None,
+        )
+        .unwrap();
         // Different skill on the same commit should not match.
         let result = db.get_quality_gate("abc1234", "legion-review").unwrap();
         assert!(result.is_none());
@@ -222,22 +251,29 @@ mod tests {
     fn quality_gate_multiple_skills_on_same_commit() {
         let db = test_db();
         let hash = "deadbeef12345";
-        db.record_quality_gate("main", hash, "legion-simplify", "clean", 0, None)
+        db.record_quality_gate("main", hash, "legion-simplify", GateResult::Clean, 0, None)
             .unwrap();
-        db.record_quality_gate("main", hash, "legion-review", "issues", 2, Some("{}"))
-            .unwrap();
+        db.record_quality_gate(
+            "main",
+            hash,
+            "legion-review",
+            GateResult::Issues,
+            2,
+            Some("{}"),
+        )
+        .unwrap();
 
         let simplify = db
             .get_quality_gate(hash, "legion-simplify")
             .unwrap()
             .expect("simplify gate should exist");
-        assert_eq!(simplify.result, "clean");
+        assert_eq!(simplify.result, GateResult::Clean);
 
         let review = db
             .get_quality_gate(hash, "legion-review")
             .unwrap()
             .expect("review gate should exist");
-        assert_eq!(review.result, "issues");
+        assert_eq!(review.result, GateResult::Issues);
         assert_eq!(review.findings_count, 2);
     }
 
@@ -246,10 +282,10 @@ mod tests {
         let db = test_db();
         let hash = "cafecafe99";
         // First run: issues found.
-        db.record_quality_gate("main", hash, "legion-simplify", "issues", 3, None)
+        db.record_quality_gate("main", hash, "legion-simplify", GateResult::Issues, 3, None)
             .unwrap();
         // Second run after fixing: clean.
-        db.record_quality_gate("main", hash, "legion-simplify", "clean", 0, None)
+        db.record_quality_gate("main", hash, "legion-simplify", GateResult::Clean, 0, None)
             .unwrap();
 
         let gate = db
@@ -257,7 +293,8 @@ mod tests {
             .unwrap()
             .expect("gate should exist");
         assert_eq!(
-            gate.result, "clean",
+            gate.result,
+            GateResult::Clean,
             "should return the most recent (clean) result"
         );
     }
@@ -271,7 +308,7 @@ mod tests {
                 "feat/x",
                 "hash123",
                 "legion-simplify",
-                "issues",
+                GateResult::Issues,
                 1,
                 Some(details),
             )
@@ -292,9 +329,9 @@ mod tests {
         // done` may run on a different commit than verify did.
         let db = test_db();
         let skill = "legion-verify:card-7";
-        db.record_quality_gate("feat/x", "commit-old", skill, "issues", 1, None)
+        db.record_quality_gate("feat/x", "commit-old", skill, GateResult::Issues, 1, None)
             .unwrap();
-        db.record_quality_gate("main", "commit-new", skill, "clean", 0, None)
+        db.record_quality_gate("main", "commit-new", skill, GateResult::Clean, 0, None)
             .unwrap();
 
         let latest = db
@@ -302,7 +339,8 @@ mod tests {
             .unwrap()
             .expect("a verify gate should exist for the card");
         assert_eq!(
-            latest.result, "clean",
+            latest.result,
+            GateResult::Clean,
             "most recent row wins across commits"
         );
         assert_eq!(latest.commit_hash, "commit-new");
@@ -313,5 +351,21 @@ mod tests {
                 .unwrap()
                 .is_none()
         );
+    }
+
+    #[test]
+    fn gate_result_display_roundtrip() {
+        for r in [GateResult::Clean, GateResult::Issues] {
+            let s = r.to_string();
+            let parsed = s.parse::<GateResult>().expect("parse");
+            assert_eq!(r, parsed);
+        }
+    }
+
+    #[test]
+    fn gate_result_parse_invalid_returns_err() {
+        assert!("unknown".parse::<GateResult>().is_err());
+        assert!("Clean".parse::<GateResult>().is_err());
+        assert!("".parse::<GateResult>().is_err());
     }
 }

--- a/src/db/quality_gates.rs
+++ b/src/db/quality_gates.rs
@@ -80,10 +80,7 @@ impl Database {
     ) -> Result<QualityGateRow> {
         let id = Uuid::now_v7().to_string();
         let created_at = Utc::now().to_rfc3339();
-        let result_str: &str = match result {
-            GateResult::Clean => "clean",
-            GateResult::Issues => "issues",
-        };
+        let result_str: &str = result.as_str();
         self.conn.execute(
             "INSERT INTO quality_gates \
              (id, branch, commit_hash, skill, result, findings_count, details, created_at) \
@@ -351,21 +348,5 @@ mod tests {
                 .unwrap()
                 .is_none()
         );
-    }
-
-    #[test]
-    fn gate_result_display_roundtrip() {
-        for r in [GateResult::Clean, GateResult::Issues] {
-            let s = r.to_string();
-            let parsed = s.parse::<GateResult>().expect("parse");
-            assert_eq!(r, parsed);
-        }
-    }
-
-    #[test]
-    fn gate_result_parse_invalid_returns_err() {
-        assert!("unknown".parse::<GateResult>().is_err());
-        assert!("Clean".parse::<GateResult>().is_err());
-        assert!("".parse::<GateResult>().is_err());
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -245,14 +245,13 @@ mod tests {
     }
 
     #[test]
-    fn exit_with_carries_code() {
-        // ExitWith must preserve the exact code so callers that differ by code
-        // (e.g. exit(2) for bad --kind vs exit(1) for gate failures) are not collapsed.
-        let err = LegionError::ExitWith(2);
-        assert!(matches!(err, LegionError::ExitWith(2)));
-
-        let err1 = LegionError::ExitWith(1);
-        assert!(matches!(err1, LegionError::ExitWith(1)));
+    fn exit_with_displays_empty() {
+        // main() intercepts ExitWith and exits without printing; the empty
+        // Display is the contract that keeps a stray eprintln!("{e}") from
+        // emitting a blank-prefixed error line if a future refactor reorders
+        // the intercept below the generic printer.
+        assert_eq!(LegionError::ExitWith(1).to_string(), "");
+        assert_eq!(LegionError::ExitWith(2).to_string(), "");
     }
 
     #[test]

--- a/src/error.rs
+++ b/src/error.rs
@@ -160,6 +160,19 @@ pub enum LegionError {
 
     #[error("wake attempt state decode error: {0}")]
     WakeAttemptStateDecodeError(String),
+
+    #[error("invalid gate result: '{0}' (expected 'clean' or 'issues')")]
+    InvalidGateResult(String),
+
+    /// Signals that the process should exit with a specific non-zero code.
+    ///
+    /// Used by CLI handlers that have already printed a user-facing message
+    /// and need to propagate a specific exit code back to `main()` without
+    /// calling `std::process::exit` at the call site. `main()` intercepts
+    /// this variant and calls `std::process::exit(code)` -- the only
+    /// legitimate use of `process::exit` in the binary.
+    #[error("")]
+    ExitWith(i32),
 }
 
 pub type Result<T> = std::result::Result<T, LegionError>;
@@ -229,5 +242,24 @@ mod tests {
 
         let err: Result<i32> = Err(LegionError::NoHomeDir);
         assert!(err.is_err());
+    }
+
+    #[test]
+    fn exit_with_carries_code() {
+        // ExitWith must preserve the exact code so callers that differ by code
+        // (e.g. exit(2) for bad --kind vs exit(1) for gate failures) are not collapsed.
+        let err = LegionError::ExitWith(2);
+        assert!(matches!(err, LegionError::ExitWith(2)));
+
+        let err1 = LegionError::ExitWith(1);
+        assert!(matches!(err1, LegionError::ExitWith(1)));
+    }
+
+    #[test]
+    fn invalid_gate_result_display() {
+        let err = LegionError::InvalidGateResult("bad".to_string());
+        assert!(err.to_string().contains("bad"));
+        assert!(err.to_string().contains("clean"));
+        assert!(err.to_string().contains("issues"));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -72,17 +72,29 @@ mod cli;
 pub(crate) use cli::datadir::data_dir;
 pub(crate) use cli::ops::ClusterAction;
 
-fn main() -> error::Result<()> {
+fn main() {
     // Windows default stack (1MB) is too small for clap + Tantivy init.
     // Spawn with 8MB stack to match macOS/Linux defaults.
     const STACK_SIZE: usize = 8 * 1024 * 1024;
     let builder = std::thread::Builder::new().stack_size(STACK_SIZE);
-    let handler = builder.spawn(run).map_err(error::LegionError::Io)?;
-    handler.join().unwrap_or_else(|_| {
-        Err(error::LegionError::Io(std::io::Error::other(
-            "thread panicked",
-        )))
-    })
+    let result: error::Result<()> = match builder.spawn(run) {
+        Err(e) => Err(error::LegionError::Io(e)),
+        Ok(handle) => handle.join().unwrap_or_else(|_| {
+            Err(error::LegionError::Io(std::io::Error::other(
+                "thread panicked",
+            )))
+        }),
+    };
+    match result {
+        Ok(()) => {}
+        // ExitWith: the handler already printed the user-facing message;
+        // propagate the exit code without printing again.
+        Err(error::LegionError::ExitWith(code)) => std::process::exit(code),
+        Err(e) => {
+            eprintln!("{e}");
+            std::process::exit(1);
+        }
+    }
 }
 
 fn run() -> error::Result<()> {

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -19,6 +19,54 @@
 //     ->Done; any Uncertain (no Fail) routes the card to NeedsInput; all Pass
 //     proceeds.
 
+use std::fmt;
+use std::str::FromStr;
+
+use crate::error::{LegionError, Result};
+
+/// Result of a quality gate run: either clean (no issues) or issues found.
+///
+/// Stored as lowercase string in the `quality_gates.result` column so the
+/// SQL stays human-readable. Parse and display are symmetric: the closed
+/// set of valid values is enforced at the boundary rather than scattered
+/// across `== "clean"` comparisons.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum GateResult {
+    Clean,
+    Issues,
+}
+
+impl fmt::Display for GateResult {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Clean => write!(f, "clean"),
+            Self::Issues => write!(f, "issues"),
+        }
+    }
+}
+
+impl FromStr for GateResult {
+    type Err = LegionError;
+
+    fn from_str(s: &str) -> Result<Self> {
+        match s {
+            "clean" => Ok(Self::Clean),
+            "issues" => Ok(Self::Issues),
+            other => Err(LegionError::InvalidGateResult(other.to_string())),
+        }
+    }
+}
+
+/// Build the quality-gate skill key for a verify verdict on `card_id`.
+///
+/// The key is single-sourced here so that the handler that writes the gate
+/// (`cli::verify::handle_verify`) and the handler that reads it
+/// (`cli::kanban::handle_done`) cannot drift.
+pub fn verify_gate_key(card_id: &str) -> String {
+    format!("legion-verify:{card_id}")
+}
+
 /// One verdict for one acceptance criterion.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "lowercase")]
@@ -442,5 +490,50 @@ mod tests {
     fn is_vacuous_unicode_safe() {
         // Unicode text with no assertion markers is vacuous; must not panic.
         assert!(is_vacuous_evidence("critere", "\u{00e9}l\u{00e8}ve"));
+    }
+
+    // --- GateResult tests ---
+
+    #[test]
+    fn gate_result_display_roundtrip() {
+        // Every variant serializes to lowercase and parses back exactly.
+        for r in [GateResult::Clean, GateResult::Issues] {
+            let s = r.to_string();
+            let parsed = s.parse::<GateResult>().expect("parse should succeed");
+            assert_eq!(r, parsed, "display/parse roundtrip failed for {r}");
+        }
+    }
+
+    #[test]
+    fn gate_result_display_values() {
+        assert_eq!(GateResult::Clean.to_string(), "clean");
+        assert_eq!(GateResult::Issues.to_string(), "issues");
+    }
+
+    #[test]
+    fn gate_result_parse_invalid_returns_err() {
+        // Typos and case variants are rejected at the parse boundary.
+        assert!("unknown".parse::<GateResult>().is_err());
+        assert!("Clean".parse::<GateResult>().is_err());
+        assert!("CLEAN".parse::<GateResult>().is_err());
+        assert!("".parse::<GateResult>().is_err());
+    }
+
+    // --- verify_gate_key tests ---
+
+    #[test]
+    fn verify_gate_key_format() {
+        // The key is the single-source for the card-keyed gate used by
+        // handle_verify (write site) and handle_done (read site).
+        let key = verify_gate_key("card-abc-123");
+        assert_eq!(key, "legion-verify:card-abc-123");
+    }
+
+    #[test]
+    fn verify_gate_key_stable_across_callers() {
+        // Both call sites must produce identical keys for the same card_id.
+        // This test documents the contract rather than testing logic.
+        let card_id = "019e-some-uuid-v7";
+        assert_eq!(verify_gate_key(card_id), format!("legion-verify:{card_id}"));
     }
 }

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -37,12 +37,20 @@ pub enum GateResult {
     Issues,
 }
 
+impl GateResult {
+    /// The serialized column value. Display and the SQL write path both
+    /// delegate here so the wire form has exactly one source.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Clean => "clean",
+            Self::Issues => "issues",
+        }
+    }
+}
+
 impl fmt::Display for GateResult {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::Clean => write!(f, "clean"),
-            Self::Issues => write!(f, "issues"),
-        }
+        f.write_str(self.as_str())
     }
 }
 
@@ -527,13 +535,5 @@ mod tests {
         // handle_verify (write site) and handle_done (read site).
         let key = verify_gate_key("card-abc-123");
         assert_eq!(key, "legion-verify:card-abc-123");
-    }
-
-    #[test]
-    fn verify_gate_key_stable_across_callers() {
-        // Both call sites must produce identical keys for the same card_id.
-        // This test documents the contract rather than testing logic.
-        let card_id = "019e-some-uuid-v7";
-        assert_eq!(verify_gate_key(card_id), format!("legion-verify:{card_id}"));
     }
 }

--- a/tests/integration/kanban.rs
+++ b/tests/integration/kanban.rs
@@ -303,7 +303,7 @@ fn kanban_invalid_transition() {
     let (_stdout, stderr) =
         run_fail(legion_cmd(dir.path()).args(["kanban", "review", "--id", &id]));
     assert!(
-        stderr.contains("InvalidCardTransition"),
+        stderr.contains("invalid card transition"),
         "expected transition error, got: {stderr}"
     );
 }

--- a/tests/integration/memory.rs
+++ b/tests/integration/memory.rs
@@ -422,8 +422,8 @@ fn forget_rejects_wrong_repo_safety_check() {
     let (_stdout, stderr) =
         run_fail(legion_cmd(dir.path()).args(["forget", "--id", &id, "--repo", "rafters"]));
     assert!(
-        stderr.contains("ReflectionRepoMismatch"),
-        "expected safety check error variant, got: {stderr}"
+        stderr.contains("repo safety check failed"),
+        "expected safety check error, got: {stderr}"
     );
     assert!(
         stderr.contains("kelex"),
@@ -539,7 +539,7 @@ fn reflect_no_input_errors() {
     // neither --text nor --transcript is provided.
     let (_stdout, stderr) = run_fail(legion_cmd(dir.path()).args(["reflect", "--repo", "test"]));
     assert!(
-        stderr.contains("NoReflectionInput"),
+        stderr.contains("no reflection text provided"),
         "expected missing input error, got: {stderr}"
     );
 }

--- a/tests/integration/task.rs
+++ b/tests/integration/task.rs
@@ -181,7 +181,7 @@ fn task_invalid_state_transition() {
     let (_stdout, stderr) =
         run_fail(legion_cmd(dir.path()).args(["task", "done", "--id", &task_id]));
     assert!(
-        stderr.contains("InvalidTaskTransition"),
+        stderr.contains("invalid state transition"),
         "expected state transition error, got: {stderr}"
     );
 }


### PR DESCRIPTION
## Summary

Step 3 of #610, the last code stream of refactor epic #607. The 18 `std::process::exit` sites left inside the extracted cli/ handlers become typed errors rendered by `main()` -- with exact exit codes preserved via a `LegionError::ExitWith(code)` variant -- and the quality-gate result plus the verify gate-key stop being stringly-typed: `GateResult { Clean, Issues }` follows the CardStatus/Priority enum pattern end-to-end through the DB layer, and `verify::verify_gate_key()` single-sources the key both the write site and the read site previously formatted independently.

## Acceptance criteria mapping

### 1. require_worksource/open_db helpers in place; Done propagation audited like cancel

Landed earlier in this issue's serial sequence: the in-place DRY PR (#628) added `require_worksource()` (killing the 19-site resolve-or-die paste) and the `open_db`/`open_db_and_index` helpers, and folded `Commands::Done` through `propagate_card_close_to_worksource` restoring audit parity with cancel. This PR builds on those; no regression to them in this diff.
Evidence: #628 merged 2026-06-10 (commit 0edae5b); the helpers are called throughout the cli/ handlers this diff touches.

### 2. cli/ tree: mod.rs dispatch-only, domain files own handlers + action enums + tests

Landed in #631 (the carve, commit 6077b8a). This diff works entirely inside that tree -- the conversions in step 3 touch the domain files (autonomy, index_cmd, kanban, memory, ops, pr, verify) without adding any logic to the dispatch layer beyond the `ExitWith` intercept in `main()`.
Evidence: `git diff main..HEAD --stat` shows changes confined to src/cli/ domain files, src/error.rs, src/verify.rs, src/db/quality_gates.rs, and the main() intercept.

### 3. Zero std::process::exit inside extracted handlers

All 18 sites across seven handler files convert to `return Err(error::LegionError::ExitWith(code))`. The handler prints its message exactly as before (stderr text unchanged), then signals the code through the error channel; `main()` intercepts `ExitWith` and exits with that code without printing -- `ExitWith` has an empty Display, and a test pins that contract so a reordered intercept cannot leak a blank error line. The one non-1 code in the file set (exit 2 for bad `--kind` at index_cmd.rs:173) is preserved as `ExitWith(2)`. Four integration tests that had pinned the OLD behavior -- the Rust runtime printing Debug variant names like `InvalidCardTransition` when main returned Err -- now assert the thiserror Display messages, which is the actual human contract; all 43 plugin hook scripts were checked and none parse the old variant names.
Evidence: `grep -c "process::exit" src/cli/*.rs` is zero outside main's intercept; `exit_with_displays_empty` test in src/error.rs; integration suite 172 passed.

### 4. Gate result + verify gate-key are typed, single-sourced

`GateResult { Clean, Issues }` in src/verify.rs with Display/FromStr/serde lowercase, the CardStatus/Priority pattern. `QualityGateRow.result` is now `GateResult` (was String); `record_quality_gate()` takes the enum; every read comparison (`== "clean"`) is now `== GateResult::Clean`; the SQL column stays lowercase TEXT with `parse_result_from_db()` as the boundary. The wire form has exactly one source: `GateResult::as_str()`, which Display and the SQL write path both delegate to. `verify_gate_key()` replaces the two independent `format!("legion-verify:{card_id}")` sites (cli/verify.rs write, cli/kanban.rs read).
Evidence: gate_result roundtrip/parse tests in src/verify.rs; verify_gate_key_format test; no remaining `"clean"` comparisons outside the parse boundary and clap value parser.

### 5. Parent epic: #607

This is the final code stream of the epic: with #628/#629/#631/#632/#633/#636/#637 merged and this PR, every stream (A-F, H) is landed and only the epic's closing line-count proof remains.
Evidence: issue #610's four-step scope maps to #628 (step 1), #631 (steps 2-3 carve), and this PR (the step 3/4 semantic follow-ups).

## Not done

AuditAction/AuditOutcome enums (the step 4 optional item): not applicable, deliberately. The `legion audit --action` help text documents an open set -- "additional verbs introduced by future subcommands work automatically" -- so a closed enum would contradict the command's own designed extensibility. The audit action field stays a string by design, not by omission.