### PR TITLE
feat(#528): card-spec binding -- document_id, transactional status sync, verify reads spec AC

### DIFF
--- a/src/cli/kanban.rs
+++ b/src/cli/kanban.rs
@@ -238,6 +238,29 @@ pub(crate) enum KanbanAction {
         id: String,
     },
 
+    /// Bind a spec document to a card.
+    ///
+    /// Creates the card<->document link by setting `tasks.document_id`.
+    /// Once bound, `legion verify` reads acceptance criteria from
+    /// the document's `verification.acceptance` block (when present)
+    /// instead of `tasks.acceptance`. Status transitions that map to
+    /// spec statuses (accepted, in-review, done, cancelled) also update
+    /// the document's `meta.status` transactionally.
+    ///
+    /// Errors when:
+    /// - The card is already bound to a document.
+    /// - The document does not exist or is archived.
+    /// - Another live (non-cancelled) card is already bound to the document.
+    Bind {
+        /// Card ID to bind
+        #[arg(long)]
+        id: String,
+
+        /// Document ID to bind to the card
+        #[arg(long)]
+        document: String,
+    },
+
     /// Reconcile kanban cards with their linked GitHub issue state.
     ///
     /// Detects two drift directions:
@@ -750,6 +773,10 @@ pub(crate) fn handle(action: KanbanAction) -> error::Result<()> {
                     }
                 }
             }
+        }
+        KanbanAction::Bind { id, document } => {
+            kanban::bind_document(&database, &id, &document)?;
+            println!("{id}");
         }
         KanbanAction::Assign { id, to } => {
             database.assign_card(&id, &to)?;

--- a/src/cli/verify.rs
+++ b/src/cli/verify.rs
@@ -60,13 +60,59 @@ pub(crate) fn handle_quality_gate(action: QualityGateAction) -> error::Result<()
     Ok(())
 }
 
+/// Resolve acceptance criteria for a card, with spec-document precedence (#528).
+///
+/// Returns `(criteria, source_label)`.
+///
+/// Precedence:
+/// 1. When the card has a `document_id` AND the bound document's payload has a
+///    non-empty `verification.acceptance` array, those strings become the AC.
+///    Source label: `"spec:<document_id>"`.
+/// 2. Otherwise: `tasks.acceptance` split by newline, same as before.
+///    Source label: `"card"`.
+fn resolve_acceptance_criteria(
+    database: &crate::db::Database,
+    card: &kanban::Card,
+) -> error::Result<(Vec<String>, String)> {
+    // When the card has a bound document, try to read verification.acceptance
+    // from the document payload. A JSON parse failure is non-fatal: fall back
+    // to tasks.acceptance so a corrupt payload does not hard-block verify.
+    if let Some(ref doc_id) = card.document_id
+        && let Some(doc) = database.get_document(doc_id)?
+        && let Ok(value) = serde_json::from_str::<serde_json::Value>(&doc.payload)
+        && let Some(arr) = value
+            .get("verification")
+            .and_then(|v| v.get("acceptance"))
+            .and_then(|a| a.as_array())
+    {
+        let criteria: Vec<String> = arr
+            .iter()
+            .filter_map(|v| v.as_str())
+            .map(str::to_owned)
+            .filter(|s| !s.trim().is_empty())
+            .collect();
+        if !criteria.is_empty() {
+            return Ok((criteria, format!("spec:{doc_id}")));
+        }
+    }
+    // Fallback: tasks.acceptance.
+    let criteria = verify::acceptance_items(card.acceptance.as_deref());
+    Ok((criteria, "card".to_string()))
+}
+
 pub(crate) fn handle_verify(card: String, verdicts_file: Option<String>) -> error::Result<()> {
     let database = open_db()?;
 
     let card_row = database
         .get_card_by_id(&card)?
         .ok_or_else(|| error::LegionError::CardNotFound(card.clone()))?;
-    let acceptance = verify::acceptance_items(card_row.acceptance.as_deref());
+
+    // AC source precedence (#528):
+    // 1. When the card has a bound document AND the document's payload has a
+    //    non-empty `verification.acceptance` array, those strings are the
+    //    canonical criteria -- the spec is authoritative.
+    // 2. Otherwise fall back to `tasks.acceptance` exactly as before.
+    let (acceptance, ac_source) = resolve_acceptance_criteria(&database, &card_row)?;
 
     // Read the agent's per-criterion verdicts (file or stdin).
     let raw = read_file_or_stdin(verdicts_file.as_deref(), "--verdicts-file")?;
@@ -114,7 +160,7 @@ pub(crate) fn handle_verify(card: String, verdicts_file: Option<String>) -> erro
     match decision {
         verify::VerifyDecision::Proceed => {
             println!(
-                "[legion] verify PASS for card {card} ({} criteria). ->Done is unblocked.",
+                "[legion] verify PASS for card {card} ({} criteria, source: {ac_source}). ->Done is unblocked.",
                 acceptance.len()
             );
         }
@@ -174,4 +220,152 @@ pub(crate) fn handle_verify(card: String, verdicts_file: Option<String>) -> erro
         }
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::testutil::test_db;
+    use crate::documents::DocumentMeta;
+    use crate::kanban::{Card, CardStatus, Priority};
+
+    fn make_card(doc_id: Option<&str>, acceptance: Option<&str>) -> Card {
+        Card {
+            id: "card-test".to_string(),
+            from_repo: "legion".to_string(),
+            to_repo: "legion".to_string(),
+            text: "test card".to_string(),
+            context: None,
+            priority: Priority::Med,
+            status: CardStatus::Accepted,
+            note: None,
+            labels: None,
+            parent_card_id: None,
+            source_url: None,
+            source_type: None,
+            sort_order: 0,
+            created_at: "2026-06-12T00:00:00Z".to_string(),
+            updated_at: "2026-06-12T00:00:00Z".to_string(),
+            assigned_at: None,
+            started_at: None,
+            completed_at: None,
+            problem: None,
+            solution: None,
+            acceptance: acceptance.map(str::to_string),
+            document_id: doc_id.map(str::to_string),
+        }
+    }
+
+    /// When no document_id, falls back to tasks.acceptance.
+    #[test]
+    fn resolve_ac_falls_back_to_tasks_acceptance_when_no_document() {
+        let db = test_db();
+        let card = make_card(None, Some("criterion one\ncriterion two"));
+        let (criteria, source) = resolve_acceptance_criteria(&db, &card).expect("resolve");
+        assert_eq!(criteria, vec!["criterion one", "criterion two"]);
+        assert_eq!(source, "card");
+    }
+
+    /// When document_id present but document has no verification block,
+    /// falls back to tasks.acceptance.
+    #[test]
+    fn resolve_ac_falls_back_when_doc_has_no_verification_block() {
+        let db = test_db();
+        let meta = DocumentMeta {
+            id: Some("doc-no-ver"),
+            doc_type: "requirement",
+            surface: Some("test"),
+            status: Some("draft"),
+            priority: None,
+            owner: "legion",
+        };
+        let payload = serde_json::json!({
+            "meta": {"id": "doc-no-ver", "type": "requirement", "surface": "test",
+                     "status": "draft", "priority": "SHOULD", "owner": "legion",
+                     "date": "2026-06-12", "author": "test"},
+            "title": "Test",
+            "description": "desc",
+            "traces_to": "x",
+            "depends_on": []
+        })
+        .to_string();
+        db.insert_document(&meta, &payload).expect("insert");
+
+        let card = make_card(Some("doc-no-ver"), Some("fallback criterion"));
+        let (criteria, source) = resolve_acceptance_criteria(&db, &card).expect("resolve");
+        assert_eq!(criteria, vec!["fallback criterion"]);
+        assert_eq!(source, "card");
+    }
+
+    /// When document has a non-empty verification.acceptance array,
+    /// those strings are the criteria.
+    #[test]
+    fn resolve_ac_uses_spec_verification_acceptance_when_present() {
+        let db = test_db();
+        let meta = DocumentMeta {
+            id: Some("doc-with-ver"),
+            doc_type: "requirement",
+            surface: Some("test"),
+            status: Some("draft"),
+            priority: None,
+            owner: "legion",
+        };
+        let payload = serde_json::json!({
+            "meta": {"id": "doc-with-ver", "type": "requirement", "surface": "test",
+                     "status": "draft", "priority": "SHOULD", "owner": "legion",
+                     "date": "2026-06-12", "author": "test"},
+            "title": "Test",
+            "description": "desc",
+            "traces_to": "x",
+            "depends_on": [],
+            "verification": {
+                "acceptance": [
+                    "spec criterion alpha",
+                    "spec criterion beta"
+                ]
+            }
+        })
+        .to_string();
+        db.insert_document(&meta, &payload).expect("insert");
+
+        // tasks.acceptance says something different -- the spec wins.
+        let card = make_card(Some("doc-with-ver"), Some("should be ignored"));
+        let (criteria, source) = resolve_acceptance_criteria(&db, &card).expect("resolve");
+        assert_eq!(
+            criteria,
+            vec!["spec criterion alpha", "spec criterion beta"]
+        );
+        assert_eq!(source, "spec:doc-with-ver");
+    }
+
+    /// When the verification.acceptance array is empty, falls back to tasks.acceptance.
+    #[test]
+    fn resolve_ac_falls_back_when_verification_acceptance_is_empty() {
+        let db = test_db();
+        let meta = DocumentMeta {
+            id: Some("doc-empty-ver"),
+            doc_type: "requirement",
+            surface: Some("test"),
+            status: Some("draft"),
+            priority: None,
+            owner: "legion",
+        };
+        let payload = serde_json::json!({
+            "meta": {"id": "doc-empty-ver", "type": "requirement", "surface": "test",
+                     "status": "draft", "priority": "SHOULD", "owner": "legion",
+                     "date": "2026-06-12", "author": "test"},
+            "title": "Test",
+            "description": "desc",
+            "traces_to": "x",
+            "depends_on": [],
+            "verification": {"acceptance": []}
+        })
+        .to_string();
+        db.insert_document(&meta, &payload).expect("insert");
+
+        let card = make_card(Some("doc-empty-ver"), Some("fallback when spec empty"));
+        let (criteria, source) = resolve_acceptance_criteria(&db, &card).expect("resolve");
+        assert_eq!(criteria, vec!["fallback when spec empty"]);
+        assert_eq!(source, "card");
+    }
 }

--- a/src/cli/verify.rs
+++ b/src/cli/verify.rs
@@ -68,34 +68,53 @@ pub(crate) fn handle_quality_gate(action: QualityGateAction) -> error::Result<()
 /// 1. When the card has a `document_id` AND the bound document's payload has a
 ///    non-empty `verification.acceptance` array, those strings become the AC.
 ///    Source label: `"spec:<document_id>"`.
-/// 2. Otherwise: `tasks.acceptance` split by newline, same as before.
-///    Source label: `"card"`.
+/// 2. When the card has a `document_id` but the document cannot be found, this
+///    is a hard error -- a bound card whose spec has vanished must not silently
+///    fall back; verify must not paper over a dangling reference. This matches
+///    the behavior of `transition_card_status_with_sync`, which also hard-errors
+///    on a missing bound document.
+/// 3. When the bound document exists but has no `verification` block, or the
+///    `verification.acceptance` array is empty, or the payload cannot be parsed
+///    (corrupt doc), falls back to `tasks.acceptance` with source `"card"`.
+/// 4. When the card has no `document_id`: `tasks.acceptance`. Source `"card"`.
 fn resolve_acceptance_criteria(
     database: &crate::db::Database,
     card: &kanban::Card,
 ) -> error::Result<(Vec<String>, String)> {
-    // When the card has a bound document, try to read verification.acceptance
-    // from the document payload. A JSON parse failure is non-fatal: fall back
-    // to tasks.acceptance so a corrupt payload does not hard-block verify.
-    if let Some(ref doc_id) = card.document_id
-        && let Some(doc) = database.get_document(doc_id)?
-        && let Ok(value) = serde_json::from_str::<serde_json::Value>(&doc.payload)
-        && let Some(arr) = value
-            .get("verification")
-            .and_then(|v| v.get("acceptance"))
-            .and_then(|a| a.as_array())
-    {
-        let criteria: Vec<String> = arr
-            .iter()
-            .filter_map(|v| v.as_str())
-            .map(str::to_owned)
-            .filter(|s| !s.trim().is_empty())
-            .collect();
-        if !criteria.is_empty() {
-            return Ok((criteria, format!("spec:{doc_id}")));
+    if let Some(ref doc_id) = card.document_id {
+        // The document must exist. A dangling document_id is a hard error: the
+        // spec that was authoritative has been deleted while work was in flight.
+        let doc = database.get_document(doc_id)?.ok_or_else(|| {
+            error::LegionError::WorkSource(format!(
+                "card '{}' has document_id '{doc_id}' but the document does not exist; \
+                 verify cannot proceed with a dangling spec reference",
+                card.id
+            ))
+        })?;
+
+        // Parse the payload and look for verification.acceptance. A corrupt
+        // payload or a missing verification block is non-fatal: fall back to
+        // tasks.acceptance so a structural gap in the spec does not hard-block
+        // verify (the intent is that the human fills in the spec).
+        if let Ok(value) = serde_json::from_str::<serde_json::Value>(&doc.payload)
+            && let Some(arr) = value
+                .get("verification")
+                .and_then(|v| v.get("acceptance"))
+                .and_then(|a| a.as_array())
+        {
+            let criteria: Vec<String> = arr
+                .iter()
+                .filter_map(|v| v.as_str())
+                .map(str::to_owned)
+                .filter(|s| !s.trim().is_empty())
+                .collect();
+            if !criteria.is_empty() {
+                return Ok((criteria, format!("spec:{doc_id}")));
+            }
         }
+        // Document exists but has no usable verification.acceptance: fall back.
     }
-    // Fallback: tasks.acceptance.
+    // No document_id, or document exists without usable verification.acceptance.
     let criteria = verify::acceptance_items(card.acceptance.as_deref());
     Ok((criteria, "card".to_string()))
 }
@@ -367,5 +386,22 @@ mod tests {
         let (criteria, source) = resolve_acceptance_criteria(&db, &card).expect("resolve");
         assert_eq!(criteria, vec!["fallback when spec empty"]);
         assert_eq!(source, "card");
+    }
+
+    /// When the card has a document_id that refers to a non-existent document,
+    /// resolve_acceptance_criteria must hard-error. A dangling reference means
+    /// the spec was deleted while work was in flight; verify must not silently
+    /// fall back to tasks.acceptance in that state.
+    #[test]
+    fn resolve_ac_hard_errors_on_dangling_document_id() {
+        let db = test_db();
+        // Card points at a document that was never inserted.
+        let card = make_card(Some("nonexistent-doc-id"), Some("card fallback criterion"));
+        let err = resolve_acceptance_criteria(&db, &card)
+            .expect_err("expected hard error on dangling document_id");
+        assert!(
+            err.to_string().contains("nonexistent-doc-id"),
+            "error must name the missing document id, got: {err}"
+        );
     }
 }

--- a/src/db/kanban.rs
+++ b/src/db/kanban.rs
@@ -509,18 +509,28 @@ impl Database {
         }
     }
 
-    /// Map a kanban card status to its requirement `meta.status` equivalent
+    /// Map a typed `CardStatus` to its requirement `meta.status` equivalent
     /// for the v2 requirement schema status enum (#528).
     ///
     /// Returns `None` for statuses that carry no spec meaning (the spec stays
     /// where it is). Returns `Some(status_str)` for the four mapped states.
-    pub(crate) fn requirement_status_for_card_status(card_status: &str) -> Option<&'static str> {
+    /// The match is exhaustive with no catch-all so a new `CardStatus` variant
+    /// forces a compile-time decision here.
+    pub(crate) fn requirement_status_for_card_status(
+        card_status: crate::kanban::CardStatus,
+    ) -> Option<&'static str> {
+        use crate::kanban::CardStatus;
         match card_status {
-            "accepted" => Some("accepted"),
-            "in-review" => Some("implemented"),
-            "done" => Some("verified"),
-            "cancelled" => Some("cancelled"),
-            _ => None,
+            // Mapped: these transitions carry spec meaning.
+            CardStatus::Accepted => Some("accepted"),
+            CardStatus::InReview => Some("implemented"),
+            CardStatus::Done => Some("verified"),
+            CardStatus::Cancelled => Some("cancelled"),
+            // Unmapped: spec stays where it is.
+            CardStatus::Backlog => None,
+            CardStatus::Pending => None,
+            CardStatus::NeedsInput => None,
+            CardStatus::Blocked => None,
         }
     }
 
@@ -574,8 +584,13 @@ impl Database {
         }
 
         // -- sync the bound document if the new status maps to a spec status --
+        // Parse `status` into the typed enum so requirement_status_for_card_status
+        // gets an exhaustive-match guarantee. An unrecognised status string is
+        // treated as no-sync (same outcome as a None return from the mapping).
+        let card_status_typed = std::str::FromStr::from_str(status).ok();
         if let Some(doc_id) = document_id
-            && let Some(spec_status) = Self::requirement_status_for_card_status(status)
+            && let Some(typed) = card_status_typed
+            && let Some(spec_status) = Self::requirement_status_for_card_status(typed)
         {
             // Fetch and mutate the payload inside the transaction.
             // Borrowing `tx` as a read source is fine because rusqlite
@@ -713,17 +728,45 @@ impl Database {
         Ok(rows > 0)
     }
 
-    /// Look up a card by its bound document_id.
+    /// Return the id of the live (non-cancelled, non-deleted) card bound to
+    /// `document_id`, or `None` when no such card exists.
     ///
-    /// Returns the first live (non-deleted) card whose `document_id` matches.
-    /// `document_id` has application-layer uniqueness, so at most one card
-    /// should ever match; the query uses LIMIT 1 as a safety net.
+    /// "Live" matches the bind guard's definition: `status != 'cancelled'` AND
+    /// `deleted_at IS NULL`. Both `archive_document` and `bind_card_to_document`
+    /// call this to enforce uniqueness.
+    pub fn live_card_bound_to_document(&self, document_id: &str) -> Result<Option<String>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT id FROM tasks WHERE document_id = ?1 \
+             AND deleted_at IS NULL \
+             AND status != 'cancelled' \
+             LIMIT 1",
+        )?;
+        let mut rows = stmt.query([document_id])?;
+        match rows.next()? {
+            Some(row) => Ok(Some(row.get(0)?)),
+            None => Ok(None),
+        }
+    }
+
+    /// Look up the live (non-cancelled, non-deleted) card whose `document_id`
+    /// matches.
+    ///
+    /// Invariant: at most one live card is bound to a given document at any
+    /// time (enforced by `bind_card_to_document`). The query adds
+    /// `status != 'cancelled'` so a cancelled card that retains its
+    /// `document_id` is never returned in place of a live successor.
+    ///
+    /// No production code path reaches this today; it is retained for the
+    /// reverse-lookup AC from #512 and exercised by the binding tests (#528).
+    #[allow(dead_code)]
     pub fn get_card_by_document_id(
         &self,
         document_id: &str,
     ) -> Result<Option<crate::kanban::Card>> {
         let sql = format!(
-            "SELECT {} FROM tasks WHERE document_id = ?1 AND deleted_at IS NULL LIMIT 1",
+            "SELECT {} FROM tasks \
+             WHERE document_id = ?1 AND deleted_at IS NULL AND status != 'cancelled' \
+             LIMIT 1",
             Self::CARD_COLUMNS
         );
         let mut stmt = self.conn.prepare(&sql)?;
@@ -754,16 +797,7 @@ impl Database {
         }
 
         // Guard 2: no other live card is bound to this document_id.
-        // "Live" means not cancelled and not deleted.
-        let mut check_stmt = self.conn.prepare(
-            "SELECT id FROM tasks WHERE document_id = ?1 \
-             AND deleted_at IS NULL \
-             AND status != 'cancelled' \
-             LIMIT 1",
-        )?;
-        let mut rows = check_stmt.query([document_id])?;
-        if let Some(row) = rows.next()? {
-            let existing_id: String = row.get(0)?;
+        if let Some(existing_id) = self.live_card_bound_to_document(document_id)? {
             return Err(LegionError::WorkSource(format!(
                 "document '{document_id}' is already bound to live card '{existing_id}'"
             )));
@@ -1130,30 +1164,62 @@ mod tests {
         assert_eq!(card2.document_id.as_deref(), Some(doc_id.as_str()));
     }
 
+    /// get_card_by_document_id returns the LIVE card when both a cancelled and
+    /// a live card share the same document_id. The cancelled card must not
+    /// shadow the live one.
+    #[test]
+    fn get_card_by_document_id_returns_live_card_not_cancelled() {
+        let db = test_db();
+        let card_id1 = insert_test_card(&db);
+        let card_id2 = insert_test_card(&db);
+        let doc_id = insert_test_document(&db);
+
+        // Bind to card1, cancel it, then bind card2 to the same doc.
+        db.bind_card_to_document(&card_id1, &doc_id)
+            .expect("bind card1");
+        db.force_move_card(&card_id1, "cancelled", None)
+            .expect("cancel card1");
+        db.bind_card_to_document(&card_id2, &doc_id)
+            .expect("bind card2");
+
+        // Reverse lookup must return card2 (live), not card1 (cancelled).
+        let found = db
+            .get_card_by_document_id(&doc_id)
+            .expect("lookup")
+            .expect("some card found");
+        assert_eq!(
+            found.id, card_id2,
+            "get_card_by_document_id must return the live card, not the cancelled one"
+        );
+    }
+
     /// requirement_status_for_card_status maps the four expected statuses.
+    /// Uses typed CardStatus so adding a new variant forces a compile-time
+    /// decision in the match (no catch-all).
     #[test]
     fn requirement_status_mapping_covers_all_mapped_statuses() {
+        use crate::kanban::CardStatus;
         assert_eq!(
-            Database::requirement_status_for_card_status("accepted"),
+            Database::requirement_status_for_card_status(CardStatus::Accepted),
             Some("accepted")
         );
         assert_eq!(
-            Database::requirement_status_for_card_status("in-review"),
+            Database::requirement_status_for_card_status(CardStatus::InReview),
             Some("implemented")
         );
         assert_eq!(
-            Database::requirement_status_for_card_status("done"),
+            Database::requirement_status_for_card_status(CardStatus::Done),
             Some("verified")
         );
         assert_eq!(
-            Database::requirement_status_for_card_status("cancelled"),
+            Database::requirement_status_for_card_status(CardStatus::Cancelled),
             Some("cancelled")
         );
         // Statuses that carry no spec meaning return None.
-        assert!(Database::requirement_status_for_card_status("backlog").is_none());
-        assert!(Database::requirement_status_for_card_status("pending").is_none());
-        assert!(Database::requirement_status_for_card_status("needs-input").is_none());
-        assert!(Database::requirement_status_for_card_status("blocked").is_none());
+        assert!(Database::requirement_status_for_card_status(CardStatus::Backlog).is_none());
+        assert!(Database::requirement_status_for_card_status(CardStatus::Pending).is_none());
+        assert!(Database::requirement_status_for_card_status(CardStatus::NeedsInput).is_none());
+        assert!(Database::requirement_status_for_card_status(CardStatus::Blocked).is_none());
     }
 
     /// Transactional sync: transitioning a bound card to "done" updates BOTH

--- a/src/db/kanban.rs
+++ b/src/db/kanban.rs
@@ -463,11 +463,14 @@ impl Database {
     /// Atomically pick the next pending card for a repo and accept it.
     ///
     /// Selects highest priority, then lowest sort_order, then oldest.
-    /// Transitions to Accepted and sets started_at. Returns None if empty.
+    /// Transitions to Accepted and sets started_at. Returns None if empty
+    /// or if the card was raced away (another picker accepted it first).
     ///
-    /// Routes through `transition_card_status_with_sync` so a bound document's
-    /// `meta.status` and hoisted `status` column are kept in sync (#528). The
-    /// prior direct UPDATE bypassed the sync path and left specs stale.
+    /// The `expected_from_status = Some("pending")` argument to
+    /// `transition_card_status_with_sync` ensures only one concurrent picker
+    /// wins: the UPDATE's `AND status = 'pending'` predicate makes it
+    /// conditional, so the second caller gets `rows_affected == 0` -> `CardNotFound`
+    /// -> `Ok(None)` here, matching the original direct-UPDATE semantics.
     pub fn pick_next_card(&self, repo: &str) -> Result<Option<crate::kanban::Card>> {
         let sql = format!(
             "SELECT {} FROM tasks WHERE to_repo = ?1 AND status = 'pending' AND deleted_at IS NULL \
@@ -484,16 +487,17 @@ impl Database {
         drop(rows);
         drop(stmt);
 
-        // Use the shared sync path: updates tasks + syncs bound document in one
-        // transaction. The optimistic WHERE status='pending' guard is preserved
-        // inside transition_card_status_with_sync via rows_affected == 0 ->
-        // CardNotFound, which callers can treat as a lost race (return None).
+        // Pass expected_from_status = Some("pending") so the UPDATE is
+        // conditional on the card still being pending at write time.
+        // CardNotFound covers both "card deleted" and "status already changed"
+        // (lost race) -- both map to Ok(None).
         match self.transition_card_status_with_sync(
             &card.id,
             &crate::kanban::CardStatus::Accepted.to_string(),
             None,
             CardTimestamp::Started,
             card.document_id.as_deref(),
+            Some("pending"),
         ) {
             Ok(()) => {}
             Err(LegionError::CardNotFound(_)) => return Ok(None),
@@ -554,6 +558,14 @@ impl Database {
     ///
     /// When `document_id` is `None` this behaves identically to the old
     /// `update_card_status` path but inside an `unchecked_transaction`.
+    ///
+    /// `expected_from_status`: when `Some(s)`, the UPDATE predicate includes
+    /// `AND status = s` so the write is conditional on the card still being in
+    /// that exact status at write time. A mismatch (rows_affected == 0) maps
+    /// to `CardNotFound`, letting callers treat a lost race as "no card to
+    /// update" without a separate read-modify-write. `pick_next_card` passes
+    /// `Some("pending")` to restore the atomicity guarantee the prior direct
+    /// UPDATE had. All other callers pass `None`.
     pub fn transition_card_status_with_sync(
         &self,
         id: &str,
@@ -561,32 +573,59 @@ impl Database {
         note: Option<&str>,
         timestamp: CardTimestamp,
         document_id: Option<&str>,
+        expected_from_status: Option<&str>,
     ) -> Result<()> {
         let now = chrono::Utc::now().to_rfc3339();
 
         let tx = self.conn.unchecked_transaction()?;
 
         // -- update the card row --
-        let rows_affected = match timestamp {
-            CardTimestamp::Assigned => tx.execute(
+        // When expected_from_status is Some, the WHERE clause includes
+        // `AND status = ?` so the update is conditional on the card still
+        // being in the expected status at commit time.
+        let rows_affected = match (timestamp, expected_from_status) {
+            (CardTimestamp::Assigned, None) => tx.execute(
                 "UPDATE tasks SET status = ?1, note = COALESCE(?2, note), \
                  assigned_at = ?3, updated_at = ?4 WHERE id = ?5 AND deleted_at IS NULL",
                 rusqlite::params![status, note, now, now, id],
             )?,
-            CardTimestamp::Started => tx.execute(
+            (CardTimestamp::Assigned, Some(from)) => tx.execute(
+                "UPDATE tasks SET status = ?1, note = COALESCE(?2, note), \
+                 assigned_at = ?3, updated_at = ?4 \
+                 WHERE id = ?5 AND status = ?6 AND deleted_at IS NULL",
+                rusqlite::params![status, note, now, now, id, from],
+            )?,
+            (CardTimestamp::Started, None) => tx.execute(
                 "UPDATE tasks SET status = ?1, note = COALESCE(?2, note), \
                  started_at = ?3, updated_at = ?4 WHERE id = ?5 AND deleted_at IS NULL",
                 rusqlite::params![status, note, now, now, id],
             )?,
-            CardTimestamp::Completed => tx.execute(
+            (CardTimestamp::Started, Some(from)) => tx.execute(
+                "UPDATE tasks SET status = ?1, note = COALESCE(?2, note), \
+                 started_at = ?3, updated_at = ?4 \
+                 WHERE id = ?5 AND status = ?6 AND deleted_at IS NULL",
+                rusqlite::params![status, note, now, now, id, from],
+            )?,
+            (CardTimestamp::Completed, None) => tx.execute(
                 "UPDATE tasks SET status = ?1, note = COALESCE(?2, note), \
                  completed_at = ?3, updated_at = ?4 WHERE id = ?5 AND deleted_at IS NULL",
                 rusqlite::params![status, note, now, now, id],
             )?,
-            CardTimestamp::None => tx.execute(
+            (CardTimestamp::Completed, Some(from)) => tx.execute(
+                "UPDATE tasks SET status = ?1, note = COALESCE(?2, note), \
+                 completed_at = ?3, updated_at = ?4 \
+                 WHERE id = ?5 AND status = ?6 AND deleted_at IS NULL",
+                rusqlite::params![status, note, now, now, id, from],
+            )?,
+            (CardTimestamp::None, None) => tx.execute(
                 "UPDATE tasks SET status = ?1, note = COALESCE(?2, note), \
                  updated_at = ?3 WHERE id = ?4 AND deleted_at IS NULL",
                 rusqlite::params![status, note, now, id],
+            )?,
+            (CardTimestamp::None, Some(from)) => tx.execute(
+                "UPDATE tasks SET status = ?1, note = COALESCE(?2, note), \
+                 updated_at = ?3 WHERE id = ?4 AND status = ?5 AND deleted_at IS NULL",
+                rusqlite::params![status, note, now, id, from],
             )?,
         };
         if rows_affected == 0 {
@@ -741,9 +780,12 @@ impl Database {
     /// Return the id of the live (non-cancelled, non-deleted) card bound to
     /// `document_id`, or `None` when no such card exists.
     ///
-    /// "Live" matches the bind guard's definition: `status != 'cancelled'` AND
-    /// `deleted_at IS NULL`. Both `archive_document` and `bind_card_to_document`
-    /// call this to enforce uniqueness.
+    /// "Live" means `status != 'cancelled'` AND `deleted_at IS NULL`.
+    ///
+    /// `archive_document` calls this to enforce the guard. `bind_card_to_document`
+    /// uses equivalent inline SQL inside its own transaction (it cannot call this
+    /// method because `&self` and `&Transaction` are incompatible receivers);
+    /// if the live definition changes, both sites must be kept in sync.
     pub fn live_card_bound_to_document(&self, document_id: &str) -> Result<Option<String>> {
         let mut stmt = self.conn.prepare(
             "SELECT id FROM tasks WHERE document_id = ?1 \
@@ -1294,6 +1336,7 @@ mod tests {
             None,
             CardTimestamp::Completed,
             Some(&doc_id),
+            None,
         )
         .expect("transition");
 
@@ -1338,6 +1381,7 @@ mod tests {
             None,
             CardTimestamp::Completed,
             Some(&doc_id),
+            None,
         )
         .expect("cancel transition");
 
@@ -1403,6 +1447,7 @@ mod tests {
                 None,
                 CardTimestamp::Completed,
                 Some(&doc_id),
+                None,
             )
             .unwrap_err();
         assert!(
@@ -1444,6 +1489,7 @@ mod tests {
             None,
             CardTimestamp::None,
             Some(&doc_id),
+            None,
         )
         .expect("transition to blocked");
 
@@ -1490,6 +1536,51 @@ mod tests {
             payload["meta"]["status"].as_str(),
             Some("accepted"),
             "spec payload meta.status must be updated by pick_next_card"
+        );
+    }
+
+    /// Concurrent-pick loser returns Ok(None). Simulated by calling
+    /// transition_card_status_with_sync directly with expected_from_status =
+    /// Some("pending") after the card is already accepted -- the AND status =
+    /// 'pending' predicate finds no matching row (rows_affected == 0 ->
+    /// CardNotFound), and pick_next_card maps that to Ok(None).
+    ///
+    /// This pins the guard that pick_next_card relies on: two concurrent callers
+    /// race to transition the same card; exactly one wins, the other gets None.
+    #[test]
+    fn pick_next_card_race_loser_returns_none() {
+        let db = test_db();
+        let card_id = insert_test_card(&db);
+
+        // Move the card to pending so the first pick succeeds.
+        db.force_move_card(&card_id, "pending", None)
+            .expect("move to pending");
+
+        // First pick: succeeds and transitions the card to accepted.
+        let first = db.pick_next_card("legion").expect("first pick");
+        assert!(first.is_some(), "first pick must succeed");
+        assert_eq!(
+            first.unwrap().status,
+            crate::kanban::CardStatus::Accepted,
+            "first pick must set status to accepted"
+        );
+
+        // Simulate the second picker: it read the card when it was still pending,
+        // but by the time it writes, the card is accepted. Call the inner path
+        // directly with expected_from_status = Some("pending") -- the predicate
+        // now fails because status = 'accepted', so rows_affected == 0 ->
+        // CardNotFound, which pick_next_card maps to Ok(None).
+        let race_result = db.transition_card_status_with_sync(
+            &card_id,
+            &crate::kanban::CardStatus::Accepted.to_string(),
+            None,
+            CardTimestamp::Started,
+            None,
+            Some("pending"), // stale expectation: card is already accepted
+        );
+        assert!(
+            matches!(race_result, Err(LegionError::CardNotFound(_))),
+            "stale expected_from_status must yield CardNotFound, got: {race_result:?}"
         );
     }
 }

--- a/src/db/kanban.rs
+++ b/src/db/kanban.rs
@@ -96,6 +96,14 @@ pub(super) fn migrate(conn: &Connection) -> Result<()> {
         conn.execute_batch("ALTER TABLE tasks ADD COLUMN deleted_at TEXT;")?;
     }
 
+    // Migration 15: Partial indexes for soft-deleted rows (#256).
+    conn.execute_batch(
+        "CREATE INDEX IF NOT EXISTS idx_tasks_to_live \
+                 ON tasks(to_repo, status) WHERE deleted_at IS NULL;
+             CREATE INDEX IF NOT EXISTS idx_tasks_from_live \
+                 ON tasks(from_repo) WHERE deleted_at IS NULL;",
+    )?;
+
     // Migration 16: card<->document binding (#528).
     // TEXT NULL; application-layer uniqueness enforced in bind_card_to_document.
     // No REFERENCES clause -- PRAGMA foreign_keys is not enabled globally.
@@ -106,14 +114,6 @@ pub(super) fn migrate(conn: &Connection) -> Result<()> {
              ON tasks(document_id) WHERE document_id IS NOT NULL;",
         )?;
     }
-
-    // Migration 15: Partial indexes for soft-deleted rows (#256).
-    conn.execute_batch(
-        "CREATE INDEX IF NOT EXISTS idx_tasks_to_live \
-                 ON tasks(to_repo, status) WHERE deleted_at IS NULL;
-             CREATE INDEX IF NOT EXISTS idx_tasks_from_live \
-                 ON tasks(from_repo) WHERE deleted_at IS NULL;",
-    )?;
     Ok(())
 }
 
@@ -463,7 +463,11 @@ impl Database {
     /// Atomically pick the next pending card for a repo and accept it.
     ///
     /// Selects highest priority, then lowest sort_order, then oldest.
-    /// Transitions to accepted and sets started_at. Returns None if empty.
+    /// Transitions to Accepted and sets started_at. Returns None if empty.
+    ///
+    /// Routes through `transition_card_status_with_sync` so a bound document's
+    /// `meta.status` and hoisted `status` column are kept in sync (#528). The
+    /// prior direct UPDATE bypassed the sync path and left specs stale.
     pub fn pick_next_card(&self, repo: &str) -> Result<Option<crate::kanban::Card>> {
         let sql = format!(
             "SELECT {} FROM tasks WHERE to_repo = ?1 AND status = 'pending' AND deleted_at IS NULL \
@@ -480,14 +484,20 @@ impl Database {
         drop(rows);
         drop(stmt);
 
-        let now = chrono::Utc::now().to_rfc3339();
-        let rows_affected = self.conn.execute(
-            "UPDATE tasks SET status = 'accepted', started_at = ?1, updated_at = ?2 \
-             WHERE id = ?3 AND status = 'pending' AND deleted_at IS NULL",
-            rusqlite::params![now, now, card.id],
-        )?;
-        if rows_affected == 0 {
-            return Ok(None);
+        // Use the shared sync path: updates tasks + syncs bound document in one
+        // transaction. The optimistic WHERE status='pending' guard is preserved
+        // inside transition_card_status_with_sync via rows_affected == 0 ->
+        // CardNotFound, which callers can treat as a lost race (return None).
+        match self.transition_card_status_with_sync(
+            &card.id,
+            &crate::kanban::CardStatus::Accepted.to_string(),
+            None,
+            CardTimestamp::Started,
+            card.document_id.as_deref(),
+        ) {
+            Ok(()) => {}
+            Err(LegionError::CardNotFound(_)) => return Ok(None),
+            Err(e) => return Err(e),
         }
 
         self.get_card_by_id(&card.id)
@@ -779,16 +789,32 @@ impl Database {
 
     /// Bind a document to a card by setting `tasks.document_id`.
     ///
+    /// All guards and the UPDATE run inside a single `unchecked_transaction`
+    /// to prevent TOCTOU races: without the transaction two concurrent callers
+    /// could both pass the live-card uniqueness check and then both write,
+    /// leaving two live cards bound to the same document.
+    ///
     /// Errors if:
     /// - The card does not exist or is deleted.
     /// - The card already has a `document_id` (already bound).
     /// - Another live (non-cancelled, non-deleted) card is already bound
     ///   to `document_id` (uniqueness guard).
     pub fn bind_card_to_document(&self, card_id: &str, document_id: &str) -> Result<()> {
+        let tx = self.conn.unchecked_transaction()?;
+
         // Guard 1: card must exist and not already be bound.
-        let card = self
-            .get_card_by_id(card_id)?
-            .ok_or_else(|| LegionError::CardNotFound(card_id.to_string()))?;
+        let card = {
+            let sql = format!(
+                "SELECT {} FROM tasks WHERE id = ?1 AND deleted_at IS NULL LIMIT 1",
+                Self::CARD_COLUMNS
+            );
+            let mut stmt = tx.prepare(&sql)?;
+            let mut rows = stmt.query_map([card_id], crate::kanban::map_card_row)?;
+            match rows.next() {
+                Some(row) => row.map_err(LegionError::Database)?,
+                None => return Err(LegionError::CardNotFound(card_id.to_string())),
+            }
+        };
         if card.document_id.is_some() {
             return Err(LegionError::WorkSource(format!(
                 "card '{card_id}' is already bound to document '{}'",
@@ -796,15 +822,25 @@ impl Database {
             )));
         }
 
-        // Guard 2: no other live card is bound to this document_id.
-        if let Some(existing_id) = self.live_card_bound_to_document(document_id)? {
-            return Err(LegionError::WorkSource(format!(
-                "document '{document_id}' is already bound to live card '{existing_id}'"
-            )));
+        // Guard 2: no other live card is bound to this document_id (inside tx).
+        {
+            let mut stmt = tx.prepare(
+                "SELECT id FROM tasks WHERE document_id = ?1 \
+                 AND deleted_at IS NULL \
+                 AND status != 'cancelled' \
+                 LIMIT 1",
+            )?;
+            let mut rows = stmt.query([document_id])?;
+            if let Some(row) = rows.next()? {
+                let existing_id: String = row.get(0)?;
+                return Err(LegionError::WorkSource(format!(
+                    "document '{document_id}' is already bound to live card '{existing_id}'"
+                )));
+            }
         }
 
         let now = chrono::Utc::now().to_rfc3339();
-        let affected = self.conn.execute(
+        let affected = tx.execute(
             "UPDATE tasks SET document_id = ?1, updated_at = ?2 \
              WHERE id = ?3 AND deleted_at IS NULL",
             rusqlite::params![document_id, now, card_id],
@@ -812,6 +848,8 @@ impl Database {
         if affected == 0 {
             return Err(LegionError::CardNotFound(card_id.to_string()));
         }
+
+        tx.commit()?;
         Ok(())
     }
 
@@ -1050,21 +1088,35 @@ mod tests {
             .id
     }
 
-    /// Migration adds document_id column idempotently: opening the same DB
-    /// file twice must not fail (the ALTER-if-missing guard handles this).
+    /// Migration 16 is idempotent: opening the same file-backed database a
+    /// second time must not fail even though the `document_id` column already
+    /// exists. Uses a real file path (not in-memory) to prove the ALTER-if-
+    /// missing guard fires correctly on re-open. The `TempDir` is kept alive
+    /// for the duration of the test by binding it to a local variable.
     #[test]
-    fn migration_adds_document_id_column_idempotently() {
-        let db = test_db();
-        // A second open over the same in-memory path would be a new DB;
-        // we verify idempotency by checking the column exists after the
-        // first open and confirming a card can be inserted and read back
-        // without errors -- if the column were missing this would panic.
-        let id = insert_test_card(&db);
-        let card = db.get_card_by_id(&id).expect("get").expect("exists");
+    fn migration_document_id_column_is_idempotent_on_reopen() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("test_idempotent.db");
+
+        // First open: creates the schema including the document_id column.
+        let db1 = Database::open(&db_path).expect("first open");
+        let id = insert_test_card(&db1);
+        let card = db1.get_card_by_id(&id).expect("get").expect("exists");
         assert!(
             card.document_id.is_none(),
             "new card has no document_id by default"
         );
+        drop(db1);
+
+        // Second open over the same path: migration 16's has_column guard must
+        // prevent a duplicate ALTER TABLE from failing.
+        let db2 = Database::open(&db_path).expect("second open must not fail");
+        let card2 = db2.get_card_by_id(&id).expect("get").expect("exists");
+        assert!(
+            card2.document_id.is_none(),
+            "card from first open readable after second open"
+        );
+        // dir is dropped here, cleaning up the temp files.
     }
 
     /// Bind happy path: bind_card_to_document sets document_id on the card.
@@ -1358,9 +1410,20 @@ mod tests {
             "expected unparseable payload error, got: {err}"
         );
 
-        // Card must NOT have changed status.
+        // Card must NOT have changed status (transaction rolled back).
         let card = db.get_card_by_id(&card_id).expect("get").expect("exists");
-        assert_eq!(card.status.to_string(), "accepted");
+        assert_eq!(
+            card.status.to_string(),
+            "accepted",
+            "card status must not change"
+        );
+
+        // Document status must also be unchanged (both sides of the tx rolled back).
+        let doc = db.get_document(&doc_id).expect("get doc").expect("exists");
+        assert_eq!(
+            doc.status, "draft",
+            "document status must remain 'draft' when transition fails"
+        );
     }
 
     /// Status sync does NOT fire for statuses with no spec mapping (e.g. "blocked").
@@ -1388,6 +1451,45 @@ mod tests {
         assert_eq!(
             doc.status, "draft",
             "document status must be unchanged for unmapped card status"
+        );
+    }
+
+    /// pick_next_card on a bound card must update BOTH tasks.status and the
+    /// spec document's status column + payload meta.status. Previously the
+    /// direct UPDATE in pick_next_card bypassed transition_card_status_with_sync
+    /// entirely, leaving the document stale (#528 HIGH finding).
+    #[test]
+    fn pick_next_card_syncs_bound_document_status() {
+        let db = test_db();
+        let card_id = insert_test_card(&db);
+        let doc_id = insert_test_document(&db);
+
+        // Bind the spec and move the card to pending (pick_next_card selects pending).
+        db.bind_card_to_document(&card_id, &doc_id).expect("bind");
+        db.force_move_card(&card_id, "pending", None)
+            .expect("move to pending");
+
+        // pick_next_card accepts the card -- must also update the spec to "accepted".
+        let picked = db
+            .pick_next_card("legion")
+            .expect("pick")
+            .expect("card returned");
+        assert_eq!(picked.id, card_id);
+        assert_eq!(picked.status, crate::kanban::CardStatus::Accepted);
+
+        // Spec document status column must be "accepted".
+        let doc = db.get_document(&doc_id).expect("get doc").expect("exists");
+        assert_eq!(
+            doc.status, "accepted",
+            "spec document status column must be updated by pick_next_card"
+        );
+
+        // Spec payload meta.status must also be "accepted".
+        let payload: serde_json::Value = serde_json::from_str(&doc.payload).expect("parse payload");
+        assert_eq!(
+            payload["meta"]["status"].as_str(),
+            Some("accepted"),
+            "spec payload meta.status must be updated by pick_next_card"
         );
     }
 }

--- a/src/db/kanban.rs
+++ b/src/db/kanban.rs
@@ -96,6 +96,17 @@ pub(super) fn migrate(conn: &Connection) -> Result<()> {
         conn.execute_batch("ALTER TABLE tasks ADD COLUMN deleted_at TEXT;")?;
     }
 
+    // Migration 16: card<->document binding (#528).
+    // TEXT NULL; application-layer uniqueness enforced in bind_card_to_document.
+    // No REFERENCES clause -- PRAGMA foreign_keys is not enabled globally.
+    if !Database::has_column(conn, "tasks", "document_id")? {
+        conn.execute_batch("ALTER TABLE tasks ADD COLUMN document_id TEXT;")?;
+        conn.execute_batch(
+            "CREATE INDEX IF NOT EXISTS idx_tasks_document_id \
+             ON tasks(document_id) WHERE document_id IS NOT NULL;",
+        )?;
+    }
+
     // Migration 15: Partial indexes for soft-deleted rows (#256).
     conn.execute_batch(
         "CREATE INDEX IF NOT EXISTS idx_tasks_to_live \
@@ -271,10 +282,20 @@ impl Database {
     // --- Card CRUD (kanban) ---
 
     /// The full column list for card queries.
+    ///
+    /// Column index reference (0-based, matches `map_card_row`):
+    ///  0  id              8  labels          16 started_at
+    ///  1  from_repo       9  parent_card_id  17 completed_at
+    ///  2  to_repo        10  source_url       18 problem
+    ///  3  text           11  source_type      19 solution
+    ///  4  context        12  sort_order       20 acceptance
+    ///  5  priority       13  created_at       21 document_id
+    ///  6  status         14  updated_at
+    ///  7  note           15  assigned_at
     const CARD_COLUMNS: &'static str = "id, from_repo, to_repo, text, context, priority, status, note, \
          labels, parent_card_id, source_url, source_type, sort_order, \
          created_at, updated_at, assigned_at, started_at, completed_at, \
-         problem, solution, acceptance";
+         problem, solution, acceptance, document_id";
 
     /// SQL fragment for consistent priority ordering across all card queries.
     const PRIORITY_ORDER: &'static str = "CASE priority WHEN 'critical' THEN 0 WHEN 'high' THEN 1 \
@@ -488,41 +509,122 @@ impl Database {
         }
     }
 
-    /// Update a card's status with timestamp tracking.
-    pub fn update_card_status(
+    /// Map a kanban card status to its requirement `meta.status` equivalent
+    /// for the v2 requirement schema status enum (#528).
+    ///
+    /// Returns `None` for statuses that carry no spec meaning (the spec stays
+    /// where it is). Returns `Some(status_str)` for the four mapped states.
+    pub(crate) fn requirement_status_for_card_status(card_status: &str) -> Option<&'static str> {
+        match card_status {
+            "accepted" => Some("accepted"),
+            "in-review" => Some("implemented"),
+            "done" => Some("verified"),
+            "cancelled" => Some("cancelled"),
+            _ => None,
+        }
+    }
+
+    /// Transition a card's status and -- if the card has a bound document --
+    /// update that document's `meta.status` and hoisted `status` column in
+    /// a single atomic transaction.
+    ///
+    /// When `document_id` is `Some`, the payload parse must succeed; a bound
+    /// document with an unparseable payload fails the whole transition so
+    /// neither the card nor the spec drift silently.
+    ///
+    /// When `document_id` is `None` this behaves identically to the old
+    /// `update_card_status` path but inside an `unchecked_transaction`.
+    pub fn transition_card_status_with_sync(
         &self,
         id: &str,
         status: &str,
         note: Option<&str>,
         timestamp: CardTimestamp,
+        document_id: Option<&str>,
     ) -> Result<()> {
         let now = chrono::Utc::now().to_rfc3339();
 
-        let rows = match timestamp {
-            CardTimestamp::Assigned => self.conn.execute(
+        let tx = self.conn.unchecked_transaction()?;
+
+        // -- update the card row --
+        let rows_affected = match timestamp {
+            CardTimestamp::Assigned => tx.execute(
                 "UPDATE tasks SET status = ?1, note = COALESCE(?2, note), \
                  assigned_at = ?3, updated_at = ?4 WHERE id = ?5 AND deleted_at IS NULL",
                 rusqlite::params![status, note, now, now, id],
             )?,
-            CardTimestamp::Started => self.conn.execute(
+            CardTimestamp::Started => tx.execute(
                 "UPDATE tasks SET status = ?1, note = COALESCE(?2, note), \
                  started_at = ?3, updated_at = ?4 WHERE id = ?5 AND deleted_at IS NULL",
                 rusqlite::params![status, note, now, now, id],
             )?,
-            CardTimestamp::Completed => self.conn.execute(
+            CardTimestamp::Completed => tx.execute(
                 "UPDATE tasks SET status = ?1, note = COALESCE(?2, note), \
                  completed_at = ?3, updated_at = ?4 WHERE id = ?5 AND deleted_at IS NULL",
                 rusqlite::params![status, note, now, now, id],
             )?,
-            CardTimestamp::None => self.conn.execute(
+            CardTimestamp::None => tx.execute(
                 "UPDATE tasks SET status = ?1, note = COALESCE(?2, note), \
                  updated_at = ?3 WHERE id = ?4 AND deleted_at IS NULL",
                 rusqlite::params![status, note, now, id],
             )?,
         };
-        if rows == 0 {
-            return Err(LegionError::CardNotFound(id.to_string()));
+        if rows_affected == 0 {
+            return Err(crate::error::LegionError::CardNotFound(id.to_string()));
         }
+
+        // -- sync the bound document if the new status maps to a spec status --
+        if let Some(doc_id) = document_id
+            && let Some(spec_status) = Self::requirement_status_for_card_status(status)
+        {
+            // Fetch and mutate the payload inside the transaction.
+            // Borrowing `tx` as a read source is fine because rusqlite
+            // allows reads mid-transaction on the same connection.
+            let payload_str: Option<String> = {
+                let mut stmt = tx.prepare(
+                    "SELECT payload FROM documents WHERE id = ?1 AND deleted_at IS NULL",
+                )?;
+                let mut rows = stmt.query(rusqlite::params![doc_id])?;
+                rows.next()?
+                    .map(|row| row.get::<_, String>(0))
+                    .transpose()
+                    .map_err(crate::error::LegionError::Database)?
+            };
+
+            let payload_str = payload_str.ok_or_else(|| {
+                crate::error::LegionError::WorkSource(format!(
+                    "bound document '{doc_id}' not found -- cannot sync status"
+                ))
+            })?;
+
+            let mut value: serde_json::Value = serde_json::from_str(&payload_str).map_err(|e| {
+                crate::error::LegionError::WorkSource(format!(
+                    "bound document '{doc_id}' has unparseable payload: {e}"
+                ))
+            })?;
+
+            let meta = value
+                .get_mut("meta")
+                .and_then(|m| m.as_object_mut())
+                .ok_or_else(|| {
+                    crate::error::LegionError::WorkSource(format!(
+                        "bound document '{doc_id}' payload has no 'meta' object"
+                    ))
+                })?;
+            meta.insert(
+                "status".to_string(),
+                serde_json::Value::String(spec_status.to_string()),
+            );
+
+            let updated_payload = serde_json::to_string(&value)?;
+            tx.execute(
+                "UPDATE documents SET payload = ?1, status = ?2, updated_at = ?3 \
+                 WHERE id = ?4 AND deleted_at IS NULL",
+                rusqlite::params![updated_payload, spec_status, now, doc_id],
+            )?;
+        }
+
+        tx.commit()?;
         Ok(())
     }
 
@@ -611,7 +713,75 @@ impl Database {
         Ok(rows > 0)
     }
 
-    /// Get per-agent workload summary.
+    /// Look up a card by its bound document_id.
+    ///
+    /// Returns the first live (non-deleted) card whose `document_id` matches.
+    /// `document_id` has application-layer uniqueness, so at most one card
+    /// should ever match; the query uses LIMIT 1 as a safety net.
+    pub fn get_card_by_document_id(
+        &self,
+        document_id: &str,
+    ) -> Result<Option<crate::kanban::Card>> {
+        let sql = format!(
+            "SELECT {} FROM tasks WHERE document_id = ?1 AND deleted_at IS NULL LIMIT 1",
+            Self::CARD_COLUMNS
+        );
+        let mut stmt = self.conn.prepare(&sql)?;
+        let mut rows = stmt.query_map([document_id], crate::kanban::map_card_row)?;
+        match rows.next() {
+            Some(row) => Ok(Some(row.map_err(LegionError::Database)?)),
+            None => Ok(None),
+        }
+    }
+
+    /// Bind a document to a card by setting `tasks.document_id`.
+    ///
+    /// Errors if:
+    /// - The card does not exist or is deleted.
+    /// - The card already has a `document_id` (already bound).
+    /// - Another live (non-cancelled, non-deleted) card is already bound
+    ///   to `document_id` (uniqueness guard).
+    pub fn bind_card_to_document(&self, card_id: &str, document_id: &str) -> Result<()> {
+        // Guard 1: card must exist and not already be bound.
+        let card = self
+            .get_card_by_id(card_id)?
+            .ok_or_else(|| LegionError::CardNotFound(card_id.to_string()))?;
+        if card.document_id.is_some() {
+            return Err(LegionError::WorkSource(format!(
+                "card '{card_id}' is already bound to document '{}'",
+                card.document_id.as_deref().unwrap_or("")
+            )));
+        }
+
+        // Guard 2: no other live card is bound to this document_id.
+        // "Live" means not cancelled and not deleted.
+        let mut check_stmt = self.conn.prepare(
+            "SELECT id FROM tasks WHERE document_id = ?1 \
+             AND deleted_at IS NULL \
+             AND status != 'cancelled' \
+             LIMIT 1",
+        )?;
+        let mut rows = check_stmt.query([document_id])?;
+        if let Some(row) = rows.next()? {
+            let existing_id: String = row.get(0)?;
+            return Err(LegionError::WorkSource(format!(
+                "document '{document_id}' is already bound to live card '{existing_id}'"
+            )));
+        }
+
+        let now = chrono::Utc::now().to_rfc3339();
+        let affected = self.conn.execute(
+            "UPDATE tasks SET document_id = ?1, updated_at = ?2 \
+             WHERE id = ?3 AND deleted_at IS NULL",
+            rusqlite::params![document_id, now, card_id],
+        )?;
+        if affected == 0 {
+            return Err(LegionError::CardNotFound(card_id.to_string()));
+        }
+        Ok(())
+    }
+
+    /// Per-agent workload summary.
     pub fn get_agent_workloads(&self) -> Result<Vec<crate::kanban::AgentWorkload>> {
         let mut stmt = self.conn.prepare(
             "SELECT to_repo, \
@@ -800,6 +970,358 @@ mod tests {
         assert!(
             !deleted_again,
             "soft_delete_card on already-deleted should return false"
+        );
+    }
+
+    // --- document_id migration / binding tests (#528) ---
+
+    fn insert_test_card(db: &Database) -> String {
+        db.insert_card(
+            "legion",
+            "legion",
+            "test card",
+            None,
+            crate::kanban::Priority::Med,
+            None,
+            None,
+            None,
+            None,
+            None,
+            crate::kanban::CardStatus::Backlog,
+        )
+        .expect("insert card")
+    }
+
+    fn insert_test_document(db: &Database) -> String {
+        let meta = crate::documents::DocumentMeta {
+            id: None,
+            doc_type: "requirement",
+            surface: Some("test"),
+            status: Some("draft"),
+            priority: None,
+            owner: "legion",
+        };
+        let payload = serde_json::json!({
+            "meta": {"id": "test", "type": "requirement", "surface": "test",
+                     "status": "draft", "priority": "SHOULD", "owner": "legion",
+                     "date": "2026-06-12", "author": "test"},
+            "title": "Test Req",
+            "description": "desc",
+            "traces_to": "doc#mot.1",
+            "depends_on": []
+        })
+        .to_string();
+        db.insert_document(&meta, &payload)
+            .expect("insert document")
+            .id
+    }
+
+    /// Migration adds document_id column idempotently: opening the same DB
+    /// file twice must not fail (the ALTER-if-missing guard handles this).
+    #[test]
+    fn migration_adds_document_id_column_idempotently() {
+        let db = test_db();
+        // A second open over the same in-memory path would be a new DB;
+        // we verify idempotency by checking the column exists after the
+        // first open and confirming a card can be inserted and read back
+        // without errors -- if the column were missing this would panic.
+        let id = insert_test_card(&db);
+        let card = db.get_card_by_id(&id).expect("get").expect("exists");
+        assert!(
+            card.document_id.is_none(),
+            "new card has no document_id by default"
+        );
+    }
+
+    /// Bind happy path: bind_card_to_document sets document_id on the card.
+    #[test]
+    fn bind_card_to_document_happy_path() {
+        let db = test_db();
+        let card_id = insert_test_card(&db);
+        let doc_id = insert_test_document(&db);
+
+        db.bind_card_to_document(&card_id, &doc_id).expect("bind");
+
+        let card = db.get_card_by_id(&card_id).expect("get").expect("exists");
+        assert_eq!(
+            card.document_id.as_deref(),
+            Some(doc_id.as_str()),
+            "document_id set on card after bind"
+        );
+
+        // Reverse lookup: get_card_by_document_id returns the bound card.
+        let found = db
+            .get_card_by_document_id(&doc_id)
+            .expect("lookup")
+            .expect("found");
+        assert_eq!(found.id, card_id);
+    }
+
+    /// Error: card already has a document_id.
+    #[test]
+    fn bind_fails_when_card_already_bound() {
+        let db = test_db();
+        let card_id = insert_test_card(&db);
+        let doc_id1 = insert_test_document(&db);
+        let doc_id2 = insert_test_document(&db);
+
+        db.bind_card_to_document(&card_id, &doc_id1)
+            .expect("first bind");
+        let err = db.bind_card_to_document(&card_id, &doc_id2).unwrap_err();
+        assert!(
+            err.to_string().contains("already bound"),
+            "expected already-bound error, got: {err}"
+        );
+    }
+
+    /// Error: document already bound to another live card.
+    #[test]
+    fn bind_fails_when_document_already_bound_to_live_card() {
+        let db = test_db();
+        let card_id1 = insert_test_card(&db);
+        let card_id2 = insert_test_card(&db);
+        let doc_id = insert_test_document(&db);
+
+        db.bind_card_to_document(&card_id1, &doc_id)
+            .expect("first bind");
+        let err = db.bind_card_to_document(&card_id2, &doc_id).unwrap_err();
+        assert!(
+            err.to_string().contains("already bound to live card"),
+            "expected already-bound-to-live-card error, got: {err}"
+        );
+    }
+
+    /// Error: card not found.
+    #[test]
+    fn bind_fails_when_card_not_found() {
+        let db = test_db();
+        let doc_id = insert_test_document(&db);
+        let err = db
+            .bind_card_to_document("nonexistent-id", &doc_id)
+            .unwrap_err();
+        assert!(
+            matches!(err, LegionError::CardNotFound(_)),
+            "expected CardNotFound, got: {err}"
+        );
+    }
+
+    /// Binding a document to a cancelled card is allowed in bind_card_to_document
+    /// (the uniqueness guard only blocks live non-cancelled cards). This tests
+    /// that a cancelled card's document_id slot does NOT block a new card from
+    /// binding to the same doc.
+    #[test]
+    fn bind_allows_rebind_after_card_cancelled() {
+        let db = test_db();
+        let card_id1 = insert_test_card(&db);
+        let card_id2 = insert_test_card(&db);
+        let doc_id = insert_test_document(&db);
+
+        // Bind to card1, then cancel card1.
+        db.bind_card_to_document(&card_id1, &doc_id)
+            .expect("bind to card1");
+        // Cancel by force_move (bypasses state machine for test simplicity).
+        db.force_move_card(&card_id1, "cancelled", None)
+            .expect("cancel card1");
+
+        // Now card2 can bind to the same doc (card1 is cancelled, not live).
+        db.bind_card_to_document(&card_id2, &doc_id)
+            .expect("rebind to card2 after cancel");
+        let card2 = db.get_card_by_id(&card_id2).expect("get").expect("exists");
+        assert_eq!(card2.document_id.as_deref(), Some(doc_id.as_str()));
+    }
+
+    /// requirement_status_for_card_status maps the four expected statuses.
+    #[test]
+    fn requirement_status_mapping_covers_all_mapped_statuses() {
+        assert_eq!(
+            Database::requirement_status_for_card_status("accepted"),
+            Some("accepted")
+        );
+        assert_eq!(
+            Database::requirement_status_for_card_status("in-review"),
+            Some("implemented")
+        );
+        assert_eq!(
+            Database::requirement_status_for_card_status("done"),
+            Some("verified")
+        );
+        assert_eq!(
+            Database::requirement_status_for_card_status("cancelled"),
+            Some("cancelled")
+        );
+        // Statuses that carry no spec meaning return None.
+        assert!(Database::requirement_status_for_card_status("backlog").is_none());
+        assert!(Database::requirement_status_for_card_status("pending").is_none());
+        assert!(Database::requirement_status_for_card_status("needs-input").is_none());
+        assert!(Database::requirement_status_for_card_status("blocked").is_none());
+    }
+
+    /// Transactional sync: transitioning a bound card to "done" updates BOTH
+    /// tasks.status AND documents.status + documents.payload in one commit.
+    #[test]
+    fn transition_with_sync_updates_both_card_and_document() {
+        let db = test_db();
+        let card_id = insert_test_card(&db);
+        let doc_id = insert_test_document(&db);
+
+        // Bind and move the card to a state where Done is reachable.
+        db.bind_card_to_document(&card_id, &doc_id).expect("bind");
+        db.force_move_card(&card_id, "accepted", None)
+            .expect("move to accepted");
+
+        // Transition to Done -- syncs the doc to "verified".
+        db.transition_card_status_with_sync(
+            &card_id,
+            "done",
+            None,
+            CardTimestamp::Completed,
+            Some(&doc_id),
+        )
+        .expect("transition");
+
+        // Card must be done.
+        let card = db.get_card_by_id(&card_id).expect("get").expect("exists");
+        assert_eq!(card.status.to_string(), "done");
+
+        // Document status column must be "verified".
+        let doc = db
+            .get_document(&doc_id)
+            .expect("get doc")
+            .expect("doc exists");
+        assert_eq!(
+            doc.status, "verified",
+            "hoisted status column must be 'verified'"
+        );
+
+        // Document payload meta.status must also be "verified".
+        let payload: serde_json::Value = serde_json::from_str(&doc.payload).expect("parse payload");
+        assert_eq!(
+            payload["meta"]["status"].as_str(),
+            Some("verified"),
+            "payload meta.status must be 'verified'"
+        );
+    }
+
+    /// Transactional sync: cancelled card -> doc status "cancelled".
+    #[test]
+    fn done_to_verified_and_cancelled_to_cancelled_mapping() {
+        let db = test_db();
+        let card_id = insert_test_card(&db);
+        let doc_id = insert_test_document(&db);
+
+        db.bind_card_to_document(&card_id, &doc_id).expect("bind");
+        // Force to accepted so Cancel is valid from the state machine perspective
+        db.force_move_card(&card_id, "accepted", None)
+            .expect("move");
+
+        db.transition_card_status_with_sync(
+            &card_id,
+            "cancelled",
+            None,
+            CardTimestamp::Completed,
+            Some(&doc_id),
+        )
+        .expect("cancel transition");
+
+        let doc = db.get_document(&doc_id).expect("get").expect("exists");
+        assert_eq!(doc.status, "cancelled");
+        let payload: serde_json::Value = serde_json::from_str(&doc.payload).expect("parse");
+        assert_eq!(payload["meta"]["status"].as_str(), Some("cancelled"));
+    }
+
+    /// Illegal transition is rolled back -- neither card nor doc changes.
+    #[test]
+    fn illegal_transition_rolls_back_both_card_and_doc() {
+        use crate::kanban::{Action, CardStatus, transition_card};
+        let db = test_db();
+        let card_id = insert_test_card(&db);
+        let doc_id = insert_test_document(&db);
+
+        db.bind_card_to_document(&card_id, &doc_id).expect("bind");
+        // Card is in Backlog -- Done is not a valid action from Backlog.
+        let err = transition_card(&db, &card_id, Action::Done, None).unwrap_err();
+        assert!(
+            matches!(err, LegionError::InvalidCardTransition { .. }),
+            "expected InvalidCardTransition, got: {err}"
+        );
+
+        // Card must still be in Backlog.
+        let card = db.get_card_by_id(&card_id).expect("get").expect("exists");
+        assert_eq!(card.status, CardStatus::Backlog);
+
+        // Document must still be "draft".
+        let doc = db.get_document(&doc_id).expect("get").expect("exists");
+        assert_eq!(doc.status, "draft");
+    }
+
+    /// Unparseable bound document payload fails the transition.
+    #[test]
+    fn unparseable_bound_payload_fails_transition() {
+        let db = test_db();
+        let card_id = insert_test_card(&db);
+
+        // Insert a document with an invalid (non-JSON) payload.
+        let meta = crate::documents::DocumentMeta {
+            id: None,
+            doc_type: "requirement",
+            surface: Some("test"),
+            status: Some("draft"),
+            priority: None,
+            owner: "legion",
+        };
+        let doc_id = db
+            .insert_document(&meta, "NOT VALID JSON")
+            .expect("insert corrupt doc")
+            .id;
+        db.bind_card_to_document(&card_id, &doc_id).expect("bind");
+        db.force_move_card(&card_id, "accepted", None)
+            .expect("move");
+
+        // Transitioning to "done" should fail because the payload is unparseable.
+        let err = db
+            .transition_card_status_with_sync(
+                &card_id,
+                "done",
+                None,
+                CardTimestamp::Completed,
+                Some(&doc_id),
+            )
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("unparseable payload"),
+            "expected unparseable payload error, got: {err}"
+        );
+
+        // Card must NOT have changed status.
+        let card = db.get_card_by_id(&card_id).expect("get").expect("exists");
+        assert_eq!(card.status.to_string(), "accepted");
+    }
+
+    /// Status sync does NOT fire for statuses with no spec mapping (e.g. "blocked").
+    #[test]
+    fn transition_without_mapped_status_does_not_touch_document() {
+        let db = test_db();
+        let card_id = insert_test_card(&db);
+        let doc_id = insert_test_document(&db);
+
+        db.bind_card_to_document(&card_id, &doc_id).expect("bind");
+        db.force_move_card(&card_id, "accepted", None)
+            .expect("move");
+
+        // blocked has no spec mapping -- doc stays "draft".
+        db.transition_card_status_with_sync(
+            &card_id,
+            "blocked",
+            None,
+            CardTimestamp::None,
+            Some(&doc_id),
+        )
+        .expect("transition to blocked");
+
+        let doc = db.get_document(&doc_id).expect("get").expect("exists");
+        assert_eq!(
+            doc.status, "draft",
+            "document status must be unchanged for unmapped card status"
         );
     }
 }

--- a/src/documents.rs
+++ b/src/documents.rs
@@ -247,11 +247,14 @@ impl Database {
             .filter(|a| !a.is_empty())
             .map(|a| a.join("\n"));
 
+        // NOTE on param numbering: status binds ?16 (matching the pattern in
+        // db/kanban.rs insert_card). document_id is appended as ?17 and binds
+        // the 17th param slot -- do not reuse earlier numbers.
         tx.execute(
             "INSERT INTO tasks (id, from_repo, to_repo, text, context, priority, status, \
              labels, parent_card_id, source_url, source_type, created_at, updated_at, \
-             problem, solution, acceptance) \
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?16, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15)",
+             problem, solution, acceptance, document_id) \
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?16, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?17)",
             rusqlite::params![
                 card_id,
                 card_from_repo,
@@ -268,7 +271,8 @@ impl Database {
                 problem,
                 solution,
                 acceptance,
-                "backlog", // status -- born Backlog
+                "backlog", // status -- born Backlog (?16)
+                &doc_id,   // document_id (#528 binding) (?17)
             ],
         )?;
 
@@ -291,7 +295,26 @@ impl Database {
     /// Mark a document archived. Sets `archived_at = now`, updates
     /// `updated_at`. Idempotent: archiving an already-archived doc is
     /// a no-op success. Returns the updated Document.
+    ///
+    /// Errors when the document is bound to a live (non-cancelled, non-deleted)
+    /// kanban card (#528): archiving a live requirement while work is in flight
+    /// would orphan the card from its spec.
     pub fn archive_document(&self, id: &str) -> Result<Document> {
+        // Guard: refuse archive when a live card is bound to this document.
+        let mut check_stmt = self.conn.prepare(
+            "SELECT id FROM tasks WHERE document_id = ?1 \
+             AND deleted_at IS NULL \
+             AND status != 'cancelled' \
+             LIMIT 1",
+        )?;
+        let mut rows = check_stmt.query(params![id])?;
+        if let Some(row) = rows.next()? {
+            let card_id: String = row.get(0)?;
+            return Err(LegionError::WorkSource(format!(
+                "document '{id}' cannot be archived: live card '{card_id}' is bound to it"
+            )));
+        }
+
         let now = Utc::now().to_rfc3339();
         let rows = self.conn.execute(
             "UPDATE documents \
@@ -685,6 +708,67 @@ mod tests {
         let db = test_db();
         let err = db.archive_document("FR-NOPE").unwrap_err();
         assert!(err.to_string().contains("not found"));
+    }
+
+    // -- archive guard: bound-live-card protection (#528) ------------------
+
+    fn insert_bound_card(db: &Database, doc_id: &str) -> String {
+        let card_id = db
+            .insert_card(
+                "legion",
+                "legion",
+                "bound card",
+                None,
+                crate::kanban::Priority::Med,
+                None,
+                None,
+                None,
+                None,
+                None,
+                crate::kanban::CardStatus::Accepted,
+            )
+            .expect("insert card");
+        db.bind_card_to_document(&card_id, doc_id).expect("bind");
+        card_id
+    }
+
+    /// archive_document errors when a live (non-cancelled) card is bound.
+    #[test]
+    fn archive_document_blocked_by_live_bound_card() {
+        let db = test_db();
+        let mut m = sample_meta("requirement", "mail");
+        m.id = Some("FR-LIVE");
+        db.insert_document(&m, "{}").unwrap();
+
+        let card_id = insert_bound_card(&db, "FR-LIVE");
+
+        let err = db.archive_document("FR-LIVE").unwrap_err();
+        assert!(
+            err.to_string().contains("cannot be archived"),
+            "archive must be blocked: {err}"
+        );
+        assert!(
+            err.to_string().contains(&card_id),
+            "error must name the blocking card: {err}"
+        );
+    }
+
+    /// archive_document succeeds when the bound card is cancelled.
+    #[test]
+    fn archive_document_allowed_when_bound_card_is_cancelled() {
+        let db = test_db();
+        let mut m = sample_meta("requirement", "mail");
+        m.id = Some("FR-CANCEL");
+        db.insert_document(&m, "{}").unwrap();
+
+        let card_id = insert_bound_card(&db, "FR-CANCEL");
+        // Cancel the card.
+        db.force_move_card(&card_id, "cancelled", None)
+            .expect("cancel card");
+
+        // Now archive_document should succeed.
+        let doc = db.archive_document("FR-CANCEL").expect("archive");
+        assert!(doc.archived_at.is_some(), "should be archived");
     }
 
     // -- schema payload validation (#526) ---------------------------------

--- a/src/documents.rs
+++ b/src/documents.rs
@@ -301,15 +301,7 @@ impl Database {
     /// would orphan the card from its spec.
     pub fn archive_document(&self, id: &str) -> Result<Document> {
         // Guard: refuse archive when a live card is bound to this document.
-        let mut check_stmt = self.conn.prepare(
-            "SELECT id FROM tasks WHERE document_id = ?1 \
-             AND deleted_at IS NULL \
-             AND status != 'cancelled' \
-             LIMIT 1",
-        )?;
-        let mut rows = check_stmt.query(params![id])?;
-        if let Some(row) = rows.next()? {
-            let card_id: String = row.get(0)?;
+        if let Some(card_id) = self.live_card_bound_to_document(id)? {
             return Err(LegionError::WorkSource(format!(
                 "document '{id}' cannot be archived: live card '{card_id}' is bound to it"
             )));

--- a/src/kanban/format.rs
+++ b/src/kanban/format.rs
@@ -293,6 +293,7 @@ mod tests {
             problem: None,
             solution: None,
             acceptance: None,
+            document_id: None,
         };
         let output = format_work_card(&card);
         assert!(output.contains("Priority: high"));
@@ -333,6 +334,7 @@ mod tests {
             problem: None,
             solution: None,
             acceptance: None,
+            document_id: None,
         };
         let output = format_work_card(&card);
         assert!(output.contains("minimal card"));
@@ -365,6 +367,7 @@ mod tests {
             problem: None,
             solution: None,
             acceptance: ac.map(str::to_string),
+            document_id: None,
         };
 
         // An Accepted card with AC becomes the goal, listing its criteria.
@@ -412,6 +415,7 @@ mod tests {
             problem: Some("Things are broken".to_string()),
             solution: Some("Fix them".to_string()),
             acceptance: Some("Tests pass\nClipy clean".to_string()),
+            document_id: None,
         };
         let output = format_card_view(&card);
         assert!(output.contains("Test Card"), "title derived correctly");
@@ -450,6 +454,7 @@ mod tests {
             problem: None,
             solution: None,
             acceptance: None,
+            document_id: None,
         };
         let output = format_card_view(&card);
         assert!(output.contains("## Context"), "context section present");
@@ -481,6 +486,7 @@ mod tests {
             problem: None,
             solution: None,
             acceptance: None,
+            document_id: None,
         };
         let json = format_card_json(&card).expect("json");
         let parsed: serde_json::Value = serde_json::from_str(&json).expect("parse");

--- a/src/kanban/mod.rs
+++ b/src/kanban/mod.rs
@@ -241,13 +241,6 @@ pub fn view_card(db: &Database, id: &str) -> Result<Card> {
         .ok_or_else(|| LegionError::CardNotFound(id.to_string()))
 }
 
-/// Look up a card by its bound document id.
-///
-/// Returns None when no live card is bound to the given document_id.
-pub fn find_card_for_document(db: &Database, document_id: &str) -> Result<Option<Card>> {
-    db.get_card_by_document_id(document_id)
-}
-
 /// Bind a document to a card (manual path; spec-gen uses the atomic insert).
 ///
 /// Fails when the card is already bound, the document does not exist or is

--- a/src/kanban/mod.rs
+++ b/src/kanban/mod.rs
@@ -38,6 +38,10 @@ pub struct Card {
     pub problem: Option<String>,
     pub solution: Option<String>,
     pub acceptance: Option<String>,
+    /// Optional bound document id (#528). When set, the spec document's
+    /// `verification.acceptance` block overrides `tasks.acceptance` as the
+    /// source of acceptance criteria for `legion verify`.
+    pub document_id: Option<String>,
 }
 
 /// Per-agent workload summary for the dashboard agent strip.
@@ -81,6 +85,7 @@ pub fn map_card_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<Card> {
         problem: row.get(18)?,
         solution: row.get(19)?,
         acceptance: row.get(20)?,
+        document_id: row.get(21)?,
     })
 }
 
@@ -133,6 +138,11 @@ fn timestamp_for_action(action: &Action) -> crate::db::CardTimestamp {
 }
 
 /// Transition a card through the state machine.
+///
+/// When the card has a `document_id`, the bound document's `meta.status` and
+/// hoisted `status` column are updated in the same transaction as the card's
+/// status column. A bound document with an unparseable payload fails the whole
+/// transition -- neither card nor spec drift silently (#528).
 pub fn transition_card(
     db: &Database,
     id: &str,
@@ -145,7 +155,13 @@ pub fn transition_card(
 
     let new_status = transition(card.status, action)?;
     let ts = timestamp_for_action(&action);
-    db.update_card_status(id, &new_status.to_string(), note, ts)?;
+    db.transition_card_status_with_sync(
+        id,
+        &new_status.to_string(),
+        note,
+        ts,
+        card.document_id.as_deref(),
+    )?;
     db.get_card_by_id(id)?
         .ok_or_else(|| LegionError::CardNotFound(id.to_string()))
 }
@@ -223,6 +239,30 @@ pub fn agent_workloads(db: &Database) -> Result<Vec<AgentWorkload>> {
 pub fn view_card(db: &Database, id: &str) -> Result<Card> {
     db.get_card_by_id(id)?
         .ok_or_else(|| LegionError::CardNotFound(id.to_string()))
+}
+
+/// Look up a card by its bound document id.
+///
+/// Returns None when no live card is bound to the given document_id.
+pub fn find_card_for_document(db: &Database, document_id: &str) -> Result<Option<Card>> {
+    db.get_card_by_document_id(document_id)
+}
+
+/// Bind a document to a card (manual path; spec-gen uses the atomic insert).
+///
+/// Fails when the card is already bound, the document does not exist or is
+/// archived, or another live card is already bound to the document.
+pub fn bind_document(db: &Database, card_id: &str, document_id: &str) -> Result<()> {
+    // Verify the document exists and is not archived before writing.
+    let doc = db
+        .get_document(document_id)?
+        .ok_or_else(|| LegionError::WorkSource(format!("document '{document_id}' not found")))?;
+    if doc.archived_at.is_some() {
+        return Err(LegionError::WorkSource(format!(
+            "document '{document_id}' is archived and cannot be bound"
+        )));
+    }
+    db.bind_card_to_document(card_id, document_id)
 }
 
 /// Parameters for updating a card's mutable fields.

--- a/src/kanban/mod.rs
+++ b/src/kanban/mod.rs
@@ -161,6 +161,7 @@ pub fn transition_card(
         note,
         ts,
         card.document_id.as_deref(),
+        None,
     )?;
     db.get_card_by_id(id)?
         .ok_or_else(|| LegionError::CardNotFound(id.to_string()))

--- a/src/spec_gen.rs
+++ b/src/spec_gen.rs
@@ -50,8 +50,6 @@ use crate::db::Database;
 use crate::documents::{Document, DocumentFilter, DocumentMeta, validate_instance};
 use crate::error::{LegionError, Result};
 
-const REQUIREMENT_SCHEMA_ID: &str = "019eb45a-2fdd-7fd2-a574-96a3302bd15a";
-
 /// Service-design document types that spec-gen reads as input.
 ///
 /// Journey, blueprint, and painmatrix are included so the CLI can filter for
@@ -155,14 +153,11 @@ pub fn persist_requirements(
     surface: &str,
     outcome: GenerateOutcome,
 ) -> Result<PersistOutcome> {
-    // Load the requirement schema document for validation.
-    let schema_doc = db.get_document(REQUIREMENT_SCHEMA_ID)?.ok_or_else(|| {
-        LegionError::WorkSource(format!(
-            "requirement schema document '{}' not found -- run `legion document create` \
-             to land the adopted schema first",
-            REQUIREMENT_SCHEMA_ID
-        ))
-    })?;
+    // Dynamically find the newest non-archived schema document whose payload
+    // title is "Requirement" (#528: the v1 schema id is archived; hardcoding
+    // ids is fragile across schema versions). The filter returns docs ordered
+    // by updated_at DESC, so the first result is the most recent live schema.
+    let schema_doc = find_requirement_schema(db)?;
     let schema_value: serde_json::Value =
         serde_json::from_str(&schema_doc.payload).map_err(|e| {
             LegionError::WorkSource(format!(
@@ -259,6 +254,39 @@ pub fn persist_requirements(
 }
 
 // -- private helpers ---------------------------------------------------------
+
+/// Find the active requirement schema document.
+///
+/// Searches for non-archived documents of `doc_type = "schema"` whose
+/// payload carries `"title": "Requirement"` (case-sensitive). The list
+/// is ordered by `updated_at DESC` so the first match is the most
+/// recently updated live schema.
+///
+/// Returns a clear error naming what was looked for when no schema is found,
+/// so operators know exactly which document is missing rather than seeing a
+/// generic "not found" from a stale hardcoded id.
+fn find_requirement_schema(db: &Database) -> Result<Document> {
+    let filter = DocumentFilter {
+        doc_type: Some("schema"),
+        archived: Some(false),
+        ..Default::default()
+    };
+    let candidates = db.list_documents(&filter)?;
+    for doc in candidates {
+        // Parse lazily; skip docs whose payload is not valid JSON or has no title.
+        if let Ok(value) = serde_json::from_str::<serde_json::Value>(&doc.payload)
+            && value["title"].as_str() == Some("Requirement")
+        {
+            return Ok(doc);
+        }
+    }
+    Err(LegionError::WorkSource(
+        "no active requirement schema found: expected a non-archived document \
+         of doc_type='schema' with payload title='Requirement'. \
+         Run `legion document create --type schema` to land the requirement schema."
+            .to_string(),
+    ))
+}
 
 /// Parse a service-design document's surface and JSON payload.
 ///
@@ -787,6 +815,9 @@ mod tests {
     }
 
     /// Land the requirement schema doc so persist_requirements can validate.
+    ///
+    /// No longer uses a hardcoded id -- the dynamic lookup in find_requirement_schema
+    /// finds any non-archived schema doc with title "Requirement" (#528).
     fn seed_requirement_schema(db: &Database) {
         let schema_payload = std::fs::read_to_string(concat!(
             env!("CARGO_MANIFEST_DIR"),
@@ -794,7 +825,7 @@ mod tests {
         ))
         .expect("requirement schema file");
         let meta = DocumentMeta {
-            id: Some(REQUIREMENT_SCHEMA_ID),
+            id: None, // generate a fresh UUIDv7; the lookup is by title, not id
             doc_type: "schema",
             surface: Some("definition-layer"),
             status: Some("adopted"),
@@ -1196,6 +1227,105 @@ mod tests {
             cards[0].source_url.as_deref(),
             Some(req_docs[0].id.as_str()),
             "card source_url links to the requirement document"
+        );
+    }
+
+    // --- dynamic schema lookup + card document_id binding (#528) ---
+
+    /// Dynamic schema lookup finds v2 by title "Requirement" when no hardcoded id is used.
+    #[test]
+    fn dynamic_schema_lookup_finds_requirement_schema_by_title() {
+        let db = test_db();
+        seed_requirement_schema(&db);
+
+        let schema = find_requirement_schema(&db).expect("should find schema");
+        // The schema file has "title": "Requirement".
+        let value: serde_json::Value =
+            serde_json::from_str(&schema.payload).expect("parse schema payload");
+        assert_eq!(
+            value["title"].as_str(),
+            Some("Requirement"),
+            "found schema must have title Requirement"
+        );
+    }
+
+    /// Dynamic schema lookup returns a clear error when no requirement schema exists.
+    #[test]
+    fn dynamic_schema_lookup_errors_clearly_when_no_schema_exists() {
+        let db = test_db();
+        // No schema seeded.
+        let err = find_requirement_schema(&db).unwrap_err();
+        assert!(
+            err.to_string().contains("no active requirement schema"),
+            "error must name what was looked for: {err}"
+        );
+        assert!(
+            err.to_string().contains("Requirement"),
+            "error must mention the expected title: {err}"
+        );
+    }
+
+    /// spec-gen created cards carry document_id pointing at the requirement doc (#528).
+    #[test]
+    fn spec_gen_card_has_document_id_set() {
+        let db = test_db();
+        seed_requirement_schema(&db);
+
+        let docs = vec![persona_doc_with_mot()];
+        let outcome = generate_requirements(&docs).expect("generate");
+        persist_requirements(&db, "gitpress", outcome).expect("persist");
+
+        let req_docs = db
+            .list_documents(&DocumentFilter {
+                doc_type: Some("requirement"),
+                surface: Some("gitpress"),
+                ..Default::default()
+            })
+            .expect("list docs");
+        assert_eq!(req_docs.len(), 1, "one requirement document");
+
+        let cards = list_cards(&db, "gitpress", Direction::Inbound, CardScope::Backlog)
+            .expect("list cards");
+        assert_eq!(cards.len(), 1, "one born-Backlog card");
+
+        // The card must have document_id set to the requirement document's id.
+        assert_eq!(
+            cards[0].document_id.as_deref(),
+            Some(req_docs[0].id.as_str()),
+            "card document_id must point to the requirement document"
+        );
+    }
+
+    /// Dynamic lookup skips archived schemas and finds the live one.
+    #[test]
+    fn dynamic_schema_lookup_skips_archived_schema() {
+        let db = test_db();
+        // Seed the schema, then archive it.
+        seed_requirement_schema(&db);
+
+        // To archive, we need to find the schema doc first.
+        let candidates = db
+            .list_documents(&DocumentFilter {
+                doc_type: Some("schema"),
+                ..Default::default()
+            })
+            .expect("list");
+        assert_eq!(candidates.len(), 1);
+        // Archive the only schema -- but first we need to make sure there's no
+        // live card bound (there isn't in this test). Use conn directly via
+        // a raw UPDATE since archive_document checks for live cards.
+        db.conn
+            .execute(
+                "UPDATE documents SET archived_at = ?1 WHERE id = ?2",
+                rusqlite::params!["2026-06-12T00:00:00Z", candidates[0].id],
+            )
+            .expect("archive");
+
+        // Now the lookup should fail (no live requirement schema).
+        let err = find_requirement_schema(&db).unwrap_err();
+        assert!(
+            err.to_string().contains("no active requirement schema"),
+            "archived schema must not be found: {err}"
         );
     }
 }

--- a/src/spec_gen.rs
+++ b/src/spec_gen.rs
@@ -259,12 +259,18 @@ pub fn persist_requirements(
 ///
 /// Searches for non-archived documents of `doc_type = "schema"` whose
 /// payload carries `"title": "Requirement"` (case-sensitive). The list
-/// is ordered by `updated_at DESC` so the first match is the most
-/// recently updated live schema.
+/// is ordered by `updated_at DESC` (from `list_documents`), so the first
+/// match is the most recently updated live schema.
 ///
-/// Returns a clear error naming what was looked for when no schema is found,
-/// so operators know exactly which document is missing rather than seeing a
-/// generic "not found" from a stale hardcoded id.
+/// The lookup is deterministic only when exactly one live schema titled
+/// "Requirement" exists. The expected workflow is archive-on-adopt: when a
+/// new schema version is adopted, the prior one should be archived so only
+/// one live match exists at any time. When more than one live match is found,
+/// this function emits a warning to stderr naming the chosen document id and
+/// the number of shadowed documents, so operators can see the violation and
+/// archive the stale copies.
+///
+/// Returns a clear error when no active schema is found.
 fn find_requirement_schema(db: &Database) -> Result<Document> {
     let filter = DocumentFilter {
         doc_type: Some("schema"),
@@ -272,20 +278,41 @@ fn find_requirement_schema(db: &Database) -> Result<Document> {
         ..Default::default()
     };
     let candidates = db.list_documents(&filter)?;
-    for doc in candidates {
-        // Parse lazily; skip docs whose payload is not valid JSON or has no title.
-        if let Ok(value) = serde_json::from_str::<serde_json::Value>(&doc.payload)
-            && value["title"].as_str() == Some("Requirement")
-        {
-            return Ok(doc);
-        }
+
+    // Collect all matches; warn when there is more than one.
+    let mut matches: Vec<Document> = candidates
+        .into_iter()
+        .filter(|doc| {
+            serde_json::from_str::<serde_json::Value>(&doc.payload)
+                .ok()
+                .and_then(|v| v["title"].as_str().map(str::to_owned))
+                .as_deref()
+                == Some("Requirement")
+        })
+        .collect();
+
+    if matches.is_empty() {
+        return Err(LegionError::WorkSource(
+            "no active requirement schema found: expected a non-archived document \
+             of doc_type='schema' with payload title='Requirement'. \
+             Run `legion document create --type schema` to land the requirement schema."
+                .to_string(),
+        ));
     }
-    Err(LegionError::WorkSource(
-        "no active requirement schema found: expected a non-archived document \
-         of doc_type='schema' with payload title='Requirement'. \
-         Run `legion document create --type schema` to land the requirement schema."
-            .to_string(),
-    ))
+
+    if matches.len() > 1 {
+        // The list is ordered by updated_at DESC; the first element is the
+        // most recently updated and is what we will use.
+        let shadowed = matches.len() - 1;
+        eprintln!(
+            "[legion] warning: {} live requirement schema(s) found in addition to '{}'; \
+             using the most recently updated one. Archive the {} shadowed document(s) \
+             with `legion document archive` to restore deterministic lookup.",
+            shadowed, matches[0].id, shadowed,
+        );
+    }
+
+    Ok(matches.remove(0))
 }
 
 /// Parse a service-design document's surface and JSON payload.


### PR DESCRIPTION
## Summary

Card<->spec binding: a kanban card and its requirement document become two views of one work item. Cards gain a `document_id` column (idempotent ALTER-if-missing migration on the tasks table); binding is settable at birth (spec-gen's `insert_requirement_with_card` now writes it in the same transaction that creates the document) or manually via the new `legion kanban bind` subcommand with four guard rails. Kanban transitions of a bound card update the spec's `meta.status` transactionally -- payload rewrite, hoisted status column, and card status commit together or not at all -- using the schema-canon mapping (Accepted->accepted, InReview->implemented, Done->verified, Cancelled->cancelled; the issue text's in-progress/in-review values predated the adopted schema enum and were superseded by it). The verify gate now reads the bound spec's `verification.acceptance` as its AC source, falling back to `tasks.acceptance`, with requirement schema v2 (adopted today as 019ebd17-5925) specifying that block's shape. spec-gen's hardcoded schema id -- broken by the v1 archival -- is replaced with a dynamic newest-adopted lookup.

## Acceptance criteria mapping

### 1. card<->document FK exists both ways

`document_id TEXT` on tasks via the established has_column-guarded ALTER migration; Card struct, CARD_COLUMNS, and map_card_row extended. The reverse direction is `Database::get_card_by_document_id`, which returns the live card only (a cancelled card retains its document_id by design so history survives, but `AND status != 'cancelled'` keeps it from shadowing a live successor -- the invariant is at most one LIVE card per document, enforced by the bind guard and single-sourced in `live_card_bound_to_document`). No SQLite FK constraint and no PRAGMA foreign_keys: enforcement is application-layer by deliberate choice -- flipping FK enforcement on globally is out of #528's blast radius. Evidence: migration idempotency test; `get_card_by_document_id_returns_live_card_not_cancelled`; bind guard tests (nonexistent doc, archived doc, already-bound card, doc bound to another live card all error).

### 2. kanban transition updates meta.status transactionally

`transition_card_status_with_sync` wraps three writes in one `unchecked_transaction` (the rename_repo pattern): tasks.status UPDATE, documents.payload rewrite (parse, set meta.status, re-serialize), and the hoisted documents.status column + updated_at. The mapping function takes typed `CardStatus` and matches exhaustively with no catch-all, so adding a card status forces a compile-time decision here. A bound document that is missing or unparseable fails the transition -- no silent drift. Unbound cards take the old single-UPDATE path unchanged. Evidence: transactional sync tests assert both rows after a Done transition (card done + spec verified) and that an illegal transition changes neither; unparseable-payload transition failure test; Cancelled->cancelled mapping test.

### 3. verify reads the bound spec's verification block as AC

`resolve_acceptance_criteria` in the verify flow: a bound card with `verification.acceptance` (non-empty, per the v2 schema's sub-shape) gets its criteria from the spec, and verify's output names the source (`spec:<doc id>` vs `card`). Fallback to `tasks.acceptance` when the block is absent or empty (v1-shaped docs stay valid). A dangling `document_id` -- bound but the document is gone -- is a hard error, matching the sync path's semantics: a card whose spec vanished is precisely what verify must not paper over. Corrupt payload falls back with the rationale documented. Evidence: integration test binds a doc with a verification block and asserts verify's criteria come from the spec; fallback test with no block; `resolve_ac_hard_errors_on_dangling_document_id`.

### 4. generated requirement + its card are created atomically

`insert_requirement_with_card` (from #527) now also writes `document_id` on the card row inside its existing transaction, so spec-gen output is born bound -- document, card, and binding are one atomic unit; `source_url` stays for display compatibility. Evidence: spec-gen tests assert created cards carry `document_id` = the requirement doc id; the #527 atomicity structure is unchanged (one tx, commit after both inserts).

### 5. PR created and linked

The PR is the delivery vehicle the criterion asks for, and the linkage is structural rather than cosmetic: the title's feat(#528) prefix ties the diff to this issue, the body maps every criterion to its hunks and tests, and the gate chain makes the linkage machine-checked -- `legion pr create` refuses to open a PR unless both the legion-simplify gate and the pr-write gate are clean on the exact HEAD being proposed, so an unreviewed or unmapped diff cannot reach review wearing this issue's number.
Evidence: quality-gate rows 019ebd46-363c (legion-simplify) and 019ebd46-364c (legion-review, approved after three fix rounds) clean on HEAD 14a0b8a, plus the pr-write gate on the same HEAD; `legion pr create` exits nonzero without them, which is the observable behavior that pins PR-to-issue linkage.

## Not done

PRAGMA foreign_keys stays off and no REFERENCES clause is added -- referential integrity is application-layer (bind guards + dangling-binding hard errors), because enabling SQLite FK enforcement globally would change delete semantics for every table in one PR about binding. The card->spec sync is one-directional (board drives spec); editing a document's meta.status directly does not move the card -- the board is the execution surface, the spec records it. Requirement schema v2's adoption (verification sub-schema + cancelled enum value) happened as a substrate operation today rather than in this diff; this PR's code consumes it via the dynamic lookup. spec-gen still emits no verification block in v1 -- generated specs get criteria authored at promotion time; the schema now defines where they go.