### PR TITLE
fix(#663): remove transient index.scip from repo root after ingest

### DIFF
--- a/src/scip.rs
+++ b/src/scip.rs
@@ -326,11 +326,12 @@ fn run_scip_go(repo_path: &Path) -> Result<Vec<u8>> {
 }
 
 /// Run a SCIP indexer binary against `repo_path`. Returns the bytes of the
-/// `index.scip` protobuf written into the repo root, or a typed error
-/// describing the failure mode (binary not on PATH, subprocess exited
+/// `index.scip` protobuf the binary writes into the repo root, or a typed
+/// error describing the failure mode (binary not on PATH, subprocess exited
 /// non-zero, output file unreadable). The `lang` is carried into error
 /// variants so callers see which language failed even when several share
-/// this helper.
+/// this helper. The on-disk `index.scip` is removed once its bytes are read
+/// (best-effort) -- it is a transient artifact, never read again after ingest.
 fn run_indexer_binary(
     lang: &str,
     binary: &str,
@@ -362,6 +363,14 @@ fn run_indexer_binary(
 
     let scip_path = repo_path.join("index.scip");
     let bytes = std::fs::read(&scip_path)?;
+    // The protobuf is transient: the caller ingests these bytes into the
+    // SQLite scip_indexes column, and no regen ever reads the prior file as
+    // input -- each run regenerates it from source. Left in the repo root it
+    // reads as a stray artifact that agents repeatedly try to delete, so
+    // remove it once the bytes are captured. Best-effort by design: the bytes
+    // are already in hand, so a failed removal must not fail the index. The
+    // `/index.scip` gitignore entry remains as a safety net for that edge.
+    let _ = std::fs::remove_file(&scip_path);
     Ok(bytes)
 }
 
@@ -985,6 +994,12 @@ mod tests {
         }
         let bytes = bytes_result.expect("rust-analyzer fallback should succeed");
         assert_eq!(bytes, b"fake-scip-bytes");
+        // The transient protobuf is removed once its bytes are captured, so a
+        // successful index leaves no stray index.scip in the repo root.
+        assert!(
+            !repo.path().join("index.scip").exists(),
+            "index.scip should be removed from repo root after ingest"
+        );
         drop(shim_dir);
 
         // Phase 2: empty PATH (no binaries) -> IndexerNotFound naming both.


### PR DESCRIPTION
## Summary

legion left a multi-MB `index.scip` protobuf sitting in the root of every repo it indexed. Because gitignored files are still visible in the working tree, agents doing housekeeping repeatedly tried to delete it as junk. This change removes the file as soon as its bytes are read into memory, in the single shared indexer path, so the stray artifact stops existing across every language and every indexed repo. The file is purely transient -- its bytes are ingested into the SQLite `scip_indexes` column and no regen ever reads the prior file as input (each run rebuilds it from source) -- so deleting it after ingest is safe.

## Acceptance criteria mapping

### 1. index.scip no longer persists in repo root after legion index
`run_indexer_binary` reads the protobuf into `bytes`, then calls `std::fs::remove_file(&scip_path)` before returning the bytes to the caller. Because this helper is the single path-construction and read site shared by all nine per-language indexer wrappers, one removal call covers every language and every indexed repo -- there is no per-language or per-repo duplication to keep in sync. The file's lifetime is now bounded to the microseconds between the external tool writing it and this read, after which it is gone; nothing reads the resting file between regens, so removing it cannot break a later index (each run regenerates from source). Removal is best-effort: the result is intentionally discarded with `let _ =`, because by the time it runs the bytes are already captured, so a failed unlink must not turn a successful index into an error -- in that edge the file lingers and stays covered by the retained `/index.scip` gitignore entry. The `fs::read` above remains a hard error (no bytes means no index).
Evidence: `src/scip.rs` `run_indexer_binary` -- `let _ = std::fs::remove_file(&scip_path);` directly after `let bytes = std::fs::read(&scip_path)?;`; unit test `run_scip_rust_fallback_chain` now asserts `!repo.path().join("index.scip").exists()` after a successful index.

### 2. All tests pass; clippy --all-targets clean; fmt clean
The DB ingest path is untouched -- the change only deletes the on-disk file after the bytes are already returned -- so the existing suite continues to pass, including the integration test that drives a real fixture index through the CLI and then queries symbols from the DB (sym queries read the SQLite BLOB, never the file). The new file-absence assertion exercises the removal directly. clippy was run with `--all-targets` (CI parity, catching test/example code the bare invocation misses) and fmt with `--check`.
Evidence: full `cargo test` exits 0; `cargo clippy --all-targets -- -D warnings` finishes clean; `cargo fmt -- --check` clean.

### 3. Simplify + review passes complete
The simplify gate was run against the branch diff and recorded clean for HEAD -- the diff is a single file with no duplication, new abstraction, or stringly-typed state, and the lone `let _ =` is documented intentional best-effort, not error swallowing. The review pass (legion-review) runs after this PR is opened, per the pipeline order simplify -> pr-write -> review.
Evidence: `legion quality-gate record --skill legion-simplify --result clean` gate row `019edd1a-f75e-7213-996d-b096263fac7e` on HEAD; pre-commit simplify hook also returned PASS on the staged diff.

### 4. PR linked to this issue
This PR is opened with `legion pr create --repo legion ... --task`, whose title and body both reference issue #663, and the branch name `feat/663-remove-transient-index-scip` carries the issue number, so the issue and PR are cross-linked for the verify gate and human reviewer.
Evidence: PR title `fix(#663): ...`; branch `feat/663-remove-transient-index-scip`; this body's header references #663.

## Not done

No move to `.legion/` and no per-tool output-path redirection -- both were considered and rejected in favor of delete-after-ingest, which is one shared edit, requires no per-tool CLI-flag research (8 of 9 external indexers cannot be redirected), and leaves nothing on disk to be mistaken for junk. The `/index.scip` gitignore line is deliberately retained (not deleted) as a safety net for the best-effort-removal edge case. No cleanup of pre-existing stray `index.scip` files in already-indexed repos -- those are overwritten then removed on the next index run.