### PR TITLE
feat(#654): auto-reconcile shipped-pending kanban drift in the daemon

### DIFF
--- a/src/cli/kanban.rs
+++ b/src/cli/kanban.rs
@@ -327,6 +327,32 @@ enum PropagateOutcome {
     Failed,
 }
 
+/// Print one drift bucket of a `legion kanban reconcile` scan to stdout: the
+/// empty-state line when nothing drifted, otherwise the count line followed by
+/// one row per card. Keeps the operator-facing report in the CLI while the
+/// scan/action logic lives in `kanban::reconcile`.
+fn print_drift_bucket(
+    drifts: &[kanban::reconcile::Drift],
+    plural_label: &str,
+    empty_message: &str,
+) {
+    if drifts.is_empty() {
+        println!("[legion] reconcile: {empty_message}");
+        return;
+    }
+    println!("[legion] reconcile: {} {plural_label} found", drifts.len());
+    for drift in drifts {
+        println!(
+            "  card={} status={} source={}#{} to_repo={}",
+            drift.card.id,
+            drift.card.status.label(),
+            drift.source_repo,
+            drift.number,
+            drift.card.to_repo
+        );
+    }
+}
+
 /// Close the GitHub issue linked to a kanban card via the work source
 /// plugin, and write an audit entry describing the propagation. Called by
 /// `legion kanban cancel` and `legion done --id` (#610 folded the Done
@@ -854,305 +880,54 @@ pub(crate) fn handle(action: KanbanAction) -> error::Result<()> {
             let close_stale = close_stale || apply;
             let cancel_shipped = cancel_shipped || apply;
 
-            // One pass over the board, partitioning by drift
-            // direction. Each card with a `source_url` triggers
-            // exactly one `view_issue` probe; the resulting state
-            // determines which (if any) bucket it lands in.
-            let cards = kanban::board_cards(&database)?;
-            let mut stale: Vec<(kanban::Card, u64, String)> = Vec::new();
-            let mut shipped_pending: Vec<(kanban::Card, u64, String)> = Vec::new();
+            // One pass over the board, partitioning by drift direction. The
+            // scan, the close-stale action, and the cancel-shipped action all
+            // live in `kanban::reconcile` so the daemon's auto-reconcile tick
+            // (#654) shares exactly this logic; this arm owns only the
+            // operator-facing stdout report and the dry-run hints.
+            let report = kanban::reconcile::scan_drift(&database, repo.as_deref(), "[legion]")?;
 
-            for card in cards {
-                // Active vs. terminal: terminal cards (done /
-                // cancelled) are direction-1 candidates;
-                // anything else (pending, in-progress, blocked,
-                // ...) is direction-2.
-                let is_terminal = matches!(
-                    card.status,
-                    kanban::CardStatus::Done | kanban::CardStatus::Cancelled
-                );
+            print_drift_bucket(
+                &report.stale_open,
+                "stale-open issue(s)",
+                "no stale-open issues found",
+            );
+            print_drift_bucket(
+                &report.shipped_pending,
+                "shipped-pending card(s)",
+                "no shipped-pending cards found",
+            );
 
-                if let Some(ref filter) = repo
-                    && card.to_repo != *filter
-                {
-                    continue;
-                }
-
-                let Some(ref source_url) = card.source_url else {
-                    continue;
-                };
-                let Some(number) = worksource::extract_issue_number(source_url) else {
-                    continue;
-                };
-                let Some(source) = card.source_type.as_deref() else {
-                    continue;
-                };
-                let Some((_, source_repo, _)) = worksource::resolve_config(&card.to_repo) else {
-                    eprintln!(
-                        "[legion] reconcile: skipping card {} -- to_repo '{}' has no work source configured",
-                        card.id, card.to_repo
-                    );
-                    continue;
-                };
-
-                // Query the live issue state. view_issue returns
-                // ExternalIssue with a `state` field that is
-                // "OPEN" or "CLOSED" for GitHub. Any other
-                // value is treated as "unknown" and skipped
-                // with a warning so a plugin that returns a
-                // non-standard state does not silently get
-                // reported as stale-open.
-                let state = match worksource::view_issue(source, &source_repo, number) {
-                    Ok(issue) => issue.state,
-                    Err(e) => {
-                        eprintln!(
-                            "[legion] reconcile: failed to view {} issue #{}: {}",
-                            source_repo, number, e
-                        );
-                        continue;
-                    }
-                };
-
-                // Direction 1: terminal-local + open-on-GH.
-                // Direction 2: active-local + closed/merged-on-GH.
-                // GitHub PR-merge events report state="CLOSED" with
-                // a separate stateReason or pr metadata; treat
-                // anything in the closed-family as "shipped" for
-                // direction 2 purposes.
-                let upper = state.to_uppercase();
-                match (is_terminal, upper.as_str()) {
-                    (true, "OPEN") => {
-                        stale.push((card.clone(), number, source_repo.clone()));
-                    }
-                    (false, "CLOSED" | "MERGED") => {
-                        shipped_pending.push((card.clone(), number, source_repo.clone()));
-                    }
-                    _ => {}
-                }
-            }
-
-            if stale.is_empty() {
-                println!("[legion] reconcile: no stale-open issues found");
-            } else {
+            if close_stale && !report.stale_open.is_empty() {
                 println!(
-                    "[legion] reconcile: {} stale-open issue(s) found",
-                    stale.len()
+                    "[legion] reconcile: closing {} stale issue(s)",
+                    report.stale_open.len()
                 );
-                for (card, number, source_repo) in &stale {
-                    println!(
-                        "  card={} status={} source={}#{} to_repo={}",
-                        card.id,
-                        card.status.label(),
-                        source_repo,
-                        number,
-                        card.to_repo
-                    );
-                }
-            }
-
-            if shipped_pending.is_empty() {
-                println!("[legion] reconcile: no shipped-pending cards found");
-            } else {
-                println!(
-                    "[legion] reconcile: {} shipped-pending card(s) found",
-                    shipped_pending.len()
-                );
-                for (card, number, source_repo) in &shipped_pending {
-                    println!(
-                        "  card={} status={} source={}#{} to_repo={}",
-                        card.id,
-                        card.status.label(),
-                        source_repo,
-                        number,
-                        card.to_repo
-                    );
-                }
-            }
-
-            if close_stale && !stale.is_empty() {
-                println!("[legion] reconcile: closing {} stale issue(s)", stale.len());
-                let mut closed = 0_u64;
-                let mut failed = 0_u64;
-                for (card, number, source_repo) in &stale {
-                    let Some(source) = card.source_type.as_deref() else {
-                        continue;
-                    };
-                    let reconcile_comment = format!(
-                        "Closed by legion reconcile: local card {} is {} but this issue was left open. Reconciling to match the local state.",
-                        card.id,
-                        card.status.label()
-                    );
-                    match worksource::close_issue(
-                        source,
-                        source_repo,
-                        *number,
-                        Some(&reconcile_comment),
-                    ) {
-                        Ok(()) => {
-                            closed += 1;
-                            eprintln!(
-                                "[legion] reconcile: closed {} issue #{}",
-                                source_repo, number
-                            );
-                            let details = serde_json::json!({
-                                "card_id": card.id,
-                                "propagation": "reconcile",
-                            });
-                            let details_str = details.to_string();
-                            audit(
-                                &database,
-                                &db::AuditInput {
-                                    agent: &card.to_repo,
-                                    action: "close-issue",
-                                    target_type: "issue",
-                                    target_ref: &number.to_string(),
-                                    task_id: Some(&card.id),
-                                    source_type: source,
-                                    details: Some(&details_str),
-                                    outcome: "success",
-                                },
-                            );
-                        }
-                        Err(e) => {
-                            failed += 1;
-                            eprintln!(
-                                "[legion] reconcile: failed to close {} issue #{}: {}",
-                                source_repo, number, e
-                            );
-                            // Record the failure in the audit log
-                            // so a human operator running
-                            // `legion audit --action close-issue`
-                            // can see exactly which stale issues
-                            // reconcile could not close. Without
-                            // this, a reconcile run that fails
-                            // on 3 of 10 issues leaves no durable
-                            // record of which 3 -- same class of
-                            // invisibility the PR is fixing for
-                            // the direct cancel path.
-                            let err_msg = e.to_string();
-                            let details = serde_json::json!({
-                                "card_id": card.id,
-                                "propagation": "reconcile",
-                                "error": err_msg,
-                            });
-                            let details_str = details.to_string();
-                            audit(
-                                &database,
-                                &db::AuditInput {
-                                    agent: &card.to_repo,
-                                    action: "close-issue",
-                                    target_type: "issue",
-                                    target_ref: &number.to_string(),
-                                    task_id: Some(&card.id),
-                                    source_type: source,
-                                    details: Some(&details_str),
-                                    outcome: "failure",
-                                },
-                            );
-                        }
-                    }
-                }
-                println!("[legion] reconcile: {} closed, {} failed", closed, failed);
+                let (closed, failed) =
+                    kanban::reconcile::close_stale_open(&database, &report.stale_open, "[legion]");
+                println!("[legion] reconcile: {closed} closed, {failed} failed");
             } else if close_stale {
                 println!("[legion] reconcile: nothing to close");
-            } else if !stale.is_empty() {
+            } else if !report.stale_open.is_empty() {
                 println!(
                     "[legion] reconcile: dry-run -- pass --close-stale to actually close these issues"
                 );
             }
 
-            // Direction 2 action: cancel shipped-pending cards
-            // locally with --no-propagate semantics. The linked
-            // GitHub issue is already CLOSED/MERGED, so calling
-            // worksource::close_issue would either no-op or
-            // double-touch the audit log.
-            if cancel_shipped && !shipped_pending.is_empty() {
+            if cancel_shipped && !report.shipped_pending.is_empty() {
                 println!(
                     "[legion] reconcile: cancelling {} shipped-pending card(s) locally",
-                    shipped_pending.len()
+                    report.shipped_pending.len()
                 );
-                let mut cancelled = 0_u64;
-                let mut failed = 0_u64;
-                for (card, number, source_repo) in &shipped_pending {
-                    // The partition above only enqueued cards
-                    // whose source_type was Some; defensively
-                    // re-check to avoid a misleading audit row
-                    // if a future refactor moves the guard.
-                    let Some(source_type) = card.source_type.as_deref() else {
-                        continue;
-                    };
-                    let note = format!(
-                        "reconcile: linked {}#{} already closed on GitHub",
-                        source_repo, number
-                    );
-                    match kanban::transition_card(
-                        &database,
-                        &card.id,
-                        kanban::Action::Cancel,
-                        Some(&note),
-                    ) {
-                        Ok(_) => {
-                            cancelled += 1;
-                            eprintln!(
-                                "[legion] reconcile: cancelled card {} ({}#{})",
-                                card.id, source_repo, number
-                            );
-                            let details = serde_json::json!({
-                                "card_id": card.id,
-                                "propagation": "reconcile-shipped",
-                                "external_number": number,
-                            });
-                            let details_str = details.to_string();
-                            audit(
-                                &database,
-                                &db::AuditInput {
-                                    agent: &card.to_repo,
-                                    action: "cancel-card",
-                                    target_type: "card",
-                                    target_ref: &card.id,
-                                    task_id: Some(&card.id),
-                                    source_type,
-                                    details: Some(&details_str),
-                                    outcome: "success",
-                                },
-                            );
-                        }
-                        Err(e) => {
-                            failed += 1;
-                            eprintln!(
-                                "[legion] reconcile: failed to cancel card {}: {}",
-                                card.id, e
-                            );
-                            let err_msg = e.to_string();
-                            let details = serde_json::json!({
-                                "card_id": card.id,
-                                "propagation": "reconcile-shipped",
-                                "error": err_msg,
-                            });
-                            let details_str = details.to_string();
-                            audit(
-                                &database,
-                                &db::AuditInput {
-                                    agent: &card.to_repo,
-                                    action: "cancel-card",
-                                    target_type: "card",
-                                    target_ref: &card.id,
-                                    task_id: Some(&card.id),
-                                    source_type,
-                                    details: Some(&details_str),
-                                    outcome: "failure",
-                                },
-                            );
-                        }
-                    }
-                }
-                println!(
-                    "[legion] reconcile: {} cancelled, {} failed",
-                    cancelled, failed
+                let (cancelled, failed) = kanban::reconcile::cancel_shipped_pending(
+                    &database,
+                    &report.shipped_pending,
+                    "[legion]",
                 );
+                println!("[legion] reconcile: {cancelled} cancelled, {failed} failed");
             } else if cancel_shipped {
                 println!("[legion] reconcile: nothing to cancel");
-            } else if !shipped_pending.is_empty() {
+            } else if !report.shipped_pending.is_empty() {
                 println!(
                     "[legion] reconcile: dry-run -- pass --cancel-shipped to actually cancel these cards"
                 );

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -480,6 +480,8 @@ async fn run_watch_task(data_dir: &Path) {
     // Timer intervals are read from the loop-owned config.
     let poll_interval = std::time::Duration::from_secs(state.config.poll_interval_secs);
     let health_interval = std::time::Duration::from_secs(state.config.health_poll_secs);
+    // Auto-reconcile (#654) runs on a slow cadence; 0 disables it entirely.
+    let reconcile_interval = std::time::Duration::from_secs(state.config.reconcile_interval_secs);
 
     let mut poll_timer = tokio::time::Instant::now()
         .checked_sub(poll_interval)
@@ -487,6 +489,12 @@ async fn run_watch_task(data_dir: &Path) {
     let mut health_timer = tokio::time::Instant::now()
         .checked_sub(health_interval)
         .unwrap_or_else(tokio::time::Instant::now);
+    // Unlike poll/health, the reconcile timer starts at `now` (not
+    // now - interval) so the first pass fires one full interval after
+    // startup. Reconcile probes the work source once per linked card, so
+    // firing it immediately on every daemon bounce would storm `gh`; one
+    // interval of staleness after a restart is the cheaper tradeoff.
+    let mut reconcile_timer = tokio::time::Instant::now();
 
     loop {
         // Yield to tokio scheduler each iteration.
@@ -500,6 +508,13 @@ async fn run_watch_task(data_dir: &Path) {
         if poll_timer.elapsed() >= poll_interval {
             state.tick_poll();
             poll_timer = tokio::time::Instant::now();
+        }
+
+        if state.config.reconcile_interval_secs > 0
+            && reconcile_timer.elapsed() >= reconcile_interval
+        {
+            state.tick_reconcile();
+            reconcile_timer = tokio::time::Instant::now();
         }
     }
 }

--- a/src/kanban/mod.rs
+++ b/src/kanban/mod.rs
@@ -4,6 +4,7 @@
 //! this file keeps the Card type, row mapping, and CRUD wrappers.
 
 mod format;
+pub mod reconcile;
 mod state;
 
 pub use format::*;

--- a/src/kanban/reconcile.rs
+++ b/src/kanban/reconcile.rs
@@ -1,0 +1,378 @@
+//! Kanban-to-worksource reconciliation (#444, #654).
+//!
+//! Detects and resolves drift between a local card's state and the lifecycle
+//! of its linked GitHub issue. Two directions:
+//!
+//!   1. **stale-open**: the local card is terminal (`done`/`cancelled`) but
+//!      the linked issue is still `OPEN`. Resolved by [`close_stale_open`],
+//!      which closes the issue via the work source plugin.
+//!   2. **shipped-pending**: the local card is active (`pending`, ...) but the
+//!      linked issue is already `CLOSED`/`MERGED`. Resolved by
+//!      [`cancel_shipped_pending`], which cancels the card locally without
+//!      touching GitHub (the issue is already closed).
+//!
+//! [`scan_drift`] does both detections in a single board pass -- one
+//! `view_issue` probe per card with a resolvable linked issue. Per-card
+//! failures (no work source configured, probe error, unrecognised state) are
+//! logged and skipped; they never abort the pass.
+//!
+//! The CLI `legion kanban reconcile` command and the daemon's periodic
+//! auto-reconcile tick (#654) both build on these functions. The daemon only
+//! ever runs the safe direction ([`cancel_shipped_pending`], purely local);
+//! closing live GitHub issues from local state stays a manual, opt-in CLI
+//! action behind `--close-stale`.
+
+use super::{Action, Card, CardStatus, board_cards, transition_card};
+use crate::db::{self, Database};
+use crate::error::Result;
+use crate::worksource;
+
+/// A single drift finding: a card paired with the linked issue it diverged
+/// from. Carries the resolved `source_repo` and issue `number` so the action
+/// functions do not re-resolve work source config per card.
+pub struct Drift {
+    pub card: Card,
+    pub number: u64,
+    pub source_repo: String,
+}
+
+/// Both drift directions found in one board pass.
+#[derive(Default)]
+pub struct DriftReport {
+    /// Terminal-local cards whose linked GitHub issue is still OPEN.
+    pub stale_open: Vec<Drift>,
+    /// Active-local cards whose linked GitHub issue is CLOSED/MERGED.
+    pub shipped_pending: Vec<Drift>,
+}
+
+/// Scan the board once, partitioning cards by drift direction.
+///
+/// `repo_filter` restricts the scan to cards whose `to_repo` matches. Every
+/// card with a `source_url`, an extractable issue number, a `source_type`,
+/// and a configured work source triggers exactly one `view_issue` probe; its
+/// live state decides which bucket (if any) it lands in. Cards missing any of
+/// the first three are skipped silently (they are pure-local), while a card
+/// whose `to_repo` has no configured work source logs a warning so an
+/// operator can spot a misconfigured repo. A probe error or an unrecognised
+/// issue state (anything outside the OPEN / CLOSED / MERGED set) is logged
+/// and the card is skipped -- a single failing repo never aborts the pass.
+///
+/// `log_prefix` tags the skip/error breadcrumbs (`"[legion]"` for the CLI,
+/// the loop prefix for the daemon).
+pub fn scan_drift(
+    db: &Database,
+    repo_filter: Option<&str>,
+    log_prefix: &str,
+) -> Result<DriftReport> {
+    let cards = board_cards(db)?;
+    let mut report = DriftReport::default();
+
+    for card in cards {
+        if let Some(filter) = repo_filter
+            && card.to_repo != *filter
+        {
+            continue;
+        }
+
+        // Terminal cards (done / cancelled) are direction-1 candidates;
+        // anything still active (pending, in-progress, blocked, ...) is
+        // direction-2.
+        let is_terminal = matches!(card.status, CardStatus::Done | CardStatus::Cancelled);
+
+        let Some(ref source_url) = card.source_url else {
+            continue;
+        };
+        let Some(number) = worksource::extract_issue_number(source_url) else {
+            continue;
+        };
+        let Some(source) = card.source_type.as_deref() else {
+            continue;
+        };
+        let Some((_, source_repo, _)) = worksource::resolve_config(&card.to_repo) else {
+            eprintln!(
+                "{log_prefix} reconcile: skipping card {} -- to_repo '{}' has no work source configured",
+                card.id, card.to_repo
+            );
+            continue;
+        };
+
+        // Query the live issue state. `view_issue` returns an `ExternalIssue`
+        // whose `state` is "OPEN" or "CLOSED" for GitHub; a PR-merge reports
+        // "CLOSED" (or "MERGED" on some plugins), so the closed-family covers
+        // both shipped cases. Any other value is treated as unknown and
+        // skipped rather than misclassified.
+        let state = match worksource::view_issue(source, &source_repo, number) {
+            Ok(issue) => issue.state,
+            Err(e) => {
+                eprintln!(
+                    "{log_prefix} reconcile: failed to view {source_repo} issue #{number}: {e}"
+                );
+                continue;
+            }
+        };
+
+        match (is_terminal, state.to_uppercase().as_str()) {
+            (true, "OPEN") => report.stale_open.push(Drift {
+                card,
+                number,
+                source_repo,
+            }),
+            (false, "CLOSED" | "MERGED") => report.shipped_pending.push(Drift {
+                card,
+                number,
+                source_repo,
+            }),
+            _ => {}
+        }
+    }
+
+    Ok(report)
+}
+
+/// Cancel shipped-pending cards locally, with no GitHub propagation -- the
+/// linked issue is already CLOSED/MERGED, so closing it again would no-op or
+/// double-touch the audit log. Writes one `cancel-card` audit row per card
+/// (success or failure) so a reconcile that fails on some cards leaves a
+/// durable record of which. Returns `(cancelled, failed)`. Per-card failures
+/// are logged and counted; the pass never aborts.
+pub fn cancel_shipped_pending(db: &Database, drifts: &[Drift], log_prefix: &str) -> (u64, u64) {
+    let mut cancelled = 0_u64;
+    let mut failed = 0_u64;
+
+    for drift in drifts {
+        let card = &drift.card;
+        // The scan only enqueues cards whose source_type was Some;
+        // defensively re-check so a future refactor cannot produce a
+        // misleading audit row with an empty source_type.
+        let Some(source_type) = card.source_type.as_deref() else {
+            continue;
+        };
+        let note = format!(
+            "reconcile: linked {}#{} already closed on GitHub",
+            drift.source_repo, drift.number
+        );
+        match transition_card(db, &card.id, Action::Cancel, Some(&note)) {
+            Ok(_) => {
+                cancelled += 1;
+                eprintln!(
+                    "{log_prefix} reconcile: cancelled card {} ({}#{})",
+                    card.id, drift.source_repo, drift.number
+                );
+                let details = serde_json::json!({
+                    "card_id": card.id,
+                    "propagation": "reconcile-shipped",
+                    "external_number": drift.number,
+                })
+                .to_string();
+                best_effort_audit(
+                    db,
+                    &db::AuditInput {
+                        agent: &card.to_repo,
+                        action: "cancel-card",
+                        target_type: "card",
+                        target_ref: &card.id,
+                        task_id: Some(&card.id),
+                        source_type,
+                        details: Some(&details),
+                        outcome: "success",
+                    },
+                );
+            }
+            Err(e) => {
+                failed += 1;
+                eprintln!(
+                    "{log_prefix} reconcile: failed to cancel card {}: {e}",
+                    card.id
+                );
+                let details = serde_json::json!({
+                    "card_id": card.id,
+                    "propagation": "reconcile-shipped",
+                    "error": e.to_string(),
+                })
+                .to_string();
+                best_effort_audit(
+                    db,
+                    &db::AuditInput {
+                        agent: &card.to_repo,
+                        action: "cancel-card",
+                        target_type: "card",
+                        target_ref: &card.id,
+                        task_id: Some(&card.id),
+                        source_type,
+                        details: Some(&details),
+                        outcome: "failure",
+                    },
+                );
+            }
+        }
+    }
+
+    (cancelled, failed)
+}
+
+/// Close the GitHub issues linked to stale-open cards (terminal-local but the
+/// issue is still OPEN), posting a reconciling comment. Writes one
+/// `close-issue` audit row per attempt. Returns `(closed, failed)`.
+///
+/// This is the destructive direction -- it mutates live GitHub state -- so
+/// only the CLI invokes it, behind the explicit `--close-stale` flag. The
+/// daemon's auto-reconcile never runs it.
+pub fn close_stale_open(db: &Database, drifts: &[Drift], log_prefix: &str) -> (u64, u64) {
+    let mut closed = 0_u64;
+    let mut failed = 0_u64;
+
+    for drift in drifts {
+        let card = &drift.card;
+        let Some(source) = card.source_type.as_deref() else {
+            continue;
+        };
+        let comment = format!(
+            "Closed by legion reconcile: local card {} is {} but this issue was left open. Reconciling to match the local state.",
+            card.id,
+            card.status.label()
+        );
+        match worksource::close_issue(source, &drift.source_repo, drift.number, Some(&comment)) {
+            Ok(()) => {
+                closed += 1;
+                eprintln!(
+                    "{log_prefix} reconcile: closed {} issue #{}",
+                    drift.source_repo, drift.number
+                );
+                let details = serde_json::json!({
+                    "card_id": card.id,
+                    "propagation": "reconcile",
+                })
+                .to_string();
+                best_effort_audit(
+                    db,
+                    &db::AuditInput {
+                        agent: &card.to_repo,
+                        action: "close-issue",
+                        target_type: "issue",
+                        target_ref: &drift.number.to_string(),
+                        task_id: Some(&card.id),
+                        source_type: source,
+                        details: Some(&details),
+                        outcome: "success",
+                    },
+                );
+            }
+            Err(e) => {
+                failed += 1;
+                eprintln!(
+                    "{log_prefix} reconcile: failed to close {} issue #{}: {e}",
+                    drift.source_repo, drift.number
+                );
+                let details = serde_json::json!({
+                    "card_id": card.id,
+                    "propagation": "reconcile",
+                    "error": e.to_string(),
+                })
+                .to_string();
+                best_effort_audit(
+                    db,
+                    &db::AuditInput {
+                        agent: &card.to_repo,
+                        action: "close-issue",
+                        target_type: "issue",
+                        target_ref: &drift.number.to_string(),
+                        task_id: Some(&card.id),
+                        source_type: source,
+                        details: Some(&details),
+                        outcome: "failure",
+                    },
+                );
+            }
+        }
+    }
+
+    (closed, failed)
+}
+
+/// Best-effort audit row: insert failures warn to stderr but never abort the
+/// reconcile pass. Mirrors `cli::util::audit` without forcing the kanban
+/// layer to depend on the cli layer.
+fn best_effort_audit(db: &Database, input: &db::AuditInput<'_>) {
+    if let Err(e) = db.insert_audit_entry(input) {
+        eprintln!("[legion] warning: audit log failed: {e}");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::kanban::{Priority, create_card};
+    use crate::testutil::test_storage;
+
+    /// Build a card with a linked GitHub issue and wrap it in a Drift so the
+    /// action functions can be exercised without a live `view_issue` probe
+    /// (which would need a real work source plugin).
+    fn shipped_drift(db: &Database) -> Drift {
+        let id = create_card(
+            db,
+            "legion",
+            "legion",
+            "reconcile test card",
+            None,
+            Priority::Med,
+            None,
+            None,
+            Some("https://github.com/runlegion/legion/issues/999"),
+            Some("github"),
+            None,
+        )
+        .expect("create card");
+        let card = db
+            .get_card_by_id(&id)
+            .expect("lookup")
+            .expect("card exists");
+        Drift {
+            card,
+            number: 999,
+            source_repo: "runlegion/legion".to_string(),
+        }
+    }
+
+    #[test]
+    fn scan_drift_on_empty_board_is_empty() {
+        let (db, _index, _dir) = test_storage();
+        let report = scan_drift(&db, None, "[test]").expect("scan");
+        assert!(report.stale_open.is_empty());
+        assert!(report.shipped_pending.is_empty());
+    }
+
+    #[test]
+    fn cancel_shipped_pending_empty_is_noop() {
+        let (db, _index, _dir) = test_storage();
+        assert_eq!(cancel_shipped_pending(&db, &[], "[test]"), (0, 0));
+    }
+
+    #[test]
+    fn cancel_shipped_pending_cancels_card_and_audits() {
+        let (db, _index, _dir) = test_storage();
+        let drift = shipped_drift(&db);
+        let card_id = drift.card.id.clone();
+
+        let (cancelled, failed) =
+            cancel_shipped_pending(&db, std::slice::from_ref(&drift), "[test]");
+        assert_eq!((cancelled, failed), (1, 0));
+
+        let card = db
+            .get_card_by_id(&card_id)
+            .expect("lookup")
+            .expect("card exists");
+        assert_eq!(card.status, CardStatus::Cancelled);
+
+        // The cancel wrote a durable audit row so an operator can see what
+        // reconcile touched.
+        let entries = db
+            .query_audit_log(None, Some("cancel-card"), 10)
+            .expect("audit");
+        assert!(
+            entries
+                .iter()
+                .any(|e| e.target_ref == card_id && e.outcome == "success"),
+            "expected a success cancel-card audit row for {card_id}, got {entries:?}"
+        );
+    }
+}

--- a/src/watch/config.rs
+++ b/src/watch/config.rs
@@ -143,6 +143,18 @@ pub struct WatchConfig {
     #[serde(default = "default_health_poll_secs")]
     pub health_poll_secs: u64,
 
+    /// Seconds between automatic shipped-pending reconcile passes (#654). On
+    /// each pass the daemon scans the board for cards whose linked GitHub
+    /// issue is already CLOSED/MERGED and cancels them locally, so a board
+    /// groomed by an agent reflects GitHub reality without a manual
+    /// `legion kanban reconcile`. Every card with a linked issue costs one
+    /// work-source probe, so this runs on a slow cadence -- default 3600 (one
+    /// hour). Set to `0` to disable auto-reconcile. Only the safe direction
+    /// (cancel-shipped, purely local) is automated; close-stale, which closes
+    /// live GitHub issues, stays a manual CLI action.
+    #[serde(default = "default_reconcile_interval_secs")]
+    pub reconcile_interval_secs: u64,
+
     /// Number of samples in the rolling pressure window.
     #[serde(default = "default_health_window_size")]
     pub health_window_size: usize,
@@ -248,6 +260,10 @@ fn default_health_poll_secs() -> u64 {
     5
 }
 
+fn default_reconcile_interval_secs() -> u64 {
+    3600
+}
+
 fn default_health_window_size() -> usize {
     6
 }
@@ -299,6 +315,7 @@ impl Default for WatchConfig {
             work_hours_end: None,
             health_threshold_pct: default_health_threshold(),
             health_poll_secs: default_health_poll_secs(),
+            reconcile_interval_secs: default_reconcile_interval_secs(),
             health_window_size: default_health_window_size(),
             retention_days: default_retention_days(),
             session_lock_ttl_secs: default_session_lock_ttl_secs(),
@@ -560,6 +577,22 @@ workdir = "/tmp"
         assert_eq!(config.submit_retry_max, 12);
         assert_eq!(config.submit_retry_interval_secs, 4);
         assert_eq!(config.submit_confirm_budget_secs, 60);
+        // #654 auto-reconcile defaults to hourly when the key is absent.
+        assert_eq!(config.reconcile_interval_secs, 3600);
+    }
+
+    #[test]
+    fn parse_config_reconcile_interval_explicit() {
+        // An operator can lengthen the cadence or disable it with 0.
+        let toml_str = r#"
+reconcile_interval_secs = 0
+
+[[repos]]
+name = "test"
+workdir = "/tmp"
+"#;
+        let config: WatchConfig = toml::from_str(toml_str).expect("parse config");
+        assert_eq!(config.reconcile_interval_secs, 0);
     }
 
     #[test]

--- a/src/watch/mod.rs
+++ b/src/watch/mod.rs
@@ -346,6 +346,44 @@ impl WatchLoop {
             eprintln!("{} watch_handled prune error: {e}", self.log_prefix);
         }
     }
+
+    /// Run one auto-reconcile tick (#654): scan the whole board for
+    /// shipped-pending drift (active-local cards whose linked GitHub issue is
+    /// already CLOSED/MERGED) and cancel those cards locally so the board a
+    /// woken agent grooms reflects GitHub reality instead of stale `pending`
+    /// rows.
+    ///
+    /// Only this safe, purely-local direction is automated. The destructive
+    /// direction (close-stale, which closes live GitHub issues from local
+    /// state) is never run here -- it stays a manual `legion kanban reconcile
+    /// --close-stale` action. A scan error or per-card cancel failure is
+    /// logged and the tick returns; it never aborts the loop.
+    ///
+    /// The caller gates the cadence on `config.reconcile_interval_secs` and
+    /// only invokes this when that interval is non-zero.
+    pub fn tick_reconcile(&mut self) {
+        let report = match crate::kanban::reconcile::scan_drift(&self.db, None, self.log_prefix) {
+            Ok(report) => report,
+            Err(e) => {
+                eprintln!("{} reconcile scan error: {e}", self.log_prefix);
+                return;
+            }
+        };
+
+        if report.shipped_pending.is_empty() {
+            return;
+        }
+
+        let (cancelled, failed) = crate::kanban::reconcile::cancel_shipped_pending(
+            &self.db,
+            &report.shipped_pending,
+            self.log_prefix,
+        );
+        eprintln!(
+            "{} reconcile: auto-cancelled {cancelled} shipped-pending card(s), {failed} failed",
+            self.log_prefix
+        );
+    }
 }
 
 /// Outcome of evaluating the per-poll spawn gates. Shared by `watch::run` and
@@ -438,6 +476,8 @@ pub fn run(data_dir: &Path) -> Result<()> {
     // Timer intervals are read from the loop-owned config.
     let poll_interval: Duration = Duration::from_secs(state.config.poll_interval_secs);
     let health_interval: Duration = Duration::from_secs(state.config.health_poll_secs);
+    // Auto-reconcile (#654) runs on a slow cadence; 0 disables it entirely.
+    let reconcile_interval: Duration = Duration::from_secs(state.config.reconcile_interval_secs);
 
     // Use checked_sub so a near-zero system clock cannot overflow and panic.
     let mut poll_timer: Instant = Instant::now()
@@ -446,6 +486,9 @@ pub fn run(data_dir: &Path) -> Result<()> {
     let mut health_timer: Instant = Instant::now()
         .checked_sub(health_interval)
         .unwrap_or_else(Instant::now);
+    // Reconcile starts at `now` so the first pass fires one full interval
+    // after startup -- see the daemon driver for the probe-storm rationale.
+    let mut reconcile_timer: Instant = Instant::now();
 
     eprintln!(
         "[legion watch] watching repos: {}",
@@ -469,6 +512,14 @@ pub fn run(data_dir: &Path) -> Result<()> {
         if poll_timer.elapsed() >= poll_interval {
             state.tick_poll();
             poll_timer = Instant::now();
+        }
+
+        // Auto-reconcile on its own slow interval (0 disables).
+        if state.config.reconcile_interval_secs > 0
+            && reconcile_timer.elapsed() >= reconcile_interval
+        {
+            state.tick_reconcile();
+            reconcile_timer = Instant::now();
         }
 
         std::thread::sleep(Duration::from_secs(1));
@@ -643,6 +694,26 @@ mod tests {
         assert!(
             after.is_empty(),
             "informational signal should be handled after tick_poll with Proceed gate"
+        );
+    }
+
+    /// `tick_reconcile` on a board with no cards is a quiet no-op (#654).
+    ///
+    /// The scan finds nothing to probe (no cards have a linked issue), so it
+    /// returns an empty report and cancels nothing. This proves the daemon's
+    /// auto-reconcile wiring is safe to fire on an idle board without a live
+    /// work source -- the real cancel path is covered in
+    /// `kanban::reconcile::tests`.
+    #[test]
+    fn watch_loop_tick_reconcile_empty_board_is_noop() {
+        let (db, _index, _dir) = test_storage();
+        let mut state = test_watch_loop(db, "[legion test]");
+        // Must not panic and must leave the (empty) board untouched.
+        state.tick_reconcile();
+        let cards = crate::kanban::board_cards(&state.db).expect("board cards");
+        assert!(
+            cards.is_empty(),
+            "no cards should exist after reconcile no-op"
         );
     }
 


### PR DESCRIPTION
## Summary

Kanban cards are minted from GitHub issues but never moved to a terminal state when the linked issue closes, so the board accumulates "shipped-pending" zombies (active-local card, closed-on-GitHub issue) until someone runs the manual `legion kanban reconcile`. This PR teaches the watch daemon to run the safe reconcile direction on its own slow timer, so a board a woken agent grooms reflects GitHub reality instead of stale `pending` rows. The reconcile scan and both actions are extracted out of the CLI handler into a shared `kanban::reconcile` module so the daemon and the CLI run identical logic rather than a re-implementation.

## Acceptance criteria mapping

### 1. Daemon automatically reconciles shipped-pending cards to a terminal state without manual invocation
`WatchLoop::tick_reconcile` (src/watch/mod.rs) calls `kanban::reconcile::scan_drift` to find active-local cards whose linked issue is CLOSED/MERGED, then `cancel_shipped_pending` to cancel them locally via the normal `Action::Cancel` transition. A reconcile timer is wired into both watch drivers -- the daemon's async `run_watch_task` (src/daemon.rs) and the standalone sync `watch::run` (src/watch/mod.rs) -- so the daemon fires it with no operator action. The timer initializes to `now` (not `now - interval`) so the first pass lands one full interval after startup, which avoids re-probing every linked card on each daemon bounce.
Evidence: `watch_loop_tick_reconcile_empty_board_is_noop` exercises the daemon's exact tick path; the cancel mechanism is proven by `kanban::reconcile::tests::cancel_shipped_pending_cancels_card_and_audits`, which asserts the card lands in `CardStatus::Cancelled`.

### 2. `--close-stale` direction remains manual-only (never auto-closes live GitHub issues)
`tick_reconcile` only ever calls `cancel_shipped_pending` -- the purely-local direction. The destructive direction lives in a separate function, `close_stale_open`, which is invoked nowhere in the watch loop; its only caller is the CLI arm behind the explicit `--close-stale` flag (src/cli/kanban.rs). Because closing a live issue requires calling `close_stale_open` and the daemon never references that symbol, auto-closing GitHub issues is structurally impossible, not merely unconfigured.
Evidence: `close_stale_open` has exactly one call site (the CLI `--close-stale` branch in src/cli/kanban.rs); `src/watch/mod.rs` and `src/daemon.rs` reference only `scan_drift` and `cancel_shipped_pending`.

### 3. Per-repo / per-card work-source failures are logged and skipped, never abort the pass
`scan_drift` returns `Result` only for the initial board read; every per-card step inside the loop (missing source_url/number/source_type, unconfigured work source, a `view_issue` probe error, an unrecognised issue state) hits a `continue` after logging, so one failing repo never aborts the scan. `cancel_shipped_pending` counts per-card cancel failures into its `failed` return and logs each, continuing to the next card. `tick_reconcile` logs a scan-level error and returns without propagating, so a reconcile failure can never take down the watch loop.
Evidence: the per-card `continue`/log arms in `scan_drift` and the `Err` arm in `cancel_shipped_pending` (src/kanban/reconcile.rs); the read-only `kanban_reconcile_dry_run_on_empty_db_is_quiet_success` integration test still passes against the refactored path.

### 4. Cadence is configurable or sensibly defaulted; documented in the daemon/config surface
A new `reconcile_interval_secs` field on `WatchConfig` (src/watch/config.rs) defaults to 3600 (hourly) via `default_reconcile_interval_secs`, with `0` disabling auto-reconcile entirely. Both drivers guard the tick on `reconcile_interval_secs > 0`. The field carries a full doc comment explaining the cadence, the per-card probe cost that motivates a slow default, and the safe-direction-only restriction -- so the config surface documents the behavior in place.
Evidence: `parse_config_defaults` asserts the 3600 default when the key is absent; `parse_config_reconcile_interval_explicit` asserts an explicit `0` parses through; the doc comment on `WatchConfig::reconcile_interval_secs` in src/watch/config.rs.

### 5. Test coverage for the shipped-pending auto-cancel path and the failure-tolerance path
The auto-cancel path is covered end to end: `cancel_shipped_pending_cancels_card_and_audits` creates a card with a linked issue, cancels it through the shared function, and asserts both the `Cancelled` status and the durable success audit row. The failure-tolerance/no-op paths are covered by `cancel_shipped_pending_empty_is_noop`, `scan_drift_on_empty_board_is_empty`, and `watch_loop_tick_reconcile_empty_board_is_noop` (proves the daemon wiring is safe on an idle board without a live work source). The pre-existing reconcile integration tests continue to pass, confirming the CLI extraction preserved behavior.
Evidence: the four new unit tests in src/kanban/reconcile.rs and src/watch/mod.rs, plus the unchanged-green `kanban_reconcile_*` integration tests.

## Not done

- **The `gh issue view failed` errors on some repos** (vault-2026 #455, huttspawn #217) noted in the issue considerations are a separate work-source/auth problem; this PR makes the pass tolerant of them (criterion 3) but does not fix the underlying probe failure. Left for its own issue.
- **Reconcile-on-read** (`legion kanban list` opportunistically converging) -- listed as an alternative in the issue, deliberately not implemented. The daemon timer is the lower-risk mechanism and does not add per-list latency or probe cost to an interactive command.
- **Lock/contention coordination with wake spawning** -- the reconcile tick runs on its own slow timer in the same single-threaded loop as poll/health, so it is already serialized against wake spawning by construction; no additional locking was added.