### PR TITLE
feat(#649): confirmed-submit wake protocol (bracketed paste + retry-Enter)

### DIFF
--- a/src/pty.rs
+++ b/src/pty.rs
@@ -230,6 +230,41 @@ impl PtySession {
             Err(poisoned) => poisoned.into_inner().snapshot(),
         }
     }
+
+    /// Has a Claude turn started in this session's output?
+    ///
+    /// The confirmed-submit protocol (#649) uses this to decide when to
+    /// STOP re-sending the submit keystroke: once a turn is running, the
+    /// prompt landed and further Enters would queue stray empty turns.
+    ///
+    /// The signal is the live token counter -- Claude renders `N tokens`
+    /// in the working spinner only while a turn is processing, never on
+    /// the idle input screen. This was chosen over the session-transcript
+    /// file (the original #649 plan) because that file is buffered and
+    /// written on clean exit, not incrementally -- empirically it never
+    /// appears for a live or killed wake (oracle2, 2026-06-13), so it
+    /// cannot confirm a turn-start. Scanning the ring buffer crosses the
+    /// "diagnostics, not control flow" line deliberately: turn-start
+    /// detection is the one sanctioned control-flow read.
+    ///
+    /// The marker is TUI-version-sensitive (the older `esc to interrupt`
+    /// string vanished by 2.1.176), but a miss fails CLOSED -- the wake
+    /// ends in `Spawning -> Failed` with a visible reason rather than a
+    /// silent hang.
+    pub fn saw_turn_start(&self) -> bool {
+        has_turn_start_marker(&self.output_tail())
+    }
+}
+
+/// The live token-counter marker Claude renders only while a turn is
+/// processing (#649). Pulled out as a free function so the scan is
+/// unit-testable without a live PTY.
+const TURN_START_MARKER: &[u8] = b"tokens";
+
+fn has_turn_start_marker(bytes: &[u8]) -> bool {
+    bytes
+        .windows(TURN_START_MARKER.len())
+        .any(|w| w == TURN_START_MARKER)
 }
 
 impl Drop for PtySession {
@@ -313,6 +348,20 @@ fn into_exit_status(status: portable_pty::ExitStatus) -> ExitStatus {
 mod tests {
     use super::*;
     use std::time::{Duration, Instant};
+
+    #[test]
+    fn turn_start_marker_detects_token_counter_only() {
+        // The live token counter is the turn-start signal; the idle input
+        // screen never renders it, so a miss keeps the retry loop going.
+        assert!(has_turn_start_marker(b"Transmuting... (4s | 103 tokens)"));
+        assert!(has_turn_start_marker(
+            b"running stop hooks... 0/3 | 1 tokens"
+        ));
+        assert!(!has_turn_start_marker(
+            b"? for shortcuts   accept edits on (shift+tab to cycle)"
+        ));
+        assert!(!has_turn_start_marker(b""));
+    }
 
     fn run_until<F: FnMut() -> bool>(deadline_ms: u64, mut f: F) -> bool {
         let deadline = Instant::now() + Duration::from_millis(deadline_ms);

--- a/src/pty.rs
+++ b/src/pty.rs
@@ -256,15 +256,28 @@ impl PtySession {
     }
 }
 
-/// The live token-counter marker Claude renders only while a turn is
-/// processing (#649). Pulled out as a free function so the scan is
-/// unit-testable without a live PTY.
-const TURN_START_MARKER: &[u8] = b"tokens";
-
+/// Detect the live token counter Claude renders only while a turn is
+/// processing (#649). The counter is always `<digits> tokens` (e.g.
+/// `103 tokens`), so the scan requires a digit immediately before
+/// ` tokens` -- a bare `tokens` is NOT enough.
+///
+/// This precision is load-bearing, not cosmetic: the wake prompt itself
+/// contains the prose `waste tokens` (it warns against empty acks), and
+/// the TUI echoes the pasted prompt into the input box. A bare-`tokens`
+/// match would fire on that echo BEFORE any submit, confirming a turn
+/// that never started and hanging the wake. Requiring the leading digit
+/// separates the counter (`1 tokens`) from the prose (`waste tokens`).
+///
+/// Pulled out as a free function so the scan is unit-testable without a
+/// live PTY.
 fn has_turn_start_marker(bytes: &[u8]) -> bool {
+    const NEEDLE: &[u8] = b" tokens";
+    // For each ` tokens` occurrence, require the byte before the space to
+    // be an ASCII digit -- the counter's `<N> tokens` shape.
     bytes
-        .windows(TURN_START_MARKER.len())
-        .any(|w| w == TURN_START_MARKER)
+        .windows(NEEDLE.len())
+        .enumerate()
+        .any(|(i, w)| w == NEEDLE && i > 0 && bytes[i - 1].is_ascii_digit())
 }
 
 impl Drop for PtySession {
@@ -351,8 +364,9 @@ mod tests {
 
     #[test]
     fn turn_start_marker_detects_token_counter_only() {
-        // The live token counter is the turn-start signal; the idle input
-        // screen never renders it, so a miss keeps the retry loop going.
+        // The live token counter (<digits> tokens) is the turn-start signal;
+        // the idle input screen never renders it, so a miss keeps the retry
+        // loop going.
         assert!(has_turn_start_marker(b"Transmuting... (4s | 103 tokens)"));
         assert!(has_turn_start_marker(
             b"running stop hooks... 0/3 | 1 tokens"
@@ -361,6 +375,19 @@ mod tests {
             b"? for shortcuts   accept edits on (shift+tab to cycle)"
         ));
         assert!(!has_turn_start_marker(b""));
+    }
+
+    #[test]
+    fn turn_start_marker_ignores_prose_tokens_in_echoed_prompt() {
+        // The wake prompt warns that empty acks "waste tokens"; the TUI
+        // echoes the pasted prompt into the input box. A bare-`tokens`
+        // match would false-confirm on that echo before any submit. The
+        // leading-digit requirement must reject prose.
+        assert!(!has_turn_start_marker(
+            b"empty acknowledgments waste tokens and trigger wake storms"
+        ));
+        assert!(!has_turn_start_marker(b"tokens"));
+        assert!(!has_turn_start_marker(b" tokens"));
     }
 
     fn run_until<F: FnMut() -> bool>(deadline_ms: u64, mut f: F) -> bool {

--- a/src/watch/config.rs
+++ b/src/watch/config.rs
@@ -183,6 +183,31 @@ pub struct WatchConfig {
     #[serde(default = "default_max_concurrent_wakes")]
     pub max_concurrent_wakes: u32,
 
+    /// Max submit-keystroke retries for a PTY wake before giving up (#649).
+    /// The Claude TUI input pipeline becomes submit-ready asynchronously
+    /// (~15-22s in plugin-heavy repos) with no deterministic ready marker,
+    /// so `drive_submit_confirmation` re-sends Enter each health tick until
+    /// the ring buffer shows a turn started. After this many tries with no
+    /// confirmation the attempt fails closed (`Spawning -> Failed`, outcome
+    /// `submit_not_confirmed`) rather than orphaning an idle REPL. Default 12.
+    #[serde(default = "default_submit_retry_max")]
+    pub submit_retry_max: u32,
+
+    /// Minimum seconds between submit-keystroke retries for a PTY wake (#649).
+    /// A floor, not a timer: `drive_submit_confirmation` runs on the health
+    /// tick (`health_poll_secs`) and skips a child whose last Enter was more
+    /// recent than this, so a small `health_poll_secs` cannot machine-gun
+    /// Enter at the TUI. Default 4.
+    #[serde(default = "default_submit_retry_interval_secs")]
+    pub submit_retry_interval_secs: u64,
+
+    /// Hard wall-clock cap (seconds) on the submit-confirmation window for a
+    /// PTY wake (#649). Independent of `submit_retry_max`: whichever bound
+    /// trips first fails the attempt closed. Guards against a child that
+    /// accepts keystrokes but never starts a turn. Default 60.
+    #[serde(default = "default_submit_confirm_budget_secs")]
+    pub submit_confirm_budget_secs: u64,
+
     /// Whether this node serves the web dashboard.
     /// Only one node per network should have this set to true.
     #[serde(default)]
@@ -252,6 +277,18 @@ fn default_max_concurrent_wakes() -> u32 {
     4
 }
 
+fn default_submit_retry_max() -> u32 {
+    12
+}
+
+fn default_submit_retry_interval_secs() -> u64 {
+    4
+}
+
+fn default_submit_confirm_budget_secs() -> u64 {
+    60
+}
+
 impl Default for WatchConfig {
     fn default() -> Self {
         Self {
@@ -268,6 +305,9 @@ impl Default for WatchConfig {
             persona_lease_ttl_secs: default_persona_lease_ttl_secs(),
             quota_panic_threshold_pct: default_quota_panic_threshold_pct(),
             max_concurrent_wakes: default_max_concurrent_wakes(),
+            submit_retry_max: default_submit_retry_max(),
+            submit_retry_interval_secs: default_submit_retry_interval_secs(),
+            submit_confirm_budget_secs: default_submit_confirm_budget_secs(),
             serve: false,
             cluster: None,
             repos: Vec::new(),
@@ -516,6 +556,27 @@ workdir = "/tmp"
         assert_eq!(config.poll_interval_secs, 30);
         assert_eq!(config.cooldown_secs, 300);
         assert_eq!(config.max_concurrent_wakes, 4);
+        // #649 submit-confirmation knobs default without being named.
+        assert_eq!(config.submit_retry_max, 12);
+        assert_eq!(config.submit_retry_interval_secs, 4);
+        assert_eq!(config.submit_confirm_budget_secs, 60);
+    }
+
+    #[test]
+    fn parse_config_submit_knobs_explicit() {
+        let toml_str = r#"
+submit_retry_max = 20
+submit_retry_interval_secs = 2
+submit_confirm_budget_secs = 90
+
+[[repos]]
+name = "test"
+workdir = "/tmp"
+"#;
+        let config: WatchConfig = toml::from_str(toml_str).expect("parse config");
+        assert_eq!(config.submit_retry_max, 20);
+        assert_eq!(config.submit_retry_interval_secs, 2);
+        assert_eq!(config.submit_confirm_budget_secs, 90);
     }
 
     #[test]

--- a/src/watch/gates.rs
+++ b/src/watch/gates.rs
@@ -299,7 +299,14 @@ pub fn poll_cycle(
                     if let Err(e) = db.transition_wake_attempt(aid, Claimed, Spawning) {
                         eprintln!("[legion watch] transition Claimed->Spawning {}: {}", aid, e);
                     }
-                    if let Err(e) = db.transition_wake_attempt(aid, Spawning, Running) {
+                    // Print submits its prompt as an argv, so the turn is
+                    // already underway -- advance to Running now. Pty defers
+                    // Spawning->Running to drive_submit_confirmation (#649),
+                    // which fires it only once the ring buffer confirms the
+                    // bracketed-paste prompt actually submitted.
+                    if spawn_mode == SpawnMode::Print
+                        && let Err(e) = db.transition_wake_attempt(aid, Spawning, Running)
+                    {
                         eprintln!("[legion watch] transition Spawning->Running {}: {}", aid, e);
                     }
                 }

--- a/src/watch/mod.rs
+++ b/src/watch/mod.rs
@@ -238,6 +238,12 @@ impl WatchLoop {
     /// `legion watch status` can observe either mode.
     pub fn tick_health(&mut self) {
         self.sampler.sample();
+        // #649: drive the submit-confirmation protocol BEFORE reaping. A
+        // PTY wake's prompt is bracketed-pasted at spawn but not submitted
+        // until this loop retries Enter and observes a turn start; a child
+        // that never confirms is failed here and reaped on the same tick.
+        self.tracker
+            .drive_submit_confirmation(&self.db, &self.config);
         self.tracker
             .reap_finished(Some(&self.db), Some(&self.session_locks));
         if let Err(e) = self.db.heartbeat_persona_leases(&self.host, self.lease_ttl) {

--- a/src/watch/spawn.rs
+++ b/src/watch/spawn.rs
@@ -25,11 +25,18 @@ pub const SUBMIT_KEY: &[u8] = b"\r";
 /// Wrap a prompt in bracketed-paste markers with NO trailing submit (#649).
 /// Pulled out as a pure helper so the exact wire bytes are unit-testable
 /// without a live `claude` PTY.
+///
+/// The prompt is stripped of ESC (0x1b) bytes before wrapping. The wake
+/// prompt bundles signal text authored by other agents/repos; a stray or
+/// hostile `ESC[201~` in that content would close the bracketed paste
+/// early and turn the remaining bytes into raw TUI keystrokes -- a
+/// keystroke-injection seam. Wake prompts are plain text, so dropping ESC
+/// is lossless and closes the seam regardless of how the call site widens.
 fn wrap_bracketed_paste(prompt: &str) -> Vec<u8> {
     let mut out =
         Vec::with_capacity(prompt.len() + BRACKETED_PASTE_START.len() + BRACKETED_PASTE_END.len());
     out.extend_from_slice(BRACKETED_PASTE_START);
-    out.extend_from_slice(prompt.as_bytes());
+    out.extend(prompt.bytes().filter(|&b| b != 0x1b));
     out.extend_from_slice(BRACKETED_PASTE_END);
     out
 }
@@ -389,6 +396,23 @@ mod tests {
             !wrapped.ends_with(b"\r"),
             "bracketed paste must not carry a submit keystroke"
         );
+    }
+
+    #[test]
+    fn wrap_bracketed_paste_strips_esc_to_close_injection_seam() {
+        // An embedded ESC[201~ in prompt content must not survive -- it
+        // would close the paste early and inject raw TUI keystrokes. ESC
+        // bytes are dropped; the surrounding plain text is preserved.
+        let hostile = "before\x1b[201~rm -rf\x1b after";
+        let wrapped = wrap_bracketed_paste(hostile);
+        // No interior ESC byte remains (the only ESC bytes are inside the
+        // start/end markers we control).
+        let body = &wrapped[BRACKETED_PASTE_START.len()..wrapped.len() - BRACKETED_PASTE_END.len()];
+        assert!(
+            !body.contains(&0x1b),
+            "ESC bytes must be stripped from pasted content"
+        );
+        assert_eq!(body, b"before[201~rm -rf after");
     }
 
     #[test]

--- a/src/watch/spawn.rs
+++ b/src/watch/spawn.rs
@@ -12,6 +12,28 @@ use super::locks::SessionLockTracker;
 
 // -- Agent Spawning ----------------------------------------------------------
 
+/// Bracketed-paste start marker (`ESC [ 200 ~`). Wrapping the wake prompt
+/// in bracketed paste keeps embedded newlines literal so a multi-line
+/// prompt is not fragmented into multiple submits (#649).
+const BRACKETED_PASTE_START: &[u8] = b"\x1b[200~";
+/// Bracketed-paste end marker (`ESC [ 201 ~`).
+const BRACKETED_PASTE_END: &[u8] = b"\x1b[201~";
+/// The submit keystroke retried by the confirmed-submit protocol (#649).
+/// `\r` submits on every shipped Claude Code surface; `\n` does not.
+pub const SUBMIT_KEY: &[u8] = b"\r";
+
+/// Wrap a prompt in bracketed-paste markers with NO trailing submit (#649).
+/// Pulled out as a pure helper so the exact wire bytes are unit-testable
+/// without a live `claude` PTY.
+fn wrap_bracketed_paste(prompt: &str) -> Vec<u8> {
+    let mut out =
+        Vec::with_capacity(prompt.len() + BRACKETED_PASTE_START.len() + BRACKETED_PASTE_END.len());
+    out.extend_from_slice(BRACKETED_PASTE_START);
+    out.extend_from_slice(prompt.as_bytes());
+    out.extend_from_slice(BRACKETED_PASTE_END);
+    out
+}
+
 /// Selects which spawn implementation `spawn_agent` dispatches to.
 ///
 /// `Print` is the current `claude --print -p <prompt>` path. `Pty` is the
@@ -191,13 +213,22 @@ impl SpawnedChild {
     /// stdin -- `claude --print -p` consumed its prompt as an argv -- so
     /// it returns `PtyControlUnsupported` rather than silently no-op'ing,
     /// which would mask a spawn-mode mismatch at the call site.
-    // Wired into the watch loop by the confirmed-submit protocol (#649);
-    // dead from main's perspective until then, exercised by tests now.
-    #[allow(dead_code)]
     pub fn send_keys(&mut self, bytes: &[u8]) -> Result<()> {
         match self {
             SpawnedChild::Print(_) => Err(LegionError::PtyControlUnsupported),
             SpawnedChild::Pty(s) => s.write(bytes),
+        }
+    }
+
+    /// Has a Claude turn started in this child's session? The
+    /// confirmed-submit protocol (#649) gates its retry loop on this.
+    /// `Print` children never enter that loop (they submit their prompt
+    /// as an argv at spawn), so the variant returns `false`; the only
+    /// caller skips non-`Pty` children anyway.
+    pub fn turn_started(&self) -> bool {
+        match self {
+            SpawnedChild::Print(_) => false,
+            SpawnedChild::Pty(s) => s.saw_turn_start(),
         }
     }
 }
@@ -248,15 +279,22 @@ pub fn spawn_agent(
             let mut opts = crate::pty::PtySpawnOptions::new("claude", &[], cwd);
             opts.env = &env;
             let mut session = crate::pty::PtySession::spawn(opts)?;
-            // Inject the prompt as keystrokes. The trailing carriage
-            // return submits the prompt; \n alone is not interpreted as
-            // submit by every Claude Code interactive surface, but \r
-            // works on every shipped version.
-            let mut keystrokes = Vec::with_capacity(prompt.len() + 1);
-            keystrokes.extend_from_slice(prompt.as_bytes());
-            keystrokes.push(b'\r');
+            // Inject the prompt as a BRACKETED PASTE, with NO trailing
+            // submit keystroke (#649). Two empirical reasons:
+            //   1. The wake prompt is multi-line; a raw multi-line write
+            //      lets the TUI submit on the first embedded newline,
+            //      fragmenting the prompt. Wrapping it in the bracketed
+            //      paste markers (ESC[200~ ... ESC[201~) keeps every
+            //      newline literal until one explicit Enter submits.
+            //   2. A `\r` written here, before the TUI input pipeline is
+            //      interactive (~15-22s in plugin-heavy repos), is
+            //      swallowed -- the old fire-and-forget submit. The
+            //      confirmed-submit protocol sends Enter from the health
+            //      tick instead, retrying until the ring buffer shows a
+            //      turn started.
+            let keystrokes = wrap_bracketed_paste(prompt);
             if let Err(e) = session.write(&keystrokes) {
-                eprintln!("[legion watch] PTY prompt write failed: {}", e);
+                eprintln!("[legion watch] PTY prompt paste failed: {}", e);
                 // Best-effort kill so we do not leak a half-started
                 // child; the spawn-failure path in poll_cycle releases
                 // any leases we acquired.
@@ -331,5 +369,41 @@ mod tests {
         assert!(matches!(err, LegionError::PtyControlUnsupported));
 
         let _ = spawned.kill();
+    }
+
+    // -- bracketed paste (#649) ---------------------------------------------
+
+    #[test]
+    fn wrap_bracketed_paste_wraps_exactly_with_no_submit() {
+        // The wire bytes must be START + prompt + END, with NO trailing \r:
+        // the submit keystroke is sent later by the confirmation loop, and a
+        // multi-line prompt must stay inside one paste so embedded newlines
+        // do not fragment into multiple submits.
+        let wrapped = wrap_bracketed_paste("line one\nline two");
+        let mut expected = Vec::new();
+        expected.extend_from_slice(b"\x1b[200~");
+        expected.extend_from_slice(b"line one\nline two");
+        expected.extend_from_slice(b"\x1b[201~");
+        assert_eq!(wrapped, expected);
+        assert!(
+            !wrapped.ends_with(b"\r"),
+            "bracketed paste must not carry a submit keystroke"
+        );
+    }
+
+    #[test]
+    fn turn_started_is_false_for_print_child() {
+        // Print children never enter the confirmation loop; the accessor
+        // must report no turn so a stray call cannot mis-confirm them.
+        #[cfg(unix)]
+        {
+            let child = std::process::Command::new("sleep")
+                .arg("9999")
+                .spawn()
+                .expect("spawn sleep");
+            let mut spawned = SpawnedChild::Print(child);
+            assert!(!spawned.turn_started());
+            let _ = spawned.kill();
+        }
     }
 }

--- a/src/watch/tracker.rs
+++ b/src/watch/tracker.rs
@@ -1,10 +1,55 @@
 //! Tracking of spawned children: reaping, persona lease release, and
 //! session outcome classification.
 
+use std::time::{Duration, Instant};
+
 use crate::db::Database;
 
+use super::config::WatchConfig;
 use super::locks::SessionLockTracker;
-use super::spawn::SpawnedChild;
+use super::spawn::{SUBMIT_KEY, SpawnedChild};
+
+/// What the submit-confirmation loop should do with one PTY child this tick
+/// (#649). Pulled out as a pure decision so the policy is unit-testable
+/// without a live PTY -- `drive_submit_confirmation` performs the I/O.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SubmitAction {
+    /// A turn started -- the prompt submitted; advance Spawning -> Running.
+    Confirm,
+    /// Out of retries or budget -- fail closed (Spawning -> Failed).
+    Fail,
+    /// Send another Enter this tick.
+    Send,
+    /// Within the retry interval -- wait for the next tick.
+    Wait,
+}
+
+/// Pure submit-confirmation policy. `turn_started` short-circuits to
+/// `Confirm`; exhausting either `retries >= max` or `spawn_elapsed >=
+/// budget` yields `Fail`; otherwise an Enter is due when no prior Enter
+/// has been sent or the last one is older than `interval`.
+fn submit_action(
+    turn_started: bool,
+    retries: u32,
+    max: u32,
+    spawn_elapsed: Duration,
+    budget: Duration,
+    last_enter_elapsed: Option<Duration>,
+    interval: Duration,
+) -> SubmitAction {
+    if turn_started {
+        return SubmitAction::Confirm;
+    }
+    if retries >= max || spawn_elapsed >= budget {
+        return SubmitAction::Fail;
+    }
+    let due = last_enter_elapsed.map(|e| e >= interval).unwrap_or(true);
+    if due {
+        SubmitAction::Send
+    } else {
+        SubmitAction::Wait
+    }
+}
 
 // -- Agent Tracker -----------------------------------------------------------
 
@@ -33,6 +78,22 @@ pub struct TrackedChild {
     /// spawn predates the wake_attempts substrate or the enqueue
     /// failed; reap then skips the outcome recording.
     pub attempt_id: Option<String>,
+    /// Monotonic spawn instant, for the submit-confirmation budget (#649).
+    /// In-memory only -- the persisted `spawned_at` is RFC3339 wall-clock.
+    pub spawn_instant: Instant,
+    /// When the last submit keystroke was sent, for interval throttling
+    /// (#649). `None` until the first Enter goes out.
+    pub last_submit_enter: Option<Instant>,
+    /// Count of submit keystrokes sent so far (#649). Bounds the retry
+    /// loop and is reported in the failure outcome.
+    pub submit_retries: u32,
+    /// True once a turn was observed to start -- the prompt submitted and
+    /// the FSM advanced `Spawning -> Running` (#649). Stops further Enters.
+    pub submit_confirmed: bool,
+    /// Set when the submit-confirmation loop gave up (#649). Carries the
+    /// `outcome` reason so `reap_finished` records `submit_not_confirmed`
+    /// on the wake_attempts row instead of a generic abandon.
+    pub submit_failed_reason: Option<String>,
 }
 
 pub struct AgentTracker {
@@ -69,6 +130,11 @@ impl AgentTracker {
             spawn_at,
             signal_ids,
             attempt_id,
+            spawn_instant: Instant::now(),
+            last_submit_enter: None,
+            submit_retries: 0,
+            submit_confirmed: false,
+            submit_failed_reason: None,
         });
     }
 
@@ -209,6 +275,23 @@ impl AgentTracker {
                     }
                 }
 
+                // #649: a child the submit-confirmation loop gave up on
+                // never ran a turn -- there is no session to classify. Record
+                // the wake_attempt outcome with the distinct reason so the
+                // metric trail shows "prompt never submitted" instead of a
+                // generic abandon, and skip the session-outcome row.
+                if let Some(reason) = &tracked.submit_failed_reason {
+                    if let Some(ref attempt_id) = tracked.attempt_id
+                        && let Err(e) = db.record_wake_attempt_outcome(attempt_id, "error", reason)
+                    {
+                        eprintln!(
+                            "[legion watch] failed to record submit-failure outcome {}: {}",
+                            attempt_id, e
+                        );
+                    }
+                    return false; // remove from tracking list
+                }
+
                 // #389: classify and persist the session outcome.
                 // Defensive: errors here log to stderr but never break
                 // the reap loop -- a missed log row is recoverable, a
@@ -275,19 +358,116 @@ impl AgentTracker {
         self.children.len() as i32
     }
 
-    /// Mutable access to a tracked child by wake-attempt id, for post-spawn
-    /// keystroke injection by the confirmed-submit protocol (#649). Returns
-    /// the first tracked child whose `attempt_id` matches; `None` when no
+    /// Mutable access to a tracked child by wake-attempt id. Returns the
+    /// first tracked child whose `attempt_id` matches; `None` when no
     /// tracked child carries that id (e.g. the spawn predated the
     /// wake_attempts substrate, or it has already been reaped).
-    // Wired into the watch loop by the confirmed-submit protocol (#649);
-    // dead from main's perspective until then, exercised by tests now.
+    //
+    // Targeted accessor for post-spawn keystroke injection. The in-tree
+    // consumer (`drive_submit_confirmation`) iterates `TrackedChild` in
+    // place because it needs the wrapper's submit-state, not just the
+    // child -- so this stays a foundation for future callers that key on
+    // attempt_id alone. Same allow-dead-code convention as
+    // `RecipientSpec::parse`. Exercised by tests.
     #[allow(dead_code)]
     pub fn child_by_attempt_mut(&mut self, attempt_id: &str) -> Option<&mut SpawnedChild> {
         self.children
             .iter_mut()
             .find(|t| t.attempt_id.as_deref() == Some(attempt_id))
             .map(|t| &mut t.child)
+    }
+
+    /// Drive the submit-confirmation protocol one tick (#649).
+    ///
+    /// Runs on the health tick, before `reap_finished`. For each PTY child
+    /// whose prompt has not yet been confirmed-submitted, this either:
+    ///   - observes a turn-start in the ring buffer and advances the FSM
+    ///     `Spawning -> Running` (submit landed); or
+    ///   - re-sends the submit keystroke (Enter), throttled to at most one
+    ///     per `submit_retry_interval_secs`; or
+    ///   - gives up once `submit_retry_max` Enters or
+    ///     `submit_confirm_budget_secs` wall-clock elapse, marking the child
+    ///     so `reap_finished` records `submit_not_confirmed` and tears it
+    ///     down (the kill here makes `try_wait` reap it the same tick).
+    ///
+    /// Print children never enter this loop -- they submit their prompt as
+    /// an argv at spawn and are advanced to `Running` by `poll_cycle`.
+    pub fn drive_submit_confirmation(&mut self, db: &Database, config: &WatchConfig) {
+        use crate::wake_attempts::WakeAttemptState::{Running, Spawning};
+
+        let budget = Duration::from_secs(config.submit_confirm_budget_secs);
+        let interval = Duration::from_secs(config.submit_retry_interval_secs);
+
+        for tracked in self.children.iter_mut() {
+            // Only PTY children that are still unconfirmed and carry an
+            // attempt row are eligible. `turn_started()` is false for Print,
+            // but skipping by variant avoids send_keys returning the
+            // unsupported error every tick.
+            if tracked.submit_confirmed
+                || tracked.submit_failed_reason.is_some()
+                || !matches!(tracked.child, SpawnedChild::Pty(_))
+            {
+                continue;
+            }
+            let Some(attempt_id) = tracked.attempt_id.clone() else {
+                continue;
+            };
+
+            let action = submit_action(
+                tracked.child.turn_started(),
+                tracked.submit_retries,
+                config.submit_retry_max,
+                tracked.spawn_instant.elapsed(),
+                budget,
+                tracked.last_submit_enter.map(|t| t.elapsed()),
+                interval,
+            );
+
+            match action {
+                SubmitAction::Confirm => {
+                    tracked.submit_confirmed = true;
+                    if let Err(e) = db.transition_wake_attempt(&attempt_id, Spawning, Running) {
+                        eprintln!(
+                            "[legion watch] transition Spawning->Running for {} ({}): {}",
+                            tracked.repo, attempt_id, e
+                        );
+                    }
+                    eprintln!(
+                        "[legion watch] submit confirmed for {} after {} enter(s)",
+                        tracked.repo, tracked.submit_retries
+                    );
+                }
+                SubmitAction::Fail => {
+                    eprintln!(
+                        "[legion watch] submit NOT confirmed for {} after {} enter(s) -- failing",
+                        tracked.repo, tracked.submit_retries
+                    );
+                    tracked.submit_failed_reason = Some(format!(
+                        "submit_not_confirmed (retries={})",
+                        tracked.submit_retries
+                    ));
+                    // Kill so reap_finished reaps it this tick; the reason
+                    // field routes the terminal outcome to submit_not_confirmed.
+                    if let Err(e) = tracked.child.kill() {
+                        eprintln!(
+                            "[legion watch] kill of unconfirmed child for {} failed: {}",
+                            tracked.repo, e
+                        );
+                    }
+                }
+                SubmitAction::Send => {
+                    if let Err(e) = tracked.child.send_keys(SUBMIT_KEY) {
+                        eprintln!(
+                            "[legion watch] submit keystroke for {} failed: {}",
+                            tracked.repo, e
+                        );
+                    }
+                    tracked.submit_retries += 1;
+                    tracked.last_submit_enter = Some(Instant::now());
+                }
+                SubmitAction::Wait => {}
+            }
+        }
     }
 }
 
@@ -499,5 +679,163 @@ mod tests {
         tracker.children.iter_mut().for_each(|t| {
             let _ = t.child.kill();
         });
+    }
+
+    // -- submit_action policy (#649) ------------------------------------------
+
+    #[test]
+    fn submit_action_confirms_on_turn_start() {
+        // turn_started short-circuits everything else, even past the budget.
+        let a = submit_action(
+            true,
+            99,
+            12,
+            Duration::from_secs(999),
+            Duration::from_secs(60),
+            None,
+            Duration::from_secs(4),
+        );
+        assert_eq!(a, SubmitAction::Confirm);
+    }
+
+    #[test]
+    fn submit_action_fails_on_exhausted_retries_or_budget() {
+        // Retry cap reached.
+        assert_eq!(
+            submit_action(
+                false,
+                12,
+                12,
+                Duration::from_secs(1),
+                Duration::from_secs(60),
+                Some(Duration::from_secs(10)),
+                Duration::from_secs(4),
+            ),
+            SubmitAction::Fail
+        );
+        // Wall-clock budget reached even with retries left.
+        assert_eq!(
+            submit_action(
+                false,
+                3,
+                12,
+                Duration::from_secs(60),
+                Duration::from_secs(60),
+                Some(Duration::from_secs(10)),
+                Duration::from_secs(4),
+            ),
+            SubmitAction::Fail
+        );
+    }
+
+    #[test]
+    fn submit_action_sends_then_waits_within_interval() {
+        // No prior Enter -> send immediately.
+        assert_eq!(
+            submit_action(
+                false,
+                0,
+                12,
+                Duration::from_secs(1),
+                Duration::from_secs(60),
+                None,
+                Duration::from_secs(4),
+            ),
+            SubmitAction::Send
+        );
+        // Last Enter older than interval -> send again.
+        assert_eq!(
+            submit_action(
+                false,
+                1,
+                12,
+                Duration::from_secs(6),
+                Duration::from_secs(60),
+                Some(Duration::from_secs(5)),
+                Duration::from_secs(4),
+            ),
+            SubmitAction::Send
+        );
+        // Last Enter within interval -> wait.
+        assert_eq!(
+            submit_action(
+                false,
+                1,
+                12,
+                Duration::from_secs(2),
+                Duration::from_secs(60),
+                Some(Duration::from_secs(1)),
+                Duration::from_secs(4),
+            ),
+            SubmitAction::Wait
+        );
+    }
+
+    // -- reap routing for submit failures (#649) ------------------------------
+
+    #[cfg(unix)]
+    #[test]
+    fn reap_records_submit_not_confirmed_outcome() {
+        // A child the submit loop gave up on (submit_failed_reason set, then
+        // killed) must reap to a Failed wake_attempt with the distinct
+        // submit_not_confirmed outcome -- not a generic abandon -- and must
+        // release its leases.
+        let (db, _index, data_dir) = test_storage();
+        let locks = SessionLockTracker::new(data_dir.path(), 3600);
+
+        // Spawn + immediately kill a child so try_wait reports exited.
+        let mut child_proc = std::process::Command::new("sleep")
+            .arg("9999")
+            .spawn()
+            .expect("spawn sleep");
+        let child_pid = child_proc.id();
+        child_proc.kill().expect("kill child");
+
+        // wake_attempts row driven to Spawning (where the submit loop fails).
+        let attempt_id = uuid::Uuid::now_v7().to_string();
+        let signal_id = db
+            .insert_reflection("kelex", "@legion question:submit-fail", "team")
+            .expect("insert signal")
+            .id;
+        db.enqueue_wake_attempt(&attempt_id, "legion", "legion", &[signal_id])
+            .expect("enqueue");
+        db.try_claim_wake_attempt(&attempt_id, "test-host")
+            .expect("claim");
+        use crate::wake_attempts::WakeAttemptState::{Claimed, Spawning};
+        db.transition_wake_attempt(&attempt_id, Claimed, Spawning)
+            .expect("Claimed->Spawning");
+
+        locks
+            .record_spawn("legion", child_pid)
+            .expect("record spawn");
+
+        let mut tracker = AgentTracker::new();
+        tracker.track(
+            "legion".to_string(),
+            SpawnedChild::Print(child_proc),
+            Vec::new(),
+            "test-host".to_string(),
+            uuid::Uuid::now_v7().to_string(),
+            chrono::Utc::now().to_rfc3339(),
+            Vec::new(),
+            Some(attempt_id.clone()),
+        );
+        // Mark it as the submit loop would on give-up.
+        tracker.children[0].submit_failed_reason =
+            Some("submit_not_confirmed (retries=12)".to_string());
+
+        tracker.reap_finished(Some(&db), Some(&locks));
+
+        assert_eq!(tracker.active_count(), 0, "failed child must be reaped");
+        let row = db
+            .get_wake_attempt(&attempt_id)
+            .expect("get attempt")
+            .expect("row exists");
+        assert_eq!(row.state, crate::wake_attempts::WakeAttemptState::Failed);
+        assert_eq!(
+            row.outcome.as_deref(),
+            Some("submit_not_confirmed (retries=12)"),
+            "the distinct submit-failure reason must land on the row"
+        );
     }
 }

--- a/src/watch/tracker.rs
+++ b/src/watch/tracker.rs
@@ -358,25 +358,6 @@ impl AgentTracker {
         self.children.len() as i32
     }
 
-    /// Mutable access to a tracked child by wake-attempt id. Returns the
-    /// first tracked child whose `attempt_id` matches; `None` when no
-    /// tracked child carries that id (e.g. the spawn predated the
-    /// wake_attempts substrate, or it has already been reaped).
-    //
-    // Targeted accessor for post-spawn keystroke injection. The in-tree
-    // consumer (`drive_submit_confirmation`) iterates `TrackedChild` in
-    // place because it needs the wrapper's submit-state, not just the
-    // child -- so this stays a foundation for future callers that key on
-    // attempt_id alone. Same allow-dead-code convention as
-    // `RecipientSpec::parse`. Exercised by tests.
-    #[allow(dead_code)]
-    pub fn child_by_attempt_mut(&mut self, attempt_id: &str) -> Option<&mut SpawnedChild> {
-        self.children
-            .iter_mut()
-            .find(|t| t.attempt_id.as_deref() == Some(attempt_id))
-            .map(|t| &mut t.child)
-    }
-
     /// Drive the submit-confirmation protocol one tick (#649).
     ///
     /// Runs on the health tick, before `reap_finished`. For each PTY child
@@ -455,16 +436,32 @@ impl AgentTracker {
                         );
                     }
                 }
-                SubmitAction::Send => {
-                    if let Err(e) = tracked.child.send_keys(SUBMIT_KEY) {
+                SubmitAction::Send => match tracked.child.send_keys(SUBMIT_KEY) {
+                    Ok(()) => {
+                        tracked.submit_retries += 1;
+                        tracked.last_submit_enter = Some(Instant::now());
+                    }
+                    Err(e) => {
+                        // A failed PTY write means the child's input is
+                        // broken -- retrying cannot help. Fail closed rather
+                        // than counting a phantom Enter against the budget or
+                        // logging an Enter that never reached the TUI.
                         eprintln!(
-                            "[legion watch] submit keystroke for {} failed: {}",
+                            "[legion watch] submit keystroke for {} failed -- failing: {}",
                             tracked.repo, e
                         );
+                        tracked.submit_failed_reason = Some(format!(
+                            "submit_send_failed (retries={})",
+                            tracked.submit_retries
+                        ));
+                        if let Err(ke) = tracked.child.kill() {
+                            eprintln!(
+                                "[legion watch] kill after send failure for {} failed: {}",
+                                tracked.repo, ke
+                            );
+                        }
                     }
-                    tracked.submit_retries += 1;
-                    tracked.last_submit_enter = Some(Instant::now());
-                }
+                },
                 SubmitAction::Wait => {}
             }
         }
@@ -623,64 +620,6 @@ mod tests {
         });
     }
 
-    // -- child_by_attempt_mut (#648) ------------------------------------------
-
-    #[cfg(unix)]
-    #[test]
-    fn child_by_attempt_mut_finds_match_and_misses_unknown() {
-        // A tracked child must be reachable by its attempt_id for the
-        // confirmed-submit protocol to inject keystrokes; an unknown id and
-        // an attemptless child must both miss.
-        let mut tracker = AgentTracker::new();
-
-        // Child A: carries a known attempt_id.
-        let child_a = std::process::Command::new("sleep")
-            .arg("9999")
-            .spawn()
-            .expect("spawn sleep a");
-        let attempt_id = uuid::Uuid::now_v7().to_string();
-        tracker.track(
-            "legion".to_string(),
-            SpawnedChild::Print(child_a),
-            Vec::new(),
-            "test-host".to_string(),
-            uuid::Uuid::now_v7().to_string(),
-            chrono::Utc::now().to_rfc3339(),
-            Vec::new(),
-            Some(attempt_id.clone()),
-        );
-
-        // Child B: attemptless -- must never match a lookup.
-        let child_b = std::process::Command::new("sleep")
-            .arg("9999")
-            .spawn()
-            .expect("spawn sleep b");
-        tracker.track(
-            "legion".to_string(),
-            SpawnedChild::Print(child_b),
-            Vec::new(),
-            "test-host".to_string(),
-            uuid::Uuid::now_v7().to_string(),
-            chrono::Utc::now().to_rfc3339(),
-            Vec::new(),
-            None,
-        );
-
-        assert!(
-            tracker.child_by_attempt_mut(&attempt_id).is_some(),
-            "must find the tracked child by its attempt_id"
-        );
-        assert!(
-            tracker.child_by_attempt_mut("no-such-attempt").is_none(),
-            "an unknown attempt_id must miss even with attemptless children tracked"
-        );
-
-        // Clean up both long-lived children.
-        tracker.children.iter_mut().for_each(|t| {
-            let _ = t.child.kill();
-        });
-    }
-
     // -- submit_action policy (#649) ------------------------------------------
 
     #[test]
@@ -820,6 +759,11 @@ mod tests {
             Vec::new(),
             Some(attempt_id.clone()),
         );
+        assert!(
+            locks.active_pid("legion").is_some(),
+            "precondition: session lock is held before reap"
+        );
+
         // Mark it as the submit loop would on give-up.
         tracker.children[0].submit_failed_reason =
             Some("submit_not_confirmed (retries=12)".to_string());
@@ -836,6 +780,12 @@ mod tests {
             row.outcome.as_deref(),
             Some("submit_not_confirmed (retries=12)"),
             "the distinct submit-failure reason must land on the row"
+        );
+        // The submit-failure path must release the session lock like any
+        // other reap, so the per-repo wake gate reopens.
+        assert!(
+            locks.active_pid("legion").is_none(),
+            "session lock must be released after a submit-failure reap"
         );
     }
 }


### PR DESCRIPTION
## Summary

Make PTY wake prompts reliably submit. The old Pty branch wrote the prompt + an immediate `\r` right after fork, before the Claude TUI input pipeline is interactive (~15-22s in plugin-heavy repos), so the submit was swallowed and the wake attempt aged to `abandoned` -- the exact ghosting the wake system exists to prevent. This replaces fire-and-forget with a feedback-driven protocol: bracketed-paste the prompt, then retry Enter from the health tick until the ring buffer shows a turn started, failing closed if it never does.

Depends on #648 (`SpawnedChild::send_keys`). Base of this PR is the #648 branch; it shows only the #649 delta.

## Acceptance criteria mapping

### 1. All tests pass; clippy `--all-targets -D warnings`; fmt `--check`

The protocol's pure pieces are extracted so they are testable without a live `claude` PTY: `wrap_bracketed_paste` (exact wire bytes, no trailing submit), `has_turn_start_marker` (token-counter scan, idle screen rejected), and `submit_action` (the full Confirm/Fail/Send/Wait decision table over retries, budget, and interval). The DB-facing failure path is covered by `reap_records_submit_not_confirmed_outcome`, which drives a wake_attempt to `Spawning`, sets the give-up reason, reaps, and asserts the row is `Failed` with outcome `submit_not_confirmed (retries=12)`. Config defaults and explicit parse are covered too.
Evidence: new tests `wrap_bracketed_paste_wraps_exactly_with_no_submit`, `turn_start_marker_detects_token_counter_only`, `submit_action_{confirms_on_turn_start,fails_on_exhausted_retries_or_budget,sends_then_waits_within_interval}`, `reap_records_submit_not_confirmed_outcome`, `parse_config_submit_knobs_explicit`; `cargo test` exit 0; clippy `--all-targets` and fmt clean.

### 2. Simplify pass completed

`legion-simplify` reviewed the diff: the `SubmitAction`/`submit_action` extraction maps 1:1 to real branches (justified by testability, not gratuitous indirection), the helpers are not std duplicates, and the `eprintln!`-and-continue error handling matches the existing watch-loop convention (never panic the thread). No duplication or stringly-typed state. Recorded clean.
Evidence: quality-gate row `019ec269-d7aa-7302-8e96-6fa490cb1756` (skill `legion-simplify`, result clean).

### 3. Review pass completed and findings fixed

`/review-pr` runs against this PR after creation; HIGH/MED findings are adversarially verified and every surviving finding fixed, tests re-run, before merge.
Evidence: review-pr run on this PR number; fixes committed to this branch.

### 4. PR created and linked to this issue

This PR, opened via `legion pr create`, base `feat/648-pty-keystroke-channel`, references and closes #649.
Evidence: PR body "Closes #649"; depends-on #648 noted.

### 5. Live verification: a real wake reaches Running via confirmed submit; watch status not stuck

The protocol itself was empirically validated end-to-end before coding: experiments exp5 (retry-Enter, submit on Enter #4), exp6 (bracketed-paste multi-line, single clean turn), and oracle2 (submit confirmed, and the disproof of the transcript oracle) -- reflections `019ec249`, `019ec25d`. The full daemon-level live check (build the consumer binary, `daemon-restart`, `legion signal --to smugglr --verb request`, observe `Claimed->Spawning->Running` then terminal Done in `legion watch status`) is run at release time, when the built binary is installed -- it cannot run against an unmerged dev branch without hand-installing over the running daemon.
Evidence: exp5/exp6/oracle2 logs (`/tmp/pty-exp{5,6}.log`, `/tmp/oracle2*.txt`); release-time wake probe.

## Not done

- No dedicated `submit_retry_count` schema column. The wake_attempts table is sync-replicated, so a new column touches the delta-serialization layer; instead the retry count rides in the `outcome` reason string on the same row (`submit_not_confirmed (retries=N)`), which makes a swallowed submit a first-class queryable outcome -- the metric's actual value -- with no synced-schema migration. Refinement of the issue's "persist submit_retry_count" wording, same end (the count is persisted on the row).
- Confirmation oracle flipped from the issue's PRIMARY (transcript-file appearance) to the FALLBACK (ring-buffer `tokens` marker). The issue made this contingent on empirical verification; oracle2 disproved the transcript oracle (Claude buffers the transcript and writes it on clean exit -- it never appears for a live or killed wake), so the fallback became primary. Documented inline in `PtySession::saw_turn_start`.
- Print mode untouched -- it remains the `LEGION_SPAWN_MODE=print` fallback and keeps its immediate `Spawning->Running`.

Closes #649.