### PR TITLE
feat(#648): PTY post-spawn keystroke channel

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -145,6 +145,9 @@ pub enum LegionError {
     #[error("pty wait failed: {0}")]
     PtyWaitFailed(String),
 
+    #[error("cannot send keystrokes to a non-interactive (print-mode) child")]
+    PtyControlUnsupported,
+
     #[error(
         "illegal wake attempt transition for {attempt_id}: {from} -> {to} (current state: {current})"
     )]

--- a/src/watch/spawn.rs
+++ b/src/watch/spawn.rs
@@ -136,8 +136,13 @@ pub fn record_session_end(db: &Database, attempt_id: &str, data_dir: &Path) -> R
 /// Implements the minimal subset of operations the watch reaper +
 /// lease release path actually need: `pid` for liveness + log lines,
 /// `try_wait` for non-blocking exit detection, `kill` for shutdown.
-/// Direct stdin/stdout streams are NOT exposed -- the PTY ring buffer
-/// is for diagnostics, not control flow.
+///
+/// `send_keys` is the one sanctioned WRITE control path: the
+/// confirmed-submit protocol (#649) injects the prompt paste and retry
+/// submit keystrokes through it after spawn. Reading the other
+/// direction stays off-limits -- the PTY ring buffer (`output_tail`) is
+/// for diagnostics, not control flow; submit confirmation is the
+/// filesystem oracle, not output scraping.
 pub enum SpawnedChild {
     Print(Child),
     Pty(crate::pty::PtySession),
@@ -175,6 +180,24 @@ impl SpawnedChild {
         match self {
             SpawnedChild::Print(c) => c.kill().map_err(LegionError::Io),
             SpawnedChild::Pty(s) => s.kill(),
+        }
+    }
+
+    /// Send raw bytes to the child's interactive input after spawn.
+    ///
+    /// The confirmed-submit protocol (#649) uses this to bracketed-paste
+    /// the wake prompt and to retry the submit keystroke until the TUI
+    /// input pipeline is ready. The `Print` variant has no interactive
+    /// stdin -- `claude --print -p` consumed its prompt as an argv -- so
+    /// it returns `PtyControlUnsupported` rather than silently no-op'ing,
+    /// which would mask a spawn-mode mismatch at the call site.
+    // Wired into the watch loop by the confirmed-submit protocol (#649);
+    // dead from main's perspective until then, exercised by tests now.
+    #[allow(dead_code)]
+    pub fn send_keys(&mut self, bytes: &[u8]) -> Result<()> {
+        match self {
+            SpawnedChild::Print(_) => Err(LegionError::PtyControlUnsupported),
+            SpawnedChild::Pty(s) => s.write(bytes),
         }
     }
 }
@@ -286,5 +309,27 @@ mod tests {
     fn spawn_mode_as_str_matches_env_values() {
         assert_eq!(SpawnMode::Print.as_str(), "print");
         assert_eq!(SpawnMode::Pty.as_str(), "pty");
+    }
+
+    // -- send_keys (#648) ---------------------------------------------------
+
+    #[cfg(unix)]
+    #[test]
+    fn send_keys_on_print_child_is_unsupported() {
+        // The Print variant has no interactive stdin -- send_keys must
+        // surface a typed error, not silently swallow the keystrokes,
+        // so a spawn-mode mismatch is visible at the call site.
+        let child = std::process::Command::new("sleep")
+            .arg("9999")
+            .spawn()
+            .expect("spawn sleep");
+        let mut spawned = SpawnedChild::Print(child);
+
+        let err = spawned
+            .send_keys(b"\r")
+            .expect_err("send_keys on a print child must error");
+        assert!(matches!(err, LegionError::PtyControlUnsupported));
+
+        let _ = spawned.kill();
     }
 }

--- a/src/watch/tracker.rs
+++ b/src/watch/tracker.rs
@@ -274,6 +274,21 @@ impl AgentTracker {
     pub fn active_count(&self) -> i32 {
         self.children.len() as i32
     }
+
+    /// Mutable access to a tracked child by wake-attempt id, for post-spawn
+    /// keystroke injection by the confirmed-submit protocol (#649). Returns
+    /// the first tracked child whose `attempt_id` matches; `None` when no
+    /// tracked child carries that id (e.g. the spawn predated the
+    /// wake_attempts substrate, or it has already been reaped).
+    // Wired into the watch loop by the confirmed-submit protocol (#649);
+    // dead from main's perspective until then, exercised by tests now.
+    #[allow(dead_code)]
+    pub fn child_by_attempt_mut(&mut self, attempt_id: &str) -> Option<&mut SpawnedChild> {
+        self.children
+            .iter_mut()
+            .find(|t| t.attempt_id.as_deref() == Some(attempt_id))
+            .map(|t| &mut t.child)
+    }
 }
 
 #[cfg(test)]
@@ -423,6 +438,64 @@ mod tests {
         );
 
         // Clean up the long-running child so we don't leak it in the test suite.
+        tracker.children.iter_mut().for_each(|t| {
+            let _ = t.child.kill();
+        });
+    }
+
+    // -- child_by_attempt_mut (#648) ------------------------------------------
+
+    #[cfg(unix)]
+    #[test]
+    fn child_by_attempt_mut_finds_match_and_misses_unknown() {
+        // A tracked child must be reachable by its attempt_id for the
+        // confirmed-submit protocol to inject keystrokes; an unknown id and
+        // an attemptless child must both miss.
+        let mut tracker = AgentTracker::new();
+
+        // Child A: carries a known attempt_id.
+        let child_a = std::process::Command::new("sleep")
+            .arg("9999")
+            .spawn()
+            .expect("spawn sleep a");
+        let attempt_id = uuid::Uuid::now_v7().to_string();
+        tracker.track(
+            "legion".to_string(),
+            SpawnedChild::Print(child_a),
+            Vec::new(),
+            "test-host".to_string(),
+            uuid::Uuid::now_v7().to_string(),
+            chrono::Utc::now().to_rfc3339(),
+            Vec::new(),
+            Some(attempt_id.clone()),
+        );
+
+        // Child B: attemptless -- must never match a lookup.
+        let child_b = std::process::Command::new("sleep")
+            .arg("9999")
+            .spawn()
+            .expect("spawn sleep b");
+        tracker.track(
+            "legion".to_string(),
+            SpawnedChild::Print(child_b),
+            Vec::new(),
+            "test-host".to_string(),
+            uuid::Uuid::now_v7().to_string(),
+            chrono::Utc::now().to_rfc3339(),
+            Vec::new(),
+            None,
+        );
+
+        assert!(
+            tracker.child_by_attempt_mut(&attempt_id).is_some(),
+            "must find the tracked child by its attempt_id"
+        );
+        assert!(
+            tracker.child_by_attempt_mut("no-such-attempt").is_none(),
+            "an unknown attempt_id must miss even with attemptless children tracked"
+        );
+
+        // Clean up both long-lived children.
         tracker.children.iter_mut().for_each(|t| {
             let _ = t.child.kill();
         });


### PR DESCRIPTION
## Summary

Foundation for the confirmed-submit wake protocol (#649): a sanctioned post-spawn write path so the watch loop can inject keystrokes into a specific tracked PTY child. No change to existing wake behavior.

Root cause this unblocks: `spawn_agent`'s Pty branch writes the prompt + a single `\r` immediately after fork, before the Claude TUI input pipeline is interactive, so the submit is swallowed and the wake attempt ages to `abandoned` (live-diagnosed on 0.18.0; reflection `019ebdf8`, experiments exp1-6). Retrying the submit after spawn requires this channel.

## Acceptance criteria mapping

### 1. All tests pass; clippy `--all-targets -D warnings`; fmt `--check`

The new surface is covered by two unit tests rather than left to integration. `send_keys_on_print_child_is_unsupported` (`src/watch/spawn.rs`) spawns a `Print` child and asserts `send_keys` returns `PtyControlUnsupported` -- proving the variant errors instead of silently dropping keystrokes, which would hide a spawn-mode mismatch. `child_by_attempt_mut_finds_match_and_misses_unknown` (`src/watch/tracker.rs`) tracks one child with a known attempt_id and one attemptless child, then asserts the known id resolves and an unknown id returns `None` while traversing past the attemptless entry.
Evidence: `cargo test` -> 178 passed / 0 failed / 2 ignored (exit 0); `cargo clippy --all-targets -- -D warnings` clean; `cargo fmt -- --check` clean.

### 2. Simplify pass completed

`legion-simplify` reviewed the branch diff (3 files, +123/-2) for duplication, unnecessary abstraction, stringly-typed state, and error swallowing. The new methods are thin (one match arm each) and the test setup reuses the file's existing `sleep 9999` pattern, so there was nothing to flatten; the result was recorded clean.
Evidence: quality-gate row `019ec252-617c-7711-a8c8-f397bbf94b82` (skill `legion-simplify`, result clean).

### 3. Review pass completed and findings fixed

`/review-pr` runs against this PR after creation; every finding is addressed and tests re-run before merge. (Recorded once review completes.)
Evidence: review-pr run on this PR number; fixes committed to this branch.

### 4. PR created and linked to this issue

This PR is opened via `legion pr create` with this validated body, which references and closes #648.
Evidence: PR head `feat/648-pty-keystroke-channel` -> base `main`; body line "Closes #648".

## Not done

- No change to spawn timing, prompt format, or the retry loop -- that is #649. Both new methods carry `#[allow(dead_code)]` (same soak pattern as `pty.rs`) because the watch loop does not call them yet; they are exercised by tests now and wired in by #649.
- No ring-buffer read accessor / turn-start scanner. Submit confirmation in #649 is the filesystem oracle, not output scraping, so the diagnostics-only read boundary stays intact.

Closes #648.