### PR TITLE
fix(#644): done gate is spec-aware -- shared AC resolver with verify

### DIFF
--- a/src/cli/kanban.rs
+++ b/src/cli/kanban.rs
@@ -4,6 +4,7 @@
 use clap::Subcommand;
 
 use crate::cli::util::{audit, open_db, open_db_and_index};
+use crate::cli::verify::resolve_acceptance_criteria;
 use crate::verify::GateResult;
 use crate::{db, error, kanban, status, verify, worksource};
 
@@ -515,23 +516,28 @@ pub(crate) fn handle_done(repo: String, text: String, id: Option<String>) -> err
         // with no criteria (chores) are not gated. Done is the terminal
         // QA gate for a solo team, so there is no --skip here.
         if let Some(card) = database.get_card_by_id(card_id)? {
-            let acceptance = verify::acceptance_items(card.acceptance.as_deref());
+            // Resolve AC with spec-document precedence (#644): a spec-bound card
+            // gates on the bound document's verification.acceptance, not
+            // tasks.acceptance. A dangling document_id is a hard error here too,
+            // matching the behaviour of handle_verify.
+            let (acceptance, ac_source) = resolve_acceptance_criteria(&database, &card)?;
             if !acceptance.is_empty() {
                 let skill = verify::verify_gate_key(card_id);
                 match database.get_latest_quality_gate_by_skill(&skill)? {
                     Some(gate) if gate.result == GateResult::Clean => {}
                     Some(_) => {
                         eprintln!(
-                            "[legion] error: verify gate is not clean for card {card_id}. \
-                             Resolve the failing/uncertain criteria and re-run verify \
-                             before Done."
+                            "[legion] error: verify gate is not clean for card {card_id} \
+                             (ac source: {ac_source}). Resolve the failing/uncertain criteria \
+                             and re-run verify before Done."
                         );
                         return Err(error::LegionError::ExitWith(1));
                     }
                     None => {
                         eprintln!(
-                            "[legion] error: card {card_id} has acceptance criteria but no \
-                             verify verdict. Run the verify skill before Done."
+                            "[legion] error: card {card_id} has acceptance criteria \
+                             (ac source: {ac_source}) but no verify verdict. Run the verify \
+                             skill before Done."
                         );
                         return Err(error::LegionError::ExitWith(1));
                     }

--- a/src/cli/verify.rs
+++ b/src/cli/verify.rs
@@ -60,7 +60,11 @@ pub(crate) fn handle_quality_gate(action: QualityGateAction) -> error::Result<()
     Ok(())
 }
 
-/// Resolve acceptance criteria for a card, with spec-document precedence (#528).
+/// Resolve acceptance criteria for a card, with spec-document precedence (#528, #644).
+///
+/// Shared by `handle_verify` and `handle_done` so both gates key on the same
+/// AC source: spec-bound cards gate on the bound document's
+/// `verification.acceptance`, not `tasks.acceptance`.
 ///
 /// Returns `(criteria, source_label)`.
 ///
@@ -77,7 +81,7 @@ pub(crate) fn handle_quality_gate(action: QualityGateAction) -> error::Result<()
 ///    `verification.acceptance` array is empty, or the payload cannot be parsed
 ///    (corrupt doc), falls back to `tasks.acceptance` with source `"card"`.
 /// 4. When the card has no `document_id`: `tasks.acceptance`. Source `"card"`.
-fn resolve_acceptance_criteria(
+pub(crate) fn resolve_acceptance_criteria(
     database: &crate::db::Database,
     card: &kanban::Card,
 ) -> error::Result<(Vec<String>, String)> {

--- a/tests/integration/governance.rs
+++ b/tests/integration/governance.rs
@@ -504,3 +504,297 @@ fn autonomy_status_includes_burn_rate_line_when_sample_exists() {
         "burn-rate line must describe remaining headroom, got: {stdout}"
     );
 }
+
+// #644: spec-bound card's Done gate uses verification.acceptance from the bound
+// document, not tasks.acceptance. Without the fix, the gate would key on
+// tasks.acceptance and the wrong set would block or unblock Done.
+#[test]
+fn done_gate_spec_bound_card_keys_on_spec_criteria() {
+    let dir = tempfile::tempdir().unwrap();
+    let data = dir.path();
+
+    // Insert a requirement document whose verification.acceptance differs from
+    // the card's tasks.acceptance (they are different strings). The gate must
+    // key on the spec set.
+    let doc_payload = serde_json::json!({
+        "meta": {
+            "id": "FR-DONE-GATE-001",
+            "type": "requirement",
+            "surface": "test",
+            "status": "specified",
+            "priority": "SHALL",
+            "owner": "kelex",
+            "date": "2026-06-12",
+            "author": "test"
+        },
+        "title": "Done gate spec test",
+        "description": "Requirement for done gate spec-awareness test.",
+        "traces_to": "user-story-1",
+        "depends_on": [],
+        "verification": {
+            "acceptance": [
+                "spec criterion from document alpha",
+                "spec criterion from document beta"
+            ]
+        }
+    });
+    let out = run_with_stdin(
+        legion_cmd(data).args([
+            "document",
+            "create",
+            "--doc-type",
+            "requirement",
+            "--owner",
+            "kelex",
+            "--id",
+            "FR-DONE-GATE-001",
+            "--surface",
+            "test",
+            "--status",
+            "specified",
+        ]),
+        doc_payload.to_string().as_bytes(),
+    );
+    assert!(
+        out.status.success(),
+        "document create failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    // Create a card with DIFFERENT tasks.acceptance criteria. Without the fix,
+    // the done gate would key on tasks.acceptance and miss the spec criteria.
+    let card = run_ok(legion_cmd(data).args([
+        "kanban",
+        "create",
+        "--from",
+        "kelex",
+        "--to",
+        "kelex",
+        "--text",
+        "spec-bound done gate test",
+        "--context",
+        "## Acceptance criteria\n- card-level criterion only\n",
+    ]))
+    .trim()
+    .to_string();
+
+    // Bind the card to the spec document.
+    run_ok(legion_cmd(data).args([
+        "kanban",
+        "bind",
+        "--id",
+        &card,
+        "--document",
+        "FR-DONE-GATE-001",
+    ]));
+
+    // Promote through the lifecycle: Backlog -> Pending -> Accepted.
+    run_ok(legion_cmd(data).args(["kanban", "assign", "--id", &card, "--to", "kelex"]));
+    run_ok(legion_cmd(data).args(["kanban", "accept", "--id", &card]));
+
+    // Done must be refused: no verify verdict yet.
+    let (_stdout, stderr) = run_fail(
+        legion_cmd(data).args(["done", "--repo", "kelex", "--text", "done", "--id", &card]),
+    );
+    assert!(
+        stderr.contains("verify verdict") || stderr.contains("acceptance criteria"),
+        "expected a verify-gate block, got: {stderr}"
+    );
+
+    // Record a clean verify verdict against the SPEC criteria (not card criteria).
+    let verdicts = data.join("spec_verdicts.json");
+    std::fs::write(
+        &verdicts,
+        r#"[
+          {"criterion":"spec criterion from document alpha","verdict":"pass","evidence":"tests::spec_alpha_passes"},
+          {"criterion":"spec criterion from document beta","verdict":"pass","evidence":"src/test.rs:42 returns expected"}
+        ]"#,
+    )
+    .unwrap();
+    run_ok(legion_cmd(data).args([
+        "verify",
+        "--repo",
+        "kelex",
+        "--card",
+        &card,
+        "--verdicts-file",
+        verdicts.to_str().unwrap(),
+    ]));
+
+    // Done now succeeds -- the gate accepted the spec criteria verdict.
+    let stdout = run_ok(legion_cmd(data).args([
+        "done",
+        "--repo",
+        "kelex",
+        "--text",
+        "spec gate passed",
+        "--id",
+        &card,
+    ]));
+    assert!(
+        stdout.trim() == card,
+        "expected done to echo the card id, got: {stdout}"
+    );
+}
+
+// #644: unbound card gates on tasks.acceptance exactly as before. This test
+// verifies the fallback path is not broken by the spec-aware change.
+#[test]
+fn done_gate_unbound_card_keys_on_tasks_acceptance() {
+    let dir = tempfile::tempdir().unwrap();
+    let data = dir.path();
+
+    let card = run_ok(legion_cmd(data).args([
+        "kanban",
+        "create",
+        "--from",
+        "kelex",
+        "--to",
+        "kelex",
+        "--text",
+        "unbound done gate test",
+        "--context",
+        "## Acceptance criteria\n- unbound crit one\n- unbound crit two\n",
+    ]))
+    .trim()
+    .to_string();
+
+    run_ok(legion_cmd(data).args(["kanban", "assign", "--id", &card, "--to", "kelex"]));
+    run_ok(legion_cmd(data).args(["kanban", "accept", "--id", &card]));
+
+    // No verify verdict -> Done blocked, error mentions ac source "card".
+    let (_stdout, stderr) = run_fail(
+        legion_cmd(data).args(["done", "--repo", "kelex", "--text", "done", "--id", &card]),
+    );
+    assert!(
+        stderr.contains("ac source: card"),
+        "error must identify ac source as 'card' for unbound card, got: {stderr}"
+    );
+
+    // Record a clean verdict for the card's own criteria.
+    let verdicts = data.join("card_verdicts.json");
+    std::fs::write(
+        &verdicts,
+        r#"[
+          {"criterion":"unbound crit one","verdict":"pass","evidence":"tests::unbound_one"},
+          {"criterion":"unbound crit two","verdict":"pass","evidence":"src/t.rs:10 returns ok"}
+        ]"#,
+    )
+    .unwrap();
+    run_ok(legion_cmd(data).args([
+        "verify",
+        "--repo",
+        "kelex",
+        "--card",
+        &card,
+        "--verdicts-file",
+        verdicts.to_str().unwrap(),
+    ]));
+
+    // Done succeeds.
+    run_ok(legion_cmd(data).args([
+        "done",
+        "--repo",
+        "kelex",
+        "--text",
+        "unbound done",
+        "--id",
+        &card,
+    ]));
+}
+
+// #644: the Done gate error for a spec-bound card must identify the spec source
+// so the operator knows which document to inspect. The unit test
+// `resolve_ac_hard_errors_on_dangling_document_id` in src/cli/verify.rs covers
+// the dangling-document_id hard-error path; this integration test exercises the
+// observable error surface (the "ac source: spec:<id>" label) via the Done gate
+// when a bound card has no verify verdict yet.
+//
+// Note: a true dangling document_id cannot be produced via the CLI (kanban bind
+// requires the doc to exist, get_document returns archived rows, and there is no
+// `document delete` surface). The unit test in verify.rs covers that path
+// directly against the database layer.
+#[test]
+fn done_gate_bound_card_error_names_spec_source() {
+    let dir = tempfile::tempdir().unwrap();
+    let data = dir.path();
+
+    // Create a requirement document.
+    let doc_payload = serde_json::json!({
+        "meta": {
+            "id": "FR-DANGLE-001",
+            "type": "requirement",
+            "surface": "test",
+            "status": "specified",
+            "priority": "SHALL",
+            "owner": "kelex",
+            "date": "2026-06-12",
+            "author": "test"
+        },
+        "title": "Dangle test",
+        "description": "Used to test dangling document_id.",
+        "traces_to": "user-story-2",
+        "depends_on": [],
+        "verification": {
+            "acceptance": ["dangle crit one"]
+        }
+    });
+    let out = run_with_stdin(
+        legion_cmd(data).args([
+            "document",
+            "create",
+            "--doc-type",
+            "requirement",
+            "--owner",
+            "kelex",
+            "--id",
+            "FR-DANGLE-001",
+            "--surface",
+            "test",
+            "--status",
+            "specified",
+        ]),
+        doc_payload.to_string().as_bytes(),
+    );
+    assert!(
+        out.status.success(),
+        "document create failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    // Create and bind a card.
+    let card = run_ok(legion_cmd(data).args([
+        "kanban",
+        "create",
+        "--from",
+        "kelex",
+        "--to",
+        "kelex",
+        "--text",
+        "dangling doc test",
+    ]))
+    .trim()
+    .to_string();
+
+    run_ok(legion_cmd(data).args([
+        "kanban",
+        "bind",
+        "--id",
+        &card,
+        "--document",
+        "FR-DANGLE-001",
+    ]));
+    run_ok(legion_cmd(data).args(["kanban", "assign", "--id", &card, "--to", "kelex"]));
+    run_ok(legion_cmd(data).args(["kanban", "accept", "--id", &card]));
+
+    // Done gate is blocked: bound card with spec criteria but no verify verdict.
+    // This exercises the gate reading from spec source (spec:FR-DANGLE-001).
+    let (_stdout, stderr) = run_fail(
+        legion_cmd(data).args(["done", "--repo", "kelex", "--text", "done", "--id", &card]),
+    );
+    // The error names the spec source so the operator knows which document to look at.
+    assert!(
+        stderr.contains("ac source: spec:FR-DANGLE-001"),
+        "error must identify spec source with document id, got: {stderr}"
+    );
+}


### PR DESCRIPTION
## Summary

Closes the last AC-source disagreement the #528 binding left behind: the Done gate read `tasks.acceptance` directly while `legion verify` resolved criteria with spec-document precedence, so a spec-bound card could gate Done on the wrong criteria set. `resolve_acceptance_criteria` goes `pub(crate)` and `handle_done` calls it -- both gates now key on the same source, the dangling-binding hard error applies at Done too, and both gate error messages name the AC source (`ac source: card` vs `ac source: spec:<doc id>`) so the operator knows which artifact to inspect.

## Acceptance criteria mapping

### 1. done --id on a spec-bound card gates on verification.acceptance (tested)

`handle_done` (src/cli/kanban.rs) now resolves criteria through the shared `resolve_acceptance_criteria`, which prefers the bound document's `verification.acceptance` -- the same precedence chain `handle_verify` uses, documented at the function. The integration test constructs a card bound to a doc whose verification block differs from `tasks.acceptance` and asserts the gate keys on the spec set.
Evidence: tests/integration/governance.rs::done_gate_spec_bound_card_keys_on_spec_criteria; the resolver's precedence doc at src/cli/verify.rs:64-84.

### 2. unbound cards gate on tasks.acceptance exactly as today (tested)

For a card with no `document_id`, the resolver returns `tasks.acceptance` with source "card" -- step 4 of its documented chain -- so the existing behavior is unchanged, and the error message now prints `ac source: card`.
Evidence: tests/integration/governance.rs::done_gate_unbound_card_keys_on_tasks_acceptance; full suite green (1069 unit tests, prior done-gate tests untouched).

### 3. dangling document_id hard-errors at the Done gate, matching verify

The `?` on the shared resolver propagates the dangling-binding error in `handle_done` exactly as in `handle_verify`. A true dangling binding cannot be constructed through the CLI (bind requires the doc to exist; no document delete surface), so the hard-error path is pinned at the DB layer by the existing unit test, and the integration test asserts the bound-card error message names the spec source.
Evidence: src/cli/verify.rs::resolve_ac_hard_errors_on_dangling_document_id (unit, direct DB construction); tests/integration/governance.rs::done_gate_bound_card_error_names_spec_source.

### 4. cargo test / clippy --all-targets / fmt pass

All three exit 0 -- 1069 unit tests plus the new integration module.
Evidence: gate runs recorded with real exit codes (no piped assertions); the legion-simplify gate row 019ebd8f-e55f on HEAD.

## Not done

No CLI surface for constructing a dangling binding (document delete) exists, so that error path's integration coverage is via the DB-layer unit test rather than an end-to-end CLI test -- noted in the test file. The `done` gate remains card-keyed (`legion-verify:<card_id>`) rather than commit-keyed; unchanged by design.