### PR TITLE
docs(#643): help + docs pass, release 0.18.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1473,7 +1473,7 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "legion"
-version = "0.17.2"
+version = "0.18.0"
 dependencies = [
  "async-stream",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "legion"
-version = "0.17.2"
+version = "0.18.0"
 edition = "2024"
 description = "Agent specialization through deliberate practice"
 

--- a/docs/plans/2026-06-refactor-audit.md
+++ b/docs/plans/2026-06-refactor-audit.md
@@ -1,0 +1,149 @@
+# Refactor audit -- 2026-06
+
+Produced by an 8-explorer workflow run under the legion-explore discipline (sym-first,
+recall-first, telemetry-logged fallback), with every must-change-together duplication
+claim adversarially verified by an independent refuter agent. Per-subsystem detail
+(every finding with file:line evidence) lives in the substrate:
+`legion document list --doc-type audit-finding`.
+
+## Executive summary
+
+Legion is 53,807 lines of Rust in 47 files, plus ~5,200 lines of plugin shell. The
+problem is concentrated: four god files (db.rs 8,815; main.rs 8,130; integration.rs
+6,696; watch.rs 4,767) hold 53% of the Rust. The remaining 43 files are individually
+healthy. 94 findings: 24 high, 37 med, 33 low. 30 duplication clusters were
+adversarially verified: 19 true duplicates (must change together; DRY them), 10
+coincidences (look alike, must NOT be unified), 1 uncertain. The split is unusually
+low-risk because the kessel recipe's core trick -- `impl Database` spanning files --
+is already proven in this repo by documents.rs and uncertainty/storage.rs, and the
+god files already carry section banners marking their seams.
+
+The audit also surfaced three live defects and confirmed one open issue:
+
+- **#606 (new): runtime panic path.** `get_reflections_by_ids` SELECTs 10 columns
+  against an 11-column row mapper; serve search is the trigger (db.rs:1866, serve.rs:1233).
+- **#536 (confirmed independently): daemon never spawns the cluster sync actor.**
+  The #582 WatchLoop unification held for the loop body, but the pre-loop side
+  effects re-forked: watch::run spawns SyncHandle (watch.rs:2292-2308), daemon does
+  not, despite a comment claiming it has "its own wiring" (sym refs: SyncHandle's
+  only spawn site is watch.rs:2299).
+- **MCP `legion_signal` bypasses the #587 required-fields gate.** Verb-manifest
+  enforcement lives inline in the CLI arm only (main.rs:4316-4333); the MCP handler
+  (mcp.rs:392-441) formats signals with no manifest check.
+- **Schedule firing is a side effect of SSE connections.** Schedules fire only while
+  a dashboard client is connected, N times per tick with N clients, racing
+  get_due/mark_run across connections (serve.rs:272-295).
+
+## Ranked findings (high)
+
+| # | Subsystem | Finding | Evidence |
+|---|-----------|---------|----------|
+| 1 | db | god file: ~120 methods, 7 impl blocks, 700-line init_schema, 3,700-line test module | db.rs:312,3725,4075,383 |
+| 2 | db | get_reflections_by_ids column shift -> InvalidColumnIndex (filed #606) | db.rs:85,1866; serve.rs:1233 |
+| 3 | db | tasks + cards: two divergent CRUD families over one table; priority ORDER BY already differs | db.rs:2557-3148,2670 |
+| 4 | db | init_schema interleaves ~18 tables in patch order; documents/uncertainty DDL stranded away from their modules | db.rs:383-1085,899,948 |
+| 5 | cli | run() is a 3,700-line match over 58 arms; six arms >150 lines carry real domain logic inline | main.rs:3942-7648 |
+| 6 | cli | worksource resolve-or-die block pasted ~19x (+5 variants) | main.rs:6040,6294,6790 |
+| 7 | cli | fat domain logic inline: Reconcile algorithm, Verify gate recording, Pr Create gates | main.rs:5570,7089,6236 |
+| 8 | comms | mcp.rs is five domains in one file (log, tools, dispatch, notifier, stdio loop) | mcp.rs:33-1270 |
+| 9 | comms | '@recipient' addressing implemented 4 divergent ways; colon-suffix delivers live but never wakes | mcp.rs:637,684; signal.rs:43; db.rs LIKE |
+| 10 | comms | MCP legion_signal bypasses required-fields gate (#587 leak) | main.rs:4316; mcp.rs:392 |
+| 11 | comms/serve | serve.rs and channel.rs are parallel live HTTP feed stacks, already diverged (api_post shape, index-failure policy) | channel.rs:73-193; serve.rs:402-484 |
+| 12 | serve | no error type w/ IntoResponse: 29 hand-written match-to-json_error blocks | serve.rs:39,44,365,427 |
+| 13 | serve | schedule firing rides per-connection SSE streams (fires only with dashboard open; races) | serve.rs:272-295 |
+| 14 | watch | daemon path lost the cluster-sync actor spawn (#536 confirmed) | watch.rs:2292; daemon.rs:449-518 |
+| 15 | watch | god file: seven banner-marked domains | watch.rs:16-2329 |
+| 16 | watch | watch::ClusterConfig is a dead parallel config path (parsed, never consumed in production) | watch.rs:113-289,2292 |
+| 17 | watch | wake-address-set construction duplicated 3x incl. main.rs pending-replies -- the #585/#586 conflict surface | watch.rs:1595,1625; main.rs:4398 |
+| 18 | hooks | four generations of 'intercept search, substitute legion'; only newest uses the shared library | hooks.json:66-125; pre-grep-*.sh |
+| 19 | hooks | 10-site hook preamble diverging on LEGION_REPO honor (9 yes, 7 no) | pre-bash-grep.sh:54; stop.sh:42 |
+| 20 | hooks | binary resolution split: 3 hooks PATH-resolve and are silently inert without a system install | pre-whoami-rewrite.sh:70; uncertainty-*.sh |
+| 21 | tests | god file: 161 tests, ~14 domains, seams already banner-marked | integration.rs:2092,3690 |
+| 22 | tests | zero integration coverage: serve, health, pty, cluster, sync_actor, wake_attempts, verbs, pr_write; watch thin (config CRUD only) | integration.rs:4633 |
+| 23 | midtier | worksource plugin-call boilerplate ~19x; list_issues/list_prs silently return empty on missing plugin (policy split vs #190 lesson) | worksource.rs:300,632,347 |
+| 24 | cli | 18 std::process::exit(1) inside handler bodies block extraction and testing | main.rs:6277,7156,5208 |
+
+Med/low findings (37/33) and all cluster verdicts: `legion document list --doc-type audit-finding`.
+
+## Verified duplication clusters
+
+True duplicates (19) -- DRY these, each is one invariant written N times:
+db-open prelude (~50 arms), done-vs-propagate-close (already drifted: audit parity lost),
+verify-gate-key construction (write site vs read site), active-team-post WHERE fragment (6
+sites), reflection column list (11+ sites, caused #606), tasks-vs-cards dual CRUD,
+recipient matching (4 implementations), details wire parsing (CLI + MCP), serve/channel
+HTTP clone (16 sites), open-db match boilerplate (29 sites), agents-json (2), feed-item
+mapping (4), hook preamble (10 hooks), symbol-redirect logic (2 generations),
+process-alive (watch + daemon), wake-address-set (3 sites incl. cross-file),
+recall join+score (BM25 + hybrid paths), scip install-hint error mapping (9 sites),
+test-harness stub-legion contract.
+
+Coincidences (10) -- look-alike, deliberately NOT unified: worksource resolve-or-die
+(error text should be pinned by a helper, but the 23 sites are policy-independent),
+sync delta-getter SQL shape, verb-classification sets (fix is manifest-driven, not
+extraction), emit-JSON dialects (migrate to one shape instead), cluster-config twins
+(one is dead code -- delete, don't merge), recall hot-shims (delete), kanban promotion
+ladder in tests, worksource error-string assertions, pr-stub generators, C1 stderr greps.
+
+## Sequencing plan
+
+Kessel lessons encoded: PRs touching the same hot file are NOT independent (21-PR
+cascade); mechanical moves never mix with semantic changes; the test net lands before
+the trapeze. Streams below are serial within themselves; separate streams may interleave.
+
+**Stream 0 -- pre-split in-place DRY (small PRs, land first; each shrinks the later move):**
+0a. #606 fix + REFLECTION_COLUMNS const.
+0b. require_worksource() + open_db()/open_db_and_index() helpers; fold Commands::Done
+    through propagate_card_close_to_worksource (behavior fix: restores audit parity).
+0c. ServeError + IntoResponse; handlers become Result-returning (kills 29 match blocks).
+0d. signal::recipient_token/is_addressed_to + signal::parse_details_arg + compose/validate
+    entry point (closes the MCP required-fields bypass -- behavior fix).
+0e. WatchRepoConfig::wake_addresses(); shared process_alive.
+
+**Stream 1 -- test net:** split tests/integration.rs into tests/integration/{main,common,domain}.rs
+(one PR, mechanical); then add missing coverage: watch wake-loop (cap, preflight),
+sym round-trip, pr write-check gate, serve bind+health. Coverage PRs gate streams 2-4.
+
+**Stream 2 -- db/ split:** ONE extraction PR per the kessel recipe. mod.rs = infra only
+(Database, open, has_column, thin init_schema dispatcher); domain files own DDL + methods +
+tests (reflections, board, kanban, schedules, sync, leases/wake_attempts, health,
+statusline_samples, stats, quality_gates, autonomy, audit, scip, heartbeat); db/testutil.rs.
+Tasks/cards land side-by-side in db/kanban.rs; collapse is a follow-up.
+
+**Stream 3 -- cli split:** 3a. extract cli/datadir.rs (lowest blast radius, 95 crate refs
+via re-export hub). 3b+. one domain handler file per PR, largest arms first (pr, kanban,
+issue, autonomy, watch, index); arms keep arg massaging + print/json only; algorithm
+bodies push into domain modules; exits become typed errors as each arm moves.
+
+**Stream 4 -- watch/ split + sync-actor decision:** decide #536 fix shape FIRST (shared
+WatchLoop::bootstrap owning the sync-actor spawn), then split watch/ {config, locks,
+signals, spawn, tracker, gates}; delete dead watch::ClusterConfig.
+
+**Stream 5 -- comms:** mcp/ split (log, tools, dispatch, notifier); serve mounts
+channel::router and deletes its four duplicate handlers; schedule firing moves to a
+background tokio task.
+
+**Stream 6 -- hooks (independent of Rust streams, may run anytime):** lib/{prelude,emit,
+probe,markers}.sh; merge the grep-guard generations onto _legion-prequery; delete
+bullpen-check.sh (orphaned) and _legion-warn.sh dead plumbing; tests/testutil.sh with
+parameterized stub-legion.
+
+**Stream 7 -- the crate question:** answered LAST with compile-time data from the
+post-split tree. Prior: scip/sym and pty are the only candidates with a real boundary;
+default answer remains modules-not-crates.
+
+## Coverage gaps (pre-refactor net)
+
+Zero integration tests: serve.rs (1,492 lines -- the HTTP surface), health.rs, pty.rs,
+cluster.rs, sync_actor.rs, wake_attempts.rs, verbs.rs, now.rs, embed.rs, pr_write.rs.
+Thin: watch.rs (config CRUD only -- no wake loop, no gates). The Stream 1 coverage PRs
+are the precondition for Streams 2-4.
+
+## Explore-tooling appendix (dogfood measurement)
+
+Index fresh for all 8 explorers. 13 lane-4 bypasses total: tests 4 (test files are not
+richly SCIP-indexed for fn-level lookup), hooks 2 + cli 2 + serve 2 (shell, literal
+strings, static assets), db 1, watch 1, midtier 1, comms 0. Reading: sym served the
+symbol-shaped load; the honest gaps are shell scripts and literal-string lookups,
+matching the lane-4 design rationale. Verifier verdicts overturned 10 of 30 claimed
+must-change-together clusters -- the adversarial stage earned its cost.

--- a/docs/site/architecture.md
+++ b/docs/site/architecture.md
@@ -215,6 +215,10 @@ The `init_schema` function applies migrations incrementally using `has_column` c
 | 14 | LWW conflict resolution: add updated_at on reflections and schedules (#255) |
 | 15 | Partial indexes that skip soft-deleted rows (#256) |
 | 16 | Card-spec binding: add document_id to tasks, partial index on document_id (#528) |
+| 17 | SCIP indexes for code intelligence (#278); also assigned to persona wake leases (#308) -- the number collides across domain modules, the guards make it harmless |
+| 18 | Bullpen post decay (#376) |
+| 19 | Signal/post resolution marker (#362) |
+| 20 | Agent session log (#389) |
 | 21 | Documents table for the coordination substrate (#456) |
 | 22 | Uncertainty engine: uncertainty_prediction + uncertainty_calibration_snapshot tables (#355) |
 | 23 | wake_attempts table -- per-wake lifecycle FSM for PTY spawn tracking (#487) |
@@ -736,10 +740,10 @@ Status transitions for bound cards are synchronized to the document's `status` f
 
 `legion verify` determines acceptance criteria in this order:
 
-1. If the card has a `document_id`, load the bound document and read `spec.verification.acceptance` from the payload. If that key is present and non-empty, it is used.
-2. Otherwise, use `tasks.acceptance` (the newline-separated criteria parsed from the issue body at sync time).
+1. If the card has a `document_id`, load the bound document and read the top-level `verification.acceptance` array from the payload. If that key is present and non-empty, it is used (source labeled `spec:<doc id>` in output).
+2. Otherwise, use `tasks.acceptance` (the newline-separated criteria parsed from the issue body at sync time; source labeled `card`).
 
-A card with `document_id` pointing to a document that does not exist, or a document whose payload does not parse as a spec, is a hard error -- `verify` exits non-zero rather than silently falling back to `tasks.acceptance`.
+Only a dangling `document_id` -- the bound document does not exist -- is a hard error: `verify` (and the Done gate, which shares the resolver as of #644) exits non-zero rather than gating on criteria for a spec that vanished. An unparseable payload or an absent/empty `verification.acceptance` block is non-fatal and falls back to `tasks.acceptance`.
 
 ## Quality-gate chain
 
@@ -751,14 +755,14 @@ A card with `document_id` pointing to a document that does not exist, or a docum
 
 The full quality pipeline for a branch is:
 
-1. `/legion-simplify` -- review for code quality (duplication, unnecessary abstraction, stringly-typed state). Records a `simplify` gate via `legion quality-gate record`.
+1. `/legion-simplify` -- review for code quality (duplication, unnecessary abstraction, stringly-typed state). Records a `legion-simplify` gate via `legion quality-gate record`.
 2. `/legion-pr-write` -- compose the PR body mapping each acceptance criterion to the change that satisfies it, with evidence. Validates the body is non-empty and non-boilerplate via `legion pr write-check`. Records a `legion-pr-write` gate.
 3. `/legion-review` -- parallel dimension review (spec, correctness, quality, security) with adversarial refutation of HIGH/MED findings. Records a `legion-review` gate.
 4. `/legion-verify` -- per-criterion verdict (pass/fail/uncertain + evidence). Records a `legion-verify:<card>` gate.
 
 ### PR create gate requirements
 
-`legion pr create` requires a clean `simplify` gate AND a clean `legion-pr-write` gate on HEAD before a PR may be opened. Both forcing functions must have run. `--skip-gates` bypasses both with an audit row.
+`legion pr create` requires a clean `legion-simplify` gate AND a clean `legion-pr-write` gate on HEAD before a PR may be opened. Both forcing functions must have run. `--skip-gates` bypasses both with an audit row.
 
 ### Done verify gate
 

--- a/docs/site/architecture.md
+++ b/docs/site/architecture.md
@@ -80,16 +80,48 @@ CREATE TABLE tasks (
     assigned_at TEXT,                                   -- when card was assigned to an agent
     started_at TEXT,                                    -- when agent accepted the card
     completed_at TEXT,                                  -- when card reached done/cancelled
-    deleted_at TEXT                                     -- tombstone for multi-node sync (nullable)
+    deleted_at TEXT,                                    -- tombstone for multi-node sync (nullable)
+    problem TEXT,                                       -- parsed problem statement from issue body
+    solution TEXT,                                      -- parsed solution statement from issue body
+    acceptance TEXT,                                    -- newline-separated acceptance criteria
+    document_id TEXT                                    -- bound spec document (nullable, #528)
 );
 
 CREATE INDEX idx_tasks_to ON tasks(to_repo, status);
 CREATE INDEX idx_tasks_from ON tasks(from_repo, status);
 CREATE INDEX idx_tasks_parent ON tasks(parent_card_id);
 CREATE INDEX idx_tasks_status_sort ON tasks(status, sort_order, created_at);
+CREATE INDEX idx_tasks_document_id ON tasks(document_id) WHERE document_id IS NOT NULL;
 ```
 
 `tasks.updated_at` already existed pre-sync and is reused for LWW.
+
+### documents
+
+Coordination substrate for specs, NFRs, blueprints, personas, journeys, and schemas (#456, #526). Type-agnostic at the storage layer -- the payload is validated JSON; the meta columns (type, surface, status, priority, owner) are hoisted out of the payload and indexed so SQL can filter without parsing JSON. Hot/cold tiered: `archived_at` is null for hot documents and populated when work referencing the doc completes.
+
+```sql
+CREATE TABLE documents (
+    id TEXT PRIMARY KEY,                               -- UUIDv7 or caller-supplied typed id
+    type TEXT NOT NULL,                                 -- doc_type: requirement, schema, persona, etc.
+    surface TEXT,                                       -- functional surface (optional)
+    status TEXT NOT NULL DEFAULT 'draft',               -- lifecycle status
+    priority TEXT,                                      -- RFC 2119 level: SHALL, SHOULD, MAY
+    owner TEXT NOT NULL,                                -- owning agent id
+    payload TEXT NOT NULL,                              -- validated JSON payload
+    archived_at TEXT,                                   -- hot/cold tier: null = hot
+    created_at TEXT NOT NULL,                           -- ISO 8601
+    updated_at TEXT NOT NULL,                           -- ISO 8601
+    deleted_at TEXT                                     -- tombstone (nullable)
+);
+
+CREATE INDEX idx_documents_type ON documents(type) WHERE archived_at IS NULL AND deleted_at IS NULL;
+CREATE INDEX idx_documents_surface ON documents(surface) WHERE archived_at IS NULL AND deleted_at IS NULL;
+CREATE INDEX idx_documents_owner ON documents(owner) WHERE archived_at IS NULL AND deleted_at IS NULL;
+CREATE INDEX idx_documents_status ON documents(status) WHERE archived_at IS NULL AND deleted_at IS NULL;
+```
+
+Schema documents (`doc_type=schema`) are validated structurally at insert: the payload must be a valid JSON Schema with `$schema`, `title`, `type:object`, and non-empty `properties`. Invalid schema payloads are rejected at create time. A dual-write pointer reflection (`domain=schema`) is stored so `legion recall --domain schema` surfaces every landed schema with its document id. `legion document archive` is idempotent: re-archiving preserves the original `archived_at` timestamp via COALESCE.
 
 ### schedules
 
@@ -182,6 +214,13 @@ The `init_schema` function applies migrations incrementally using `has_column` c
 | 13 | Soft delete support for multi-node sync: add deleted_at on reflections, tasks, schedules (#245) |
 | 14 | LWW conflict resolution: add updated_at on reflections and schedules (#255) |
 | 15 | Partial indexes that skip soft-deleted rows (#256) |
+| 16 | Card-spec binding: add document_id to tasks, partial index on document_id (#528) |
+| 21 | Documents table for the coordination substrate (#456) |
+| 22 | Uncertainty engine: uncertainty_prediction + uncertainty_calibration_snapshot tables (#355) |
+| 23 | wake_attempts table -- per-wake lifecycle FSM for PTY spawn tracking (#487) |
+| 24 | watch_heartbeat table -- daemon liveness heartbeat (#581) |
+
+Migration numbers above 15 are applied in the domain modules that own the corresponding DDL, not in the reflections/kanban/schedules patch sequence. All migrations are idempotent: `CREATE TABLE IF NOT EXISTS` for new tables, `has_column` guards for `ALTER TABLE` column additions.
 
 On a fully-migrated database, `init_schema` does minimal work: `CREATE IF NOT EXISTS` checks and a few `PRAGMA table_info` queries.
 
@@ -362,6 +401,25 @@ Invalid transitions return `InvalidCardTransition` with the current state and at
 | assigned_at | TEXT | When assigned (nullable) |
 | started_at | TEXT | When accepted (nullable) |
 | completed_at | TEXT | When done/cancelled (nullable) |
+| problem | TEXT | Problem statement parsed from issue body (nullable) |
+| solution | TEXT | Solution statement parsed from issue body (nullable) |
+| acceptance | TEXT | Newline-separated acceptance criteria parsed from issue body (nullable) |
+| document_id | TEXT | Bound spec document id (nullable, #528) |
+
+### Transactional status sync
+
+When a card has a `document_id`, status transitions are synchronized to the bound document's `status` field in the same transaction. The mapping is:
+
+| Card status reached | Document status set |
+|--------------------|---------------------|
+| accepted | accepted |
+| in-review | implemented |
+| done | verified |
+| cancelled | cancelled |
+
+Only the four terminal/review statuses trigger a sync write. Other transitions (pending, blocked, needs-input, resume) leave the document status unchanged.
+
+If the bound document does not exist or the payload cannot be parsed as the expected spec shape, the transition fails and the card status is not changed. A dangling `document_id` is a hard error, not a silent no-op.
 
 ## Watch daemon
 
@@ -432,7 +490,7 @@ claude --print -p "<wake prompt>"
 
 In the repo's `workdir`, with `LEGION_AUTO_WAKE=1` in the environment. Stdout and stderr are redirected to `/dev/null`.
 
-A wake fires only for signals whose `--verb` is in the wake-worthy set: `question`, `request`, `help`, `blocker`. Signals with other verbs (`announce`, `ack`, `info`, `answer`) deliver to live sessions via channel push but do not spawn an asleep recipient. Posts never wake -- posts are broadcast, not direction.
+A wake fires only for signals whose `--verb` is in the wake-worthy set: `question`, `request`, `handoff`, `correction`, `proposal`, `decision`, `rfc`, `routing`. Signals with other verbs (`announce`, `ack`, `info`, `answer`) deliver to live sessions via channel push but do not spawn an asleep recipient. Posts never wake -- posts are broadcast, not direction.
 
 When a wake fires, `build_wake_prompt` in `src/watch.rs` groups pending signals into two sections matching the same verb cut:
 
@@ -637,6 +695,93 @@ Output format:
 ```
 
 Returns an empty string when there is nothing to surface.
+
+## Coordination substrate
+
+### Document storage
+
+The `documents` table (migration 21) is the persistence layer for the coordination substrate. Documents are type-agnostic at the storage layer: any document whose payload is well-formed JSON can be inserted. Meta columns (`type`, `surface`, `status`, `priority`, `owner`) are caller-supplied at insert time and indexed via partial indexes scoped to the hot pool (`archived_at IS NULL AND deleted_at IS NULL`).
+
+Hot/cold tiering mirrors the reflections model. `legion document list` returns only hot (non-archived) documents by default. `--archived` returns only the cold partition. Archiving is idempotent: `archive_document` uses `COALESCE(archived_at, now)` so re-archiving preserves the original timestamp.
+
+### Schema registry
+
+Documents with `doc_type=schema` are the schema registry. They serve two roles:
+
+1. **Structural gate at insert** -- `legion document create --doc-type schema` validates the payload before storage. The dependency-free check requires: `$schema` field, `title`, `type: object`, and at least one property in `properties`. `required` must reference only defined properties. A payload failing this check is rejected with a descriptive error; the document is not stored.
+
+2. **Instance validation** -- `legion document validate --schema <id> --file <path>` loads a landed schema document and validates the instance against it. The validator covers: `type` (including nullable arrays), `required`, `properties`, `items`, `enum`. Each violation produces one JSON-path error; exits non-zero when there are violations.
+
+When a schema document is created successfully, a pointer reflection is dual-written on `domain=schema` so `legion recall --domain schema` surfaces every landed schema with its document id and a human-readable summary. The canonical payload lives in the document; the reflection is the searchable pointer.
+
+### Spec-gen pipeline
+
+`legion spec-gen --repo <surface>` derives requirement documents from service-design inputs (#527). The `--repo` argument is the `surface` field on the source documents (e.g. "payments"), not a git repository name.
+
+Input types: `persona`, `journey`, `blueprint`, `painmatrix`, `ecosystem` -- all non-archived documents on the specified surface. One requirement candidate is derived per `moment_of_truth` entry across all inputs. Each candidate is validated against the `requirement` schema before storage.
+
+Idempotency key: `(traces_to, surface)`. A candidate whose `traces_to` value already exists for the surface is skipped. Re-running on unchanged input is always safe.
+
+`traces_to` convention: `<doc_id>#moment_of_truth[.n]` where `n` is the index within the source document's `moments_of_truth` array (zero-based). Each born card is born in `Backlog` status.
+
+Rejection classes: schema validation failure, source document not found, duplicate `(traces_to, surface)` pair.
+
+### Card-spec binding and bind guards
+
+`tasks.document_id` binds a kanban card to a spec document (#528). The binding is application-layer unique: `bind_card_to_document` enforces that a given `document_id` is held by at most one non-cancelled card. Attempting to bind a document already bound to another card returns a hard error.
+
+Status transitions for bound cards are synchronized to the document's `status` field in the same transaction (see "Transactional status sync" above). A dangling `document_id` (pointing to a non-existent document) is a hard error on any transition that triggers a sync write.
+
+### Verify AC precedence
+
+`legion verify` determines acceptance criteria in this order:
+
+1. If the card has a `document_id`, load the bound document and read `spec.verification.acceptance` from the payload. If that key is present and non-empty, it is used.
+2. Otherwise, use `tasks.acceptance` (the newline-separated criteria parsed from the issue body at sync time).
+
+A card with `document_id` pointing to a document that does not exist, or a document whose payload does not parse as a spec, is a hard error -- `verify` exits non-zero rather than silently falling back to `tasks.acceptance`.
+
+## Quality-gate chain
+
+### GateResult enum
+
+`GateResult { Clean, Issues }` is the canonical result type stored in the `quality_gates` table. Stored as lowercase strings (`"clean"`, `"issues"`) for SQL readability. `Display` and `FromStr` are symmetric. The enum is defined in `src/verify.rs` alongside the verify decision logic.
+
+### The four skills
+
+The full quality pipeline for a branch is:
+
+1. `/legion-simplify` -- review for code quality (duplication, unnecessary abstraction, stringly-typed state). Records a `simplify` gate via `legion quality-gate record`.
+2. `/legion-pr-write` -- compose the PR body mapping each acceptance criterion to the change that satisfies it, with evidence. Validates the body is non-empty and non-boilerplate via `legion pr write-check`. Records a `legion-pr-write` gate.
+3. `/legion-review` -- parallel dimension review (spec, correctness, quality, security) with adversarial refutation of HIGH/MED findings. Records a `legion-review` gate.
+4. `/legion-verify` -- per-criterion verdict (pass/fail/uncertain + evidence). Records a `legion-verify:<card>` gate.
+
+### PR create gate requirements
+
+`legion pr create` requires a clean `simplify` gate AND a clean `legion-pr-write` gate on HEAD before a PR may be opened. Both forcing functions must have run. `--skip-gates` bypasses both with an audit row.
+
+### Done verify gate
+
+`legion done --id <card>` checks for a clean `legion-verify:<card>` gate when the card has acceptance criteria. Cards with no acceptance criteria are not gated. The gate key is constructed by `verify_gate_key(card_id)` in `src/verify.rs` -- the single source of truth for both the writer (`cli::verify::handle_verify`) and the reader (`cli::kanban::handle_done`).
+
+### ExitWith typed exits
+
+The binary uses `LegionError::ExitWith(code)` for controlled non-zero exits. `main()` is the only site that calls `std::process::exit`; all handler code returns `Result<T>` and propagates errors up. This allows handlers to be tested without spawning a subprocess and prevents `process::exit` from bypassing destructors in test contexts.
+
+## Source layout
+
+The source tree is organized into carved domain modules. File counts reflect the state at 0.18.0.
+
+| Tree | Files | Owns |
+|------|-------|------|
+| `src/cli/` | 17 | clap `Commands` enum + per-domain handler modules |
+| `src/db/` | 19 | SQLite layer: `Database` handle, `init_schema` dispatcher, per-domain `impl` blocks + DDL |
+| `src/watch/` | 7 | Watch daemon: config, locks, signals, spawn, tracker, gates, mod |
+| `src/mcp/` | 4 | MCP stdio server: log, tools, notifier, mod |
+| `src/kanban/` | 3 | Kanban FSM and card parsing |
+| `src/worksource/` | 3 | Work source plugin bridge (issues, PRs, mod) |
+
+Other top-level modules in `src/` are single-file (e.g. `documents.rs`, `verify.rs`, `signal.rs`, `verbs.rs`, `spec_gen.rs`). Tests live alongside the code they test in `#[cfg(test)] mod tests` blocks. Integration tests are split across `tests/integration/` (one file per domain).
 
 ## File descriptor limit
 

--- a/docs/site/getting-started.md
+++ b/docs/site/getting-started.md
@@ -281,7 +281,7 @@ legion signal --repo myproject --to platform --verb request --status help \
 legion signal --repo myproject --to all --verb announce --note "Phase 2.1 shipped"
 ```
 
-Watch wakes the recipient when `--verb` is in the wake-worthy set: `question`, `request`, `help`, `blocker`. Other verbs (`announce`, `ack`, `info`, `answer`) deliver to live sessions via the channel push but do not spawn an asleep recipient. Use the wake-worthy set when you need a reply; use the others when the recipient should see it but does not need to be paged out of sleep.
+Watch wakes the recipient when `--verb` is in the wake-worthy set: `question`, `request`, `handoff`, `correction`, `proposal`, `decision`, `rfc`, `routing`. `rfc` additionally requires a `budget` detail (e.g. `--details "budget:2h"`). Informational verbs (`announce`, `ack`, `info`, `answer`) deliver to live sessions via the channel push but do not spawn an asleep recipient. Use the wake-worthy set when you need a reply; use the others when the recipient should see it but does not need to be paged out of sleep.
 
 The `--note` flag has a 280 character limit. Signals are pings, not content delivery. If you need more space, use `legion post` instead.
 
@@ -291,7 +291,7 @@ The `--note` flag has a 280 character limit. Signals are pings, not content deli
 |------|----------|-------------|
 | `--repo` | yes | Sender identity (comma-separated for multi-repo) |
 | `--to` | yes | Recipient agent name, or "all" for broadcast |
-| `--verb` | yes | Action verb (review, request, announce, question, blocker, answer) |
+| `--verb` | yes | Action verb. Wake-worthy: question, request, handoff, correction, proposal, decision, rfc, routing. Informational: announce, ack, info, answer. |
 | `--status` | no | Status qualifier (approved, blocked, ready, help) |
 | `--note` | no | Free-text note (max 280 chars) |
 | `--details` | no | Comma-separated key:value pairs (e.g., "surface:cap-output,chain:confirmed") |
@@ -426,7 +426,7 @@ legion done --repo myproject --text "implemented BM25 search" --id <card-id>
 
 ## Watch daemon
 
-The watch daemon monitors the bullpen for signals directed at idle agents and auto-wakes them by spawning `claude --print` sessions.
+The watch daemon monitors the bullpen for signals directed at idle agents and auto-wakes them by spawning interactive `claude` PTY sessions (subscription-billed path; the legacy `--print` mode is available via `WATCH_SPAWN_MODE=print`).
 
 ### Start the watcher
 
@@ -484,7 +484,7 @@ The daemon runs a dual-interval loop:
 
 When signals are found for a repo:
 - Builds a wake prompt listing all pending signals
-- Spawns `claude --print -p "<prompt>"` in the repo's workdir with `LEGION_AUTO_WAKE=1`
+- Spawns an interactive `claude` PTY session in the repo's workdir with `LEGION_AUTO_WAKE=1`
 - Marks signals as handled (per-repo, so @all broadcasts are seen by every repo)
 - Records a cooldown to prevent wake storms
 - Staggers multiple spawns by `stagger_secs` to prevent I/O overheating
@@ -579,7 +579,7 @@ If you installed the plugin, these slash commands are available in Claude Code:
 | `/bullpen [--signals\|--musings\|--count]` | Read the team board |
 | `/consult <context query>` | Search across all agents |
 | `/surface` | Surface cross-repo highlights |
-| `/snooze` | Session wind-down with full team memory consolidation |
+| `/checkpoint` | Save a structured resume-anchor and consolidate team memory |
 | `/watch-sync` | Sync working directories into watch.toml |
 
 ## Plugin agents

--- a/docs/site/plugin-guide.md
+++ b/docs/site/plugin-guide.md
@@ -168,11 +168,13 @@ Runs `legion consult --context '<arguments>'`. Searches across ALL repos/agents.
 
 Runs `legion surface --repo $(basename $PWD)`. Shows recent bullpen posts, high-value reflections, and learning chain extensions.
 
-### /snooze
+### /checkpoint
 
 ```
-/snooze
+/checkpoint
 ```
+
+Save a structured resume-anchor and consolidate team memory. Renamed from `/snooze` in v0.16.3 (the word primed agents to go dormant; a checkpoint is a waypoint you cross and keep moving).
 
 Full session wind-down with six phases:
 

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -2,15 +2,15 @@
 
 ## 0.18.0
 
-The refactor release. Six streams of structural work deliver a codebase that is split by domain, observable, and covered. The god files (db.rs 8,815 lines; main.rs 8,130 lines; watch.rs 4,767 lines) are carved into 50+ focused modules. Three live defects are fixed alongside the structural work. The coordination substrate gains spec binding, spec-gen, and a verify gate that reads bound-spec AC. The quality-gate chain ships end to end.
+The refactor release. Six streams of structural work deliver a codebase that is split by domain, observable, and covered. The god files (per the June audit: db.rs 8,815 lines; main.rs 8,130 lines; watch.rs 4,767 lines) are carved into 50+ focused modules. Three live defects are fixed alongside the structural work. The coordination substrate gains spec binding, spec-gen, and a verify gate that reads bound-spec AC. The quality-gate chain ships end to end. Minor release: structural refactor plus additive features and one additive schema migration (tasks.document_id); no wire-format change.
 
 ### New
 
 - **Spec-gen pipeline** (PR #639, #527): `legion spec-gen --repo <surface>` derives requirement documents from non-archived service-design inputs (persona, journey, blueprint, painmatrix, ecosystem) on the specified surface. One requirement candidate is produced per `moment_of_truth` entry, validated against the requirement schema, and inserted as a `doc_type=requirement` document plus a born-Backlog kanban card. Re-running on unchanged input is safe: existing `(traces_to, surface)` pairs are skipped. The `--repo` argument is the `surface` field on the source documents, not a git repository name.
 
-- **Card-spec binding and transactional status sync** (PR #640, #528): `tasks.document_id` binds a kanban card to a spec document. Status transitions for bound cards synchronize the document's `status` field in the same transaction (accepted -> accepted, in-review -> implemented, done -> verified, cancelled -> cancelled). A dangling `document_id` is a hard error on any syncing transition. `legion verify` reads AC from `spec.verification.acceptance` when a bound spec is present, falling back to `tasks.acceptance`. The bind guard ensures a given document is held by at most one non-cancelled card.
+- **Card-spec binding and transactional status sync** (PR #640, #528): `tasks.document_id` binds a kanban card to a spec document. Status transitions for bound cards synchronize the document's `status` field in the same transaction (accepted -> accepted, in-review -> implemented, done -> verified, cancelled -> cancelled). A dangling `document_id` is a hard error on any syncing transition. `legion verify` reads AC from the bound document's top-level `verification.acceptance` when present and non-empty, falling back to `tasks.acceptance`. The bind guard ensures a given document is held by at most one non-cancelled card.
 
-- **Done verify gate is spec-aware** (PR #TBD, #644): ...
+- **Done verify gate is spec-aware** (PR #645, #644): `legion done --id` resolved its acceptance criteria from `tasks.acceptance` directly while `legion verify` used spec-document precedence, so a spec-bound card gated Done on the wrong criteria set. Both gates now share one resolver: bound `verification.acceptance` first, `tasks.acceptance` fallback, hard error on a dangling binding. Gate error messages name the AC source (`ac source: card` or `ac source: spec:<doc id>`).
 
 ### Fixed
 

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -1,10 +1,52 @@
 # Legion Changelog
 
-## Unreleased
+## 0.18.0
+
+The refactor release. Six streams of structural work deliver a codebase that is split by domain, observable, and covered. The god files (db.rs 8,815 lines; main.rs 8,130 lines; watch.rs 4,767 lines) are carved into 50+ focused modules. Three live defects are fixed alongside the structural work. The coordination substrate gains spec binding, spec-gen, and a verify gate that reads bound-spec AC. The quality-gate chain ships end to end.
+
+### New
+
+- **Spec-gen pipeline** (PR #639, #527): `legion spec-gen --repo <surface>` derives requirement documents from non-archived service-design inputs (persona, journey, blueprint, painmatrix, ecosystem) on the specified surface. One requirement candidate is produced per `moment_of_truth` entry, validated against the requirement schema, and inserted as a `doc_type=requirement` document plus a born-Backlog kanban card. Re-running on unchanged input is safe: existing `(traces_to, surface)` pairs are skipped. The `--repo` argument is the `surface` field on the source documents, not a git repository name.
+
+- **Card-spec binding and transactional status sync** (PR #640, #528): `tasks.document_id` binds a kanban card to a spec document. Status transitions for bound cards synchronize the document's `status` field in the same transaction (accepted -> accepted, in-review -> implemented, done -> verified, cancelled -> cancelled). A dangling `document_id` is a hard error on any syncing transition. `legion verify` reads AC from `spec.verification.acceptance` when a bound spec is present, falling back to `tasks.acceptance`. The bind guard ensures a given document is held by at most one non-cancelled card.
+
+- **Done verify gate is spec-aware** (PR #TBD, #644): ...
+
+### Fixed
+
+- **Cluster sync runs under the daemon and actually transfers data** (PR #624, #536): the `#582` WatchLoop unification held for the loop body, but the daemon path had lost its sync-actor spawn. `SyncHandle` was only spawned in `watch::run` (standalone `legion watch`), not in `daemon::run_watch_task`. The daemon now spawns the cluster sync actor alongside the health/spawn loops, so reflections, cards, and schedules actually replicate when running under `legion daemon`.
+
+- **REFLECTION_COLUMNS const ends column-list drift** (PR #623, #606): a `get_reflections_by_ids` SELECT projected 10 columns against an 11-column row mapper, producing `InvalidColumnIndex` panics when `legion serve` triggered a search. A single `REFLECTION_COLUMNS` const in `src/db/reflections.rs` is now the one source of truth for the column list used across every query; the mapper and the SELECT cannot drift.
+
+- **PR merge defers to repo review policy** (PR #622, #621): `legion pr merge` was hardcoding `APPROVED` as the required review state. It now reads the repository's branch-protection rules via the work source plugin, deferring to the repo's own policy. Repos with no required reviews are not blocked.
+
+- **Priority::Med passed in gates.rs blocked_card helper** (PR #635, #634): `gates.rs::blocked_card` was constructing a test card with `Priority::Low` instead of `Priority::Med`. The mismatch caused `evaluate_spawn_gate` tests to use a card that did not match the priority filter in the real scheduling path, making the helper a misleading fixture.
+
+- **cfg(unix) the daemon-attribution bind test** (PR #642, #641): the daemon-attribution bind test used `libc::getpid()` unconditionally. On Windows (where the CI also runs), `libc` does not export `getpid`; the test failed to compile. Wrapped in `#[cfg(unix)]` to match the unix-gated `libc` dependency.
 
 ### Changed
 
-- **Hooks refactor: shared lib/, one Grep/Glob guard, dead plumbing deleted** (#614): the hook preamble that had quietly diverged across 10+ scripts now lives in `plugin/hooks/lib/prelude.sh` -- stdin parse, repo identity (LEGION_REPO env takes precedence over basename(cwd) in EVERY hook), binary resolution (`${CLAUDE_PLUGIN_ROOT}/bin/legion` first, PATH fallback; pre-whoami-rewrite and both uncertainty hooks were PATH-only and silently inert in hook subshells), and the coverage gate. `plugin/hooks/lib/emit.sh` owns the output vocabulary (emit_allow/emit_deny/emit_block/emit_context); the legacy PreToolUse `{decision:block}` dialect is migrated to the documented `permissionDecision:deny` shape. `pre-grep-recall.sh` + `pre-grep-scip.sh` (two forked hooks per Grep/Glob call) merged into one `pre-grep.sh` running the same sym-block / sym-inject / recall-inject ladder as `pre-bash-grep.sh`, so Grep-tool and Bash-grep enforcement agree on the same pattern -- including the #458 relevance gate and the LEGION_BYPASS_GREP refusal for local-symbol queries. Deleted: `bullpen-check.sh` (registered nowhere) and `_legion-warn.sh` plus the ~80 lines of unreachable WARN branches its six consumers carried. Tests converge on `plugin/hooks/tests/testutil.sh`: one parameterized stub-legion contract (FAKE_* env vars) instead of 12 bespoke heredocs, plus a structural lock that every production hook sources the prelude.
+- **Typed exits via ExitWith, GateResult enum, verify_gate_key single-source** (PR #638, #610): `std::process::exit(1)` calls scattered across handler bodies are replaced with `LegionError::ExitWith(code)`. `main()` is now the only exit site. `GateResult { Clean, Issues }` is the canonical stored gate result (lowercase string in SQL). `verify_gate_key(card_id)` is sourced once in `src/verify.rs` so the writer (`cli::verify`) and the reader (`cli::kanban`) cannot drift on the key format.
+
+- **Serve stream: ServeError, channel::router, schedule firing moved off SSE** (PR #637, #613): `ServeError` implements `axum::response::IntoResponse`, replacing 29 hand-written `match-to-json_error` blocks in `src/serve.rs`. `channel::router` now owns the `/post` and `/tasks` endpoints that `serve.rs` previously duplicated. Schedule firing moved from per-SSE-connection side effects into a background `tokio::spawn` task, so schedules fire once per tick regardless of dashboard client count and without racing across connections.
+
+- **Comms stream: one addressing rule, signal::compose gate, mcp/ carve, verb canon** (PR #636, #612): the four divergent `@recipient` addressing implementations are replaced by `signal::is_addressed_to`. `signal::compose` is the single validation+format entry point for all signal creation (CLI and MCP); the MCP `legion_signal` handler now goes through `compose`, closing the `#587` required-fields bypass for rfc signals. `src/mcp/` is split into `log.rs`, `tools.rs`, `notifier.rs`, and `mod.rs`. Dead `review` verb removed from the verb canon (it had no entry in `plugin/verbs/default.toml`).
+
+- **Midtier cleanup: plugin_call boundary, recall single-sourcing, Priority enum, kanban/ and worksource/ carves** (PR #633, #615): `require_worksource()` replaces ~19 copy-pasted worksource-resolve-or-die blocks. Recall is single-sourced through one `recall::search` function. `Priority` is an enum (Low, Med, High, Critical) with `Display` and `FromStr`, replacing stringly-typed priority comparisons. `src/kanban/` is carved out for the FSM and card-parse logic. `src/worksource/` is carved out for the plugin bridge.
+
+- **Watch stream: bootstrap unification, watch/ tree, dead ClusterConfig deleted** (PR #632, #611): `watch::run` and `daemon::run_watch_task` share one `WatchLoop::bootstrap` that owns the sync-actor spawn, so a safety gate can never again be present in one loop and absent in the other. `src/watch/` is split into `config.rs`, `locks.rs`, `signals.rs`, `spawn.rs`, `tracker.rs`, `gates.rs`, and `mod.rs`. The dead `watch::ClusterConfig` parallel config path (parsed, never consumed in production) is deleted.
+
+- **Carve main.rs into cli/ module tree** (PR #631, #610): the 3,700-line `run()` match over 58 arms is split into per-domain handler modules under `src/cli/`. Each handler module owns arg massaging + print/JSON; algorithm bodies remain in the domain modules they were already in.
+
+- **Split db.rs into a db/ domain module tree** (PR #629, #609): the 8,815-line `db.rs` is split into 19 domain files under `src/db/`. `mod.rs` owns infrastructure only (Database handle, `open`, `has_column`, `init_schema` dispatcher). Each domain file owns its DDL, `impl Database` block, and co-located tests.
+
+- **In-place DRY: require_worksource, open_db, Done propagation fold** (PR #628, #610): three high-frequency pain points addressed in-place before the cli/ split. `require_worksource()` replaces the first wave of duplicated resolve blocks. `open_db()` / `open_db_and_index()` replace duplicated db-open preludes. `propagate_card_close_to_worksource` unifies the done/cancel propagation paths.
+
+- **Hooks refactor: shared lib/, one Grep/Glob guard, dead plumbing deleted** (PR #627, #614): the hook preamble that had quietly diverged across 10+ scripts now lives in `plugin/hooks/lib/prelude.sh` -- stdin parse, repo identity (LEGION_REPO env takes precedence over basename(cwd) in EVERY hook), binary resolution (`${CLAUDE_PLUGIN_ROOT}/bin/legion` first, PATH fallback; pre-whoami-rewrite and both uncertainty hooks were PATH-only and silently inert in hook subshells), and the coverage gate. `plugin/hooks/lib/emit.sh` owns the output vocabulary (emit_allow/emit_deny/emit_block/emit_context); the legacy PreToolUse `{decision:block}` dialect is migrated to the documented `permissionDecision:deny` shape. `pre-grep-recall.sh` + `pre-grep-scip.sh` (two forked hooks per Grep/Glob call) merged into one `pre-grep.sh` running the same sym-block / sym-inject / recall-inject ladder as `pre-bash-grep.sh`, so Grep-tool and Bash-grep enforcement agree on the same pattern -- including the #458 relevance gate and the LEGION_BYPASS_GREP refusal for local-symbol queries. Deleted: `bullpen-check.sh` (registered nowhere) and `_legion-warn.sh` plus the ~80 lines of unreachable WARN branches its six consumers carried. Tests converge on `plugin/hooks/tests/testutil.sh`: one parameterized stub-legion contract (FAKE_* env vars) instead of 12 bespoke heredocs, plus a structural lock that every production hook sources the prelude.
+
+- **Split tests/integration.rs into a module tree + lay the coverage net** (PR #626, #608): the 6,696-line `tests/integration.rs` is split into `tests/integration/{main.rs, common.rs}` plus per-domain files. New coverage added for previously-untested surfaces: serve bind + health endpoint, sym round-trip, pr write-check gate, watch wake-loop with spawn-gate outcomes.
+
+- **Propagate v0.14-v0.17.2 features across docs** (PR #625, #616): README, `llms.txt`, `llms-full.txt`, and `docs/site/concepts.md` updated to reflect features landed since v0.14.0 -- documents substrate, spec-gen, card-spec binding, the verify gate, the autonomy budget, the quality-gate chain, and the watch PTY migration.
 
 ## 0.17.2
 

--- a/src/cli/document.rs
+++ b/src/cli/document.rs
@@ -11,9 +11,11 @@ use crate::{db, documents, error};
 pub(crate) enum DocumentAction {
     /// Insert a new document. Payload is read from --from (file path)
     /// or stdin when --from is omitted. Meta fields are passed
-    /// explicitly to keep the storage layer type-agnostic; the schema
-    /// registry (sibling child of #455) will validate payloads against
-    /// the meta.type's schema once it ships.
+    /// explicitly to keep the storage layer type-agnostic. Payloads
+    /// with doc_type=schema are validated structurally at create (must
+    /// be a valid JSON Schema object with $schema, title, type:object,
+    /// and non-empty properties). Other document types are checked
+    /// against a landed schema via `legion document validate --schema <id>`.
     Create {
         /// Document type (e.g. "requirement", "nfr", "persona").
         #[arg(long, value_name = "TYPE")]
@@ -47,12 +49,16 @@ pub(crate) enum DocumentAction {
     },
     /// List documents, optionally filtered.
     List {
+        /// Filter by document type (e.g. "requirement", "schema", "persona").
         #[arg(long, value_name = "TYPE")]
         doc_type: Option<String>,
+        /// Filter by functional surface (matches the surface field on the document).
         #[arg(long)]
         surface: Option<String>,
+        /// Filter by lifecycle status (e.g. "draft", "active", "archived").
         #[arg(long)]
         status: Option<String>,
+        /// Filter by owning agent id.
         #[arg(long)]
         owner: Option<String>,
         /// Include archived documents (default: hot only).

--- a/src/cli/index_cmd.rs
+++ b/src/cli/index_cmd.rs
@@ -28,6 +28,7 @@ pub(crate) enum SymAction {
 
     /// Print references / call sites of a symbol
     Refs {
+        /// Symbol name to look up (substring-matched against SCIP symbol strings)
         name: String,
         #[arg(long)]
         repo: Option<String>,
@@ -39,7 +40,7 @@ pub(crate) enum SymAction {
 
     /// Print types implementing a trait or interface
     Impl {
-        /// Trait or interface name
+        /// Trait or interface name (substring-matched against SCIP symbol strings)
         trait_name: String,
         #[arg(long)]
         repo: Option<String>,
@@ -51,6 +52,7 @@ pub(crate) enum SymAction {
 
     /// Print signature + docstring for a symbol
     Hover {
+        /// Symbol name to look up (substring-matched against SCIP symbol strings)
         name: String,
         #[arg(long)]
         repo: Option<String>,

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -295,10 +295,15 @@ pub(crate) enum Commands {
 
     /// Send a directed message to another agent.
     ///
-    /// Watch wakes the recipient when `--verb` is in the wake-worthy set
-    /// (`question`, `request`, `help`, `blocker`). Other verbs (`announce`,
-    /// `ack`, `info`, `answer`, bare `review`) deliver to live sessions via
-    /// the channel push but do not wake an asleep recipient.
+    /// Watch wakes the recipient when `--verb` is in the wake-worthy set.
+    /// Wake-worthy verbs: `question`, `request`, `handoff`, `correction`,
+    /// `proposal`, `decision`, `routing` -- these spawn an asleep recipient.
+    /// `rfc` is also wake-worthy but additionally requires a `budget:` detail
+    /// in `--details` (e.g. `--details "budget:2h"`).
+    ///
+    /// Informational verbs: `announce`, `ack`, `info`, `answer` -- these
+    /// deliver to live sessions via the channel push but do not wake an
+    /// asleep recipient. Silence is acknowledgment; do not send empty acks.
     ///
     /// The minimum form is `--to <agent> --verb <verb>`; everything else is
     /// optional structure for RFC-shaped asks. For a one-line ask, just
@@ -312,9 +317,12 @@ pub(crate) enum Commands {
         #[arg(long)]
         to: String,
 
-        /// Signal verb. Wake-worthy: question, request, help, blocker
-        /// (these spawn an asleep recipient). Informational: announce, ack,
-        /// info, answer, review (deliver to live sessions only).
+        /// Signal verb.
+        /// Wake-worthy (spawn an asleep recipient): question, request,
+        /// handoff, correction, proposal, decision, rfc, routing.
+        /// rfc additionally requires --details budget:<amount>.
+        /// Informational (deliver to live sessions only, no wake):
+        /// announce, ack, info, answer.
         #[arg(long)]
         verb: String,
 
@@ -619,7 +627,9 @@ pub(crate) enum Commands {
         #[arg(long)]
         text: String,
 
-        /// Card ID to mark as complete (optional)
+        /// Card ID to mark as complete (optional). When the card has
+        /// acceptance criteria, a clean `legion verify` verdict must
+        /// exist for it before Done is accepted; exits non-zero otherwise.
         #[arg(long)]
         id: Option<String>,
     },
@@ -779,6 +789,12 @@ pub(crate) enum Commands {
     /// ->Done (records a clean legion-verify:<card> gate); any Fail hard-blocks;
     /// any Uncertain (or a Pass with no evidence) routes the card to NeedsInput
     /// for a human. A card with no acceptance criteria is blocked outright.
+    ///
+    /// Acceptance-criteria precedence: the bound spec document
+    /// (`spec.verification.acceptance` in the document payload) is consulted
+    /// first when the card has a `document_id`; if absent, `tasks.acceptance`
+    /// is used. A card whose `document_id` points to a non-existent or
+    /// non-spec document is a hard error.
     Verify {
         /// Repository name (resolves work source config from watch.toml)
         #[arg(long)]
@@ -883,7 +899,11 @@ pub(crate) enum Commands {
     /// plus born-Backlog kanban cards.  Re-running on unchanged input is safe
     /// (idempotent): existing (traces_to, surface) pairs are skipped.
     SpecGen {
-        /// Surface (repo/functional area) to generate requirements for.
+        /// Functional surface to generate requirements for. This is the
+        /// `surface` field stored on the source service-design documents
+        /// (e.g. "payments", "onboarding"), NOT a git repository name.
+        /// All non-archived service-design documents whose `surface` field
+        /// matches this value are used as input.
         #[arg(long)]
         repo: String,
     },

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -790,11 +790,11 @@ pub(crate) enum Commands {
     /// any Uncertain (or a Pass with no evidence) routes the card to NeedsInput
     /// for a human. A card with no acceptance criteria is blocked outright.
     ///
-    /// Acceptance-criteria precedence: the bound spec document
-    /// (`spec.verification.acceptance` in the document payload) is consulted
-    /// first when the card has a `document_id`; if absent, `tasks.acceptance`
-    /// is used. A card whose `document_id` points to a non-existent or
-    /// non-spec document is a hard error.
+    /// Acceptance-criteria precedence: when the card has a `document_id`,
+    /// the bound document's top-level `verification.acceptance` array is
+    /// consulted first; a missing or empty block (or an unparseable payload)
+    /// falls back to `tasks.acceptance`. A dangling `document_id` -- the
+    /// document does not exist -- is a hard error.
     Verify {
         /// Repository name (resolves work source config from watch.toml)
         #[arg(long)]


### PR DESCRIPTION
## Summary

The docs and --help pass behind the 0.18.0 release. Nine help-text corrections (the stale pre-#586 signal verb set was the worst -- it named verbs that no longer wake and listed `review`, which has no manifest entry at all); architecture.md gains the coordination substrate, quality-gate chain, and source layout sections plus the documents table, extended migrations table (including the 17/17 number collision across domain modules, documented honestly), and the transactional status-sync narrative; getting-started and plugin-guide lose their `/snooze`-era references; the June refactor audit is committed as a historical plan doc; and the release lands as the final commit -- Cargo.toml 0.18.0, CHANGELOG entry covering every PR since 0.17.2 with the house format's release-type sentence, Cargo.lock staged explicitly per the recorded procedure.

## Acceptance criteria mapping

### 1. every CLI command --help accurately describes current behavior (audited list in PR body)

Fixes applied, each verified against code or the verb manifest rather than trusted from the audit: Signal doc + --verb arg (wake-worthy = question, request, handoff, correction, proposal, decision, rfc, routing per plugin/verbs/default.toml; informational = announce, ack, info, answer; `review` dropped -- no manifest entry); document create (present-tense structural validation + `document validate --schema`); Verify (AC precedence: top-level `verification.acceptance`, fallback rules, dangling-binding hard error -- wording matched to resolve_acceptance_criteria's actual behavior after the simplify review caught an overclaim); Done --id (verify-gate requirement); spec-gen --repo (surface, not git repo); document list's four undescribed flags; sym refs/impl/hover NAME positional.
Evidence: src/ diff hunks are exclusively doc comments and clap help strings -- the simplify reviewer verified zero executable-code changes; verb sets diffed against plugin/verbs/default.toml.

### 2. architecture.md documents the spec substrate (documents, schemas, spec-gen, binding, verify precedence)

New sections: Coordination substrate (document storage with meta hoisting, schema registry with the structural gate and archive-on-adopt versioning, spec-gen pipeline with the traces_to convention and rejection classes, card-spec binding with the bind guards), Quality-gate chain (GateResult, the four skills by their real gate keys, pr-create and Done gate requirements, ExitWith typed exits), Source layout (the carved trees). The schema section gains the documents table DDL, migrations 16-24 (with 17-20 restored and the 17/17 collision noted), the four new card columns, and the transactional sync mapping. Verify AC precedence states the honest fallback behavior: only a dangling binding hard-errors.
Evidence: docs/site/architecture.md sections at the diff's hunks; factual claims spot-verified by the simplify reviewer against src/db/ migrate fns and src/cli/verify.rs.

### 3. CHANGELOG 0.18.0 entry covers all seven PRs with issue refs

The entry covers everything since 0.17.2 -- #622 through #645 -- in the house format (intro prose with the release-type sentence, New/Fixed/Changed/Internal sections, `- **title** (PR #NNN, #NNN): body` entries, no emoji). The #644 line carries its real PR number (#645), filled after that PR merged. Line counts in the intro are attributed to the June audit. The audit's suggested range wrongly included three 0.17.2 PRs (#618-#620); they remain in the prior entry.
Evidence: plugin/CHANGELOG.md 0.18.0 block; entries spot-checked against `legion pr view` by the simplify reviewer; no TBD/placeholder remains (grep clean).

### 4. version bumped to 0.18.0 with Cargo.lock committed and sync-version hook clean

Cargo.toml 0.18.0, Cargo.lock refreshed by cargo build and staged explicitly (the sync-version pre-commit hook syncs plugin.json/marketplace.json and validates the CHANGELOG top version but does NOT auto-stage the lock -- the recorded procedure). The bump is the branch's release commit.
Evidence: Cargo.toml and Cargo.lock both at 0.18.0 in the diff; the sync-version hook passed on commit (commit exists -- the hook gates it).

### 5. cargo test / clippy --all-targets / fmt all pass

A docs branch still has to prove the gates because the help pass edits live Rust source (doc comments and clap strings compile into the binary) and the version bump regenerates Cargo.lock -- either can break the build if botched. All three gates were run after the rebase onto post-#645 main, with exit codes captured directly rather than through pipes, per the recorded gate-verification discipline.
Evidence: test=0 (full unit + integration suite), clippy=0 under --all-targets -D warnings, fmt=0; the legion-simplify gate row 019ebd9c-0425 is keyed to this HEAD, which legion pr create checks before opening.

## Not done

concepts.md was skimmed but not restructured -- it needs document/spec-gen/bind concept entries to be written in the site's pedagogical register, which is happening in the parallel runlegion.dev site pass rather than twice here. The cli-reference content on the public site is likewise the site pass's deliverable (this repo's docs/site/cli-reference.md was not regenerated; the binary's --help is canonical and now accurate). Migration number unification (the 17/17 collision) is documented, not fixed -- renumbering shipped migrations would churn guards for zero behavior; the two-tier numbering note in architecture.md is the durable fix.