### PR TITLE
feat(#665): simplify articulation forcing-function (kill the rubber stamp)

### DIFF
--- a/plugin/skills/legion-simplify/SKILL.md
+++ b/plugin/skills/legion-simplify/SKILL.md
@@ -2,118 +2,94 @@
 name: legion-simplify
 description: |
   Review the current branch diff for code quality issues: duplicate logic, unnecessary
-  abstraction, stringly-typed state, and other structural problems. Produces structured
-  JSON output and records the result via `legion quality-gate record` so `legion pr create`
-  can verify clean state before opening a PR. Run this on every feature branch before
-  creating a PR.
-version: 1.0.0
+  abstraction, stringly-typed state, and other structural problems. Articulate, per changed
+  file, what you checked and why the verdict holds; `legion quality-gate check` validates the
+  articulation (coverage + non-boilerplate) and records the gate so `legion pr create` can
+  verify clean state before opening a PR. Run this on every feature branch before a PR.
+version: 2.0.0
 user-invocable: true
 allowed-tools: Bash, Read
 ---
 
 # Legion Simplify
 
-Review the git diff on this branch for structural quality issues. Record the result
-via `legion quality-gate record` so `legion pr create` can gate on it.
+Review the git diff on this branch for structural quality issues, and write down -- per
+changed file -- what you checked and the reasoning behind your verdict. `legion quality-gate
+check` refuses the gate unless every changed file is addressed with real prose, then records
+it so `legion pr create` can gate on it.
+
+This is a forcing function, not a checkbox. The old version of this skill let you record
+`"clean"` without reading the diff, and the corpus proved it: simplify caught structural
+issues 0.7% of the time while `pr write-check` -- the same self-review, but with validated
+prose -- caught 24%. You cannot clear this gate by typing "clean". You clear it by showing,
+file by file, the reasoning that says clean.
 
 ## What to Review
 
-Inspect the output of `git diff main..HEAD` (or `git diff origin/main..HEAD`).
+Inspect `git diff main..HEAD` (or `git diff origin/main..HEAD`). For each changed file, look for:
 
-Look for:
-
-- **Duplicate logic** -- same transformation or check written twice in different places;
-  could be extracted to a shared helper
+- **Duplicate logic** -- same transformation or check written twice; extract a shared helper
 - **Unnecessary abstraction** -- a wrapper or trait that adds indirection without buying
   extensibility; flatten it
-- **Stringly-typed state** -- `status: String` where `"pending" | "done"` would be an enum;
-  suggest the enum
-- **Hand-rolled helpers** -- functions that duplicate something already in `std` or an
-  existing module helper
-- **Unnecessary new parameters** -- a parameter that is always the same value at every
-  call site
-- **Copy-paste variations** -- two near-identical blocks that differ by one variable;
-  could be a loop or a shared function with a parameter
+- **Stringly-typed state** -- `status: String` where `"pending" | "done"` would be an enum
+- **Hand-rolled helpers** -- functions duplicating something already in `std` or a module helper
+- **Unnecessary new parameters** -- a parameter that is the same value at every call site
+- **Copy-paste variations** -- two near-identical blocks differing by one variable; loop or parametrize
 - **Error swallowing** -- `.unwrap_or(())` or `let _ =` on a result that should propagate
-- **Unused comments that narrate the change** -- comments that say what the diff did rather
-  than why the code exists
+- **Change-narrating comments** -- comments saying what the diff did rather than why the code exists
 
-Do NOT flag:
-- Style preferences (naming, ordering) unless they violate project conventions
-- Things that are outside the diff (pre-existing issues)
-- Hypothetical future improvements unrelated to the changed code
+Do NOT flag: style preferences (naming, ordering) unless they violate project conventions;
+pre-existing issues outside the diff; hypothetical future improvements.
 
-## Output Format
+## Output: the articulation file
 
-Produce a JSON object:
+Write a markdown file with one `### <path>` entry per changed file in the diff. Every changed
+file must have an entry -- the validator refuses on any gap. Each entry is composed prose, not
+a checklist: name the categories you actually checked against this file's hunks and give the
+reasoning for the verdict. Entries under ~12 words are rejected as boilerplate, so a bare
+"clean" or a restated category list will not pass. A `clean` verdict still requires the
+reasoning -- "I read X, the duplicated-looking Y is justified because Z." A finding states the
+problem, the file:line, and the fix.
 
-```json
-{
-  "result": "clean",
-  "findings_count": 0,
-  "findings": []
-}
+```markdown
+### src/db/foo.rs
+Checked for duplicate logic and stringly-typed state across the two new query methods. The
+WHERE-clause construction is identical in both (lines 40 and 92) -- duplicate logic, extractable
+to a helper. State uses the GateResult enum, not strings -- clean there. No new abstraction.
+Verdict: finding (duplication, MED).
+
+### src/cli/bar.rs
+Two table-printer fns look copy-pasted but diverge in columns and alignment; merging them would
+need a generic table abstraction that costs more than the duplication saves -- intentionally left.
+Error paths propagate via `?`. No stringly-typed state. Verdict: clean.
 ```
-
-Or with findings:
-
-```json
-{
-  "result": "issues",
-  "findings_count": 2,
-  "findings": [
-    {
-      "severity": "HIGH",
-      "file": "src/db.rs",
-      "line": 142,
-      "issue": "same date-formatting logic duplicated from format_date helper on line 13",
-      "suggestion": "call format_date() instead"
-    },
-    {
-      "severity": "MED",
-      "file": "src/main.rs",
-      "line": 310,
-      "issue": "status field is String but only ever 'pending' or 'done'",
-      "suggestion": "introduce a Status enum with Pending and Done variants"
-    }
-  ]
-}
-```
-
-Severity is `HIGH` (structural problem that will compound) or `MED` (worth fixing but
-not blocking).
-
-## Recording the Result
-
-After producing the JSON, record it via:
-
-```bash
-legion quality-gate record \
-  --skill legion-simplify \
-  --result <clean|issues> \
-  --findings-count <N> \
-  --details-json '<full JSON>'
-```
-
-The command reads `git rev-parse HEAD` and `git rev-parse --abbrev-ref HEAD` automatically.
-It prints the gate row ID on success.
 
 ## Procedure
 
-1. Run `git diff main..HEAD` (fall back to `git diff origin/main..HEAD` if main is not local).
-2. Read the changed files named in the diff to understand context.
-3. Review each changed hunk for the issues listed above.
-4. Produce the JSON result.
-5. Call `legion quality-gate record` to persist it.
-6. Print the JSON so the caller can see the findings.
+1. `git diff --name-only main..HEAD` (fall back to `origin/main..HEAD`) -- this is your coverage list.
+2. For EACH changed file: read it, review its hunks against the categories above, and write its
+   `### <path>` entry with real reasoning.
+3. Write the articulation to a file (e.g. `/tmp/simplify-<branch>.md`).
+4. Validate and record:
+   ```bash
+   legion quality-gate check \
+     --skill legion-simplify \
+     --result <clean|issues> \
+     --findings-count <N> \
+     --articulation-file /tmp/simplify-<branch>.md
+   ```
+   `--findings-count` is the number of real structural findings you recorded (0 for a clean
+   verdict). The validator resolves the changed-file set from git, checks every file has a
+   non-boilerplate entry, then records the gate for HEAD.
+   - Clean -> the gate is recorded; proceed to pr-write.
+   - Refused -> the output names the gap (an unaddressed file, a boilerplate entry). Fix it by
+     actually reading that file and writing real reasoning -- do not pad to clear the check. Re-run.
+5. If your verdict is `issues`, fix the findings, then re-run from step 1 on the new HEAD (the
+   gate is HEAD-keyed) until the articulation is clean.
 
 ## Pass Criteria for `legion pr create`
 
-`legion pr create` calls `legion quality-gate record` implicitly by checking the DB before
-opening the PR. The gate passes only when:
-
-- A gate row exists for the current HEAD commit hash
-- The row's `result` is `"clean"`
-
-If you find issues, fix them (or note them as acceptable with a rationale), then re-run
-this skill. The most recent gate row for the commit wins.
+`legion pr create` checks the DB before opening the PR. The gate passes only when a gate row
+exists for the current HEAD commit hash with `result = "clean"`. Because the gate is recorded
+only by `legion quality-gate check`, a clean row now means an accepted per-file articulation
+exists -- not merely that someone typed "clean".

--- a/plugin/skills/legion-simplify/SKILL.md
+++ b/plugin/skills/legion-simplify/SKILL.md
@@ -26,7 +26,9 @@ file by file, the reasoning that says clean.
 
 ## What to Review
 
-Inspect `git diff main..HEAD` (or `git diff origin/main..HEAD`). For each changed file, look for:
+Inspect `git diff main...HEAD` (or `git diff origin/main...HEAD`). Use the three-dot form
+(`...`) -- it diffs against the merge base, so files changed only on main since your branch
+point do not appear in your coverage list. The validator uses the same three-dot range. For each changed file, look for:
 
 - **Duplicate logic** -- same transformation or check written twice; extract a shared helper
 - **Unnecessary abstraction** -- a wrapper or trait that adds indirection without buying
@@ -66,7 +68,11 @@ Error paths propagate via `?`. No stringly-typed state. Verdict: clean.
 
 ## Procedure
 
-1. `git diff --name-only main..HEAD` (fall back to `origin/main..HEAD`) -- this is your coverage list.
+1. `git -c core.quotePath=false diff --name-only main...HEAD` (fall back to
+   `origin/main...HEAD`) -- this is your coverage list. The `-c core.quotePath=false` flag
+   ensures paths with non-ASCII characters are returned unescaped, matching the headings you
+   write in step 2. Use `### <path>` headings that are repo-root-relative paths exactly as
+   git reports them (e.g. `### src/café.rs`, not an escaped or shortened form).
 2. For EACH changed file: read it, review its hunks against the categories above, and write its
    `### <path>` entry with real reasoning.
 3. Write the articulation to a file (e.g. `/tmp/simplify-<branch>.md`).

--- a/src/cli/util.rs
+++ b/src/cli/util.rs
@@ -129,9 +129,15 @@ pub(crate) fn git_changed_files() -> Result<std::collections::HashSet<String>, e
             return Ok(set);
         }
     }
-    // Both attempts failed. Return an empty set rather than hard-erroring so
-    // the validator can still run (it will vacuously pass with no files, which
-    // is correct for an initial commit with no base branch).
+    // Both attempts failed. This is expected for an initial commit with no
+    // base branch (the validator then vacuously passes). But it can also mean
+    // git itself failed -- warn so a misconfigured environment does not
+    // silently disable the gate by reporting zero changed files.
+    eprintln!(
+        "[legion] warning: could not resolve changed files from main..HEAD or \
+         origin/main..HEAD; simplify-check will see an empty changed-set. If this \
+         branch has a base, the gate may pass without checking coverage."
+    );
     Ok(std::collections::HashSet::new())
 }
 

--- a/src/cli/util.rs
+++ b/src/cli/util.rs
@@ -102,6 +102,39 @@ pub(crate) fn read_file_or_stdin(
     }
 }
 
+/// List files changed between main (or origin/main) and HEAD.
+///
+/// Runs `git diff --name-only main..HEAD`. When `main` is not present locally
+/// (e.g. on a freshly checked-out feature branch in CI), falls back to
+/// `origin/main..HEAD`. Returns one path per line, trimmed, with blank lines
+/// discarded.
+///
+/// Used by `legion quality-gate check` to build the coverage set the
+/// articulation must address.
+pub(crate) fn git_changed_files() -> Result<std::collections::HashSet<String>, error::LegionError> {
+    // Try `main` first, fall back to `origin/main`.
+    let refs: [&str; 2] = ["main..HEAD", "origin/main..HEAD"];
+    for refspec in refs {
+        let out = std::process::Command::new("git")
+            .args(["diff", "--name-only", refspec])
+            .output()
+            .map_err(|e| error::LegionError::WorkSource(format!("failed to run git diff: {e}")))?;
+        if out.status.success() {
+            let set = String::from_utf8_lossy(&out.stdout)
+                .lines()
+                .map(str::trim)
+                .filter(|l| !l.is_empty())
+                .map(str::to_owned)
+                .collect();
+            return Ok(set);
+        }
+    }
+    // Both attempts failed. Return an empty set rather than hard-erroring so
+    // the validator can still run (it will vacuously pass with no files, which
+    // is correct for an initial commit with no base branch).
+    Ok(std::collections::HashSet::new())
+}
+
 pub(crate) fn format_age(d: std::time::Duration) -> String {
     let secs = d.as_secs();
     if secs < 60 {

--- a/src/cli/util.rs
+++ b/src/cli/util.rs
@@ -104,41 +104,106 @@ pub(crate) fn read_file_or_stdin(
 
 /// List files changed between main (or origin/main) and HEAD.
 ///
-/// Runs `git diff --name-only main..HEAD`. When `main` is not present locally
-/// (e.g. on a freshly checked-out feature branch in CI), falls back to
-/// `origin/main..HEAD`. Returns one path per line, trimmed, with blank lines
-/// discarded.
+/// Uses `git diff -c core.quotePath=false --name-only main...HEAD` (three-dot
+/// merge-base range) so that files changed only on main since the branch point
+/// do not appear in the set. Falls back to `origin/main...HEAD` when `main` is
+/// absent locally.
+///
+/// Before trying the diff, each candidate base ref is probed with
+/// `git rev-parse --verify <ref>`. When a ref resolves but the diff command
+/// still fails, that is a hard error (the environment is broken, not a
+/// legitimate no-base situation). When neither ref resolves AND HEAD has no
+/// parent commit (initial commit), an empty set is returned so the gate passes
+/// vacuously. In any other failure mode this function returns `Err` so the
+/// caller can refuse to record a gate rather than silently accepting vacuous
+/// coverage.
 ///
 /// Used by `legion quality-gate check` to build the coverage set the
 /// articulation must address.
 pub(crate) fn git_changed_files() -> Result<std::collections::HashSet<String>, error::LegionError> {
-    // Try `main` first, fall back to `origin/main`.
-    let refs: [&str; 2] = ["main..HEAD", "origin/main..HEAD"];
-    for refspec in refs {
-        let out = std::process::Command::new("git")
-            .args(["diff", "--name-only", refspec])
+    // Probe whether git is available at all first.
+    let probe = std::process::Command::new("git")
+        .args(["rev-parse", "--is-inside-work-tree"])
+        .output()
+        .map_err(|e| {
+            error::LegionError::WorkSource(format!("failed to run git (is it installed?): {e}"))
+        })?;
+    if !probe.status.success() {
+        return Err(error::LegionError::WorkSource(
+            "git rev-parse --is-inside-work-tree failed -- not inside a git repo".to_owned(),
+        ));
+    }
+
+    // Probe each candidate base ref. Collect the ones that resolve.
+    let candidates: [&str; 2] = ["main", "origin/main"];
+    let mut resolved_base: Option<&str> = None;
+    for candidate in candidates {
+        let verify = std::process::Command::new("git")
+            .args(["rev-parse", "--verify", candidate])
             .output()
-            .map_err(|e| error::LegionError::WorkSource(format!("failed to run git diff: {e}")))?;
-        if out.status.success() {
-            let set = String::from_utf8_lossy(&out.stdout)
-                .lines()
-                .map(str::trim)
-                .filter(|l| !l.is_empty())
-                .map(str::to_owned)
-                .collect();
-            return Ok(set);
+            .map_err(|e| {
+                error::LegionError::WorkSource(format!(
+                    "failed to probe git ref '{candidate}': {e}"
+                ))
+            })?;
+        if verify.status.success() {
+            resolved_base = Some(candidate);
+            break;
         }
     }
-    // Both attempts failed. This is expected for an initial commit with no
-    // base branch (the validator then vacuously passes). But it can also mean
-    // git itself failed -- warn so a misconfigured environment does not
-    // silently disable the gate by reporting zero changed files.
-    eprintln!(
-        "[legion] warning: could not resolve changed files from main..HEAD or \
-         origin/main..HEAD; simplify-check will see an empty changed-set. If this \
-         branch has a base, the gate may pass without checking coverage."
-    );
-    Ok(std::collections::HashSet::new())
+
+    let Some(base_ref) = resolved_base else {
+        // Neither main nor origin/main exists. This is legitimate only when
+        // HEAD itself has no parent (initial commit / orphan branch). Probe
+        // for a parent commit; if there is one, the branch just has an unusual
+        // base-ref name, which is a hard error rather than vacuous-pass.
+        let parent = std::process::Command::new("git")
+            .args(["rev-parse", "--verify", "HEAD~1"])
+            .output()
+            .map_err(|e| error::LegionError::WorkSource(format!("failed to probe HEAD~1: {e}")))?;
+        if parent.status.success() {
+            // HEAD has a parent but no known base ref -- refuse rather than
+            // vacuously pass. An agent running on an unusual default branch
+            // (master, develop, etc.) must configure the base ref.
+            return Err(error::LegionError::WorkSource(
+                "could not find base ref 'main' or 'origin/main' and HEAD has a parent commit; \
+                 the simplify gate cannot determine the changed-file set. \
+                 Ensure 'main' or 'origin/main' exists in this repo."
+                    .to_owned(),
+            ));
+        }
+        // HEAD has no parent: genuine initial commit, vacuously valid.
+        return Ok(std::collections::HashSet::new());
+    };
+
+    // Run the three-dot diff with core.quotePath=false so non-ASCII paths
+    // are returned as-is (no octal escaping) and match heading paths exactly.
+    let refspec = format!("{base_ref}...HEAD");
+    let out = std::process::Command::new("git")
+        .args([
+            "-c",
+            "core.quotePath=false",
+            "diff",
+            "--name-only",
+            &refspec,
+        ])
+        .output()
+        .map_err(|e| error::LegionError::WorkSource(format!("failed to run git diff: {e}")))?;
+    if !out.status.success() {
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        return Err(error::LegionError::WorkSource(format!(
+            "git diff --name-only {refspec} failed (base ref '{base_ref}' resolved \
+             but diff did not): {stderr}"
+        )));
+    }
+
+    let set: std::collections::HashSet<String> = String::from_utf8_lossy(&out.stdout)
+        .lines()
+        .map(str::trim)
+        .filter(|l| !l.is_empty())
+        .map(str::to_owned)
+        .collect();
+    Ok(set)
 }
 
 pub(crate) fn format_age(d: std::time::Duration) -> String {

--- a/src/cli/verify.rs
+++ b/src/cli/verify.rs
@@ -85,8 +85,11 @@ pub(crate) enum QualityGateAction {
 
     /// Validate a simplify articulation file before recording the gate (#665).
     ///
-    /// Resolves the changed-file set from `git diff --name-only main..HEAD`
-    /// (falls back to origin/main..HEAD when main is absent locally). Parses
+    /// Resolves the changed-file set from
+    /// `git -c core.quotePath=false diff --name-only main...HEAD` (three-dot
+    /// merge-base range; falls back to origin/main...HEAD when main is absent).
+    /// If no base ref resolves and HEAD has a parent commit, this hard-errors
+    /// rather than recording a gate against an empty set. Parses
     /// the articulation file -- markdown with one `### <path>` heading per
     /// changed file followed by prose -- and refuses when:
     ///   - Coverage gap: a changed file has no `### <path>` entry (reports

--- a/src/cli/verify.rs
+++ b/src/cli/verify.rs
@@ -4,10 +4,12 @@ use std::str::FromStr;
 
 use clap::Subcommand;
 
-use crate::cli::util::{git_head_commit_and_branch, open_db, read_file_or_stdin};
+use crate::cli::util::{
+    git_changed_files, git_head_commit_and_branch, open_db, read_file_or_stdin,
+};
 use crate::db::quality_gates::{QualityGateFilter, QualityGateRow, QualityGateStats};
 use crate::verify::GateResult;
-use crate::{error, kanban, verify};
+use crate::{error, kanban, simplify_check, verify};
 
 #[derive(Subcommand, Debug)]
 pub(crate) enum QualityGateAction {
@@ -80,6 +82,44 @@ pub(crate) enum QualityGateAction {
         #[arg(long)]
         json: bool,
     },
+
+    /// Validate a simplify articulation file before recording the gate (#665).
+    ///
+    /// Resolves the changed-file set from `git diff --name-only main..HEAD`
+    /// (falls back to origin/main..HEAD when main is absent locally). Parses
+    /// the articulation file -- markdown with one `### <path>` heading per
+    /// changed file followed by prose -- and refuses when:
+    ///   - Coverage gap: a changed file has no `### <path>` entry (reports
+    ///     which files are unaddressed).
+    ///   - Boilerplate / thin: an entry's prose is below the substance threshold
+    ///     (reuses the same word-count heuristic as `pr write-check`).
+    ///
+    /// On pass: records a quality gate for HEAD under `--skill` with
+    /// `--result` as the gate outcome. On failure: lists each gap and exits
+    /// non-zero without recording a gate.
+    ///
+    /// Mirror of `legion pr write-check` for the simplify gate. The
+    /// `--result` flag carries the skill's own verdict (clean = no findings;
+    /// issues = real simplify findings were found). The validator gates on
+    /// articulation completeness and substance independently of that verdict:
+    /// a clean result still requires a complete articulation.
+    Check {
+        /// Skill name to record the gate under (e.g. "legion-simplify").
+        #[arg(long)]
+        skill: String,
+
+        /// Gate result from the skill run: "clean" or "issues".
+        #[arg(long, value_parser = ["clean", "issues"])]
+        result: String,
+
+        /// Path to the markdown articulation file. Reads stdin when omitted.
+        #[arg(long)]
+        articulation_file: Option<String>,
+
+        /// Number of skill findings (default 0; used when --result is "issues").
+        #[arg(long, default_value = "0")]
+        findings_count: u64,
+    },
 }
 
 pub(crate) fn handle_quality_gate(action: QualityGateAction) -> error::Result<()> {
@@ -144,6 +184,76 @@ pub(crate) fn handle_quality_gate(action: QualityGateAction) -> error::Result<()
             } else {
                 print_stats_table(&stats);
             }
+        }
+
+        QualityGateAction::Check {
+            skill,
+            result,
+            articulation_file,
+            findings_count,
+        } => {
+            // Parse and validate the result flag before touching the FS.
+            let gate_result: GateResult = GateResult::from_str(&result)?;
+
+            // Resolve the changed-file set from git. Falls back gracefully
+            // when main is not present locally.
+            let changed_files = git_changed_files()?;
+
+            // Read the articulation from --articulation-file or stdin.
+            let articulation =
+                read_file_or_stdin(articulation_file.as_deref(), "--articulation-file")?;
+
+            let report = simplify_check::validate_articulation(&changed_files, &articulation);
+
+            // The gate is only recorded when the articulation passes the
+            // structural validator. A failed articulation exits non-zero
+            // without recording so the gate on HEAD stays absent (pr create
+            // will refuse until a valid articulation is submitted).
+            if !report.ok {
+                let gap_count = report.findings.len();
+                eprintln!(
+                    "[legion] simplify-check FAILED for skill '{skill}' -- {gap_count} gap(s):"
+                );
+                for f in &report.findings {
+                    eprintln!("  - {f}");
+                }
+                eprintln!(
+                    "\nThe articulation must have one `### <path>` entry per changed file, \
+                     each with composed prose explaining which simplify checks were applied \
+                     and the reasoning for the clean-or-finding verdict. Fix the articulation \
+                     and re-run."
+                );
+                return Err(error::LegionError::ExitWith(1));
+            }
+
+            // Articulation is valid. Record the gate under HEAD.
+            // findings_count is the skill's own count (real simplify findings),
+            // not the validator's gap count (which is 0 when we reach here).
+            let (commit_hash, branch) = git_head_commit_and_branch()?;
+            let details = serde_json::json!({
+                "skill": skill,
+                "result": result,
+                "entry_count": report.entry_count,
+                "findings_count": findings_count,
+                "articulation": articulation,
+            })
+            .to_string();
+
+            let database = open_db()?;
+            let row = database.record_quality_gate(
+                &branch,
+                &commit_hash,
+                &skill,
+                gate_result,
+                findings_count,
+                Some(&details),
+            )?;
+
+            println!(
+                "[legion] simplify-check gate clean for skill '{skill}' ({} file entries, \
+                 {findings_count} skill findings). Gate id: {}",
+                report.entry_count, row.id,
+            );
         }
     }
     Ok(())
@@ -553,6 +663,139 @@ mod tests {
         assert!(
             err.to_string().contains("nonexistent-doc-id"),
             "error must name the missing document id, got: {err}"
+        );
+    }
+
+    // --- simplify-check gate tests (#665) ---
+
+    /// A valid articulation covering all changed files records a clean gate
+    /// in the quality_gates table under the given skill + commit.
+    #[test]
+    fn simplify_check_gate_recorded_on_valid_articulation() {
+        use std::collections::HashSet;
+
+        use crate::simplify_check::validate_articulation;
+        use crate::verify::GateResult;
+
+        let db = test_db();
+        let changed: HashSet<String> = ["src/foo.rs", "src/bar.rs"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+        let articulation = "### src/foo.rs\n\
+             Checked all six categories. No duplicate logic found: each function \
+             handles exactly one concern. No stringly-typed state; enums used \
+             throughout. Error handling propagates via the ? operator.\n\
+             ### src/bar.rs\n\
+             Reviewed for unnecessary abstraction and copy-paste variation. \
+             The single trait bound on this module is load-bearing -- removing \
+             it would require duplicating the impl block in three callers. \
+             Clean verdict: no simplify findings.\n";
+
+        let report = validate_articulation(&changed, articulation);
+        assert!(
+            report.ok,
+            "expected valid articulation, got {:?}",
+            report.findings
+        );
+
+        // Simulate what the handler does: record the gate.
+        let row = db
+            .record_quality_gate(
+                "feat/665-simplify-articulation",
+                "deadbeefdeadbeef",
+                "legion-simplify",
+                GateResult::Clean,
+                0,
+                Some(&serde_json::json!({"articulation": articulation}).to_string()),
+            )
+            .expect("record_quality_gate failed");
+        assert!(!row.id.is_empty());
+
+        // Verify it can be retrieved by the commit + skill pair.
+        let fetched = db
+            .get_quality_gate("deadbeefdeadbeef", "legion-simplify")
+            .expect("get_quality_gate failed")
+            .expect("expected Some gate row");
+        assert_eq!(fetched.result, GateResult::Clean);
+        assert_eq!(fetched.skill, "legion-simplify");
+    }
+
+    /// A missing-coverage gap causes the validator to refuse. The gate should
+    /// NOT be recorded (the handler exits non-zero before touching the DB).
+    #[test]
+    fn simplify_check_refuses_missing_coverage() {
+        use std::collections::HashSet;
+
+        use crate::simplify_check::validate_articulation;
+
+        let changed: HashSet<String> = ["src/foo.rs", "src/missing.rs"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+        let articulation = "### src/foo.rs\n\
+             Checked all six simplify categories. No findings: each function \
+             is focused on a single concern, types are explicit, error handling \
+             propagates via ? throughout the module.\n";
+
+        let report = validate_articulation(&changed, articulation);
+        assert!(!report.ok, "expected refusal for missing coverage");
+        assert!(
+            report
+                .findings
+                .iter()
+                .any(|f| f.contains("src/missing.rs") && f.contains("missing coverage")),
+            "expected a missing-coverage finding naming src/missing.rs, got {:?}",
+            report.findings
+        );
+    }
+
+    /// A boilerplate entry (restates category names without reasoning, under
+    /// the word threshold) causes the validator to refuse.
+    #[test]
+    fn simplify_check_refuses_boilerplate_entry() {
+        use std::collections::HashSet;
+
+        use crate::simplify_check::validate_articulation;
+
+        let changed: HashSet<String> = ["src/foo.rs"].iter().map(|s| s.to_string()).collect();
+        // Entry only lists the check names -- not enough words or reasoning.
+        let articulation = "### src/foo.rs\nClean. No issues.\n";
+
+        let report = validate_articulation(&changed, articulation);
+        assert!(!report.ok, "expected refusal for thin entry");
+        assert!(
+            report
+                .findings
+                .iter()
+                .any(|f| f.contains("too thin") && f.contains("src/foo.rs")),
+            "expected a thin-entry finding, got {:?}",
+            report.findings
+        );
+    }
+
+    /// An articulation with real findings (issues result) still passes the
+    /// structural validator if coverage and substance are present.
+    #[test]
+    fn simplify_check_accepts_issues_result_with_substantive_articulation() {
+        use std::collections::HashSet;
+
+        use crate::simplify_check::validate_articulation;
+
+        let changed: HashSet<String> = ["src/foo.rs"].iter().map(|s| s.to_string()).collect();
+        let articulation = "### src/foo.rs\n\
+             Checked for duplicate logic: found two match arms at lines 47 and \
+             62 that share an identical body. Extracted into a helper \
+             `fn apply_default` to remove the copy-paste variation. No other \
+             issues found: stringly-typed state is absent, error handling uses \
+             ? throughout, no hand-rolled standard library duplication.\n";
+
+        let report = validate_articulation(&changed, articulation);
+        assert!(
+            report.ok,
+            "issues result with substantive articulation should pass the structural validator, \
+             got {:?}",
+            report.findings
         );
     }
 }

--- a/src/cli/verify.rs
+++ b/src/cli/verify.rs
@@ -229,6 +229,9 @@ pub(crate) fn handle_quality_gate(action: QualityGateAction) -> error::Result<()
             // Articulation is valid. Record the gate under HEAD.
             // findings_count is the skill's own count (real simplify findings),
             // not the validator's gap count (which is 0 when we reach here).
+            // It is valid for --result issues to carry --findings-count 0: the
+            // flag is informational, and the skill runner may not always surface
+            // a count. The gate result is what matters for `legion pr create`.
             let (commit_hash, branch) = git_head_commit_and_branch()?;
             let details = serde_json::json!({
                 "skill": skill,

--- a/src/cli/verify.rs
+++ b/src/cli/verify.rs
@@ -250,8 +250,9 @@ pub(crate) fn handle_quality_gate(action: QualityGateAction) -> error::Result<()
             )?;
 
             println!(
-                "[legion] simplify-check gate clean for skill '{skill}' ({} file entries, \
-                 {findings_count} skill findings). Gate id: {}",
+                "[legion] simplify-check articulation accepted for skill '{skill}' \
+                 (result '{result}', {} file entries, {findings_count} skill findings). \
+                 Gate id: {}",
                 report.entry_count, row.id,
             );
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,6 +24,7 @@ mod scip;
 mod search;
 mod serve;
 mod signal;
+mod simplify_check;
 mod spec_gen;
 mod stats;
 mod status;

--- a/src/pr_write.rs
+++ b/src/pr_write.rs
@@ -21,7 +21,7 @@ use crate::card_parse::parse_issue_body;
 /// heading and the evidence line are stripped. A genuine "this change
 /// satisfies it because..." explanation clears this easily; a verbatim
 /// restatement of a short criterion does not.
-const MIN_MAPPING_WORDS: usize = 12;
+pub(crate) const MIN_MAPPING_WORDS: usize = 12;
 
 /// Finding emitted when the body has no "Not done" section. Shared by the
 /// early-return (no mapping) path and the main flow so the two cannot drift.

--- a/src/pr_write.rs
+++ b/src/pr_write.rs
@@ -171,7 +171,10 @@ fn split_entries(mapping: &str) -> Vec<String> {
 /// leaving the explanatory prose to be word-counted. The heading restates the
 /// criterion and the evidence line is checked separately, so neither should
 /// count toward the substance threshold.
-fn strip_evidence_lines(entry: &str) -> String {
+///
+/// Shared with `simplify_check`, which uses the same strip-then-count logic
+/// to validate per-file simplify articulation entries.
+pub(crate) fn strip_evidence_lines(entry: &str) -> String {
     entry
         .lines()
         .filter(|l| {

--- a/src/simplify_check.rs
+++ b/src/simplify_check.rs
@@ -86,7 +86,8 @@ pub fn parse_articulation(articulation: &str) -> Vec<ArticulationEntry> {
 
 /// Validate a simplify articulation against the set of changed files.
 ///
-/// `changed_files` is the set of paths from `git diff --name-only main..HEAD`.
+/// `changed_files` is the set of paths from
+/// `git -c core.quotePath=false diff --name-only main...HEAD`.
 /// `articulation` is the markdown text produced by the skill. Returns a
 /// `SimplifyCheckReport` that names every coverage and substance gap found.
 ///

--- a/src/simplify_check.rs
+++ b/src/simplify_check.rs
@@ -1,0 +1,289 @@
+// Simplify articulation validator (#665).
+//
+// `legion quality-gate check` is the forcing-function analog of `legion pr
+// write-check` for the simplify gate. Before `legion quality-gate record
+// --skill legion-simplify` can record a clean gate, the agent must produce a
+// structured articulation that this module validates.
+//
+// The lifetime audit (2026-06-18) showed legion-simplify has a 0.66% catch
+// rate -- 7 issues in 1062 runs. The mechanism mirrors what makes pr-write
+// work at 23.5%: require structured prose (one entry per changed file),
+// validate it, and refuse boilerplate. Articulation is verification: composing
+// the file-by-file analysis forces the agent to re-read the diff.
+//
+// The articulation file is a markdown document with one `### <path>` heading
+// per changed file followed by prose explaining the simplify checks applied
+// and the clean-or-finding verdict with reasoning. This module validates that
+// every changed file is covered and each entry's prose is substantive.
+
+use std::collections::HashSet;
+
+use crate::pr_write::strip_evidence_lines;
+
+/// Minimum words of prose per file entry, after the heading is stripped.
+/// Matches the `MIN_MAPPING_WORDS` threshold in `pr_write` so the two gates
+/// use the same substance bar. A genuine per-file analysis clears this easily;
+/// a verbatim restatement of category names does not.
+const MIN_ENTRY_WORDS: usize = 12;
+
+/// A parsed entry from a simplify articulation document.
+#[derive(Debug, Clone)]
+pub struct ArticulationEntry {
+    /// The file path from the `### <path>` heading.
+    pub file_path: String,
+    /// The full entry text, including the heading line.
+    pub raw: String,
+}
+
+/// Result of validating a simplify articulation against a changed-file set.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SimplifyCheckReport {
+    /// True when every file is covered with substantive prose.
+    pub ok: bool,
+    /// Human-readable gaps, one per failed requirement. Empty when `ok`.
+    pub findings: Vec<String>,
+    /// Number of file entries found in the articulation.
+    pub entry_count: usize,
+}
+
+/// Parse a simplify articulation document into per-file entries.
+///
+/// Splits on `### ` subheadings. Text before the first `### ` is ignored
+/// (treated as preamble). Each returned entry carries the heading path and the
+/// full raw text (heading + body).
+pub fn parse_articulation(articulation: &str) -> Vec<ArticulationEntry> {
+    let mut entries: Vec<ArticulationEntry> = Vec::new();
+    let mut current_path: Option<String> = None;
+    let mut current_buf: String = String::new();
+
+    for line in articulation.lines() {
+        if line.trim_start().starts_with("### ") {
+            if let Some(path) = current_path.take() {
+                entries.push(ArticulationEntry {
+                    file_path: path,
+                    raw: current_buf.trim().to_string(),
+                });
+            }
+            // Extract the path from the heading. Strip leading `### ` and
+            // any trailing whitespace. A heading like `### src/foo.rs` yields
+            // `src/foo.rs`.
+            let path = line.trim_start_matches('#').trim().to_string();
+            current_path = Some(path.clone());
+            current_buf = format!("{line}\n");
+        } else if current_path.is_some() {
+            current_buf.push_str(line);
+            current_buf.push('\n');
+        }
+    }
+    if let Some(path) = current_path {
+        entries.push(ArticulationEntry {
+            file_path: path,
+            raw: current_buf.trim().to_string(),
+        });
+    }
+    entries
+}
+
+/// Validate a simplify articulation against the set of changed files.
+///
+/// `changed_files` is the set of paths from `git diff --name-only main..HEAD`.
+/// `articulation` is the markdown text produced by the skill. Returns a
+/// `SimplifyCheckReport` that names every coverage and substance gap found.
+///
+/// Validation rules:
+/// 1. Coverage: every path in `changed_files` must have a `### <path>` entry.
+///    A missing entry is reported by name.
+/// 2. Substance: each entry's prose (after the heading is stripped) must
+///    contain at least `MIN_ENTRY_WORDS` words. A thin entry that only
+///    restates the category list is refused.
+/// 3. No boilerplate: entries that just list the check categories without
+///    reasoning are refused by the word threshold. No evidence requirement is
+///    enforced here (unlike pr-write) because the simplify analysis is
+///    prose-in, prose-out -- there is no test name or file:line to cite.
+pub fn validate_articulation(
+    changed_files: &HashSet<String>,
+    articulation: &str,
+) -> SimplifyCheckReport {
+    let mut findings: Vec<String> = Vec::new();
+    let entries = parse_articulation(articulation);
+
+    // Index entries by file path for O(1) lookup.
+    let mut covered: HashSet<&str> = HashSet::new();
+    for entry in &entries {
+        covered.insert(entry.file_path.as_str());
+    }
+
+    // Coverage check: every changed file must have an entry.
+    let mut missing: Vec<&str> = changed_files
+        .iter()
+        .filter(|f| !covered.contains(f.as_str()))
+        .map(String::as_str)
+        .collect();
+    missing.sort_unstable();
+    for path in &missing {
+        findings.push(format!(
+            "missing coverage: no articulation entry for changed file '{path}'"
+        ));
+    }
+
+    // Substance check: each entry must have enough prose.
+    for entry in &entries {
+        let prose = strip_evidence_lines(&entry.raw);
+        let words = prose.split_whitespace().count();
+        if words < MIN_ENTRY_WORDS {
+            findings.push(format!(
+                "entry '{}' is too thin ({} words) -- explain which checks were \
+                 applied and the reasoning for the clean-or-finding verdict, \
+                 do not just list category names.",
+                entry.file_path, words,
+            ));
+        }
+    }
+
+    // When there are no changed files and no entries, the articulation is
+    // vacuously valid (e.g. a docs-only commit with no source files). Report
+    // clean without requiring entries.
+    SimplifyCheckReport {
+        ok: findings.is_empty(),
+        findings,
+        entry_count: entries.len(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn changed(paths: &[&str]) -> HashSet<String> {
+        paths.iter().map(|s| s.to_string()).collect()
+    }
+
+    fn good_articulation() -> String {
+        "# Simplify articulation\n\n\
+         ### src/foo.rs\n\
+         Checked for duplicate logic, unnecessary abstraction, stringly-typed state, \
+         hand-rolled standard library dupes, copy-paste variation, and error swallowing. \
+         No issues found: the module is focused and each function has a single \
+         responsibility. The error handling propagates via the `?` operator throughout.\n\n\
+         ### src/bar.rs\n\
+         Reviewed for duplicate logic clusters and abstraction altitude. Found one \
+         instance where two adjacent match arms share a body -- extracted into a helper \
+         `fn apply_default` at line 42. The remaining logic is clean: no stringly-typed \
+         state, no hand-rolled stdlib dupes, no error swallowing detected.\n"
+            .to_string()
+    }
+
+    #[test]
+    fn accepts_substantive_articulation() {
+        let files = changed(&["src/foo.rs", "src/bar.rs"]);
+        let report = validate_articulation(&files, &good_articulation());
+        assert!(report.ok, "expected clean, got {:?}", report.findings);
+        assert_eq!(report.entry_count, 2);
+    }
+
+    #[test]
+    fn refuses_missing_coverage() {
+        let files = changed(&["src/foo.rs", "src/bar.rs", "src/baz.rs"]);
+        let report = validate_articulation(&files, &good_articulation());
+        assert!(!report.ok);
+        assert!(
+            report
+                .findings
+                .iter()
+                .any(|f| f.contains("src/baz.rs") && f.contains("missing coverage")),
+            "expected a missing-coverage finding naming src/baz.rs, got {:?}",
+            report.findings
+        );
+    }
+
+    #[test]
+    fn refuses_boilerplate_thin_entry() {
+        let files = changed(&["src/foo.rs"]);
+        let thin = "### src/foo.rs\nLooks clean.\n";
+        let report = validate_articulation(&files, thin);
+        assert!(!report.ok);
+        assert!(
+            report
+                .findings
+                .iter()
+                .any(|f| f.contains("too thin") && f.contains("src/foo.rs")),
+            "expected a thin-entry finding, got {:?}",
+            report.findings
+        );
+    }
+
+    #[test]
+    fn vacuously_valid_when_no_changed_files() {
+        let files: HashSet<String> = HashSet::new();
+        let report = validate_articulation(&files, "# No changed files\n");
+        assert!(report.ok);
+        assert_eq!(report.entry_count, 0);
+    }
+
+    #[test]
+    fn parse_articulation_extracts_entries() {
+        let entries = parse_articulation(&good_articulation());
+        assert_eq!(entries.len(), 2);
+        assert_eq!(entries[0].file_path, "src/foo.rs");
+        assert_eq!(entries[1].file_path, "src/bar.rs");
+        assert!(entries[0].raw.contains("single"));
+    }
+
+    #[test]
+    fn multiple_missing_files_all_named() {
+        let files = changed(&["src/a.rs", "src/b.rs", "src/c.rs"]);
+        let articulation = "### src/a.rs\n\
+             Checked all categories: duplicate logic, unnecessary abstraction, \
+             stringly-typed state, hand-rolled std dupes, copy-paste, error swallowing. \
+             All clear: single-purpose functions with explicit types throughout.\n";
+        let report = validate_articulation(&files, articulation);
+        assert!(!report.ok);
+        // Both b.rs and c.rs should be named.
+        let gap_count = report
+            .findings
+            .iter()
+            .filter(|f| f.contains("missing coverage"))
+            .count();
+        assert_eq!(
+            gap_count, 2,
+            "expected 2 missing-coverage findings, got {:?}",
+            report.findings
+        );
+    }
+
+    #[test]
+    fn mixed_gaps_names_all() {
+        // Two changed files: one covered thinly, one missing entirely.
+        let files = changed(&["src/foo.rs", "src/bar.rs"]);
+        let articulation = "### src/foo.rs\nThin.\n";
+        let report = validate_articulation(&files, articulation);
+        assert!(!report.ok);
+        let has_thin = report.findings.iter().any(|f| f.contains("too thin"));
+        let has_missing = report
+            .findings
+            .iter()
+            .any(|f| f.contains("missing coverage") && f.contains("src/bar.rs"));
+        assert!(has_thin, "expected thin-entry finding");
+        assert!(has_missing, "expected missing-coverage finding for bar.rs");
+    }
+
+    #[test]
+    fn findings_vec_reflects_gaps() {
+        let report = SimplifyCheckReport {
+            ok: false,
+            findings: vec!["gap one".to_string(), "gap two".to_string()],
+            entry_count: 1,
+        };
+        assert_eq!(report.findings.len(), 2);
+    }
+
+    #[test]
+    fn findings_vec_empty_on_clean() {
+        let report = SimplifyCheckReport {
+            ok: true,
+            findings: vec![],
+            entry_count: 3,
+        };
+        assert_eq!(report.findings.len(), 0);
+    }
+}

--- a/src/simplify_check.rs
+++ b/src/simplify_check.rs
@@ -18,13 +18,13 @@
 
 use std::collections::HashSet;
 
-use crate::pr_write::strip_evidence_lines;
+use crate::pr_write::{MIN_MAPPING_WORDS, strip_evidence_lines};
 
 /// Minimum words of prose per file entry, after the heading is stripped.
-/// Matches the `MIN_MAPPING_WORDS` threshold in `pr_write` so the two gates
-/// use the same substance bar. A genuine per-file analysis clears this easily;
-/// a verbatim restatement of category names does not.
-const MIN_ENTRY_WORDS: usize = 12;
+/// Aliased to `pr_write::MIN_MAPPING_WORDS` so both gates share a single
+/// source of truth for the substance bar and cannot silently drift. A genuine
+/// per-file analysis clears this easily; a restatement of category names does not.
+const MIN_ENTRY_WORDS: usize = MIN_MAPPING_WORDS;
 
 /// A parsed entry from a simplify articulation document.
 #[derive(Debug, Clone)]

--- a/src/simplify_check.rs
+++ b/src/simplify_check.rs
@@ -127,6 +127,9 @@ pub fn validate_articulation(
     }
 
     // Substance check: each entry must have enough prose.
+    // strip_evidence_lines already drops `### ` heading lines (they start with
+    // "### "), so the heading path tokens do not count toward the word
+    // threshold -- only the body prose does.
     for entry in &entries {
         let prose = strip_evidence_lines(&entry.raw);
         let words = prose.split_whitespace().count();

--- a/tests/integration/worksource_pr.rs
+++ b/tests/integration/worksource_pr.rs
@@ -1208,3 +1208,358 @@ fn quality_gate_stats_filter_by_skill() {
     assert_eq!(arr.len(), 1, "expected only one skill row");
     assert_eq!(arr[0]["skill"].as_str().unwrap(), "legion-simplify");
 }
+
+// ---------------------------------------------------------------------------
+// quality-gate check end-to-end tests (#665).
+//
+// These tests require a real git repo so `git_changed_files` can probe base
+// refs and run `git diff`. Each test creates a temp repo with a `main` branch
+// and a feature branch, writes an articulation file to a second tempdir, and
+// runs `legion quality-gate check` via `legion_cmd` against a separate data dir.
+// ---------------------------------------------------------------------------
+
+/// Set up a minimal git repo with a `main` branch (one seed commit) and a
+/// feature branch with one changed file (`src/foo.rs`). Returns the repo dir.
+///
+/// The repo uses a dummy user identity so CI environments without a global
+/// git config do not fail the commit step.
+fn setup_git_repo_with_feature_branch() -> tempfile::TempDir {
+    let repo = tempfile::tempdir().unwrap();
+    let rp = repo.path();
+
+    let git = |args: &[&str]| {
+        let out = Command::new("git")
+            .args(args)
+            .current_dir(rp)
+            .output()
+            .unwrap_or_else(|e| panic!("git {args:?} failed to spawn: {e}"));
+        assert!(
+            out.status.success(),
+            "git {args:?} exited non-zero\nstderr: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+    };
+
+    git(&["init", "-b", "main"]);
+    git(&["config", "user.email", "test@example.com"]);
+    git(&["config", "user.name", "Test"]);
+
+    // Seed commit on main so `main` resolves as a real ref.
+    std::fs::write(rp.join("README.md"), "seed\n").unwrap();
+    git(&["add", "README.md"]);
+    git(&["commit", "-m", "seed"]);
+
+    // Feature branch: add one changed file.
+    git(&["checkout", "-b", "feat/test"]);
+    std::fs::create_dir_all(rp.join("src")).unwrap();
+    std::fs::write(rp.join("src/foo.rs"), "// changed\n").unwrap();
+    git(&["add", "src/foo.rs"]);
+    git(&["commit", "-m", "add foo"]);
+
+    repo
+}
+
+/// Build a substantive articulation that covers `src/foo.rs` with enough prose
+/// to clear the word-count threshold.
+fn good_articulation_for_foo() -> String {
+    "# Simplify articulation\n\n\
+     ### src/foo.rs\n\
+     Checked for duplicate logic, unnecessary abstraction, stringly-typed state, \
+     hand-rolled standard library dupes, copy-paste variation, and error swallowing. \
+     No issues found: the module is focused and each function has a single \
+     responsibility. The error handling propagates via the `?` operator throughout.\n"
+        .to_string()
+}
+
+/// quality-gate check: a valid articulation passes, records exactly one gate
+/// row for HEAD, and the row is visible via `quality-gate list --json`.
+#[cfg(unix)]
+#[test]
+fn quality_gate_check_passing_articulation_records_gate_row() {
+    let repo = setup_git_repo_with_feature_branch();
+    let data_dir = tempfile::tempdir().unwrap();
+    let artic_file = tempfile::NamedTempFile::new().unwrap();
+    std::fs::write(artic_file.path(), good_articulation_for_foo()).unwrap();
+
+    let stdout = run_ok(legion_cmd(data_dir.path()).current_dir(repo.path()).args([
+        "quality-gate",
+        "check",
+        "--skill",
+        "legion-simplify",
+        "--result",
+        "clean",
+        "--articulation-file",
+        artic_file.path().to_str().unwrap(),
+    ]));
+    assert!(
+        stdout.contains("accepted"),
+        "expected acceptance message, got: {stdout}"
+    );
+
+    // Exactly one gate row must be recorded.
+    let list_out = run_ok(legion_cmd(data_dir.path()).args([
+        "quality-gate",
+        "list",
+        "--skill",
+        "legion-simplify",
+        "--json",
+    ]));
+    let rows: serde_json::Value = serde_json::from_str(&list_out).expect("expected JSON");
+    let arr = rows.as_array().expect("expected array");
+    assert_eq!(
+        arr.len(),
+        1,
+        "expected exactly one gate row, got: {list_out}"
+    );
+    assert_eq!(arr[0]["result"].as_str().unwrap(), "clean");
+}
+
+/// quality-gate check: a failing articulation (missing coverage) exits non-zero
+/// AND records NO gate row. This is the security-relevant path: the absence of
+/// a row is what blocks `legion pr create` from proceeding.
+#[cfg(unix)]
+#[test]
+fn quality_gate_check_failing_articulation_exits_nonzero_and_records_no_row() {
+    let repo = setup_git_repo_with_feature_branch();
+    let data_dir = tempfile::tempdir().unwrap();
+    // Articulation is empty -- no entries at all, so src/foo.rs is uncovered.
+    let artic_file = tempfile::NamedTempFile::new().unwrap();
+    std::fs::write(artic_file.path(), "# No entries\n").unwrap();
+
+    let (_stdout, stderr) = run_fail(legion_cmd(data_dir.path()).current_dir(repo.path()).args([
+        "quality-gate",
+        "check",
+        "--skill",
+        "legion-simplify",
+        "--result",
+        "clean",
+        "--articulation-file",
+        artic_file.path().to_str().unwrap(),
+    ]));
+    assert!(
+        stderr.contains("FAILED") || stderr.contains("missing coverage"),
+        "expected failure message in stderr, got: {stderr}"
+    );
+
+    // No row must have been recorded -- the gate on HEAD is absent.
+    let list_out = run_ok(legion_cmd(data_dir.path()).args([
+        "quality-gate",
+        "list",
+        "--skill",
+        "legion-simplify",
+        "--json",
+    ]));
+    let rows: serde_json::Value = serde_json::from_str(&list_out).expect("expected JSON");
+    let arr = rows.as_array().expect("expected array");
+    assert_eq!(
+        arr.len(),
+        0,
+        "expected zero gate rows after articulation refusal, got: {list_out}"
+    );
+}
+
+/// quality-gate check: when run outside a git repo, git_changed_files returns
+/// a hard error and the command exits non-zero without recording a gate row.
+/// This exercises the "git not in work tree" branch introduced in #665.
+#[cfg(unix)]
+#[test]
+fn quality_gate_check_outside_git_repo_exits_nonzero() {
+    // /tmp is never inside a git repo.
+    let outside_git = std::path::PathBuf::from("/tmp");
+    let data_dir = tempfile::tempdir().unwrap();
+    let artic_file = tempfile::NamedTempFile::new().unwrap();
+    std::fs::write(artic_file.path(), good_articulation_for_foo()).unwrap();
+
+    let (_stdout, stderr) = run_fail(legion_cmd(data_dir.path()).current_dir(&outside_git).args([
+        "quality-gate",
+        "check",
+        "--skill",
+        "legion-simplify",
+        "--result",
+        "clean",
+        "--articulation-file",
+        artic_file.path().to_str().unwrap(),
+    ]));
+    // The error must name git or the work-tree context.
+    assert!(
+        stderr.contains("git") || stderr.contains("work-tree") || stderr.contains("repo"),
+        "expected a git/repo error for non-git directory, got: {stderr}"
+    );
+
+    // No gate row must have been recorded.
+    let list_out = run_ok(legion_cmd(data_dir.path()).args([
+        "quality-gate",
+        "list",
+        "--skill",
+        "legion-simplify",
+        "--json",
+    ]));
+    let rows: serde_json::Value = serde_json::from_str(&list_out).expect("expected JSON");
+    assert_eq!(
+        rows.as_array().unwrap().len(),
+        0,
+        "expected zero gate rows after git failure, got: {list_out}"
+    );
+}
+
+/// quality-gate check: when run in a git repo that has no main/origin/main ref
+/// AND HEAD has a parent commit, the command exits non-zero with a descriptive
+/// error. This exercises the "base ref missing but HEAD has parent" hard-error
+/// branch -- the path that previously passed vacuously.
+#[cfg(unix)]
+#[test]
+fn quality_gate_check_no_base_ref_with_parent_commit_exits_nonzero() {
+    let repo = tempfile::tempdir().unwrap();
+    let rp = repo.path();
+
+    let git = |args: &[&str]| {
+        let out = Command::new("git")
+            .args(args)
+            .current_dir(rp)
+            .output()
+            .unwrap_or_else(|e| panic!("git {args:?} failed to spawn: {e}"));
+        assert!(
+            out.status.success(),
+            "git {args:?} exited non-zero\nstderr: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+    };
+
+    // Use a non-standard default branch name so neither `main` nor
+    // `origin/main` is present. The repo has two commits (seed + feature),
+    // so HEAD does have a parent.
+    git(&["init", "-b", "trunk"]);
+    git(&["config", "user.email", "test@example.com"]);
+    git(&["config", "user.name", "Test"]);
+    std::fs::write(rp.join("README.md"), "seed\n").unwrap();
+    git(&["add", "README.md"]);
+    git(&["commit", "-m", "seed"]);
+    std::fs::write(rp.join("change.rs"), "// changed\n").unwrap();
+    git(&["add", "change.rs"]);
+    git(&["commit", "-m", "feature"]);
+
+    let data_dir = tempfile::tempdir().unwrap();
+    let artic_file = tempfile::NamedTempFile::new().unwrap();
+    std::fs::write(artic_file.path(), good_articulation_for_foo()).unwrap();
+
+    let (_stdout, stderr) = run_fail(legion_cmd(data_dir.path()).current_dir(rp).args([
+        "quality-gate",
+        "check",
+        "--skill",
+        "legion-simplify",
+        "--result",
+        "clean",
+        "--articulation-file",
+        artic_file.path().to_str().unwrap(),
+    ]));
+    assert!(
+        stderr.contains("main") || stderr.contains("base ref"),
+        "expected error about missing base ref, got: {stderr}"
+    );
+
+    // No gate row recorded.
+    let list_out = run_ok(legion_cmd(data_dir.path()).args([
+        "quality-gate",
+        "list",
+        "--skill",
+        "legion-simplify",
+        "--json",
+    ]));
+    let rows: serde_json::Value = serde_json::from_str(&list_out).expect("expected JSON");
+    assert_eq!(
+        rows.as_array().unwrap().len(),
+        0,
+        "expected zero gate rows after base-ref-missing error, got: {list_out}"
+    );
+}
+
+/// quality-gate check: non-ASCII file paths with core.quotePath are handled
+/// correctly. The path returned by git (unescaped, with core.quotePath=false)
+/// must match the `### <path>` heading, and the articulation must pass.
+#[cfg(unix)]
+#[test]
+fn quality_gate_check_non_ascii_path_roundtrips_correctly() {
+    let repo = tempfile::tempdir().unwrap();
+    let rp = repo.path();
+
+    let git = |args: &[&str]| {
+        let out = Command::new("git")
+            .args(args)
+            .current_dir(rp)
+            .output()
+            .unwrap_or_else(|e| panic!("git {args:?} failed to spawn: {e}"));
+        assert!(
+            out.status.success(),
+            "git {args:?} exited non-zero\nstderr: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+    };
+
+    git(&["init", "-b", "main"]);
+    git(&["config", "user.email", "test@example.com"]);
+    git(&["config", "user.name", "Test"]);
+    // Seed commit on main.
+    std::fs::write(rp.join("README.md"), "seed\n").unwrap();
+    git(&["add", "README.md"]);
+    git(&["commit", "-m", "seed"]);
+
+    // Feature branch: add a file with a non-ASCII name.
+    git(&["checkout", "-b", "feat/nonascii"]);
+    std::fs::create_dir_all(rp.join("src")).unwrap();
+    // Use a UTF-8 filename. The file system must support this; macOS and
+    // Linux UTF-8 locales both do.
+    let nonascii_name = "src/cafe\u{0301}.rs"; // NFC: src/café.rs (combining acute)
+    std::fs::write(rp.join(nonascii_name), "// non-ascii\n").unwrap();
+    git(&["add", nonascii_name]);
+    git(&["commit", "-m", "add non-ascii file"]);
+
+    // Ask git what name it reports (with core.quotePath=false).
+    let diff_out = Command::new("git")
+        .args([
+            "-c",
+            "core.quotePath=false",
+            "diff",
+            "--name-only",
+            "main...HEAD",
+        ])
+        .current_dir(rp)
+        .output()
+        .expect("git diff failed");
+    let reported_path = String::from_utf8_lossy(&diff_out.stdout).trim().to_string();
+    // The path must be non-empty and not octal-quoted.
+    assert!(
+        !reported_path.is_empty(),
+        "expected a path from git diff, got empty output"
+    );
+    assert!(
+        !reported_path.starts_with('"'),
+        "expected unquoted path, got: {reported_path}"
+    );
+
+    // Build an articulation that uses exactly the path git reported.
+    let articulation = format!(
+        "### {reported_path}\n\
+         Checked for duplicate logic, unnecessary abstraction, stringly-typed state, \
+         hand-rolled standard library dupes, copy-paste variation, and error swallowing. \
+         No issues found: a single trivial file with no structure. Verdict: clean.\n"
+    );
+
+    let data_dir = tempfile::tempdir().unwrap();
+    let artic_file = tempfile::NamedTempFile::new().unwrap();
+    std::fs::write(artic_file.path(), &articulation).unwrap();
+
+    let stdout = run_ok(legion_cmd(data_dir.path()).current_dir(rp).args([
+        "quality-gate",
+        "check",
+        "--skill",
+        "legion-simplify",
+        "--result",
+        "clean",
+        "--articulation-file",
+        artic_file.path().to_str().unwrap(),
+    ]));
+    assert!(
+        stdout.contains("accepted"),
+        "expected acceptance for non-ASCII path, got: {stdout}"
+    );
+}


### PR DESCRIPTION
## Summary

Rewrites legion-simplify from a yes/no gate -- which the corpus showed agents cleared by typing "clean" without reading the diff (0.7% catch rate vs 23.5% for pr-write) -- into an articulation forcing-function. A new `legion quality-gate check` subcommand resolves the changed-file set from git, requires one `### <path>` entry of substantive prose per changed file, refuses coverage gaps and boilerplate, and only then records the gate. The skill is rewritten to drive that flow. Mechanism mirrors `legion pr write-check`, the gate that already works at 24%.

This PR dogfooded its own gate: running `quality-gate check` on this branch forced a per-file read that surfaced two real bugs in the validator (a duplicated threshold constant, a silent git-failure path), which were fixed before the clean gate was recorded.

## Acceptance criteria mapping

### 1. Simplify records a clean gate only after a coverage-complete, non-boilerplate articulation passes
`quality-gate check` calls `simplify_check::validate_articulation`, which fails unless every path from `git diff --name-only main..HEAD` has a `### <path>` entry and each entry's prose clears the substance threshold. The gate is recorded (`record_quality_gate` under HEAD) only on the `report.ok` path; a failed articulation returns `ExitWith(1)` before the DB is touched, so no gate row appears and `legion pr create` keeps refusing. The skill records via `check`, not raw `record`, so a clean row now implies an accepted articulation exists.
Evidence: `src/cli/verify.rs` `Check` handler (record only when `report.ok`); `src/simplify_check.rs` `validate_articulation`; the clean gate `019eddfa` on HEAD fa4aed3 was recorded only after a complete 6-file articulation passed.

### 2. Boilerplate / repeated-clean articulation is refused with a named gap, like pr write-check
Two refusal classes, each naming the offending file: a coverage gap ("missing coverage: no articulation entry for changed file '<path>'") and a thin entry ("entry '<path>' is too thin (<n> words) ..."). Substance is measured by reusing `pr_write::strip_evidence_lines` plus the shared `MIN_MAPPING_WORDS` threshold, so a bare "Looks clean." or a restated category list is refused exactly as pr-write refuses a pasted-back criterion.
Evidence: `src/simplify_check.rs` coverage + substance loops; unit tests `refuses_missing_coverage`, `refuses_boilerplate_thin_entry`; handler tests `simplify_check_refuses_missing_coverage`, `simplify_check_refuses_boilerplate_entry`.

### 3. Tests cover refusal and acceptance paths
The validator module has nine unit tests (acceptance, missing coverage, thin entry, multi-entry parsing, vacuous empty case) and the CLI handler has four more (gate recorded on valid articulation, refusal on coverage gap, refusal on boilerplate, issues-result with substantive articulation still passes the structural check). 13 new tests, all green.
Evidence: `src/simplify_check.rs` test module; `src/cli/verify.rs` test module; `cargo test` 1098+ passed, clippy --all-targets + fmt clean.

### 4. Simplify + review passes complete; PR linked
Two review layers ran and both found real issues. The new simplify gate caught F1 (a `MIN_ENTRY_WORDS` constant duplicating pr_write's threshold with an unenforced "matches" comment) and F2 (a git-failure empty-set) on the first pass, recorded as an issues gate (019eddf8), fixed, then re-recorded clean. Then the pre-push review gate caught a CRITICAL the simplify pass had under-weighted: F2's stderr-warning band-aid still exited 0, so a shallow clone / non-main base / detached checkout silently passed the gate -- plus three HIGHs (two-dot range over-collecting, path-quoting breaking matching, no end-to-end handler test). Those were fixed in 40de75f (three-probe base-ref resolution that hard-errors instead of vacuously passing; three-dot `main...HEAD`; `core.quotePath=false`; five integration tests including a refusal-records-no-row case), and stale doc comments corrected after. Found-fixed across both layers, not a rubber stamp. PR references #665; branch feat/665-simplify-articulation.
Evidence: simplify gate 019eddf8 (issues) -> clean; pre-push review BLOCK on git_changed_files CRITICAL -> fixed in commit 40de75f; integration tests `quality_gate_check_failing_articulation_exits_nonzero_and_records_no_row` and `quality_gate_check_outside_git_repo_exits_nonzero`.

## Not done

The substance check is word-count-based (shared with pr-write) -- it enforces that prose of substance exists, not that the reasoning is correct; judging quality stays the reviewer's job, as in pr-write. F2 is mitigated by a stderr warning rather than fully fixed: the structural fix (gate the vacuous-pass on "HEAD has a parent commit" instead of trusting an empty changed-set) is a follow-up; this PR resolves the silence, which was the doctrine concern. No retrofit of the pre-commit simplify hook (a separate yes/no instance of the same failure mode) -- worth a follow-up. No change to legion-review or legion-verify.