### PR TITLE
chore(#643): sync plugin manifests to 0.18.0 -- release follow-up

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
     {
       "name": "legion",
       "description": "Agent memory layer with recall, reflect, consult, bullpen, and cross-agent coordination. Includes health monitoring and auto-wake. Hooks wire legion into every session automatically.",
-      "version": "0.17.2",
+      "version": "0.18.0",
       "author": {
         "name": "Sean Silvius",
         "email": "sean@silvius.me"

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "legion",
-  "version": "0.17.2",
+  "version": "0.18.0",
   "description": "Institutional memory for Claude Code agents with real-time team channel.",
   "author": {
     "name": "Sean Silvius",


### PR DESCRIPTION
## Summary

The #646 release commit missed the tracked plugin manifests (plugin/.claude-plugin/plugin.json, .claude-plugin/marketplace.json) -- committed in every prior release, absent from this one, with the absence mis-attributed to gitignore by review (git check-ignore disproves it). Until they sync, /plugin reports 0.17.2 as latest against the live v0.18.0 GitHub release.

## Acceptance criteria mapping

### 1. Plugin manifests report the released version

Both files go 0.17.2 to 0.18.0 via scripts/sync-version.sh, matching Cargo.toml on main and the published v0.18.0 tag. This is the identical two-line shape of the 0.17.1 (1418f39) and 0.17.2 (4488b29) release commits.
Evidence: git diff shows exactly two version-string changes; /plugin update resolves 0.18.0 after merge -- the observable behavior that was broken.

## Not done

Root-causing why the pre-commit hook did not stage these in the #643 builder worktree -- worth its own issue if it recurs on 0.18.1.