### PR TITLE
feat(#670): block built-in Explore subagent, redirect to legion:legion-explore

### DIFF
--- a/plugin/hooks/hooks.json
+++ b/plugin/hooks/hooks.json
@@ -108,7 +108,22 @@
         "hooks": [
           {
             "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/no-harness-explore.sh",
+            "timeout": 5
+          },
+          {
+            "type": "command",
             "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/recall-first.sh",
+            "timeout": 5
+          }
+        ]
+      },
+      {
+        "matcher": "Task",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/no-harness-explore.sh",
             "timeout": 5
           }
         ]

--- a/plugin/hooks/no-harness-explore.sh
+++ b/plugin/hooks/no-harness-explore.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+# Legion PreToolUse hook: block the harness built-in `Explore` subagent and
+# redirect to the `legion:legion-explore` plugin agent.
+#
+# The built-in Explore agent greps and reads raw files. On a legion-covered
+# repo that is the wrong instrument: legion:legion-explore orients through SCIP
+# sym queries (def/refs/impl/hover) and recall/consult, returning conclusions
+# with file:line evidence instead of file dumps. This hook denies an Explore
+# spawn and names the replacement.
+#
+# Mechanism note: PreToolUse is the only event that can BLOCK a spawn
+# (permissionDecision deny). SubagentStart matches on agent type but is
+# context-only -- it cannot deny -- so the redirect must run here, before the
+# spawn, on the Agent/Task tool call that carries `subagent_type`.
+#
+# What this blocks:
+#   - An Agent/Task tool call whose tool_input.subagent_type is "Explore"
+#     (case-insensitive exact match), in a legion-covered repo.
+#
+# What this does NOT block:
+#   - legion:legion-explore / legion-explore (the redirect target).
+#   - Any other subagent type (Plan, general-purpose, custom agents).
+#   - Repos legion does not cover (the universal coverage gate).
+#
+# No bypass env: an agent that genuinely needs raw exploration can name a
+# different agent (general-purpose) or use legion:legion-explore, which itself
+# falls back to bounded Reads. The point is to retire the grep-first default,
+# not to forbid all exploration.
+
+# shellcheck source=lib/prelude.sh
+source "${CLAUDE_PLUGIN_ROOT:-}/hooks/lib/prelude.sh" 2>/dev/null || exit 0
+# shellcheck source=lib/emit.sh
+source "${CLAUDE_PLUGIN_ROOT:-}/hooks/lib/emit.sh" 2>/dev/null || exit 0
+
+legion_hook_parse || exit 0
+
+SUBAGENT=$(legion_hook_field '.tool_input.subagent_type')
+if [ -z "$SUBAGENT" ] || [ "$SUBAGENT" = "null" ]; then
+  exit 0
+fi
+
+# Case-insensitive EXACT match on "explore". An exact match must not catch the
+# redirect target (legion-explore / legion:legion-explore), so compare the whole
+# lowercased value, not a substring.
+SUBAGENT_LC=$(printf '%s' "$SUBAGENT" | tr '[:upper:]' '[:lower:]')
+if [ "$SUBAGENT_LC" != "explore" ]; then
+  exit 0
+fi
+
+# Universal gate: only enforce where legion is the intended tool (#353).
+legion_hook_covered || exit 0
+
+emit_deny "The built-in \`Explore\` subagent is disabled on legion-covered repos. Use \`legion:legion-explore\` instead -- it orients through SCIP sym queries (def/refs/impl/hover) and recall/consult rather than grep/find, and returns conclusions with file:line evidence instead of file dumps.
+
+Re-issue the call with subagent_type \`legion:legion-explore\` (same prompt)."

--- a/plugin/hooks/test-no-harness-explore.sh
+++ b/plugin/hooks/test-no-harness-explore.sh
@@ -44,6 +44,13 @@ assert_blocked "uppercase EXPLORE" '"EXPLORE"'
 echo "==> the denial redirects to legion:legion-explore"
 assert_contains "names the replacement agent" "$(run_hook '"Explore"')" 'legion:legion-explore'
 
+echo "==> the deny output is structurally valid JSON (not just a matching substring)"
+# The reason text carries backticks, em-dashes, and embedded newlines; assert
+# jq can parse the payload and read the decision field, so a malformed-but-
+# substring-present blob cannot pass.
+decision="$(run_hook '"Explore"' | jq -r '.hookSpecificOutput.permissionDecision' 2>/dev/null)"
+assert_contains "parses as JSON with permissionDecision=deny" "$decision" "deny"
+
 echo "==> passes through the redirect target and other agents (exact match, not substring)"
 assert_allowed "legion-explore"                   '"legion-explore"'
 assert_allowed "namespaced legion:legion-explore" '"legion:legion-explore"'

--- a/plugin/hooks/test-no-harness-explore.sh
+++ b/plugin/hooks/test-no-harness-explore.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+# Test runner for the no-harness-explore PreToolUse hook.
+#
+# Verifies the hook denies a built-in Explore subagent spawn and redirects to
+# legion:legion-explore, while passing through the redirect target itself,
+# other agent types, an absent subagent_type, and repos legion does not cover.
+# Run from anywhere:
+#
+#   bash plugin/hooks/test-no-harness-explore.sh
+
+set -u
+
+# shellcheck source=tests/testutil.sh
+source "$(dirname "${BASH_SOURCE[0]}")/tests/testutil.sh"
+
+make_plugin_root no-harness-explore.sh
+
+# The hook gates on legion coverage; make the test repo covered via the
+# stub's watch-list fixture.
+export FAKE_WATCH="legion-test	/tmp/legion-test"
+
+HOOK="$CLAUDE_PLUGIN_ROOT/hooks/no-harness-explore.sh"
+
+run_hook() {
+  local subagent="$1"
+  printf '%s' "{\"tool_input\":{\"subagent_type\":${subagent}},\"cwd\":\"/tmp/legion-test\",\"session_id\":\"test\"}" | bash "$HOOK"
+}
+
+assert_blocked() {
+  local desc="$1" sub="$2"
+  assert_contains "$desc" "$(run_hook "$sub")" '"permissionDecision": "deny"'
+}
+
+assert_allowed() {
+  local desc="$1" sub="$2"
+  assert_not_contains "$desc" "$(run_hook "$sub")" '"permissionDecision": "deny"'
+}
+
+echo "==> blocks the built-in Explore subagent (case-insensitive)"
+assert_blocked "exact Explore"     '"Explore"'
+assert_blocked "lowercase explore" '"explore"'
+assert_blocked "uppercase EXPLORE" '"EXPLORE"'
+
+echo "==> the denial redirects to legion:legion-explore"
+assert_contains "names the replacement agent" "$(run_hook '"Explore"')" 'legion:legion-explore'
+
+echo "==> passes through the redirect target and other agents (exact match, not substring)"
+assert_allowed "legion-explore"                   '"legion-explore"'
+assert_allowed "namespaced legion:legion-explore" '"legion:legion-explore"'
+assert_allowed "Plan"                             '"Plan"'
+assert_allowed "general-purpose"                  '"general-purpose"'
+assert_allowed "code-explorer contains explore"   '"code-explorer"'
+
+echo "==> missing subagent_type passes through"
+out=$(printf '%s' '{"tool_input":{},"cwd":"/tmp/legion-test","session_id":"test"}' | bash "$HOOK")
+assert_empty "no subagent_type field" "$out"
+
+echo "==> uncovered repo passes through"
+out=$(printf '%s' '{"tool_input":{"subagent_type":"Explore"},"cwd":"/tmp/uncovered-repo","session_id":"test"}' | bash "$HOOK")
+assert_empty "Explore allowed in a repo legion does not cover" "$out"
+
+finish_tests


### PR DESCRIPTION
## Summary

Blocks the harness built-in `Explore` subagent on legion-covered repos and redirects the model to the `legion:legion-explore` plugin agent, which orients through SCIP sym queries and recall/consult instead of grep/find. The redirect is a PreToolUse hook on the Agent/Task spawn tool, because PreToolUse is the only event that can both see `subagent_type` and `deny` the call -- SubagentStart matches the agent type but is context-only and cannot block (verified against the hooks reference, after the claude-code-guide agent mis-recommended it).

## Acceptance criteria mapping

### 1. Explore spawn is denied with a legion:legion-explore redirect in covered repos
The hook reads `tool_input.subagent_type`, lowercases it, and on an exact match to `explore` calls `emit_deny` (the lib helper that emits `permissionDecision: "deny"` + `permissionDecisionReason`). The reason text names `legion:legion-explore` and tells the model to re-issue the same prompt with that subagent_type. The deny runs at PreToolUse, before the spawn, so Explore never starts.
Evidence: `plugin/hooks/no-harness-explore.sh`; test `assert_blocked "exact Explore"` and `assert_contains "names the replacement agent" ... 'legion:legion-explore'`.

### 2. legion-explore and other agent types pass through; uncovered repos pass through
The match is an exact lowercased compare, not a substring, so `legion-explore`, `legion:legion-explore` (the redirect target), and `code-explorer` all pass. Any non-Explore agent (Plan, general-purpose) passes. The hook gates on `legion_hook_covered`, so a repo legion does not cover passes through even for Explore -- consistent with the sym/grep/read enforcement hooks.
Evidence: `plugin/hooks/no-harness-explore.sh` (the `!= "explore"` early-exit and the `legion_hook_covered || exit 0` gate); tests `assert_allowed "legion-explore"`, `"code-explorer contains explore"`, and the uncovered-repo passthrough assertion.

### 3. Hook test covers deny + passthrough cases
`test-no-harness-explore.sh` mirrors the existing `test-no-gh.sh` harness (testutil.sh, FAKE_WATCH coverage fixture). It asserts the deny path (Explore, case-insensitive), the redirect target appears, every passthrough case (redirect target, other agents, the substring-but-not-Explore `code-explorer`), an absent `subagent_type`, and the uncovered-repo passthrough. 11 assertions, all green.
Evidence: `plugin/hooks/test-no-harness-explore.sh`; run output "11 passed, 0 failed".

### 4. Simplify + review passes; PR linked
The simplify gate was recorded through the new #665 articulation mechanism (`legion quality-gate check`) with a per-file articulation for all three changed files (gate 019ee7ab) -- this PR dogfoots #665. hooks.json validated with jq; both scripts shellcheck-clean. Review runs next. PR references #670; branch feat/670-block-explore.
Evidence: simplify gate 019ee7ab on HEAD dd39f7f; `jq empty plugin/hooks/hooks.json` clean; shellcheck clean.

## Not done

No permission deny rule (`Agent(Explore)`): plugins cannot ship permission rules and deny rules carry no redirect message, so the hook is the only mechanism that both blocks and redirects from within the plugin. No bypass env var -- an agent that needs raw exploration can name `general-purpose`, and `legion:legion-explore` itself falls back to bounded Reads; the goal is to retire the grep-first default, not forbid exploration. The Agent and Task matchers wire the same hook in two blocks, matching the repo's existing Grep/Glob convention rather than a combined matcher.