### PR TITLE
fix(#641): cfg(unix) the daemon-attribution bind test -- unbreak Windows CI

### DIFF
--- a/src/serve.rs
+++ b/src/serve.rs
@@ -974,6 +974,12 @@ mod tests {
         assert_eq!(std::fs::read_to_string(&path).unwrap(), "67890");
     }
 
+    // Unix-only: liveness goes through watch::process_alive (`kill`-based,
+    // always false on other platforms), so on Windows live_daemon_pid is
+    // None by construction and the bare-error path below is the correct
+    // behavior -- pinned cross-platform by
+    // serve_bind_failure_without_daemon_stays_bare.
+    #[cfg(unix)]
     #[test]
     fn serve_refuses_port_held_by_live_daemon_with_pointer() {
         let dir = tempfile::tempdir().unwrap();


### PR DESCRIPTION
## Summary

Main's Windows CI has been red since #637 merged: the port-ownership test `serve_refuses_port_held_by_live_daemon_with_pointer` asserts the bind error names the live daemon, but liveness flows through `watch::process_alive`, which is `kill`-based and documented to return false on non-Unix -- so on Windows `live_daemon_pid` is None by construction and the assertion can never pass. The branch policy is now (correctly) blocking PR #640 on the red check. This PR cfg-gates that one test to Unix with a rationale comment; the Windows product behavior -- bare bind error, no attribution claim without a liveness signal -- is correct and remains pinned cross-platform by `serve_bind_failure_without_daemon_stays_bare`.

## Acceptance criteria mapping

### 1. cargo test passes on the branch (Unix)

The gated test still runs and passes on Unix -- the cfg attribute removes it from non-Unix builds only, changing nothing about what it proves where it can run.
Evidence: `cargo test` exits 0 on this branch (1069 unit tests incl. serve::tests::serve_refuses_port_held_by_live_daemon_with_pointer); targeted run `cargo test serve_refuses` exits 0.

### 2. the gated test does not compile into Windows builds (cfg attr present)

`#[cfg(unix)]` sits directly on the test fn at src/serve.rs:983 with a comment explaining why: process_alive is kill-based and always false off-Unix, so the attribution path is unreachable there and the bare-error fallback (exactly what the Windows run observed) is the designed behavior, not a gap.
Evidence: src/serve.rs:977-983 -- the attribute and rationale; the companion bare-error test remains ungated.

### 3. cargo clippy --all-targets -- -D warnings and cargo fmt -- --check pass

The change is one attribute and one comment inside a test module; no lint or formatting surface.
Evidence: both commands exit 0 on this branch (real exit codes, not piped).

## Not done

Making `process_alive` work on Windows (e.g. via OpenProcess) so the attribution path could function there -- the daemon supervisor stack (pidfile + kill + lsof) is Unix-flavored end to end, legion's deployment surface is macOS/Linux, and a Windows liveness shim is a feature, not a CI fix. If Windows ever becomes a real deployment target, that lands as its own issue with its own tests.