### PR TITLE
feat(#666): quality-gate list + stats read subcommands

### DIFF
--- a/src/cli/verify.rs
+++ b/src/cli/verify.rs
@@ -5,6 +5,7 @@ use std::str::FromStr;
 use clap::Subcommand;
 
 use crate::cli::util::{git_head_commit_and_branch, open_db, read_file_or_stdin};
+use crate::db::quality_gates::{QualityGateFilter, QualityGateRow, QualityGateStats};
 use crate::verify::GateResult;
 use crate::{error, kanban, verify};
 
@@ -32,6 +33,53 @@ pub(crate) enum QualityGateAction {
         #[arg(long)]
         details_json: Option<String>,
     },
+
+    /// List recorded quality gate rows, newest first.
+    ///
+    /// Filterable by skill, result, branch, and a since timestamp.
+    /// Default output is a human-readable table; --json emits an array
+    /// of objects that includes the details field.
+    List {
+        /// Restrict to rows for this skill name.
+        #[arg(long)]
+        skill: Option<String>,
+
+        /// Restrict to rows with this result value: "clean" or "issues".
+        #[arg(long, value_parser = ["clean", "issues"])]
+        result: Option<String>,
+
+        /// Restrict to rows on this branch.
+        #[arg(long)]
+        branch: Option<String>,
+
+        /// Restrict to rows recorded at or after this RFC3339 timestamp.
+        #[arg(long)]
+        since: Option<String>,
+
+        /// Emit JSON array instead of a human table.
+        #[arg(long)]
+        json: bool,
+    },
+
+    /// Show per-skill aggregate statistics.
+    ///
+    /// Prints runs, clean count, issues count, catch rate (issues/runs),
+    /// total findings, and max findings for each skill. The catch rate is
+    /// the rubberstamp tripwire: a rate near zero means the gate is not
+    /// catching anything. --json emits structured rows.
+    Stats {
+        /// Restrict to this skill name.
+        #[arg(long)]
+        skill: Option<String>,
+
+        /// Restrict to rows recorded at or after this RFC3339 timestamp.
+        #[arg(long)]
+        since: Option<String>,
+
+        /// Emit JSON array instead of a human table.
+        #[arg(long)]
+        json: bool,
+    },
 }
 
 pub(crate) fn handle_quality_gate(action: QualityGateAction) -> error::Result<()> {
@@ -56,8 +104,107 @@ pub(crate) fn handle_quality_gate(action: QualityGateAction) -> error::Result<()
             )?;
             println!("{}", row.id);
         }
+
+        QualityGateAction::List {
+            skill,
+            result,
+            branch,
+            since,
+            json,
+        } => {
+            // Parse the optional --result flag into a typed GateResult so an
+            // invalid value surfaces a descriptive error before we touch the DB.
+            let gate_result: Option<GateResult> = match result.as_deref() {
+                Some(r) => Some(GateResult::from_str(r)?),
+                None => None,
+            };
+
+            let database = open_db()?;
+            let rows: Vec<QualityGateRow> = database.list_quality_gates(&QualityGateFilter {
+                skill,
+                result: gate_result,
+                branch,
+                since,
+            })?;
+
+            if json {
+                println!("{}", serde_json::to_string(&rows)?);
+            } else {
+                print_gate_table(&rows);
+            }
+        }
+
+        QualityGateAction::Stats { skill, since, json } => {
+            let database = open_db()?;
+            let stats: Vec<QualityGateStats> =
+                database.quality_gate_stats(skill.as_deref(), since.as_deref())?;
+
+            if json {
+                println!("{}", serde_json::to_string(&stats)?);
+            } else {
+                print_stats_table(&stats);
+            }
+        }
     }
     Ok(())
+}
+
+/// Print gate rows as a human-readable table to stdout.
+///
+/// Columns: id (first 8 chars), branch, commit (first 8 chars), skill,
+/// result, findings, created_at. An empty slice prints nothing.
+fn print_gate_table(rows: &[QualityGateRow]) {
+    if rows.is_empty() {
+        return;
+    }
+    println!(
+        "{:<8}  {:<20}  {:<8}  {:<22}  {:<6}  {:>8}  CREATED",
+        "ID", "BRANCH", "COMMIT", "SKILL", "RESULT", "FINDINGS"
+    );
+    println!("{}", "-".repeat(100));
+    for row in rows {
+        let id_short: String = row.id.chars().take(8).collect();
+        let branch_trunc: String = row.branch.chars().take(20).collect();
+        let commit_short: String = row.commit_hash.chars().take(8).collect();
+        let skill_trunc: String = row.skill.chars().take(22).collect();
+        println!(
+            "{:<8}  {:<20}  {:<8}  {:<22}  {:<6}  {:>8}  {}",
+            id_short,
+            branch_trunc,
+            commit_short,
+            skill_trunc,
+            row.result.as_str(),
+            row.findings_count,
+            row.created_at,
+        );
+    }
+}
+
+/// Print per-skill stats as a human-readable table to stdout.
+///
+/// Columns: skill, runs, clean, issues, catch_rate (%), total_findings,
+/// max_findings. An empty slice prints nothing.
+fn print_stats_table(stats: &[QualityGateStats]) {
+    if stats.is_empty() {
+        return;
+    }
+    println!(
+        "{:<25}  {:>5}  {:>5}  {:>6}  {:>10}  {:>14}  {:>12}",
+        "SKILL", "RUNS", "CLEAN", "ISSUES", "CATCH_RATE", "TOTAL_FINDINGS", "MAX_FINDINGS"
+    );
+    println!("{}", "-".repeat(88));
+    for s in stats {
+        println!(
+            "{:<25}  {:>5}  {:>5}  {:>6}  {:>9.1}%  {:>14}  {:>12}",
+            s.skill,
+            s.runs,
+            s.clean,
+            s.issues,
+            s.catch_rate * 100.0,
+            s.total_findings,
+            s.max_findings,
+        );
+    }
 }
 
 /// Resolve acceptance criteria for a card, with spec-document precedence (#528, #644).

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -13,7 +13,7 @@ mod documents;
 mod health;
 mod heartbeat;
 mod kanban;
-mod quality_gates;
+pub(crate) mod quality_gates;
 mod reflections;
 mod schedules;
 mod scip;

--- a/src/db/quality_gates.rs
+++ b/src/db/quality_gates.rs
@@ -200,7 +200,7 @@ pub struct QualityGateFilter {
 }
 
 /// Aggregate stats for a single skill across matching rows.
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, serde::Serialize)]
 pub struct QualityGateStats {
     pub skill: String,
     /// Total number of gate runs recorded for this skill.
@@ -557,6 +557,10 @@ mod tests {
             None,
         )
         .unwrap();
+        // Force a strictly later timestamp so ORDER BY created_at DESC is
+        // deterministic; two back-to-back inserts can otherwise land in the
+        // same sub-second RFC3339 bucket (same fix as the filter_by_since test).
+        std::thread::sleep(std::time::Duration::from_millis(1));
         db.record_quality_gate(
             "main",
             "hash-b",

--- a/src/db/quality_gates.rs
+++ b/src/db/quality_gates.rs
@@ -219,35 +219,40 @@ pub struct QualityGateStats {
     pub max_findings: u64,
 }
 
+/// Join predicate fragments into a SQL `WHERE` clause, combining them with
+/// `AND`, or the empty string when there are no predicates.
+fn where_and(predicates: &[&str]) -> String {
+    if predicates.is_empty() {
+        String::new()
+    } else {
+        format!("WHERE {}", predicates.join(" AND "))
+    }
+}
+
 impl Database {
     /// Return gate rows matching `filter`, newest first.
     ///
     /// An empty result set is not an error; the caller decides how to
     /// present it. All filter fields are applied with AND semantics.
     pub fn list_quality_gates(&self, filter: &QualityGateFilter) -> Result<Vec<QualityGateRow>> {
-        // Build the WHERE clause dynamically so we only push predicates that
-        // were actually requested. The param vec is built in the same order.
-        let mut predicates: Vec<&str> = Vec::new();
-        let mut params: Vec<Box<dyn rusqlite::ToSql>> = Vec::new();
-
-        if filter.skill.is_some() {
-            predicates.push("skill = ?");
+        // Build (predicate, param) pairs together so a SQL fragment and its
+        // bound value can never drift out of order.
+        let mut clauses: Vec<(&str, Box<dyn rusqlite::ToSql>)> = Vec::new();
+        if let Some(ref s) = filter.skill {
+            clauses.push(("skill = ?", Box::new(s.clone())));
         }
-        if filter.result.is_some() {
-            predicates.push("result = ?");
+        if let Some(ref r) = filter.result {
+            clauses.push(("result = ?", Box::new(r.as_str().to_owned())));
         }
-        if filter.branch.is_some() {
-            predicates.push("branch = ?");
+        if let Some(ref b) = filter.branch {
+            clauses.push(("branch = ?", Box::new(b.clone())));
         }
-        if filter.since.is_some() {
-            predicates.push("created_at >= ?");
+        if let Some(ref ts) = filter.since {
+            clauses.push(("created_at >= ?", Box::new(ts.clone())));
         }
 
-        let where_clause = if predicates.is_empty() {
-            String::new()
-        } else {
-            format!("WHERE {}", predicates.join(" AND "))
-        };
+        let predicates: Vec<&str> = clauses.iter().map(|(p, _)| *p).collect();
+        let where_clause = where_and(&predicates);
 
         let sql = format!(
             "SELECT id, branch, commit_hash, skill, result, findings_count, details, created_at \
@@ -256,23 +261,9 @@ impl Database {
              ORDER BY created_at DESC"
         );
 
-        // Push param values in the same order as the predicates.
-        if let Some(ref s) = filter.skill {
-            params.push(Box::new(s.clone()));
-        }
-        if let Some(ref r) = filter.result {
-            params.push(Box::new(r.as_str().to_owned()));
-        }
-        if let Some(ref b) = filter.branch {
-            params.push(Box::new(b.clone()));
-        }
-        if let Some(ref ts) = filter.since {
-            params.push(Box::new(ts.clone()));
-        }
-
         let mut stmt = self.conn.prepare(&sql)?;
         let rows = stmt.query_map(
-            rusqlite::params_from_iter(params.iter().map(|p| p.as_ref())),
+            rusqlite::params_from_iter(clauses.iter().map(|(_, v)| v.as_ref())),
             |row| {
                 let result_str: String = row.get(4)?;
                 let findings_count_i64: i64 = row.get(5)?;
@@ -307,21 +298,16 @@ impl Database {
         skill: Option<&str>,
         since: Option<&str>,
     ) -> Result<Vec<QualityGateStats>> {
-        let mut predicates: Vec<&str> = Vec::new();
-        let mut params: Vec<Box<dyn rusqlite::ToSql>> = Vec::new();
-
-        if skill.is_some() {
-            predicates.push("skill = ?");
+        let mut clauses: Vec<(&str, Box<dyn rusqlite::ToSql>)> = Vec::new();
+        if let Some(s) = skill {
+            clauses.push(("skill = ?", Box::new(s.to_owned())));
         }
-        if since.is_some() {
-            predicates.push("created_at >= ?");
+        if let Some(ts) = since {
+            clauses.push(("created_at >= ?", Box::new(ts.to_owned())));
         }
 
-        let where_clause = if predicates.is_empty() {
-            String::new()
-        } else {
-            format!("WHERE {}", predicates.join(" AND "))
-        };
+        let predicates: Vec<&str> = clauses.iter().map(|(p, _)| *p).collect();
+        let where_clause = where_and(&predicates);
 
         let sql = format!(
             "SELECT \
@@ -337,16 +323,9 @@ impl Database {
              ORDER BY skill ASC"
         );
 
-        if let Some(s) = skill {
-            params.push(Box::new(s.to_owned()));
-        }
-        if let Some(ts) = since {
-            params.push(Box::new(ts.to_owned()));
-        }
-
         let mut stmt = self.conn.prepare(&sql)?;
         let rows = stmt.query_map(
-            rusqlite::params_from_iter(params.iter().map(|p| p.as_ref())),
+            rusqlite::params_from_iter(clauses.iter().map(|(_, v)| v.as_ref())),
             |row| {
                 let skill_str: String = row.get(0)?;
                 let runs_i64: i64 = row.get(1)?;

--- a/src/db/quality_gates.rs
+++ b/src/db/quality_gates.rs
@@ -183,6 +183,209 @@ impl Database {
     }
 }
 
+/// Filter parameters for `list_quality_gates`.
+///
+/// All fields are optional; `None` means "no filter on this dimension".
+/// Results are ordered newest-first.
+#[derive(Debug, Default)]
+pub struct QualityGateFilter {
+    /// Restrict to rows whose `skill` equals this value.
+    pub skill: Option<String>,
+    /// Restrict to rows whose `result` equals this value.
+    pub result: Option<GateResult>,
+    /// Restrict to rows whose `branch` equals this value.
+    pub branch: Option<String>,
+    /// Restrict to rows whose `created_at` is >= this RFC3339 timestamp.
+    pub since: Option<String>,
+}
+
+/// Aggregate stats for a single skill across matching rows.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct QualityGateStats {
+    pub skill: String,
+    /// Total number of gate runs recorded for this skill.
+    pub runs: u64,
+    /// Runs whose result was "clean".
+    pub clean: u64,
+    /// Runs whose result was "issues".
+    pub issues: u64,
+    /// Fraction of runs that found issues: `issues / runs`.
+    /// Zero when `runs == 0` (unreachable in practice since the row
+    /// only appears when there is at least one run).
+    pub catch_rate: f64,
+    /// Sum of `findings_count` across all matching rows.
+    pub total_findings: u64,
+    /// Maximum `findings_count` across all matching rows.
+    pub max_findings: u64,
+}
+
+impl Database {
+    /// Return gate rows matching `filter`, newest first.
+    ///
+    /// An empty result set is not an error; the caller decides how to
+    /// present it. All filter fields are applied with AND semantics.
+    pub fn list_quality_gates(&self, filter: &QualityGateFilter) -> Result<Vec<QualityGateRow>> {
+        // Build the WHERE clause dynamically so we only push predicates that
+        // were actually requested. The param vec is built in the same order.
+        let mut predicates: Vec<&str> = Vec::new();
+        let mut params: Vec<Box<dyn rusqlite::ToSql>> = Vec::new();
+
+        if filter.skill.is_some() {
+            predicates.push("skill = ?");
+        }
+        if filter.result.is_some() {
+            predicates.push("result = ?");
+        }
+        if filter.branch.is_some() {
+            predicates.push("branch = ?");
+        }
+        if filter.since.is_some() {
+            predicates.push("created_at >= ?");
+        }
+
+        let where_clause = if predicates.is_empty() {
+            String::new()
+        } else {
+            format!("WHERE {}", predicates.join(" AND "))
+        };
+
+        let sql = format!(
+            "SELECT id, branch, commit_hash, skill, result, findings_count, details, created_at \
+             FROM quality_gates \
+             {where_clause} \
+             ORDER BY created_at DESC"
+        );
+
+        // Push param values in the same order as the predicates.
+        if let Some(ref s) = filter.skill {
+            params.push(Box::new(s.clone()));
+        }
+        if let Some(ref r) = filter.result {
+            params.push(Box::new(r.as_str().to_owned()));
+        }
+        if let Some(ref b) = filter.branch {
+            params.push(Box::new(b.clone()));
+        }
+        if let Some(ref ts) = filter.since {
+            params.push(Box::new(ts.clone()));
+        }
+
+        let mut stmt = self.conn.prepare(&sql)?;
+        let rows = stmt.query_map(
+            rusqlite::params_from_iter(params.iter().map(|p| p.as_ref())),
+            |row| {
+                let result_str: String = row.get(4)?;
+                let findings_count_i64: i64 = row.get(5)?;
+                Ok(QualityGateRow {
+                    id: row.get(0)?,
+                    branch: row.get(1)?,
+                    commit_hash: row.get(2)?,
+                    skill: row.get(3)?,
+                    result: parse_result_from_db(result_str)?,
+                    findings_count: findings_count_i64.unsigned_abs(),
+                    details: row.get(6)?,
+                    created_at: row.get(7)?,
+                })
+            },
+        )?;
+
+        let mut out: Vec<QualityGateRow> = Vec::new();
+        for row in rows {
+            out.push(row.map_err(LegionError::Database)?);
+        }
+        Ok(out)
+    }
+
+    /// Return per-skill aggregate statistics, optionally filtered by `skill`
+    /// and/or `since`.
+    ///
+    /// The aggregation runs in SQLite (SUM/COUNT/MAX), then `catch_rate` is
+    /// computed in Rust from the returned counts so no floating-point SQL
+    /// functions are needed. Results are ordered by skill name ascending.
+    pub fn quality_gate_stats(
+        &self,
+        skill: Option<&str>,
+        since: Option<&str>,
+    ) -> Result<Vec<QualityGateStats>> {
+        let mut predicates: Vec<&str> = Vec::new();
+        let mut params: Vec<Box<dyn rusqlite::ToSql>> = Vec::new();
+
+        if skill.is_some() {
+            predicates.push("skill = ?");
+        }
+        if since.is_some() {
+            predicates.push("created_at >= ?");
+        }
+
+        let where_clause = if predicates.is_empty() {
+            String::new()
+        } else {
+            format!("WHERE {}", predicates.join(" AND "))
+        };
+
+        let sql = format!(
+            "SELECT \
+               skill, \
+               COUNT(*) AS runs, \
+               SUM(CASE WHEN result = 'clean'  THEN 1 ELSE 0 END) AS clean, \
+               SUM(CASE WHEN result = 'issues' THEN 1 ELSE 0 END) AS issues, \
+               SUM(findings_count) AS total_findings, \
+               MAX(findings_count) AS max_findings \
+             FROM quality_gates \
+             {where_clause} \
+             GROUP BY skill \
+             ORDER BY skill ASC"
+        );
+
+        if let Some(s) = skill {
+            params.push(Box::new(s.to_owned()));
+        }
+        if let Some(ts) = since {
+            params.push(Box::new(ts.to_owned()));
+        }
+
+        let mut stmt = self.conn.prepare(&sql)?;
+        let rows = stmt.query_map(
+            rusqlite::params_from_iter(params.iter().map(|p| p.as_ref())),
+            |row| {
+                let skill_str: String = row.get(0)?;
+                let runs_i64: i64 = row.get(1)?;
+                let clean_i64: i64 = row.get(2)?;
+                let issues_i64: i64 = row.get(3)?;
+                let total_i64: i64 = row.get(4)?;
+                let max_i64: i64 = row.get(5)?;
+                Ok((
+                    skill_str, runs_i64, clean_i64, issues_i64, total_i64, max_i64,
+                ))
+            },
+        )?;
+
+        let mut out: Vec<QualityGateStats> = Vec::new();
+        for row in rows {
+            let (skill_str, runs_i64, clean_i64, issues_i64, total_i64, max_i64) =
+                row.map_err(LegionError::Database)?;
+            let runs = runs_i64.unsigned_abs();
+            let clean = clean_i64.unsigned_abs();
+            let issues = issues_i64.unsigned_abs();
+            let catch_rate = if runs == 0 {
+                0.0
+            } else {
+                issues as f64 / runs as f64
+            };
+            out.push(QualityGateStats {
+                skill: skill_str,
+                runs,
+                clean,
+                issues,
+                catch_rate,
+                total_findings: total_i64.unsigned_abs(),
+                max_findings: max_i64.unsigned_abs(),
+            });
+        }
+        Ok(out)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::db::testutil::test_db;
@@ -348,5 +551,234 @@ mod tests {
                 .unwrap()
                 .is_none()
         );
+    }
+
+    // --- list_quality_gates tests ---
+
+    #[test]
+    fn list_quality_gates_empty_returns_empty_vec() {
+        use crate::db::quality_gates::QualityGateFilter;
+        let db = test_db();
+        let rows = db
+            .list_quality_gates(&QualityGateFilter::default())
+            .unwrap();
+        assert!(rows.is_empty());
+    }
+
+    #[test]
+    fn list_quality_gates_newest_first() {
+        use crate::db::quality_gates::QualityGateFilter;
+        let db = test_db();
+        db.record_quality_gate(
+            "main",
+            "hash-a",
+            "legion-simplify",
+            GateResult::Clean,
+            0,
+            None,
+        )
+        .unwrap();
+        db.record_quality_gate(
+            "main",
+            "hash-b",
+            "legion-simplify",
+            GateResult::Issues,
+            2,
+            None,
+        )
+        .unwrap();
+
+        let rows = db
+            .list_quality_gates(&QualityGateFilter::default())
+            .unwrap();
+        assert_eq!(rows.len(), 2);
+        // Second insert is more recent; it must appear first.
+        assert_eq!(rows[0].commit_hash, "hash-b");
+        assert_eq!(rows[1].commit_hash, "hash-a");
+    }
+
+    #[test]
+    fn list_quality_gates_filter_by_skill() {
+        use crate::db::quality_gates::QualityGateFilter;
+        let db = test_db();
+        db.record_quality_gate("main", "h1", "legion-simplify", GateResult::Clean, 0, None)
+            .unwrap();
+        db.record_quality_gate("main", "h2", "legion-review", GateResult::Issues, 1, None)
+            .unwrap();
+
+        let rows = db
+            .list_quality_gates(&QualityGateFilter {
+                skill: Some("legion-simplify".to_owned()),
+                ..Default::default()
+            })
+            .unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].skill, "legion-simplify");
+    }
+
+    #[test]
+    fn list_quality_gates_filter_by_result() {
+        use crate::db::quality_gates::QualityGateFilter;
+        let db = test_db();
+        db.record_quality_gate("main", "h1", "legion-simplify", GateResult::Clean, 0, None)
+            .unwrap();
+        db.record_quality_gate("main", "h2", "legion-simplify", GateResult::Issues, 3, None)
+            .unwrap();
+        db.record_quality_gate("main", "h3", "legion-review", GateResult::Clean, 0, None)
+            .unwrap();
+
+        let rows = db
+            .list_quality_gates(&QualityGateFilter {
+                result: Some(GateResult::Issues),
+                ..Default::default()
+            })
+            .unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].result, GateResult::Issues);
+        assert_eq!(rows[0].commit_hash, "h2");
+    }
+
+    #[test]
+    fn list_quality_gates_filter_by_branch() {
+        use crate::db::quality_gates::QualityGateFilter;
+        let db = test_db();
+        db.record_quality_gate("feat/foo", "h1", "s", GateResult::Clean, 0, None)
+            .unwrap();
+        db.record_quality_gate("main", "h2", "s", GateResult::Clean, 0, None)
+            .unwrap();
+
+        let rows = db
+            .list_quality_gates(&QualityGateFilter {
+                branch: Some("feat/foo".to_owned()),
+                ..Default::default()
+            })
+            .unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].branch, "feat/foo");
+    }
+
+    #[test]
+    fn list_quality_gates_filter_by_since() {
+        use crate::db::quality_gates::QualityGateFilter;
+        let db = test_db();
+        // Insert two rows then filter by a timestamp that falls between them.
+        // We control created_at by inserting rows with a known sleep order;
+        // since the DB stores RFC3339 strings and sorts lexicographically we can
+        // insert rows and capture their timestamps to build the filter.
+        let row_a = db
+            .record_quality_gate("main", "h-old", "s", GateResult::Clean, 0, None)
+            .unwrap();
+        // Sleep briefly so the second row has a strictly later timestamp.
+        std::thread::sleep(std::time::Duration::from_millis(10));
+        let row_b = db
+            .record_quality_gate("main", "h-new", "s", GateResult::Issues, 1, None)
+            .unwrap();
+
+        // Filter with since = row_b.created_at -- only row_b should match.
+        let rows = db
+            .list_quality_gates(&QualityGateFilter {
+                since: Some(row_b.created_at.clone()),
+                ..Default::default()
+            })
+            .unwrap();
+        assert_eq!(rows.len(), 1, "expected only the newer row");
+        assert_eq!(rows[0].commit_hash, "h-new");
+        // row_a is before the cutoff.
+        assert!(rows.iter().all(|r| r.commit_hash != row_a.commit_hash));
+    }
+
+    // --- quality_gate_stats tests ---
+
+    #[test]
+    fn quality_gate_stats_empty_returns_empty_vec() {
+        let db = test_db();
+        let stats = db.quality_gate_stats(None, None).unwrap();
+        assert!(stats.is_empty());
+    }
+
+    #[test]
+    fn quality_gate_stats_counts_and_catch_rate() {
+        let db = test_db();
+        // 3 runs for legion-simplify: 1 clean, 2 issues.
+        db.record_quality_gate("main", "h1", "legion-simplify", GateResult::Clean, 0, None)
+            .unwrap();
+        db.record_quality_gate("main", "h2", "legion-simplify", GateResult::Issues, 5, None)
+            .unwrap();
+        db.record_quality_gate("main", "h3", "legion-simplify", GateResult::Issues, 3, None)
+            .unwrap();
+        // 1 run for legion-review: 1 clean, findings = 0.
+        db.record_quality_gate("main", "h4", "legion-review", GateResult::Clean, 0, None)
+            .unwrap();
+
+        let stats = db.quality_gate_stats(None, None).unwrap();
+        assert_eq!(stats.len(), 2, "expected two skill rows");
+
+        // Results are skill-ordered ASC: legion-review first.
+        let review = &stats[0];
+        assert_eq!(review.skill, "legion-review");
+        assert_eq!(review.runs, 1);
+        assert_eq!(review.clean, 1);
+        assert_eq!(review.issues, 0);
+        assert!((review.catch_rate - 0.0).abs() < f64::EPSILON);
+        assert_eq!(review.total_findings, 0);
+        assert_eq!(review.max_findings, 0);
+
+        let simplify = &stats[1];
+        assert_eq!(simplify.skill, "legion-simplify");
+        assert_eq!(simplify.runs, 3);
+        assert_eq!(simplify.clean, 1);
+        assert_eq!(simplify.issues, 2);
+        // catch_rate = issues / runs = 2/3
+        let expected_rate = 2.0_f64 / 3.0_f64;
+        assert!(
+            (simplify.catch_rate - expected_rate).abs() < 1e-10,
+            "catch_rate mismatch: {} vs {}",
+            simplify.catch_rate,
+            expected_rate
+        );
+        assert_eq!(simplify.total_findings, 8); // 0 + 5 + 3
+        assert_eq!(simplify.max_findings, 5);
+    }
+
+    #[test]
+    fn quality_gate_stats_filter_by_skill() {
+        let db = test_db();
+        db.record_quality_gate("main", "h1", "legion-simplify", GateResult::Issues, 2, None)
+            .unwrap();
+        db.record_quality_gate("main", "h2", "legion-review", GateResult::Clean, 0, None)
+            .unwrap();
+
+        let stats = db
+            .quality_gate_stats(Some("legion-simplify"), None)
+            .unwrap();
+        assert_eq!(stats.len(), 1);
+        assert_eq!(stats[0].skill, "legion-simplify");
+        assert_eq!(stats[0].issues, 1);
+    }
+
+    #[test]
+    fn quality_gate_stats_catch_rate_all_clean() {
+        let db = test_db();
+        db.record_quality_gate("main", "h1", "s", GateResult::Clean, 0, None)
+            .unwrap();
+        db.record_quality_gate("main", "h2", "s", GateResult::Clean, 0, None)
+            .unwrap();
+
+        let stats = db.quality_gate_stats(None, None).unwrap();
+        assert_eq!(stats.len(), 1);
+        assert!((stats[0].catch_rate - 0.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn quality_gate_stats_catch_rate_all_issues() {
+        let db = test_db();
+        db.record_quality_gate("main", "h1", "s", GateResult::Issues, 1, None)
+            .unwrap();
+        db.record_quality_gate("main", "h2", "s", GateResult::Issues, 1, None)
+            .unwrap();
+
+        let stats = db.quality_gate_stats(None, None).unwrap();
+        assert_eq!(stats.len(), 1);
+        assert!((stats[0].catch_rate - 1.0).abs() < f64::EPSILON);
     }
 }

--- a/tests/integration/worksource_pr.rs
+++ b/tests/integration/worksource_pr.rs
@@ -1003,12 +1003,17 @@ fn quality_gate_list_filter_by_result() {
 
     let stdout =
         run_ok(legion_cmd(dir.path()).args(["quality-gate", "list", "--result", "issues"]));
-    // There should be exactly one row (issues). The clean row should be absent.
-    // We check the findings count column since "issues" appears in both result
-    // and the header word "ISSUES".
+    // Exactly one row (issues); the clean row must be filtered out. Assert both
+    // that the issues row is present (findings_count=2) AND that the clean row is
+    // absent -- "clean" appears nowhere in the header or the issues row, so its
+    // absence confirms the filter where contains("2") alone could not.
     assert!(
         stdout.contains("2"),
         "expected findings_count=2 in the issues row, got: {stdout}"
+    );
+    assert!(
+        !stdout.contains("clean"),
+        "expected the clean row to be filtered out, got: {stdout}"
     );
 }
 

--- a/tests/integration/worksource_pr.rs
+++ b/tests/integration/worksource_pr.rs
@@ -873,3 +873,333 @@ fn done_propagation_failure_warns_on_stdout() {
         "expected the stdout partial-failure warning, got: {stdout}"
     );
 }
+
+// --- quality-gate list + stats integration tests (#666) ---
+
+/// `legion quality-gate list` with no rows prints nothing and exits 0.
+#[test]
+fn quality_gate_list_empty_exits_zero_with_no_output() {
+    let dir = tempfile::tempdir().unwrap();
+    let stdout = run_ok(legion_cmd(dir.path()).args(["quality-gate", "list"]));
+    assert!(
+        stdout.is_empty(),
+        "expected no output for empty gate corpus, got: {stdout}"
+    );
+}
+
+/// `legion quality-gate list --json` with no rows prints `[]` and exits 0.
+#[test]
+fn quality_gate_list_empty_json_prints_empty_array() {
+    let dir = tempfile::tempdir().unwrap();
+    let stdout = run_ok(legion_cmd(dir.path()).args(["quality-gate", "list", "--json"]));
+    assert_eq!(
+        stdout.trim(),
+        "[]",
+        "expected [] for empty gate corpus with --json, got: {stdout}"
+    );
+}
+
+/// `legion quality-gate list` shows recorded rows in the human table.
+#[test]
+fn quality_gate_list_shows_recorded_rows() {
+    let dir = tempfile::tempdir().unwrap();
+
+    // Seed two rows with different skills.
+    run_ok(legion_cmd(dir.path()).args([
+        "quality-gate",
+        "record",
+        "--skill",
+        "legion-simplify",
+        "--result",
+        "clean",
+    ]));
+    run_ok(legion_cmd(dir.path()).args([
+        "quality-gate",
+        "record",
+        "--skill",
+        "legion-review",
+        "--result",
+        "issues",
+        "--findings-count",
+        "3",
+    ]));
+
+    let stdout = run_ok(legion_cmd(dir.path()).args(["quality-gate", "list"]));
+    assert!(
+        stdout.contains("legion-simplify"),
+        "expected simplify row in list output, got: {stdout}"
+    );
+    assert!(
+        stdout.contains("legion-review"),
+        "expected review row in list output, got: {stdout}"
+    );
+    assert!(
+        stdout.contains("clean"),
+        "expected 'clean' result in list output, got: {stdout}"
+    );
+    assert!(
+        stdout.contains("issues"),
+        "expected 'issues' result in list output, got: {stdout}"
+    );
+}
+
+/// `legion quality-gate list --skill` filters to the named skill only.
+#[test]
+fn quality_gate_list_filter_by_skill() {
+    let dir = tempfile::tempdir().unwrap();
+
+    run_ok(legion_cmd(dir.path()).args([
+        "quality-gate",
+        "record",
+        "--skill",
+        "legion-simplify",
+        "--result",
+        "clean",
+    ]));
+    run_ok(legion_cmd(dir.path()).args([
+        "quality-gate",
+        "record",
+        "--skill",
+        "legion-review",
+        "--result",
+        "issues",
+    ]));
+
+    let stdout =
+        run_ok(legion_cmd(dir.path()).args(["quality-gate", "list", "--skill", "legion-review"]));
+    assert!(
+        stdout.contains("legion-review"),
+        "expected review row, got: {stdout}"
+    );
+    assert!(
+        !stdout.contains("legion-simplify"),
+        "simplify row should be filtered out, got: {stdout}"
+    );
+}
+
+/// `legion quality-gate list --result issues` filters to issues-only rows.
+#[test]
+fn quality_gate_list_filter_by_result() {
+    let dir = tempfile::tempdir().unwrap();
+
+    run_ok(legion_cmd(dir.path()).args([
+        "quality-gate",
+        "record",
+        "--skill",
+        "s",
+        "--result",
+        "clean",
+    ]));
+    run_ok(legion_cmd(dir.path()).args([
+        "quality-gate",
+        "record",
+        "--skill",
+        "s",
+        "--result",
+        "issues",
+        "--findings-count",
+        "2",
+    ]));
+
+    let stdout =
+        run_ok(legion_cmd(dir.path()).args(["quality-gate", "list", "--result", "issues"]));
+    // There should be exactly one row (issues). The clean row should be absent.
+    // We check the findings count column since "issues" appears in both result
+    // and the header word "ISSUES".
+    assert!(
+        stdout.contains("2"),
+        "expected findings_count=2 in the issues row, got: {stdout}"
+    );
+}
+
+/// `legion quality-gate list --result bad-value` exits non-zero with a typed error.
+#[test]
+fn quality_gate_list_invalid_result_value_exits_nonzero() {
+    let dir = tempfile::tempdir().unwrap();
+    // clap value_parser rejects unknown values before the handler runs.
+    let (_stdout, stderr) =
+        run_fail(legion_cmd(dir.path()).args(["quality-gate", "list", "--result", "bad-value"]));
+    // clap emits an error mentioning the bad value or the possible values.
+    assert!(
+        stderr.contains("bad-value") || stderr.contains("possible values"),
+        "expected error about invalid result value, got: {stderr}"
+    );
+}
+
+/// `legion quality-gate list --json` emits a JSON array with all fields including details.
+#[test]
+fn quality_gate_list_json_emits_array_with_details() {
+    let dir = tempfile::tempdir().unwrap();
+    let details = r#"{"findings":[]}"#;
+
+    run_ok(legion_cmd(dir.path()).args([
+        "quality-gate",
+        "record",
+        "--skill",
+        "legion-simplify",
+        "--result",
+        "issues",
+        "--findings-count",
+        "1",
+        "--details-json",
+        details,
+    ]));
+
+    let stdout = run_ok(legion_cmd(dir.path()).args(["quality-gate", "list", "--json"]));
+    let parsed: serde_json::Value =
+        serde_json::from_str(&stdout).expect("expected valid JSON array");
+    let arr = parsed.as_array().expect("expected a JSON array");
+    assert_eq!(arr.len(), 1, "expected one row");
+
+    let row = &arr[0];
+    assert_eq!(row["skill"].as_str().unwrap(), "legion-simplify");
+    assert_eq!(row["result"].as_str().unwrap(), "issues");
+    assert_eq!(row["findings_count"].as_u64().unwrap(), 1);
+    // details field must be present in JSON output.
+    assert!(
+        row["details"].is_string() || row["details"].is_null(),
+        "expected details field in JSON row"
+    );
+}
+
+/// `legion quality-gate stats` with no rows prints nothing and exits 0.
+#[test]
+fn quality_gate_stats_empty_exits_zero_with_no_output() {
+    let dir = tempfile::tempdir().unwrap();
+    let stdout = run_ok(legion_cmd(dir.path()).args(["quality-gate", "stats"]));
+    assert!(
+        stdout.is_empty(),
+        "expected no output for empty gate corpus, got: {stdout}"
+    );
+}
+
+/// `legion quality-gate stats --json` with no rows prints `[]`.
+#[test]
+fn quality_gate_stats_empty_json_prints_empty_array() {
+    let dir = tempfile::tempdir().unwrap();
+    let stdout = run_ok(legion_cmd(dir.path()).args(["quality-gate", "stats", "--json"]));
+    assert_eq!(
+        stdout.trim(),
+        "[]",
+        "expected [] for empty stats with --json, got: {stdout}"
+    );
+}
+
+/// `legion quality-gate stats` shows per-skill aggregates in the human table.
+#[test]
+fn quality_gate_stats_shows_per_skill_aggregates() {
+    let dir = tempfile::tempdir().unwrap();
+
+    // 2 runs for legion-simplify: 1 clean, 1 issues (1 finding).
+    run_ok(legion_cmd(dir.path()).args([
+        "quality-gate",
+        "record",
+        "--skill",
+        "legion-simplify",
+        "--result",
+        "clean",
+    ]));
+    run_ok(legion_cmd(dir.path()).args([
+        "quality-gate",
+        "record",
+        "--skill",
+        "legion-simplify",
+        "--result",
+        "issues",
+        "--findings-count",
+        "1",
+    ]));
+
+    let stdout = run_ok(legion_cmd(dir.path()).args(["quality-gate", "stats"]));
+    assert!(
+        stdout.contains("legion-simplify"),
+        "expected skill row in stats output, got: {stdout}"
+    );
+    // 2 runs total.
+    assert!(
+        stdout.contains('2'),
+        "expected run count of 2, got: {stdout}"
+    );
+}
+
+/// `legion quality-gate stats --json` returns a JSON array with catch_rate field.
+#[test]
+fn quality_gate_stats_json_shape() {
+    let dir = tempfile::tempdir().unwrap();
+
+    // 3 runs: 1 clean, 2 issues.
+    for _ in 0..2 {
+        run_ok(legion_cmd(dir.path()).args([
+            "quality-gate",
+            "record",
+            "--skill",
+            "s",
+            "--result",
+            "issues",
+            "--findings-count",
+            "1",
+        ]));
+    }
+    run_ok(legion_cmd(dir.path()).args([
+        "quality-gate",
+        "record",
+        "--skill",
+        "s",
+        "--result",
+        "clean",
+    ]));
+
+    let stdout = run_ok(legion_cmd(dir.path()).args(["quality-gate", "stats", "--json"]));
+    let parsed: serde_json::Value =
+        serde_json::from_str(&stdout).expect("expected valid JSON array");
+    let arr = parsed.as_array().expect("expected a JSON array");
+    assert_eq!(arr.len(), 1);
+
+    let row = &arr[0];
+    assert_eq!(row["skill"].as_str().unwrap(), "s");
+    assert_eq!(row["runs"].as_u64().unwrap(), 3);
+    assert_eq!(row["clean"].as_u64().unwrap(), 1);
+    assert_eq!(row["issues"].as_u64().unwrap(), 2);
+    // catch_rate = 2/3 ~= 0.6667
+    let catch_rate = row["catch_rate"].as_f64().unwrap();
+    assert!(
+        (catch_rate - 2.0 / 3.0).abs() < 1e-6,
+        "catch_rate should be ~0.6667, got: {catch_rate}"
+    );
+    assert_eq!(row["total_findings"].as_u64().unwrap(), 2);
+    assert_eq!(row["max_findings"].as_u64().unwrap(), 1);
+}
+
+/// `legion quality-gate stats --skill` filters the aggregate to that skill only.
+#[test]
+fn quality_gate_stats_filter_by_skill() {
+    let dir = tempfile::tempdir().unwrap();
+
+    run_ok(legion_cmd(dir.path()).args([
+        "quality-gate",
+        "record",
+        "--skill",
+        "legion-simplify",
+        "--result",
+        "clean",
+    ]));
+    run_ok(legion_cmd(dir.path()).args([
+        "quality-gate",
+        "record",
+        "--skill",
+        "legion-review",
+        "--result",
+        "issues",
+    ]));
+
+    let stdout = run_ok(legion_cmd(dir.path()).args([
+        "quality-gate",
+        "stats",
+        "--skill",
+        "legion-simplify",
+        "--json",
+    ]));
+    let arr: Vec<serde_json::Value> = serde_json::from_str(&stdout).expect("expected JSON array");
+    assert_eq!(arr.len(), 1, "expected only one skill row");
+    assert_eq!(arr[0]["skill"].as_str().unwrap(), "legion-simplify");
+}


### PR DESCRIPTION
## Summary

Adds a read path to the `quality-gate` CLI, which until now was record-only. Two new read-only subcommands -- `list` (filterable gate rows) and `stats` (per-skill aggregate with catch rate) -- make the gate corpus auditable through the binary instead of requiring raw SQL against the store (which the no-direct-db hook blocks by design). This is the tooling that turns "are agents rubberstamping a gate?" into a one-line query, and makes a near-zero catch rate a visible tripwire rather than something only found by hand.

## Acceptance criteria mapping

### 1. quality-gate stats --json returns per-skill runs/clean/issues/catch-rate
`quality_gate_stats` aggregates in SQLite (COUNT, SUM(CASE...), MAX) grouped by skill, then computes `catch_rate = issues / runs` in Rust from the returned counts so no floating-point SQL is needed. The `Stats` CLI arm serializes the `QualityGateStats` vec (skill, runs, clean, issues, catch_rate as a float, total_findings, max_findings) directly to JSON under `--json`, or renders a table otherwise. catch_rate is guarded against divide-by-zero (returns 0.0 when runs is 0, though a grouped row only exists when runs >= 1).
Evidence: `src/db/quality_gates.rs` `quality_gate_stats`; `src/cli/verify.rs` `Stats` arm; unit test `quality_gate_stats_counts_and_catch_rate` asserts 2/3 catch_rate, total/max findings; integration test `quality_gate_stats_json_shape`.

### 2. quality-gate list filters by skill/result/branch/since
`list_quality_gates` builds (predicate, param) pairs only for the filter fields that are `Some`, joins them with AND via the `where_and` helper, and binds params in provably-matching order (pairs are built together). `--result` is parsed into the `GateResult` enum so an invalid value is rejected before the DB is touched. Rows are returned newest-first (`ORDER BY created_at DESC`).
Evidence: `src/db/quality_gates.rs` `list_quality_gates` + `QualityGateFilter`; unit tests `list_quality_gates_filter_by_skill` / `_by_result` / `_by_branch` / `_by_since` and `_newest_first`; integration tests `quality_gate_list_filter_by_skill` / `_by_result`.

### 3. Read-only; no write path added
The change adds only `SELECT` queries (`list_quality_gates`, `quality_gate_stats`) and read-side CLI arms; no INSERT/UPDATE/DELETE and no new mutation surface. The existing `record` path is untouched. `src/db/mod.rs` only widens the `quality_gates` module to `pub(crate)` so the CLI can name the new read types -- no behavior change.
Evidence: diff contains no write SQL; `src/db/mod.rs` is a single visibility change; `record_quality_gate` is unchanged.

### 4. Tests cover filters + stats math + json shape
11 unit tests at the DB layer cover the empty case, newest-first ordering, every individual filter, and the stats math (counts, catch_rate including all-clean=0.0 and all-issues=1.0 edges). 12 integration tests drive the actual CLI and assert table output, JSON array shape, details inclusion, and empty-set behavior (`[]` for json, nothing for table, exit 0).
Evidence: `src/db/quality_gates.rs` test module (11 tests); `tests/integration/worksource_pr.rs` (12 tests); full suite green (1096 bin + integration).

### 5. Simplify + review passes complete; PR linked
The simplify gate ran for real and caught two findings on the first pass (duplicated WHERE construction; order-coupled predicate/param vecs), recorded as `issues` (gate 019edddf), fixed in commit cc647e7 (extract `where_and`, pair predicates with params), then re-recorded clean (gate 019edde2) -- the healthy found-fixed-reclean cycle, not a rubber stamp. Review runs next per pipeline order. This PR references #666 in title and body, branch `feat/666-quality-gate-list`.
Evidence: simplify gates 019edddf (issues) -> 019edde2 (clean) on HEAD cc647e7; commit cc647e7.

## Not done

The `--result` valid-value set is declared in clap (`["clean","issues"]`) separately from `GateResult::from_str` -- a minor second source of truth, left as-is deliberately: two stable values, and a clap `ValueEnum` derive would be over-abstraction for them. No `serve`/dashboard view of the stats (the JSON is consumable later; out of scope per the issue). No change to the record path or the append model. No cross-repo aggregation beyond the local store.