### PR TITLE
feat(#656): release automation -- one-command release, changelog agent, docs review

### DIFF
--- a/plugin/agents/changelog.md
+++ b/plugin/agents/changelog.md
@@ -1,0 +1,103 @@
+---
+name: changelog
+description: |
+  Writes the legion CHANGELOG entry for a release from the commit range since the
+  last tag. Reads the merged PRs, their issues, and the key diffs, then composes a
+  "## X.Y.Z" section in the established legion changelog voice and prepends it to
+  plugin/CHANGELOG.md. Runs as a step in the release pipeline, before scripts/release.sh.
+
+  <example>
+  Context: Cutting a patch release and the CHANGELOG has no entry yet.
+  user: "Write the changelog for 0.18.3"
+  assistant: "I'll diff v0.18.2..HEAD, read the merged PRs, and prepend a 0.18.3 section."
+  <commentary>
+  The changelog agent owns release prose -- it reads the actual change set rather than
+  trusting commit subjects, and writes in the repo's voice.
+  </commentary>
+  </example>
+tools: ["Bash", "Read", "Edit", "Write"]
+---
+
+You write the CHANGELOG entry for a legion release. Your output is one new
+`## X.Y.Z` section prepended to `plugin/CHANGELOG.md`, in the voice the file
+already uses. You are given (or must infer) the version being released.
+
+## What you receive
+
+The orchestrator gives you the new version being released (e.g. `0.18.3`). That
+value is authoritative -- use it verbatim as the `## X.Y.Z` header. Do NOT read the
+version from `Cargo.toml`: you run BEFORE `scripts/release.sh` bumps it, so at this
+point `Cargo.toml` still holds the PREVIOUS release's version. If no version was
+supplied, stop and ask the orchestrator for the target -- you cannot infer the next
+version from the pre-bump `Cargo.toml`.
+
+## Gather the change set (do not trust commit subjects alone)
+
+1. Find the previous release tag. Primary: `git describe --tags --abbrev=0
+   --match 'v*'` (the most recent tag reachable from HEAD). Fall back to
+   `git tag --sort=-v:refname | head -1` only if that fails. The range is
+   `<prevtag>..HEAD`.
+2. List the merged work: `git log <prevtag>..HEAD --oneline`. Note every PR
+   number (`(#NNN)`) and the issues they reference.
+3. Read the substance, not just the subject line. For each non-trivial change,
+   `git show --stat <commit>` and read the key hunks (or `git diff <prevtag>..HEAD
+   -- <path>`). A changelog entry describes what the code now does and why it
+   matters to a user, which the commit subject usually undersells.
+4. Cross-check against the issues where useful: `legion issue view --repo legion
+   --number <n>` for the problem statement and acceptance criteria.
+
+## Voice and structure (match the existing entries exactly -- read the top of the file first)
+
+Always `Read plugin/CHANGELOG.md` and mirror the most recent few entries. The shape:
+
+```
+## X.Y.Z
+
+The <theme> release. <One paragraph of prose: what shipped and the problem it
+solves, in plain terms. Name the observable behavior, not the implementation.>
+<Patch|Minor|Major> release: <one-clause rationale -- e.g. "additive behavior
+within the existing watch surface, no wire-format change, no schema migration">.
+
+### New
+- **<Bold lead phrase>** (PR #NNN, #issue): <prose explaining the mechanism --
+  name the command/flag/function/file, explain what it does and why. One dense,
+  technical paragraph per bullet, the way the existing entries read.>
+
+### Fixed
+- **<Bold lead phrase>** (PR #NNN, #issue): <what was broken, the root cause, the fix.>
+
+### Config
+- **<knob in `watch.toml`>** (#issue): <default, what it controls, when to change it.>
+```
+
+Rules:
+- Only include the `###` sections that apply (`New`, `Fixed`, `Changed`, `Config`,
+  `Removed`). Omit empty ones. Order: New, Fixed, Changed, Config, Removed.
+- Every bullet cites its PR and/or issue number. No uncited claims.
+- Classify the release type correctly and say so in the summary: a fix within an
+  existing surface is a patch; an additive feature within existing surfaces is a
+  patch; a new surface or architectural shift is a minor (pre-1.0 minor digit =
+  architectural shift per the release doctrine); a breaking wire/schema change is
+  the higher bump. If a schema migration shipped, NAME it in the summary rather
+  than claiming "no schema migration".
+- Prose over bullets-of-fragments. The existing entries are written in full
+  sentences with real explanation; match that density. Do not pad.
+- No emoji. No marketing adjectives. Technical, specific, honest.
+
+## The version guard lives downstream -- not here
+
+Do not cross-check your header against `Cargo.toml`: it is still the pre-bump value
+when you run. `scripts/release.sh` bumps `Cargo.toml` to the target and THEN
+validates that the CHANGELOG header you wrote matches it (and the `sync-version`
+hook re-checks at commit). Your only job is to write the exact version the
+orchestrator gave you; the mismatch guard fires later, in the right place, after
+the bump.
+
+## Output
+
+Prepend your new section immediately under the `# Legion Changelog` title, above
+the previous top entry. Edit `plugin/CHANGELOG.md` in place. Then return a short
+summary to the orchestrator: the version, the section headings you wrote, and the
+PRs covered. Do NOT commit, tag, or push -- scripts/release.sh owns that. Your job
+ends when the entry is written; the version guard runs downstream in
+scripts/release.sh (post-bump), never here against the pre-bump Cargo.toml.

--- a/plugin/commands/legion-release.md
+++ b/plugin/commands/legion-release.md
@@ -1,0 +1,74 @@
+---
+description: Cut a legion release -- changelog agent writes the entry, scripts/release.sh ships it, writer-legion updates runlegion.dev docs if the change warrants it
+argument-hint: "<patch|minor|major|X.Y.Z> [--activate] [--dry-run]"
+allowed-tools: ["Bash", "Task", "Read", "Edit"]
+---
+
+# /legion-release -- orchestrated release
+
+You are cutting a legion release. The mechanical work lives in `scripts/release.sh`;
+the prose work is delegated to agents. Your job is to run the pipeline in order and
+stop on the first failure. Argument: the bump level (`patch`/`minor`/`major`) or an
+explicit `X.Y.Z`, plus optional `--activate` (build+install the binary and restart
+the local daemon) and `--dry-run`.
+
+## 1. Preconditions
+
+Confirm you are on `main`, the tree is clean, and local `main` is in sync with
+`origin/main`. If not, stop and tell the operator -- do not release from a dirty or
+behind tree. (`scripts/release.sh` re-checks these, but fail early and clearly.)
+
+## 2. Compute the target version
+
+Read the current version from `Cargo.toml`. From the bump argument, compute the
+target `NEW` (patch/minor/major arithmetic, or use the explicit `X.Y.Z`). State
+`CURRENT -> NEW` to the operator before proceeding.
+
+## 3. Changelog agent writes the entry
+
+Spawn the `changelog` agent (Task, subagent_type `changelog`) with the target
+version `NEW`. It diffs `<prevtag>..HEAD`, reads the merged PRs and their issues,
+and prepends a `## NEW` section to `plugin/CHANGELOG.md` in the repo's voice. When
+it returns, `Read plugin/CHANGELOG.md` and sanity-check the top entry yourself:
+right version, real prose, every bullet cited, correct release-type rationale. If
+it is thin or wrong, send the agent back with specifics. Do NOT hand-write the
+entry yourself -- that is the agent's job; you are the editor.
+
+## 4. Ship it
+
+Run `scripts/release.sh NEW` (pass the explicit version, plus `--activate` and/or
+`--dry-run` if the operator gave them). The script runs preflight (fmt, clippy,
+test, SCIP regen), bumps `Cargo.toml`, refreshes `Cargo.lock`, syncs the manifests,
+commits `chore(release): NEW`, tags `vNEW`, and pushes -- which fires the release
+CI that builds and publishes the platform binaries. The script validates that the
+CHANGELOG header the agent wrote matches `Cargo.toml`; a mismatch aborts the
+release, which is the safety net.
+
+If `--dry-run` was passed, stop here and report what would have happened.
+
+## 5. Docs review on shingle
+
+Resolve the shingle repo path from watch.toml -- `legion watch list` maps `shingle`
+to its working directory; the runlegion.dev docs live under
+`<shingle>/sites/runlegion.dev/src/pages/docs/` (do not hardcode an absolute path,
+it differs per machine). Spawn `writer-legion` (Task, subagent_type `writer-legion`)
+with the new changelog entry. Brief it: review the release against the docs pages
+under that dir (concepts, architecture, cli-reference, getting-started, plugin-guide
+at time of writing -- read the directory rather than trusting this list to stay
+complete). If the
+release changes user-facing behavior -- a new/changed command, verb, flag, config
+knob, or concept -- update the affected pages on a `docs/legion-NEW` branch in the
+shingle repo, in the writer-legion voice. If nothing user-facing changed (internal
+refactor, test-only, CI), it should say so and write nothing -- not every release
+needs docs.
+
+If writer-legion produced doc changes, open the shingle PR for them through the
+normal gate flow (issue -> branch -> simplify gate -> pr-write -> `legion pr create
+--repo shingle`), exactly as a runlegion.dev docs PR is opened. Report the PR URL.
+
+## 6. Report
+
+Summarize: the version shipped, the tag, the release CI status, whether docs were
+updated (and the PR if so), and -- if `--activate` was used -- the local daemon's
+new version from `/health`. Note any follow-up (e.g. "verify the GitHub Release
+published" if the CI build had not finished).

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -38,6 +38,13 @@ cargo clippy --all-targets -- -D warnings || fail "clippy"
 step "cargo test"
 cargo test || fail "tests"
 
+step "shell-script tests"
+for t in test-release.sh test-sync-version.sh; do
+  if [ -f "${REPO_ROOT}/scripts/${t}" ]; then
+    bash "${REPO_ROOT}/scripts/${t}" || fail "scripts/${t}"
+  fi
+done
+
 if [ "${SKIP_SCIP:-0}" = "1" ]; then
   printf '\n[preflight] SCIP regen skipped (SKIP_SCIP=1)\n' >&2
 else

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# preflight.sh: the quality bar that must pass before a release (or any push
+# the developer wants gated). Reusable unit shared by scripts/release.sh.
+#
+#   1. cargo fmt -- --check          (formatting is committed-clean)
+#   2. cargo clippy --all-targets -D warnings  (CI parity -- bare clippy misses
+#                                               test/example/bench code)
+#   3. cargo test                    (the suite is green)
+#   4. legion index <repo>           (SCIP index regenerated so sym queries
+#                                     answer against current code)
+#
+# Exits non-zero on the FIRST failing gate, naming it. Safe to run standalone:
+#
+#   scripts/preflight.sh             # full bar against the legion repo
+#   SKIP_SCIP=1 scripts/preflight.sh # skip the index regen (faster local loop)
+#
+# The SCIP step is best-effort by default: a missing `legion` binary or indexer
+# is a warning, not a hard failure, so the script still gates code quality on a
+# machine without the plugin installed. Set REQUIRE_SCIP=1 to make it mandatory.
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+# Repo name as known to watch.toml (for the SCIP index step). Override with
+# LEGION_REPO=<name> if this clone is registered under a different name.
+LEGION_REPO="${LEGION_REPO:-legion}"
+
+step() { printf '\n[preflight] === %s ===\n' "$1" >&2; }
+fail() { printf '\n[preflight] FAILED at: %s\n' "$1" >&2; exit 1; }
+
+step "cargo fmt -- --check"
+cargo fmt -- --check || fail "formatting (run: cargo fmt)"
+
+step "cargo clippy --all-targets -- -D warnings"
+cargo clippy --all-targets -- -D warnings || fail "clippy"
+
+step "cargo test"
+cargo test || fail "tests"
+
+if [ "${SKIP_SCIP:-0}" = "1" ]; then
+  printf '\n[preflight] SCIP regen skipped (SKIP_SCIP=1)\n' >&2
+else
+  step "legion index ${LEGION_REPO} (SCIP regen)"
+  if command -v legion >/dev/null 2>&1; then
+    if ! legion index "$LEGION_REPO"; then
+      if [ "${REQUIRE_SCIP:-0}" = "1" ]; then
+        fail "SCIP index regen"
+      fi
+      printf '[preflight] WARNING: SCIP regen failed (non-fatal; set REQUIRE_SCIP=1 to enforce)\n' >&2
+    fi
+  elif [ "${REQUIRE_SCIP:-0}" = "1" ]; then
+    fail "legion binary not found (REQUIRE_SCIP=1)"
+  else
+    printf '[preflight] legion binary not found -- skipping SCIP regen (non-fatal)\n' >&2
+  fi
+fi
+
+printf '\n[preflight] all gates passed\n' >&2

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -12,179 +12,215 @@
 #                                        # restart the local daemon
 #   scripts/release.sh patch --no-preflight  # skip the cargo/scip gate (CI re-runs it)
 #
+# Entry contract: the CHANGELOG entry for the new version must already be written
+# (by the `changelog` agent, or by hand) and left UNCOMMITTED in the working tree.
+# release.sh validates it, bumps the version, syncs the manifests, and commits the
+# whole release in one shot. The only file allowed to be dirty at entry is
+# plugin/CHANGELOG.md; everything else must be committed.
+#
 # What it does, in order:
-#   1. Guards: on main, clean working tree, in sync with origin/main.
+#   1. Guards: on main, tree clean except plugin/CHANGELOG.md, in sync with origin.
 #   2. Computes the new version from the bump level (or takes it explicitly).
-#   3. Requires plugin/CHANGELOG.md to already carry a "## <new>" top header --
-#      release prose is human-authored, never generated. Fails loudly if absent.
+#   3. Requires plugin/CHANGELOG.md's "## <new>" top header to exist.
 #   4. Runs scripts/preflight.sh (fmt, clippy --all-targets, test, SCIP regen).
 #   5. Bumps Cargo.toml, refreshes Cargo.lock.
 #   6. Syncs plugin.json + marketplace.json (scripts/sync-version.sh) and commits
-#      chore(release): <new>. Running sync-version explicitly means the release
-#      is correct even in a clone where the pre-commit hook was never installed
-#      -- the exact failure that motivated #656.
-#   7. Tags v<new> and pushes the commit + tag. The tag fires .github/workflows/
-#      release.yml, which builds the platform binaries and publishes the Release.
+#      chore(release): <new>. Running sync-version explicitly means the release is
+#      correct even in a clone where the pre-commit hook was never installed.
+#   7. Tags v<new> and atomically pushes the commit + tag. The tag fires
+#      .github/workflows/release.yml, which builds + publishes the binaries.
 #   8. With --activate: builds the release binary, installs it to the plugin data
-#      dir atomically, and restarts the local daemon so the new code runs now.
+#      dir atomically, and restarts the local daemon.
+#
+# The pure helpers below (compute_new_version, is_semver, is_strictly_greater) are
+# unit-tested by scripts/test-release.sh, which sources this file. main() runs only
+# when the script is executed, not when it is sourced.
 set -euo pipefail
-
-REPO_ROOT="$(git rev-parse --show-toplevel)"
-cd "$REPO_ROOT"
-
-CARGO_TOML="${REPO_ROOT}/Cargo.toml"
-CHANGELOG="${REPO_ROOT}/plugin/CHANGELOG.md"
-
-# -- arg parsing -------------------------------------------------------------
-BUMP=""
-DRY_RUN=0
-ACTIVATE=0
-RUN_PREFLIGHT=1
-
-for arg in "$@"; do
-  case "$arg" in
-    patch|minor|major) BUMP="$arg" ;;
-    [0-9]*.[0-9]*.[0-9]*) BUMP="$arg" ;;
-    --dry-run) DRY_RUN=1 ;;
-    --activate) ACTIVATE=1 ;;
-    --no-preflight) RUN_PREFLIGHT=0 ;;
-    *) echo "[release] unknown argument: $arg" >&2; exit 2 ;;
-  esac
-done
-
-if [ -z "$BUMP" ]; then
-  echo "[release] usage: release.sh <patch|minor|major|X.Y.Z> [--dry-run] [--activate] [--no-preflight]" >&2
-  exit 2
-fi
 
 info() { printf '[release] %s\n' "$1" >&2; }
 fail() { printf '[release] ERROR: %s\n' "$1" >&2; exit 1; }
 
-# run: execute a mutating command, or just print it under --dry-run.
-run() {
-  if [ "$DRY_RUN" = "1" ]; then
-    printf '[dry-run] %s\n' "$*" >&2
-  else
-    "$@"
-  fi
+# compute_new_version <current> <bump>
+#   bump in {patch,minor,major} -> semver-increment current; otherwise echo bump
+#   verbatim (the explicit-version path). Pure: no I/O, no globals.
+compute_new_version() {
+  local current="$1" bump="$2" maj min pat
+  case "$bump" in
+    patch|minor|major)
+      IFS='.' read -r maj min pat <<EOF
+$current
+EOF
+      case "$bump" in
+        patch) pat=$((pat + 1)) ;;
+        minor) min=$((min + 1)); pat=0 ;;
+        major) maj=$((maj + 1)); min=0; pat=0 ;;
+      esac
+      printf '%s.%s.%s\n' "$maj" "$min" "$pat"
+      ;;
+    *)
+      printf '%s\n' "$bump"
+      ;;
+  esac
 }
 
-# -- 1. guards ---------------------------------------------------------------
-BRANCH="$(git rev-parse --abbrev-ref HEAD)"
-[ "$BRANCH" = "main" ] || fail "must be on main to release (on '$BRANCH')"
+# is_semver <v> -> 0 iff v is strictly X.Y.Z (no prerelease/build/extra segments).
+is_semver() { [[ "$1" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; }
 
-[ -z "$(git status --porcelain)" ] || fail "working tree is dirty -- commit or stash first"
+# is_strictly_greater <new> <current> -> 0 iff new > current by semver ordering.
+is_strictly_greater() {
+  [ "$1" != "$2" ] && [ "$(printf '%s\n%s\n' "$1" "$2" | sort -V | head -1)" = "$2" ]
+}
 
-git fetch origin main --quiet || fail "git fetch failed"
-LOCAL="$(git rev-parse @)"
-REMOTE="$(git rev-parse '@{u}' 2>/dev/null || echo "")"
-[ -n "$REMOTE" ] || fail "no upstream for main"
-[ "$LOCAL" = "$REMOTE" ] || fail "local main is not in sync with origin/main -- pull/push first"
+main() {
+  local REPO_ROOT CARGO_TOML CHANGELOG
+  REPO_ROOT="$(git rev-parse --show-toplevel)"
+  cd "$REPO_ROOT"
+  CARGO_TOML="${REPO_ROOT}/Cargo.toml"
+  CHANGELOG="${REPO_ROOT}/plugin/CHANGELOG.md"
 
-# -- 2. compute the new version ----------------------------------------------
-# `|| true` so a missing version line surfaces as the friendly guard below
-# rather than a bare pipefail abort under `set -e`.
-CURRENT="$(grep -m1 '^version' "$CARGO_TOML" | sed 's/version = "\(.*\)"/\1/' || true)"
-[ -n "$CURRENT" ] || fail "could not read version from Cargo.toml"
-
-case "$BUMP" in
-  patch|minor|major)
-    IFS='.' read -r MAJ MIN PAT <<EOF
-$CURRENT
-EOF
-    case "$BUMP" in
-      patch) PAT=$((PAT + 1)) ;;
-      minor) MIN=$((MIN + 1)); PAT=0 ;;
-      major) MAJ=$((MAJ + 1)); MIN=0; PAT=0 ;;
+  # -- arg parsing -----------------------------------------------------------
+  local BUMP="" DRY_RUN=0 ACTIVATE=0 RUN_PREFLIGHT=1 arg
+  for arg in "$@"; do
+    case "$arg" in
+      patch|minor|major) BUMP="$arg" ;;
+      [0-9]*.[0-9]*.[0-9]*) BUMP="$arg" ;;
+      --dry-run) DRY_RUN=1 ;;
+      --activate) ACTIVATE=1 ;;
+      --no-preflight) RUN_PREFLIGHT=0 ;;
+      *) echo "[release] unknown argument: $arg" >&2; exit 2 ;;
     esac
-    NEW="${MAJ}.${MIN}.${PAT}"
-    ;;
-  *)
-    NEW="$BUMP"
-    ;;
-esac
+  done
+  [ -n "$BUMP" ] || {
+    echo "[release] usage: release.sh <patch|minor|major|X.Y.Z> [--dry-run] [--activate] [--no-preflight]" >&2
+    exit 2
+  }
 
-# Strict X.Y.Z -- the explicit-version arg glob is loose (accepts 1.2.3-beta,
-# 1.2.3.4), and a typo here becomes a pushed tag. Reject anything non-semver.
-[[ "$NEW" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || fail "invalid version '$NEW' (expected X.Y.Z)"
+  # run: execute a mutating command, or just print it under --dry-run.
+  run() {
+    if [ "$DRY_RUN" = "1" ]; then
+      printf '[dry-run] %s\n' "$*" >&2
+    else
+      "$@"
+    fi
+  }
 
-# Refuse a no-op or a downgrade (sort -V puts the lower version first).
-[ "$NEW" != "$CURRENT" ] || fail "new version equals current ($CURRENT)"
-LOWER="$(printf '%s\n%s\n' "$CURRENT" "$NEW" | sort -V | head -1)"
-[ "$LOWER" = "$CURRENT" ] || fail "refusing to downgrade $CURRENT -> $NEW"
+  # -- 1. guards -------------------------------------------------------------
+  local BRANCH LOCAL REMOTE DIRTY_OTHER
+  BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+  [ "$BRANCH" = "main" ] || fail "must be on main to release (on '$BRANCH')"
 
-info "releasing ${CURRENT} -> ${NEW}"
+  # The CHANGELOG entry is written-but-uncommitted at entry; everything else
+  # must be clean. Allow plugin/CHANGELOG.md to be dirty, reject anything else.
+  DIRTY_OTHER="$(git status --porcelain --untracked-files=no | { grep -v 'plugin/CHANGELOG\.md$' || true; })"
+  [ -z "$DIRTY_OTHER" ] || fail "working tree has changes other than plugin/CHANGELOG.md -- commit or stash first:
+$DIRTY_OTHER"
 
-# -- 3. require the CHANGELOG entry (human-authored, never generated) ---------
-TOP_HEADER="$(grep -E '^## [0-9]' "$CHANGELOG" | head -1 | sed -E 's/^## //' | awk '{print $1}')"
-if [ "$TOP_HEADER" != "$NEW" ]; then
-  fail "plugin/CHANGELOG.md top header is '## ${TOP_HEADER:-<none>}', expected '## ${NEW}'.
-       Add a '## ${NEW}' section at the top describing what shipped, then re-run."
-fi
-info "CHANGELOG header matches ${NEW}"
+  git fetch origin main --quiet || fail "git fetch failed"
+  LOCAL="$(git rev-parse @)"
+  REMOTE="$(git rev-parse '@{u}' 2>/dev/null || echo "")"
+  [ -n "$REMOTE" ] || fail "no upstream for main"
+  [ "$LOCAL" = "$REMOTE" ] || fail "local main is not in sync with origin/main -- pull/push first"
 
-# -- 4. preflight ------------------------------------------------------------
-if [ "$RUN_PREFLIGHT" = "1" ]; then
-  info "running preflight (fmt, clippy, test, scip)"
-  run bash "${REPO_ROOT}/scripts/preflight.sh"
-else
-  info "preflight skipped (--no-preflight)"
-fi
+  # -- 2. compute + validate the new version ---------------------------------
+  local CURRENT NEW
+  CURRENT="$(grep -m1 '^version' "$CARGO_TOML" | sed 's/version = "\(.*\)"/\1/' || true)"
+  [ -n "$CURRENT" ] || fail "could not read version from Cargo.toml"
 
-# -- 5. bump Cargo.toml + refresh Cargo.lock ---------------------------------
-if [ "$DRY_RUN" = "1" ]; then
-  printf '[dry-run] set Cargo.toml version %s -> %s\n' "$CURRENT" "$NEW" >&2
-else
-  # Match only the package version line (first `version = ` under [package]).
-  sed -i.bak "0,/^version = \"${CURRENT}\"/s//version = \"${NEW}\"/" "$CARGO_TOML"
-  rm -f "${CARGO_TOML}.bak"
-fi
-run cargo build --quiet   # refreshes Cargo.lock's legion entry to ${NEW}
+  NEW="$(compute_new_version "$CURRENT" "$BUMP")"
+  is_semver "$NEW" || fail "invalid version '$NEW' (expected X.Y.Z)"
+  is_strictly_greater "$NEW" "$CURRENT" || fail "refusing non-increment $CURRENT -> $NEW"
 
-# -- 6. sync manifests + commit ----------------------------------------------
-# Run sync-version explicitly so the manifests are correct even if the
-# pre-commit hook is not installed in this clone (the #656 failure mode).
-run bash "${REPO_ROOT}/scripts/sync-version.sh"
-run git add Cargo.toml Cargo.lock plugin/CHANGELOG.md \
-  plugin/.claude-plugin/plugin.json .claude-plugin/marketplace.json
-run git commit -m "chore(release): ${NEW}
+  # Refuse a tag that already exists (a re-run after a partial failure, or a typo
+  # colliding with history) before we mutate anything.
+  ! git rev-parse "v${NEW}" >/dev/null 2>&1 || fail "tag v${NEW} already exists"
+
+  info "releasing ${CURRENT} -> ${NEW}"
+
+  # -- 3. require the CHANGELOG entry (human/agent-authored, never generated) -
+  local TOP_HEADER
+  TOP_HEADER="$(grep -E '^## [0-9]' "$CHANGELOG" | head -1 | sed -E 's/^## //' | awk '{print $1}')"
+  if [ "$TOP_HEADER" != "$NEW" ]; then
+    fail "plugin/CHANGELOG.md top header is '## ${TOP_HEADER:-<none>}', expected '## ${NEW}'.
+       Have the changelog agent (or you) add a '## ${NEW}' section at the top, then re-run."
+  fi
+  info "CHANGELOG header matches ${NEW}"
+
+  # -- 4. preflight ----------------------------------------------------------
+  if [ "$RUN_PREFLIGHT" = "1" ]; then
+    info "running preflight (fmt, clippy, test, scip)"
+    run bash "${REPO_ROOT}/scripts/preflight.sh"
+  else
+    info "preflight skipped (--no-preflight)"
+  fi
+
+  # -- 5. bump Cargo.toml + refresh Cargo.lock -------------------------------
+  if [ "$DRY_RUN" = "1" ]; then
+    printf '[dry-run] set Cargo.toml version %s -> %s\n' "$CURRENT" "$NEW" >&2
+  else
+    sed -i.bak "0,/^version = \"${CURRENT}\"/s//version = \"${NEW}\"/" "$CARGO_TOML"
+    rm -f "${CARGO_TOML}.bak"
+  fi
+  run cargo build --quiet   # refreshes Cargo.lock's legion entry to ${NEW}
+
+  # -- 6. sync manifests + commit --------------------------------------------
+  # Run sync-version explicitly so the manifests are correct even if the
+  # pre-commit hook is not installed in this clone (the #656 failure mode).
+  run bash "${REPO_ROOT}/scripts/sync-version.sh"
+  run git add Cargo.toml Cargo.lock plugin/CHANGELOG.md \
+    plugin/.claude-plugin/plugin.json .claude-plugin/marketplace.json
+  run git commit -m "chore(release): ${NEW}
 
 Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
 
-# -- 7. tag + push -----------------------------------------------------------
-run git tag -a "v${NEW}" -m "legion ${NEW}"
-run git push origin main
-run git push origin "v${NEW}"
-info "pushed v${NEW} -- release.yml will build + publish the platform binaries"
+  # -- 7. tag + atomic push --------------------------------------------------
+  # --atomic so main and the tag land together: a half-push that left the
+  # commit without its tag would leave release.yml unfired.
+  run git tag -a "v${NEW}" -m "legion ${NEW}"
+  run git push --atomic origin main "v${NEW}"
+  info "pushed v${NEW} -- release.yml will build + publish the platform binaries"
 
-# -- 8. optional local activation --------------------------------------------
-if [ "$ACTIVATE" = "1" ]; then
-  DATA_DIR="${CLAUDE_PLUGIN_DATA:-${HOME}/.claude/plugins/data/legion-legion}"
-  DATA_BIN="${DATA_DIR}/legion"
-  info "activating ${NEW} locally: build + install + daemon restart"
-  run cargo build --release --quiet
-  run mkdir -p "$DATA_DIR"
-  if [ "$DRY_RUN" = "1" ]; then
-    printf '[dry-run] install target/release/legion -> %s (atomic)\n' "$DATA_BIN" >&2
-    printf '[dry-run] restart legion daemon on port 3131\n' >&2
-  else
-    cp "${REPO_ROOT}/target/release/legion" "${DATA_BIN}.new"
-    chmod +x "${DATA_BIN}.new"
-    mv -f "${DATA_BIN}.new" "$DATA_BIN"
-    info "installed $("$DATA_BIN" --version) to ${DATA_BIN}"
-    # Restart the daemon so it execs the new binary.
-    if OLDPID="$(pgrep -f 'legion daemon --port 3131' | head -1)" && [ -n "$OLDPID" ]; then
-      kill "$OLDPID" || true
-      for _ in 1 2 3 4 5; do
-        pgrep -f 'legion daemon --port 3131' >/dev/null 2>&1 || break
-        sleep 1
-      done
+  # -- 8. optional local activation ------------------------------------------
+  if [ "$ACTIVATE" = "1" ]; then
+    local DATA_DIR DATA_BIN OLDPID
+    DATA_DIR="${CLAUDE_PLUGIN_DATA:-${HOME}/.claude/plugins/data/legion-legion}"
+    DATA_BIN="${DATA_DIR}/legion"
+    info "activating ${NEW} locally: build + install + daemon restart"
+    run cargo build --release --quiet
+    run mkdir -p "$DATA_DIR"
+    if [ "$DRY_RUN" = "1" ]; then
+      printf '[dry-run] install target/release/legion -> %s (atomic)\n' "$DATA_BIN" >&2
+      printf '[dry-run] restart legion daemon on port 3131\n' >&2
+    else
+      cp "${REPO_ROOT}/target/release/legion" "${DATA_BIN}.new"
+      chmod +x "${DATA_BIN}.new"
+      mv -f "${DATA_BIN}.new" "$DATA_BIN"
+      info "installed $("$DATA_BIN" --version) to ${DATA_BIN}"
+      # Stop the old daemon and CONFIRM it died before starting a new one --
+      # otherwise the replacement loses the port bind, dies, and the health
+      # probe reads empty, masking a dead daemon.
+      if OLDPID="$(pgrep -f 'legion daemon --port 3131' | head -1)" && [ -n "$OLDPID" ]; then
+        kill "$OLDPID" || true
+        local _i
+        for _i in 1 2 3 4 5; do
+          pgrep -f 'legion daemon --port 3131' >/dev/null 2>&1 || break
+          sleep 1
+        done
+        if pgrep -f 'legion daemon --port 3131' >/dev/null 2>&1; then
+          fail "old daemon (pid ${OLDPID}) did not exit -- refusing to start a competing daemon"
+        fi
+      fi
+      nohup "$DATA_BIN" daemon --port 3131 >/tmp/legion-daemon.log 2>&1 &
+      disown || true
+      sleep 2
+      info "daemon restarted: $(curl -s http://127.0.0.1:3131/health 2>/dev/null | head -c 120)"
     fi
-    nohup "$DATA_BIN" daemon --port 3131 >/tmp/legion-daemon.log 2>&1 &
-    disown || true
-    sleep 2
-    info "daemon restarted: $(curl -s http://127.0.0.1:3131/health 2>/dev/null | head -c 120)"
   fi
-fi
 
-info "done: ${NEW}"
+  info "done: ${NEW}"
+}
+
+# Run main only when executed directly, so scripts/test-release.sh can source
+# this file to unit-test the pure helpers without triggering a release.
+if [ "${BASH_SOURCE[0]:-$0}" = "${0}" ]; then
+  main "$@"
+fi

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -16,7 +16,9 @@
 # (by the `changelog` agent, or by hand) and left UNCOMMITTED in the working tree.
 # release.sh validates it, bumps the version, syncs the manifests, and commits the
 # whole release in one shot. The only file allowed to be dirty at entry is
-# plugin/CHANGELOG.md; everything else must be committed.
+# plugin/CHANGELOG.md; everything else must be committed. (Note: even --dry-run
+# requires the "## <new>" CHANGELOG header to exist -- the header check is part of
+# what a dry-run verifies.)
 #
 # What it does, in order:
 #   1. Guards: on main, tree clean except plugin/CHANGELOG.md, in sync with origin.
@@ -24,17 +26,16 @@
 #   3. Requires plugin/CHANGELOG.md's "## <new>" top header to exist.
 #   4. Runs scripts/preflight.sh (fmt, clippy --all-targets, test, SCIP regen).
 #   5. Bumps Cargo.toml, refreshes Cargo.lock.
-#   6. Syncs plugin.json + marketplace.json (scripts/sync-version.sh) and commits
-#      chore(release): <new>. Running sync-version explicitly means the release is
-#      correct even in a clone where the pre-commit hook was never installed.
-#   7. Tags v<new> and atomically pushes the commit + tag. The tag fires
-#      .github/workflows/release.yml, which builds + publishes the binaries.
+#   6. Syncs plugin.json + marketplace.json (scripts/sync-version.sh) and commits.
+#   7. Tags v<new> and atomically pushes the commit + tag, firing release.yml.
 #   8. With --activate: builds the release binary, installs it to the plugin data
-#      dir atomically, and restarts the local daemon.
+#      dir atomically, and restarts the local daemon (verifying it comes back up).
 #
-# The pure helpers below (compute_new_version, is_semver, is_strictly_greater) are
-# unit-tested by scripts/test-release.sh, which sources this file. main() runs only
-# when the script is executed, not when it is sourced.
+# The pure helpers below (compute_new_version, is_semver, is_strictly_greater,
+# non_changelog_dirty) are unit-tested by scripts/test-release.sh, which sources
+# this file. main() runs only when the script is executed, not when it is sourced.
+# Implementation is kept POSIX-portable (no GNU-only sed/sort) because the release
+# is cut on darwin, where BSD sed/sort lack the GNU extensions.
 set -euo pipefail
 
 info() { printf '[release] %s\n' "$1" >&2; }
@@ -66,9 +67,34 @@ EOF
 # is_semver <v> -> 0 iff v is strictly X.Y.Z (no prerelease/build/extra segments).
 is_semver() { [[ "$1" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; }
 
-# is_strictly_greater <new> <current> -> 0 iff new > current by semver ordering.
+# is_strictly_greater <new> <current> -> 0 iff new > current. Field-by-field
+# numeric compare (both args must be strict semver) -- avoids `sort -V`, which is
+# a GNU-ism absent from stock BSD sort.
 is_strictly_greater() {
-  [ "$1" != "$2" ] && [ "$(printf '%s\n%s\n' "$1" "$2" | sort -V | head -1)" = "$2" ]
+  local na nb nc ca cb cc
+  IFS='.' read -r na nb nc <<EOF
+$1
+EOF
+  IFS='.' read -r ca cb cc <<EOF
+$2
+EOF
+  if [ "$na" -ne "$ca" ]; then [ "$na" -gt "$ca" ]; return; fi
+  if [ "$nb" -ne "$cb" ]; then [ "$nb" -gt "$cb" ]; return; fi
+  [ "$nc" -gt "$cc" ]
+}
+
+# non_changelog_dirty: read `git status --porcelain` on stdin, print the lines
+# whose changed path is NOT exactly plugin/CHANGELOG.md. Parses the porcelain
+# path field (handling rename/copy "ORIG -> DEST" by testing DEST) so the guard
+# allowlists the file itself, not any path that merely ends in that suffix.
+non_changelog_dirty() {
+  local line path
+  while IFS= read -r line; do
+    [ -n "$line" ] || continue
+    path="${line:3}"                       # drop the 2-char status + space
+    case "$path" in *" -> "*) path="${path##* -> }" ;; esac
+    [ "$path" = "plugin/CHANGELOG.md" ] || printf '%s\n' "$line"
+  done
 }
 
 main() {
@@ -110,8 +136,8 @@ main() {
   [ "$BRANCH" = "main" ] || fail "must be on main to release (on '$BRANCH')"
 
   # The CHANGELOG entry is written-but-uncommitted at entry; everything else
-  # must be clean. Allow plugin/CHANGELOG.md to be dirty, reject anything else.
-  DIRTY_OTHER="$(git status --porcelain --untracked-files=no | { grep -v 'plugin/CHANGELOG\.md$' || true; })"
+  # must be clean. Allow only plugin/CHANGELOG.md to be dirty.
+  DIRTY_OTHER="$(git status --porcelain --untracked-files=no | non_changelog_dirty)"
   [ -z "$DIRTY_OTHER" ] || fail "working tree has changes other than plugin/CHANGELOG.md -- commit or stash first:
 $DIRTY_OTHER"
 
@@ -125,6 +151,7 @@ $DIRTY_OTHER"
   local CURRENT NEW
   CURRENT="$(grep -m1 '^version' "$CARGO_TOML" | sed 's/version = "\(.*\)"/\1/' || true)"
   [ -n "$CURRENT" ] || fail "could not read version from Cargo.toml"
+  is_semver "$CURRENT" || fail "Cargo.toml version '$CURRENT' is not strict X.Y.Z"
 
   NEW="$(compute_new_version "$CURRENT" "$BUMP")"
   is_semver "$NEW" || fail "invalid version '$NEW' (expected X.Y.Z)"
@@ -154,11 +181,14 @@ $DIRTY_OTHER"
   fi
 
   # -- 5. bump Cargo.toml + refresh Cargo.lock -------------------------------
+  # Replace the first exact `version = "<current>"` line via awk -- portable,
+  # unlike `sed '0,/re/'` whose line-address 0 is a GNU extension BSD sed rejects.
   if [ "$DRY_RUN" = "1" ]; then
     printf '[dry-run] set Cargo.toml version %s -> %s\n' "$CURRENT" "$NEW" >&2
   else
-    sed -i.bak "0,/^version = \"${CURRENT}\"/s//version = \"${NEW}\"/" "$CARGO_TOML"
-    rm -f "${CARGO_TOML}.bak"
+    awk -v old="version = \"${CURRENT}\"" -v new="version = \"${NEW}\"" '
+      !done && $0 == old { print new; done = 1; next } { print }
+    ' "$CARGO_TOML" > "${CARGO_TOML}.tmp" && mv "${CARGO_TOML}.tmp" "$CARGO_TOML"
   fi
   run cargo build --quiet   # refreshes Cargo.lock's legion entry to ${NEW}
 
@@ -173,50 +203,69 @@ $DIRTY_OTHER"
 Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
 
   # -- 7. tag + atomic push --------------------------------------------------
-  # --atomic so main and the tag land together: a half-push that left the
-  # commit without its tag would leave release.yml unfired.
+  # --atomic so main and the tag land together: a half-push that left the commit
+  # without its tag would leave release.yml unfired.
   run git tag -a "v${NEW}" -m "legion ${NEW}"
   run git push --atomic origin main "v${NEW}"
   info "pushed v${NEW} -- release.yml will build + publish the platform binaries"
 
   # -- 8. optional local activation ------------------------------------------
   if [ "$ACTIVATE" = "1" ]; then
-    local DATA_DIR DATA_BIN OLDPID
-    DATA_DIR="${CLAUDE_PLUGIN_DATA:-${HOME}/.claude/plugins/data/legion-legion}"
-    DATA_BIN="${DATA_DIR}/legion"
-    info "activating ${NEW} locally: build + install + daemon restart"
-    run cargo build --release --quiet
-    run mkdir -p "$DATA_DIR"
-    if [ "$DRY_RUN" = "1" ]; then
-      printf '[dry-run] install target/release/legion -> %s (atomic)\n' "$DATA_BIN" >&2
-      printf '[dry-run] restart legion daemon on port 3131\n' >&2
-    else
-      cp "${REPO_ROOT}/target/release/legion" "${DATA_BIN}.new"
-      chmod +x "${DATA_BIN}.new"
-      mv -f "${DATA_BIN}.new" "$DATA_BIN"
-      info "installed $("$DATA_BIN" --version) to ${DATA_BIN}"
-      # Stop the old daemon and CONFIRM it died before starting a new one --
-      # otherwise the replacement loses the port bind, dies, and the health
-      # probe reads empty, masking a dead daemon.
-      if OLDPID="$(pgrep -f 'legion daemon --port 3131' | head -1)" && [ -n "$OLDPID" ]; then
-        kill "$OLDPID" || true
-        local _i
-        for _i in 1 2 3 4 5; do
-          pgrep -f 'legion daemon --port 3131' >/dev/null 2>&1 || break
-          sleep 1
-        done
-        if pgrep -f 'legion daemon --port 3131' >/dev/null 2>&1; then
-          fail "old daemon (pid ${OLDPID}) did not exit -- refusing to start a competing daemon"
-        fi
-      fi
-      nohup "$DATA_BIN" daemon --port 3131 >/tmp/legion-daemon.log 2>&1 &
-      disown || true
-      sleep 2
-      info "daemon restarted: $(curl -s http://127.0.0.1:3131/health 2>/dev/null | head -c 120)"
-    fi
+    activate_local "$REPO_ROOT" "$NEW" "$DRY_RUN"
   fi
 
   info "done: ${NEW}"
+}
+
+# activate_local <repo_root> <new> <dry_run>: build the release binary, install it
+# to the plugin data dir atomically, and restart the daemon -- verifying both that
+# the old one died and that the new one actually came back up on ${new}.
+activate_local() {
+  local REPO_ROOT="$1" NEW="$2" DRY_RUN="$3"
+  local DATA_DIR DATA_BIN OLDPID HEALTH _i
+  DATA_DIR="${CLAUDE_PLUGIN_DATA:-${HOME}/.claude/plugins/data/legion-legion}"
+  DATA_BIN="${DATA_DIR}/legion"
+  info "activating ${NEW} locally: build + install + daemon restart"
+
+  if [ "$DRY_RUN" = "1" ]; then
+    printf '[dry-run] cargo build --release\n' >&2
+    printf '[dry-run] install target/release/legion -> %s (atomic)\n' "$DATA_BIN" >&2
+    printf '[dry-run] restart legion daemon on port 3131 and verify /health\n' >&2
+    return 0
+  fi
+
+  cargo build --release --quiet
+  mkdir -p "$DATA_DIR"
+  cp "${REPO_ROOT}/target/release/legion" "${DATA_BIN}.new"
+  chmod +x "${DATA_BIN}.new"
+  mv -f "${DATA_BIN}.new" "$DATA_BIN"
+  info "installed $("$DATA_BIN" --version) to ${DATA_BIN}"
+
+  # Stop the old daemon and CONFIRM it died before starting a new one -- a
+  # replacement that races the old one loses the port bind and dies silently.
+  if OLDPID="$(pgrep -f 'legion daemon --port 3131' | head -1)" && [ -n "$OLDPID" ]; then
+    kill "$OLDPID" || true
+    for _i in 1 2 3 4 5; do
+      pgrep -f 'legion daemon --port 3131' >/dev/null 2>&1 || break
+      sleep 1
+    done
+    if pgrep -f 'legion daemon --port 3131' >/dev/null 2>&1; then
+      fail "old daemon (pid ${OLDPID}) did not exit -- refusing to start a competing daemon"
+    fi
+  fi
+
+  nohup "$DATA_BIN" daemon --port 3131 >/tmp/legion-daemon.log 2>&1 &
+  disown || true
+  sleep 2
+
+  # Verify the new daemon actually came up on the new version. An empty body
+  # means it failed to bind/crashed -- do NOT report success on a dead daemon.
+  HEALTH="$(curl -s http://127.0.0.1:3131/health 2>/dev/null || true)"
+  case "$HEALTH" in
+    "")          fail "daemon did not come back up (empty /health) -- see /tmp/legion-daemon.log" ;;
+    *"${NEW}"*)  info "daemon restarted on ${NEW}: ${HEALTH}" ;;
+    *)           fail "daemon /health does not report ${NEW}: ${HEALTH}" ;;
+  esac
 }
 
 # Run main only when executed directly, so scripts/test-release.sh can source

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,190 @@
+#!/usr/bin/env bash
+# release.sh: one-command release for legion. Cargo.toml is the source of truth
+# for the version; everything else is derived and validated.
+#
+# Usage:
+#   scripts/release.sh patch            # 0.18.2 -> 0.18.3
+#   scripts/release.sh minor            # 0.18.2 -> 0.19.0
+#   scripts/release.sh major            # 0.18.2 -> 1.0.0
+#   scripts/release.sh 0.20.0           # explicit version
+#   scripts/release.sh patch --dry-run  # print every step, mutate nothing
+#   scripts/release.sh patch --activate # also build+install the binary and
+#                                        # restart the local daemon
+#   scripts/release.sh patch --no-preflight  # skip the cargo/scip gate (CI re-runs it)
+#
+# What it does, in order:
+#   1. Guards: on main, clean working tree, in sync with origin/main.
+#   2. Computes the new version from the bump level (or takes it explicitly).
+#   3. Requires plugin/CHANGELOG.md to already carry a "## <new>" top header --
+#      release prose is human-authored, never generated. Fails loudly if absent.
+#   4. Runs scripts/preflight.sh (fmt, clippy --all-targets, test, SCIP regen).
+#   5. Bumps Cargo.toml, refreshes Cargo.lock.
+#   6. Syncs plugin.json + marketplace.json (scripts/sync-version.sh) and commits
+#      chore(release): <new>. Running sync-version explicitly means the release
+#      is correct even in a clone where the pre-commit hook was never installed
+#      -- the exact failure that motivated #656.
+#   7. Tags v<new> and pushes the commit + tag. The tag fires .github/workflows/
+#      release.yml, which builds the platform binaries and publishes the Release.
+#   8. With --activate: builds the release binary, installs it to the plugin data
+#      dir atomically, and restarts the local daemon so the new code runs now.
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+CARGO_TOML="${REPO_ROOT}/Cargo.toml"
+CHANGELOG="${REPO_ROOT}/plugin/CHANGELOG.md"
+
+# -- arg parsing -------------------------------------------------------------
+BUMP=""
+DRY_RUN=0
+ACTIVATE=0
+RUN_PREFLIGHT=1
+
+for arg in "$@"; do
+  case "$arg" in
+    patch|minor|major) BUMP="$arg" ;;
+    [0-9]*.[0-9]*.[0-9]*) BUMP="$arg" ;;
+    --dry-run) DRY_RUN=1 ;;
+    --activate) ACTIVATE=1 ;;
+    --no-preflight) RUN_PREFLIGHT=0 ;;
+    *) echo "[release] unknown argument: $arg" >&2; exit 2 ;;
+  esac
+done
+
+if [ -z "$BUMP" ]; then
+  echo "[release] usage: release.sh <patch|minor|major|X.Y.Z> [--dry-run] [--activate] [--no-preflight]" >&2
+  exit 2
+fi
+
+info() { printf '[release] %s\n' "$1" >&2; }
+fail() { printf '[release] ERROR: %s\n' "$1" >&2; exit 1; }
+
+# run: execute a mutating command, or just print it under --dry-run.
+run() {
+  if [ "$DRY_RUN" = "1" ]; then
+    printf '[dry-run] %s\n' "$*" >&2
+  else
+    "$@"
+  fi
+}
+
+# -- 1. guards ---------------------------------------------------------------
+BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+[ "$BRANCH" = "main" ] || fail "must be on main to release (on '$BRANCH')"
+
+[ -z "$(git status --porcelain)" ] || fail "working tree is dirty -- commit or stash first"
+
+git fetch origin main --quiet || fail "git fetch failed"
+LOCAL="$(git rev-parse @)"
+REMOTE="$(git rev-parse '@{u}' 2>/dev/null || echo "")"
+[ -n "$REMOTE" ] || fail "no upstream for main"
+[ "$LOCAL" = "$REMOTE" ] || fail "local main is not in sync with origin/main -- pull/push first"
+
+# -- 2. compute the new version ----------------------------------------------
+# `|| true` so a missing version line surfaces as the friendly guard below
+# rather than a bare pipefail abort under `set -e`.
+CURRENT="$(grep -m1 '^version' "$CARGO_TOML" | sed 's/version = "\(.*\)"/\1/' || true)"
+[ -n "$CURRENT" ] || fail "could not read version from Cargo.toml"
+
+case "$BUMP" in
+  patch|minor|major)
+    IFS='.' read -r MAJ MIN PAT <<EOF
+$CURRENT
+EOF
+    case "$BUMP" in
+      patch) PAT=$((PAT + 1)) ;;
+      minor) MIN=$((MIN + 1)); PAT=0 ;;
+      major) MAJ=$((MAJ + 1)); MIN=0; PAT=0 ;;
+    esac
+    NEW="${MAJ}.${MIN}.${PAT}"
+    ;;
+  *)
+    NEW="$BUMP"
+    ;;
+esac
+
+# Strict X.Y.Z -- the explicit-version arg glob is loose (accepts 1.2.3-beta,
+# 1.2.3.4), and a typo here becomes a pushed tag. Reject anything non-semver.
+[[ "$NEW" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || fail "invalid version '$NEW' (expected X.Y.Z)"
+
+# Refuse a no-op or a downgrade (sort -V puts the lower version first).
+[ "$NEW" != "$CURRENT" ] || fail "new version equals current ($CURRENT)"
+LOWER="$(printf '%s\n%s\n' "$CURRENT" "$NEW" | sort -V | head -1)"
+[ "$LOWER" = "$CURRENT" ] || fail "refusing to downgrade $CURRENT -> $NEW"
+
+info "releasing ${CURRENT} -> ${NEW}"
+
+# -- 3. require the CHANGELOG entry (human-authored, never generated) ---------
+TOP_HEADER="$(grep -E '^## [0-9]' "$CHANGELOG" | head -1 | sed -E 's/^## //' | awk '{print $1}')"
+if [ "$TOP_HEADER" != "$NEW" ]; then
+  fail "plugin/CHANGELOG.md top header is '## ${TOP_HEADER:-<none>}', expected '## ${NEW}'.
+       Add a '## ${NEW}' section at the top describing what shipped, then re-run."
+fi
+info "CHANGELOG header matches ${NEW}"
+
+# -- 4. preflight ------------------------------------------------------------
+if [ "$RUN_PREFLIGHT" = "1" ]; then
+  info "running preflight (fmt, clippy, test, scip)"
+  run bash "${REPO_ROOT}/scripts/preflight.sh"
+else
+  info "preflight skipped (--no-preflight)"
+fi
+
+# -- 5. bump Cargo.toml + refresh Cargo.lock ---------------------------------
+if [ "$DRY_RUN" = "1" ]; then
+  printf '[dry-run] set Cargo.toml version %s -> %s\n' "$CURRENT" "$NEW" >&2
+else
+  # Match only the package version line (first `version = ` under [package]).
+  sed -i.bak "0,/^version = \"${CURRENT}\"/s//version = \"${NEW}\"/" "$CARGO_TOML"
+  rm -f "${CARGO_TOML}.bak"
+fi
+run cargo build --quiet   # refreshes Cargo.lock's legion entry to ${NEW}
+
+# -- 6. sync manifests + commit ----------------------------------------------
+# Run sync-version explicitly so the manifests are correct even if the
+# pre-commit hook is not installed in this clone (the #656 failure mode).
+run bash "${REPO_ROOT}/scripts/sync-version.sh"
+run git add Cargo.toml Cargo.lock plugin/CHANGELOG.md \
+  plugin/.claude-plugin/plugin.json .claude-plugin/marketplace.json
+run git commit -m "chore(release): ${NEW}
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+
+# -- 7. tag + push -----------------------------------------------------------
+run git tag -a "v${NEW}" -m "legion ${NEW}"
+run git push origin main
+run git push origin "v${NEW}"
+info "pushed v${NEW} -- release.yml will build + publish the platform binaries"
+
+# -- 8. optional local activation --------------------------------------------
+if [ "$ACTIVATE" = "1" ]; then
+  DATA_DIR="${CLAUDE_PLUGIN_DATA:-${HOME}/.claude/plugins/data/legion-legion}"
+  DATA_BIN="${DATA_DIR}/legion"
+  info "activating ${NEW} locally: build + install + daemon restart"
+  run cargo build --release --quiet
+  run mkdir -p "$DATA_DIR"
+  if [ "$DRY_RUN" = "1" ]; then
+    printf '[dry-run] install target/release/legion -> %s (atomic)\n' "$DATA_BIN" >&2
+    printf '[dry-run] restart legion daemon on port 3131\n' >&2
+  else
+    cp "${REPO_ROOT}/target/release/legion" "${DATA_BIN}.new"
+    chmod +x "${DATA_BIN}.new"
+    mv -f "${DATA_BIN}.new" "$DATA_BIN"
+    info "installed $("$DATA_BIN" --version) to ${DATA_BIN}"
+    # Restart the daemon so it execs the new binary.
+    if OLDPID="$(pgrep -f 'legion daemon --port 3131' | head -1)" && [ -n "$OLDPID" ]; then
+      kill "$OLDPID" || true
+      for _ in 1 2 3 4 5; do
+        pgrep -f 'legion daemon --port 3131' >/dev/null 2>&1 || break
+        sleep 1
+      done
+    fi
+    nohup "$DATA_BIN" daemon --port 3131 >/tmp/legion-daemon.log 2>&1 &
+    disown || true
+    sleep 2
+    info "daemon restarted: $(curl -s http://127.0.0.1:3131/health 2>/dev/null | head -c 120)"
+  fi
+fi
+
+info "done: ${NEW}"

--- a/scripts/test-release.sh
+++ b/scripts/test-release.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# test-release.sh: unit tests for the pure helpers in scripts/release.sh -- the
+# version computation and validation that turn into a pushed git tag, so a
+# regression here ("a typo becomes a pushed tag") is exactly what must be caught.
+#
+# Sources release.sh; main() is BASH_SOURCE-guarded, so sourcing defines the
+# helpers without triggering a release.
+set -u
+
+DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=release.sh disable=SC1091
+source "${DIR}/release.sh"
+set +e   # release.sh enables errexit on source; tests manage their own codes.
+
+PASS=0
+FAIL=0
+
+eq() { # eq <label> <expected> <actual>
+  if [ "$2" = "$3" ]; then PASS=$((PASS + 1)); else
+    FAIL=$((FAIL + 1)); printf 'FAIL: %s -- expected [%s] got [%s]\n' "$1" "$2" "$3" >&2
+  fi
+}
+ok() { # ok <label> <cmd...>   (expect exit 0)
+  local label="$1"; shift
+  if "$@"; then PASS=$((PASS + 1)); else FAIL=$((FAIL + 1)); printf 'FAIL: %s -- expected success\n' "$label" >&2; fi
+}
+no() { # no <label> <cmd...>   (expect non-zero)
+  local label="$1"; shift
+  if "$@"; then FAIL=$((FAIL + 1)); printf 'FAIL: %s -- expected failure\n' "$label" >&2; else PASS=$((PASS + 1)); fi
+}
+
+# compute_new_version
+eq "patch"         0.18.3 "$(compute_new_version 0.18.2 patch)"
+eq "minor"         0.19.0 "$(compute_new_version 0.18.2 minor)"
+eq "major"         1.0.0  "$(compute_new_version 0.18.2 major)"
+eq "patch carry"   1.4.10 "$(compute_new_version 1.4.9 patch)"
+eq "minor resets"  2.1.0  "$(compute_new_version 2.0.7 minor)"
+eq "major resets"  3.0.0  "$(compute_new_version 2.9.9 major)"
+eq "explicit"      0.20.0 "$(compute_new_version 0.18.2 0.20.0)"
+
+# is_semver
+ok "semver ok"          is_semver 0.18.3
+no "semver prerelease"  is_semver 1.2.3-beta
+no "semver short"       is_semver 1.2
+no "semver long"        is_semver 1.2.3.4
+no "semver nonnum"      is_semver 1.2.x
+no "semver empty"       is_semver ""
+
+# is_strictly_greater
+ok "gt patch"   is_strictly_greater 0.18.3 0.18.2
+no "gt noop"    is_strictly_greater 0.18.2 0.18.2
+no "gt down"    is_strictly_greater 0.18.1 0.18.2
+ok "gt sortV"   is_strictly_greater 0.19.0 0.18.9
+ok "gt major"   is_strictly_greater 1.0.0 0.18.2
+no "gt majdown" is_strictly_greater 0.18.2 1.0.0
+
+printf '\n[test-release] %d passed, %d failed\n' "$PASS" "$FAIL" >&2
+[ "$FAIL" -eq 0 ]

--- a/scripts/test-release.sh
+++ b/scripts/test-release.sh
@@ -46,13 +46,26 @@ no "semver long"        is_semver 1.2.3.4
 no "semver nonnum"      is_semver 1.2.x
 no "semver empty"       is_semver ""
 
-# is_strictly_greater
+# is_strictly_greater (numeric, not lexical -- 0.19.0 > 0.18.9, 0.18.10 > 0.18.9)
 ok "gt patch"   is_strictly_greater 0.18.3 0.18.2
 no "gt noop"    is_strictly_greater 0.18.2 0.18.2
 no "gt down"    is_strictly_greater 0.18.1 0.18.2
-ok "gt sortV"   is_strictly_greater 0.19.0 0.18.9
+ok "gt numeric" is_strictly_greater 0.19.0 0.18.9
+ok "gt twodigit" is_strictly_greater 0.18.10 0.18.9
 ok "gt major"   is_strictly_greater 1.0.0 0.18.2
 no "gt majdown" is_strictly_greater 0.18.2 1.0.0
+
+# non_changelog_dirty: only plugin/CHANGELOG.md is allowed dirty; anything else
+# (including a rename whose destination is not CHANGELOG) is "other dirty".
+eq "dirty: changelog only allowed" "" \
+  "$(printf ' M plugin/CHANGELOG.md\n' | non_changelog_dirty)"
+eq "dirty: other file flagged" " M src/main.rs" \
+  "$(printf ' M plugin/CHANGELOG.md\n M src/main.rs\n' | non_changelog_dirty)"
+eq "dirty: suffix lookalike flagged" " M docs/plugin/CHANGELOG.md" \
+  "$(printf ' M docs/plugin/CHANGELOG.md\n' | non_changelog_dirty)"
+eq "dirty: rename dest to changelog allowed" "" \
+  "$(printf 'R  old.md -> plugin/CHANGELOG.md\n' | non_changelog_dirty)"
+eq "dirty: empty tree is clean" "" "$(printf '' | non_changelog_dirty)"
 
 printf '\n[test-release] %d passed, %d failed\n' "$PASS" "$FAIL" >&2
 [ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## Summary

Automates the legion release the way the TS repos automate theirs: a one-command release backed by a reusable preflight, an agent that writes the changelog from the actual change set, and a docs-review step that updates runlegion.dev only when a release warrants it. The 0.18.2 release was cut by hand and the missing pre-commit hook let a plugin.json/marketplace.json version mismatch slip into the release commit; this encodes the whole sequence so that class of error cannot recur.

## Acceptance criteria mapping

### 1. preflight.sh runs the full quality bar + SCIP regen, fails non-zero, standalone-safe
`scripts/preflight.sh` runs `cargo fmt -- --check`, `cargo clippy --all-targets -- -D warnings` (the `--all-targets` form CI uses, not bare clippy), `cargo test`, then `legion index legion` to regenerate the SCIP index. Each gate is wrapped in a `fail()` that names the failing stage and exits non-zero on the first failure. The SCIP step is best-effort by default (a missing `legion` binary is a warning, not a hard stop) with `REQUIRE_SCIP=1` to enforce, and `SKIP_SCIP=1` to skip for a fast local loop -- so it is genuinely runnable standalone.
Evidence: I ran it end to end on this branch -- fmt, clippy, 178 tests, and an 8.8 MB SCIP regen all passed; `set -euo pipefail` and `shellcheck` clean.

### 2. release.sh automates the release with guards, preflight, bump, CHANGELOG validation, manifest sync, commit, tag, push
`scripts/release.sh` guards first (on `main`, clean tree, `@ == @{u}` against origin), computes the target version from the bump level or explicit `X.Y.Z`, requires the `plugin/CHANGELOG.md` top header to already equal the new version (failing loudly if absent -- it never writes release prose itself), runs preflight, bumps `Cargo.toml`, refreshes `Cargo.lock` via `cargo build`, then calls `scripts/sync-version.sh` explicitly before committing. That explicit sync is the fix for the 0.18.2 failure mode: the manifests are correct even in a clone where the pre-commit hook was never installed. It then tags `vX.Y.Z` and pushes commit + tag, which fires `release.yml`.
Evidence: the guard/version/CHANGELOG/sync/commit/tag/push sequence in `scripts/release.sh`; it encodes exactly the manual steps that produced 0.18.2 successfully, with the manifest-sync gap closed.

### 3. --dry-run prints without mutating; --activate builds, installs, restarts the daemon
A `run()` wrapper prints `[dry-run] <cmd>` instead of executing every mutating command under `--dry-run`, so the full path can be rehearsed with zero side effects. `--activate` runs `cargo build --release`, installs the binary to `${CLAUDE_PLUGIN_DATA:-$HOME/.claude/plugins/data/legion-legion}/legion` via a copy-then-`mv` atomic replace (the running daemon keeps its old inode), then kills and relaunches the daemon on port 3131 and reports `/health`.
Evidence: the `run()` helper and the `--activate` block in `scripts/release.sh`; the activation steps mirror the exact build/install/restart I performed by hand for 0.18.2.

### 4. Scripts are shellcheck-clean and set -euo pipefail
All scripts open with `set -euo pipefail` and pass `shellcheck` with no warnings. `release.sh`'s version-and-validation logic is factored into pure, sourceable helpers (`compute_new_version`, `is_semver`, `is_strictly_greater`, `non_changelog_dirty`); `main()` is `BASH_SOURCE`-guarded so `scripts/test-release.sh` can source the file and unit-test them. The implementation is kept POSIX-portable for darwin (where the release is cut): the Cargo.toml bump uses `awk` first-exact-match rather than `sed '0,/re/'` (GNU-only line address 0), and version ordering uses a field-by-field numeric compare rather than `sort -V` (GNU-only).
Evidence: `shellcheck` clean across all four scripts; `scripts/test-release.sh` runs 25 assertions (bump arithmetic incl. carry/reset, every reject path -- no-op/downgrade/non-semver, the `0.18.10 > 0.18.9` numeric trap, and the dirty-tree allowlist incl. a `docs/plugin/CHANGELOG.md` suffix-lookalike and a rename-to-CHANGELOG) and is wired into `preflight.sh`. Three pre-push review rounds and the pre-commit gate caught and fixed the clean-tree contradiction, the GNU sed/sort portability breaks, and the `--activate` dead-daemon mask -- all now under test.

### 5. changelog agent writes the entry from the commit range, in voice, validating against Cargo.toml downstream
`plugin/agents/changelog.md` defines an agent that finds the previous tag, diffs `<prevtag>..HEAD`, reads the merged PRs and their issues and the substantive hunks (not just commit subjects), and prepends a `## X.Y.Z` section matching the existing CHANGELOG voice (theme paragraph + release-type rationale + `### New/Fixed/Changed/Config` bullets, each cited). It treats the orchestrator-supplied version as authoritative because it runs before `release.sh` bumps `Cargo.toml`; the header↔Cargo.toml mismatch guard is explicitly delegated downstream to `release.sh` (post-bump). It does not commit, tag, or push.
Evidence: `plugin/agents/changelog.md`. The pre-commit review caught two real ordering contradictions in earlier drafts (the agent validating against a pre-bump Cargo.toml, and a stale restatement in the Output section); both were fixed, and the version-source-of-truth is now consistent throughout the file.

### 6. /legion-release orchestrates preflight -> changelog -> release.sh -> writer-legion docs review
`plugin/commands/legion-release.md` defines the `/legion-release` command: it checks preconditions, computes `CURRENT -> NEW`, spawns the `changelog` agent to write the entry (with the orchestrator editing, not hand-writing), runs `scripts/release.sh NEW` (passing through `--activate`/`--dry-run`), then spawns `writer-legion` against the runlegion.dev docs -- resolving the shingle path from `watch.toml` rather than hardcoding it -- to update the docs on a `docs/legion-NEW` branch only when a user-facing surface changed, opening the shingle PR through the normal gate flow.
Evidence: `plugin/commands/legion-release.md`; it reuses the existing `writer-legion` subagent (the runlegion.dev copy owner) rather than inventing a new docs agent.

## Not done

- **The changelog agent and /legion-release command are not yet exercised on a live release.** They are prompt definitions whose logic was reviewed (and corrected three times by the gates -- two version-source contradictions and the dirty-tree/CHANGELOG ordering), but the first real validation is the next release cut via `/legion-release`. I deliberately did not fabricate a release to test them.
- **The `--activate` daemon-restart path is not unit-tested** (it needs a live daemon); its health-verification logic was added in response to review but is exercised only on a real `--activate` run. The pure version/guard helpers it sits behind are tested.
- **No least-privilege trim of the changelog agent's `Write` grant.** The agent only Edits the existing CHANGELOG; `Write` is in its toolset but unused. Left as-is (harmless) rather than spin another commit cycle.
- **SCIP regen is not added to the git hooks.** preflight regenerates it on release; wiring a per-push SCIP regen into `.githooks/pre-push` is a separate change (the PostToolUse re-index hook already keeps the index fresh on edits).