### PR TITLE
fix(#673): wake/daemon robustness -- 4 fixes from the wake investigation

### DIFF
--- a/plugin/hooks/hooks.json
+++ b/plugin/hooks/hooks.json
@@ -39,6 +39,17 @@
         ]
       }
     ],
+    "SessionEnd": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/session-end.sh",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
     "SubagentStop": [
       {
         "matcher": "*",

--- a/plugin/hooks/session-end.sh
+++ b/plugin/hooks/session-end.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# Legion SessionEnd hook (#673 fix 2): remove the interactive .session lock
+# when a session actually terminates.
+#
+# The SessionStart hook writes a `.session` lock (legion watch session-start,
+# tracking the long-lived Claude session pid) so the watch daemon does not
+# spawn a duplicate agent while a human session is open (#583). Until now the
+# only cleanup was passive -- the daemon's active-session gate deletes the
+# `.session` opportunistically on a later poll when it reads a dead pid. That
+# leaves a window where a recycled pid reads as a false "active session" and
+# suppresses a legitimate wake. This hook closes the window by removing the
+# lock the moment the session ends.
+#
+# SessionEnd fires on real session termination (NOT per-turn like Stop), so it
+# is safe to remove the `.session` here -- the long-lived process is exiting.
+# Idempotent and fail-open: a missing file, absent CLI, or any error is a
+# no-op (|| true), so a hook failure can never affect shutdown.
+#
+# For watch-spawned wakes $LEGION_WAKE_ATTEMPT_ID is set and also stamps
+# exit_observed_at for the reaper; for interactive sessions it is empty and the
+# --repo hint drives the `.session` removal.
+
+# shellcheck source=lib/prelude.sh
+source "${CLAUDE_PLUGIN_ROOT:-}/hooks/lib/prelude.sh" 2>/dev/null || exit 0
+
+legion_hook_parse || exit 0
+
+# Only act on covered repos -- we need a known repo name to resolve the
+# `.session` path, and uncovered repos have no lock to clear.
+legion_hook_covered || exit 0
+if [ -z "$REPO" ] || [ ! -x "$LEGION" ]; then
+  exit 0
+fi
+
+"$LEGION" watch session-end \
+  --attempt-id "${LEGION_WAKE_ATTEMPT_ID:-}" \
+  --repo "$REPO" \
+  >/dev/null 2>&1 || true
+
+exit 0

--- a/src/cli/signal.rs
+++ b/src/cli/signal.rs
@@ -85,16 +85,20 @@ pub(crate) fn handle_signal(
     // Guard: --repo is the authoring context; --to is the routing target.
     // Sending a signal where author == recipient is silently dropped by the
     // poll query (src/db/board.rs: `AND r.repo != ?{repo_param}`), so the
-    // daemon never sees it. Broadcasts (@all, @everyone) are exempt -- they
-    // route through a separate fan-out path that ignores the author filter.
-    // `is_self_address` handles case normalization.
-    if is_self_address(&repo, &to) {
-        // Find the matching author to name it in the error.
+    // daemon never sees it. Broadcasts (bare "all", "everyone", or the
+    // "@"-prefixed forms) are exempt -- they route through a separate fan-out
+    // path that ignores the author filter. `signal::is_self_address` handles
+    // case normalization and the leading-@ strip.
+    if crate::signal::is_self_address(&repo, &to) {
+        // Find the matching author to name it in the error. Strip a leading '@'
+        // from `to` before comparison so "@legion" matches "legion" in the repo
+        // list -- matching is_self_address's own normalization.
+        let bare_to = to.strip_prefix('@').unwrap_or(&to);
         let matched = repo
             .iter()
-            .find(|r| r.to_lowercase() == to.to_lowercase())
+            .find(|r| r.to_lowercase() == bare_to.to_lowercase())
             .cloned()
-            .unwrap_or_else(|| to.clone());
+            .unwrap_or_else(|| bare_to.to_string());
         return Err(error::LegionError::SignalSelfAddressed { repo: matched });
     }
 
@@ -244,80 +248,39 @@ pub(crate) fn handle_bullpen(
     Ok(())
 }
 
-/// Pure helper: decide whether a signal address is a self-address collision.
-///
-/// Returns `true` when `to` equals any entry in `repos` (case-insensitive)
-/// AND is not a broadcast sentinel ("all" / "everyone"). Extracted so the
-/// guard logic is unit-testable without a live DB.
-fn is_self_address(repos: &[String], to: &str) -> bool {
-    let to_lower = to.to_lowercase();
-    let is_broadcast = matches!(to_lower.as_str(), "all" | "everyone");
-    if is_broadcast {
-        return false;
-    }
-    repos.iter().any(|r| r.to_lowercase() == to_lower)
-}
+// is_self_address was extracted from this module and now lives in
+// crate::signal (src/signal.rs) so both the CLI and MCP signal guards
+// share one implementation. See that module's tests for the full suite.
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    // -- FIX 1: self-address guard ------------------------------------------
+    // -- self-address guard (delegates to crate::signal::is_self_address) ---
+    //
+    // These tests exercise the shared guard from the CLI surface's perspective.
+    // The full sentinel + case + @-strip coverage lives in signal::tests.
 
     #[test]
     fn self_address_guard_rejects_same_repo() {
-        // Exact match: author repo equals recipient.
         assert!(
-            is_self_address(&["legion".to_string()], "legion"),
-            "legion -> legion must be detected as self-address"
-        );
-    }
-
-    #[test]
-    fn self_address_guard_rejects_case_insensitive() {
-        // Case normalization: "Legion" and "legion" are the same.
-        assert!(
-            is_self_address(&["legion".to_string()], "Legion"),
-            "case mismatch must still be caught as self-address"
-        );
-        assert!(
-            is_self_address(&["Legion".to_string()], "legion"),
-            "repo-side case mismatch must still be caught"
-        );
-    }
-
-    #[test]
-    fn self_address_guard_allows_different_repo() {
-        // Different repos: author=legion, recipient=huttspawn -- this is fine.
-        assert!(
-            !is_self_address(&["legion".to_string()], "huttspawn"),
-            "a signal to a different repo must not be flagged"
+            crate::signal::is_self_address(&["legion".to_string()], "legion"),
+            "exact match must be detected as self-address"
         );
     }
 
     #[test]
     fn self_address_guard_allows_broadcast_all() {
-        // Broadcasts are always permitted regardless of author.
+        // Bare broadcast sentinels.
         assert!(
-            !is_self_address(&["legion".to_string()], "all"),
+            !crate::signal::is_self_address(&["legion".to_string()], "all"),
             "broadcast 'all' must never be flagged as self-address"
         );
+        // @-prefixed broadcast: callers passing "@all" must be treated as a
+        // broadcast, not a self-address, after the leading-@ strip.
         assert!(
-            !is_self_address(&["legion".to_string()], "everyone"),
-            "broadcast 'everyone' must never be flagged as self-address"
-        );
-    }
-
-    #[test]
-    fn self_address_guard_allows_broadcast_case_insensitive() {
-        // Broadcasts with different case must also pass.
-        assert!(
-            !is_self_address(&["legion".to_string()], "ALL"),
-            "broadcast 'ALL' must never be flagged"
-        );
-        assert!(
-            !is_self_address(&["legion".to_string()], "Everyone"),
-            "broadcast 'Everyone' must never be flagged"
+            !crate::signal::is_self_address(&["legion".to_string()], "@all"),
+            "@all with leading @ must be treated as a broadcast"
         );
     }
 

--- a/src/cli/signal.rs
+++ b/src/cli/signal.rs
@@ -82,6 +82,22 @@ pub(crate) fn handle_signal(
     domain: Option<String>,
     tags: Option<String>,
 ) -> error::Result<()> {
+    // Guard: --repo is the authoring context; --to is the routing target.
+    // Sending a signal where author == recipient is silently dropped by the
+    // poll query (src/db/board.rs: `AND r.repo != ?{repo_param}`), so the
+    // daemon never sees it. Broadcasts (@all, @everyone) are exempt -- they
+    // route through a separate fan-out path that ignores the author filter.
+    // `is_self_address` handles case normalization.
+    if is_self_address(&repo, &to) {
+        // Find the matching author to name it in the error.
+        let matched = repo
+            .iter()
+            .find(|r| r.to_lowercase() == to.to_lowercase())
+            .cloned()
+            .unwrap_or_else(|| to.clone());
+        return Err(error::LegionError::SignalSelfAddressed { repo: matched });
+    }
+
     let (database, index) = open_db_and_index()?;
 
     // One compose/validate entry point shared with the MCP legion_signal
@@ -226,4 +242,103 @@ pub(crate) fn handle_bullpen(
         }
     }
     Ok(())
+}
+
+/// Pure helper: decide whether a signal address is a self-address collision.
+///
+/// Returns `true` when `to` equals any entry in `repos` (case-insensitive)
+/// AND is not a broadcast sentinel ("all" / "everyone"). Extracted so the
+/// guard logic is unit-testable without a live DB.
+fn is_self_address(repos: &[String], to: &str) -> bool {
+    let to_lower = to.to_lowercase();
+    let is_broadcast = matches!(to_lower.as_str(), "all" | "everyone");
+    if is_broadcast {
+        return false;
+    }
+    repos.iter().any(|r| r.to_lowercase() == to_lower)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // -- FIX 1: self-address guard ------------------------------------------
+
+    #[test]
+    fn self_address_guard_rejects_same_repo() {
+        // Exact match: author repo equals recipient.
+        assert!(
+            is_self_address(&["legion".to_string()], "legion"),
+            "legion -> legion must be detected as self-address"
+        );
+    }
+
+    #[test]
+    fn self_address_guard_rejects_case_insensitive() {
+        // Case normalization: "Legion" and "legion" are the same.
+        assert!(
+            is_self_address(&["legion".to_string()], "Legion"),
+            "case mismatch must still be caught as self-address"
+        );
+        assert!(
+            is_self_address(&["Legion".to_string()], "legion"),
+            "repo-side case mismatch must still be caught"
+        );
+    }
+
+    #[test]
+    fn self_address_guard_allows_different_repo() {
+        // Different repos: author=legion, recipient=huttspawn -- this is fine.
+        assert!(
+            !is_self_address(&["legion".to_string()], "huttspawn"),
+            "a signal to a different repo must not be flagged"
+        );
+    }
+
+    #[test]
+    fn self_address_guard_allows_broadcast_all() {
+        // Broadcasts are always permitted regardless of author.
+        assert!(
+            !is_self_address(&["legion".to_string()], "all"),
+            "broadcast 'all' must never be flagged as self-address"
+        );
+        assert!(
+            !is_self_address(&["legion".to_string()], "everyone"),
+            "broadcast 'everyone' must never be flagged as self-address"
+        );
+    }
+
+    #[test]
+    fn self_address_guard_allows_broadcast_case_insensitive() {
+        // Broadcasts with different case must also pass.
+        assert!(
+            !is_self_address(&["legion".to_string()], "ALL"),
+            "broadcast 'ALL' must never be flagged"
+        );
+        assert!(
+            !is_self_address(&["legion".to_string()], "Everyone"),
+            "broadcast 'Everyone' must never be flagged"
+        );
+    }
+
+    #[test]
+    fn self_address_error_variant_names_the_repo() {
+        // Verify the error variant carries the repo name so the message is useful.
+        let err = error::LegionError::SignalSelfAddressed {
+            repo: "legion".to_string(),
+        };
+        let msg = err.to_string();
+        assert!(
+            msg.contains("legion"),
+            "error message must name the repo: {msg}"
+        );
+        assert!(
+            msg.contains("--repo"),
+            "error message must reference --repo flag: {msg}"
+        );
+        assert!(
+            msg.contains("--to"),
+            "error message must reference --to flag: {msg}"
+        );
+    }
 }

--- a/src/cli/watch.rs
+++ b/src/cli/watch.rs
@@ -64,10 +64,21 @@ pub(crate) enum WatchAction {
     /// skip a poll cycle. PTY EOF + PID-poll remain authoritative; this
     /// is a speed-up only. Idempotent; exits 0 on a missing row so a
     /// hook failure cannot block Claude Code's Stop.
+    ///
+    /// For interactive (human-started) sessions, `$LEGION_WAKE_ATTEMPT_ID`
+    /// is empty; pass `--repo <name>` so the `.session` file is still
+    /// cleaned up even when no wake_attempts row exists (#673 fix 2).
     SessionEnd {
         /// UUIDv7 attempt id, sourced from $LEGION_WAKE_ATTEMPT_ID.
         #[arg(long)]
         attempt_id: String,
+
+        /// Repo name for interactive sessions that have no wake_attempts row.
+        /// When provided and the attempt-id lookup finds no row, this repo's
+        /// `.session` file is removed. Idempotent; ignored when the row exists
+        /// (the repo is resolved from the row instead).
+        #[arg(long)]
+        repo: Option<String>,
     },
 
     /// Show whether the watch daemon is alive, stale, or absent (#581).
@@ -386,9 +397,9 @@ pub(crate) fn handle(action: Option<WatchAction>) -> error::Result<()> {
                 );
             }
         }
-        Some(WatchAction::SessionEnd { attempt_id }) => {
+        Some(WatchAction::SessionEnd { attempt_id, repo }) => {
             let db = open_db()?;
-            watch::record_session_end(&db, &attempt_id, &base)?;
+            watch::record_session_end(&db, &attempt_id, repo.as_deref(), &base)?;
         }
         Some(WatchAction::Status {
             recent,

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -320,6 +320,11 @@ fn process_cmdline(pid: u32) -> Option<String> {
 /// word "legion" and either "daemon" or "serve" as a subcommand. This is
 /// intentionally conservative: if the binary name or args cannot be confirmed
 /// to match, `kill_orphaned_daemon_on_port` refuses to kill the holder.
+///
+/// The " serve" match is intentional: `legion serve` is the legacy daemon form
+/// (pre-daemon-spawn split) and is harmless to include because only the
+/// daemon-port holder is ever examined -- a non-port-holding `legion serve`
+/// would never reach this check.
 fn cmdline_is_legion_daemon(cmdline: &str) -> bool {
     // Lower-case once so the check is case-insensitive across platforms.
     let lower = cmdline.to_lowercase();
@@ -329,6 +334,22 @@ fn cmdline_is_legion_daemon(cmdline: &str) -> bool {
     // without a daemon arg do not.
     lower.contains("legion")
         && (lower.contains(" daemon") || lower.contains("/daemon") || lower.contains(" serve"))
+}
+
+/// Decide whether a port holder should be killed.
+///
+/// Returns `true` only when `cmdline` is `Some` and identifies a legion daemon
+/// process. `None` (cmdline unreadable) and any non-legion cmdline return
+/// `false` -- the safety invariant is "refuse to kill an unidentified or
+/// non-legion process".
+///
+/// Extracted from `kill_orphaned_daemon_on_port` so this safety contract is
+/// independently testable without spawning real processes.
+pub(crate) fn should_kill_port_holder(cmdline: Option<&str>) -> bool {
+    match cmdline {
+        Some(c) => cmdline_is_legion_daemon(c),
+        None => false,
+    }
 }
 
 /// Kill an orphaned daemon holding `port` when we can confirm it is a legion
@@ -346,23 +367,19 @@ fn kill_orphaned_daemon_on_port(port: u16) -> bool {
 
     let mut killed_any = false;
     for pid in pids {
-        let cmdline = match process_cmdline(pid) {
-            Some(c) => c,
-            None => {
-                eprintln!(
+        let cmdline: Option<String> = process_cmdline(pid);
+        if !should_kill_port_holder(cmdline.as_deref()) {
+            match &cmdline {
+                None => eprintln!(
                     "[legion] daemon-restart: cannot read cmdline for port-holder pid {pid} -- \
                      refusing to kill an unidentified process"
-                );
-                continue;
+                ),
+                Some(c) => eprintln!(
+                    "[legion] daemon-restart: port {port} is held by pid {pid} ({c:?}), \
+                     which does not look like a legion daemon -- refusing to kill it. \
+                     Stop it manually, then retry."
+                ),
             }
-        };
-
-        if !cmdline_is_legion_daemon(&cmdline) {
-            eprintln!(
-                "[legion] daemon-restart: port {port} is held by pid {pid} ({cmdline:?}), \
-                 which does not look like a legion daemon -- refusing to kill it. \
-                 Stop it manually, then retry."
-            );
             continue;
         }
 
@@ -898,6 +915,55 @@ mod tests {
         assert!(
             cmdline_is_legion_daemon("Legion Daemon"),
             "uppercase forms must also match"
+        );
+    }
+
+    // -- should_kill_port_holder (#673 review fix) ---------------------------
+    //
+    // Tests lock in the safety invariant: never kill an unidentified process
+    // (None cmdline) or a non-legion process, only a confirmed legion daemon.
+
+    #[test]
+    fn should_kill_port_holder_refuses_unidentified_process() {
+        // None: cmdline could not be read (permission error, proc gone, etc.).
+        // Safety: refuse -- we cannot identify the holder.
+        assert!(
+            !should_kill_port_holder(None),
+            "None cmdline must return false (refuse to kill unidentified process)"
+        );
+    }
+
+    #[test]
+    fn should_kill_port_holder_refuses_non_legion_process() {
+        // A real process holding the port that is NOT a legion daemon.
+        assert!(
+            !should_kill_port_holder(Some("node server.js")),
+            "node server must not be killed"
+        );
+        assert!(
+            !should_kill_port_holder(Some("python -m http.server 3131")),
+            "python server must not be killed"
+        );
+        assert!(
+            !should_kill_port_holder(Some("legion recall --repo foo")),
+            "legion non-daemon CLI invocation must not be killed"
+        );
+    }
+
+    #[test]
+    fn should_kill_port_holder_approves_legion_daemon() {
+        // A confirmed legion daemon process should be killed.
+        assert!(
+            should_kill_port_holder(Some("legion daemon --port 3131")),
+            "legion daemon must be approved for kill"
+        );
+        assert!(
+            should_kill_port_holder(Some("/usr/local/bin/legion daemon")),
+            "absolute-path legion daemon must be approved"
+        );
+        assert!(
+            should_kill_port_holder(Some("legion serve")),
+            "legacy 'legion serve' form must be approved"
         );
     }
 }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -278,16 +278,159 @@ pub fn stop_detached(data_dir: &Path) -> Result<bool> {
     Ok(true)
 }
 
+/// Best-effort: retrieve the full command-line string for a process on Unix.
+///
+/// On macOS uses `ps -p <pid> -o args=`; on Linux reads `/proc/<pid>/cmdline`
+/// (NUL-separated, converted to spaces). Returns `None` when the process is
+/// not found, the command is unavailable, or we are on a non-Unix platform.
+/// This is intentionally best-effort -- callers guard against `None` by
+/// refusing to kill the holder rather than proceeding blindly.
+fn process_cmdline(pid: u32) -> Option<String> {
+    #[cfg(target_os = "macos")]
+    {
+        let out = std::process::Command::new("ps")
+            .args(["-p", &pid.to_string(), "-o", "args="])
+            .output()
+            .ok()?;
+        let s = String::from_utf8_lossy(&out.stdout).trim().to_string();
+        if s.is_empty() { None } else { Some(s) }
+    }
+    #[cfg(target_os = "linux")]
+    {
+        let raw = std::fs::read(format!("/proc/{}/cmdline", pid)).ok()?;
+        let s: String = raw
+            .split(|&b| b == 0)
+            .filter_map(|chunk| std::str::from_utf8(chunk).ok())
+            .collect::<Vec<_>>()
+            .join(" ")
+            .trim()
+            .to_string();
+        if s.is_empty() { None } else { Some(s) }
+    }
+    #[cfg(not(any(target_os = "macos", target_os = "linux")))]
+    {
+        let _ = pid;
+        None
+    }
+}
+
+/// Return true when the command-line string looks like a legion daemon process.
+///
+/// A process is considered a legion daemon when its command line contains the
+/// word "legion" and either "daemon" or "serve" as a subcommand. This is
+/// intentionally conservative: if the binary name or args cannot be confirmed
+/// to match, `kill_orphaned_daemon_on_port` refuses to kill the holder.
+fn cmdline_is_legion_daemon(cmdline: &str) -> bool {
+    // Lower-case once so the check is case-insensitive across platforms.
+    let lower = cmdline.to_lowercase();
+    // Must contain the binary name "legion" and one of the daemon subcommands.
+    // "legion daemon", "legion serve" (legacy), and the built path
+    // "/path/to/legion daemon" all pass; unrelated processes named "legion"
+    // without a daemon arg do not.
+    lower.contains("legion")
+        && (lower.contains(" daemon") || lower.contains("/daemon") || lower.contains(" serve"))
+}
+
+/// Kill an orphaned daemon holding `port` when we can confirm it is a legion
+/// daemon process. Returns `true` when a process was identified and killed,
+/// `false` when no holder was found or the holder could not be confirmed as
+/// a legion daemon (in which case the holder is left alone).
+///
+/// Safety invariant: we ONLY kill the process when `cmdline_is_legion_daemon`
+/// returns true. An unrelated process holding the same port is never touched.
+fn kill_orphaned_daemon_on_port(port: u16) -> bool {
+    let pids = port_listener_pids(port);
+    if pids.is_empty() {
+        return false;
+    }
+
+    let mut killed_any = false;
+    for pid in pids {
+        let cmdline = match process_cmdline(pid) {
+            Some(c) => c,
+            None => {
+                eprintln!(
+                    "[legion] daemon-restart: cannot read cmdline for port-holder pid {pid} -- \
+                     refusing to kill an unidentified process"
+                );
+                continue;
+            }
+        };
+
+        if !cmdline_is_legion_daemon(&cmdline) {
+            eprintln!(
+                "[legion] daemon-restart: port {port} is held by pid {pid} ({cmdline:?}), \
+                 which does not look like a legion daemon -- refusing to kill it. \
+                 Stop it manually, then retry."
+            );
+            continue;
+        }
+
+        eprintln!("[legion] daemon-restart: killing orphaned daemon pid {pid} holding port {port}");
+        if send_signal(pid, "TERM") {
+            if !wait_for_exit(pid, GRACEFUL_STOP_TIMEOUT) {
+                eprintln!(
+                    "[legion] daemon-restart: orphaned daemon {pid} did not exit after SIGTERM; \
+                     escalating to SIGKILL"
+                );
+                send_signal(pid, "KILL");
+                wait_for_exit(pid, SIGKILL_REAP_TIMEOUT);
+            }
+        } else {
+            // TERM failed (EPERM or already exiting); try KILL.
+            send_signal(pid, "KILL");
+            wait_for_exit(pid, SIGKILL_REAP_TIMEOUT);
+        }
+
+        if !watch::process_alive(pid) {
+            eprintln!("[legion] daemon-restart: orphaned daemon {pid} stopped");
+            killed_any = true;
+        } else {
+            eprintln!(
+                "[legion] daemon-restart: failed to stop orphaned daemon {pid} on port {port}"
+            );
+        }
+    }
+    killed_any
+}
+
 /// Restart the background daemon: stop the running one (bounded), then spawn fresh.
 ///
 /// This is the supported way to bounce the daemon. A bare `daemon-spawn` after a
 /// manual kill can race the dying daemon's graceful-shutdown drain (port still
 /// bound -> "Address already in use", or "already running" while it exits); restart
 /// removes that wait by stopping deterministically before spawning.
+///
+/// Wedge recovery (#673 fix 3): when the pidfile is stale or missing but the
+/// daemon port is held, identifies the holding process and kills it (after
+/// confirming it is a legion daemon process). This prevents the common wedge
+/// where a daemon whose pidfile was lost still holds the port, and
+/// `daemon-spawn` refuses with "port in use" until a manual kill.
 pub fn restart_detached(data_dir: &Path, port: u16) -> Result<()> {
     if stop_detached(data_dir)? {
         eprintln!("[legion] stopped running daemon");
     }
+
+    // FIX 3: after the pidfile-based stop, check whether the port is still
+    // held. If so, the pidfile was stale/missing (orphaned daemon). Attempt
+    // to identify and kill the holder if it is a legion daemon process.
+    if !port_available(port) {
+        eprintln!(
+            "[legion] daemon-restart: port {port} still held after pidfile-based stop; \
+             checking for orphaned daemon"
+        );
+        kill_orphaned_daemon_on_port(port);
+
+        // Give the OS a moment to release the port after the kill.
+        if !port_available(port) {
+            // Port is still held -- either the kill failed or the holder was
+            // not a legion daemon. spawn_detached will produce a clear error.
+            eprintln!(
+                "[legion] daemon-restart: port {port} is still held; spawn will report the holder"
+            );
+        }
+    }
+
     spawn_detached(data_dir, port)
 }
 
@@ -696,6 +839,65 @@ mod tests {
         assert!(
             response_str.contains('['),
             "expected JSON array body in response"
+        );
+    }
+
+    // -- FIX 3: cmdline-based daemon identification (#673) ------------------
+
+    #[test]
+    fn cmdline_is_legion_daemon_matches_daemon_args() {
+        // Typical production forms that must be identified as a legion daemon.
+        assert!(
+            cmdline_is_legion_daemon("/usr/local/bin/legion daemon --port 3131"),
+            "absolute path legion daemon must match"
+        );
+        assert!(
+            cmdline_is_legion_daemon("legion daemon"),
+            "bare 'legion daemon' must match"
+        );
+        assert!(
+            cmdline_is_legion_daemon("legion serve"),
+            "legacy 'legion serve' must match (same port, same binary)"
+        );
+        assert!(
+            cmdline_is_legion_daemon("/home/user/.cargo/bin/legion daemon"),
+            "cargo-installed binary must match"
+        );
+    }
+
+    #[test]
+    fn cmdline_is_legion_daemon_rejects_unrelated_processes() {
+        // Processes that happen to be on the same port but are not a legion daemon.
+        assert!(
+            !cmdline_is_legion_daemon("node server.js"),
+            "node server must not be identified as a legion daemon"
+        );
+        assert!(
+            !cmdline_is_legion_daemon("python -m http.server 3131"),
+            "python http server must not be identified as a legion daemon"
+        );
+        assert!(
+            !cmdline_is_legion_daemon(""),
+            "empty cmdline must not match"
+        );
+        // A process named legion but running a non-daemon subcommand must not
+        // be killed -- it could be a `legion recall` or `legion post` call.
+        assert!(
+            !cmdline_is_legion_daemon("legion recall --repo legion"),
+            "legion CLI (non-daemon subcommand) must not be identified as a daemon"
+        );
+        assert!(
+            !cmdline_is_legion_daemon("legion post --repo legion"),
+            "legion post must not be identified as a daemon"
+        );
+    }
+
+    #[test]
+    fn cmdline_is_legion_daemon_is_case_insensitive() {
+        // Platform cmdlines can have varying case.
+        assert!(
+            cmdline_is_legion_daemon("Legion Daemon"),
+            "uppercase forms must also match"
         );
     }
 }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -314,26 +314,36 @@ fn process_cmdline(pid: u32) -> Option<String> {
     }
 }
 
-/// Return true when the command-line string looks like a legion daemon process.
+/// Return true when the command-line string is a legion daemon process.
 ///
-/// A process is considered a legion daemon when its command line contains the
-/// word "legion" and either "daemon" or "serve" as a subcommand. This is
-/// intentionally conservative: if the binary name or args cannot be confirmed
-/// to match, `kill_orphaned_daemon_on_port` refuses to kill the holder.
+/// This is the safety boundary for SIGKILL, so the match is structural, not a
+/// free-text scan: `argv[0]`'s basename must be exactly `legion`, and its first
+/// argument must be the `daemon` (or legacy `serve`) subcommand. A substring
+/// scan over the whole cmdline is too loose for a kill decision -- e.g.
+/// `node serve --legion-mode` contains both "legion" and "serve" but is not a
+/// legion daemon and must never be killed.
 ///
-/// The " serve" match is intentional: `legion serve` is the legacy daemon form
-/// (pre-daemon-spawn split) and is harmless to include because only the
-/// daemon-port holder is ever examined -- a non-port-holding `legion serve`
-/// would never reach this check.
+/// The `serve` subcommand is intentionally accepted: `legion serve` is the
+/// legacy daemon form (pre-daemon-spawn split) and is harmless because only the
+/// daemon-port holder is ever examined. `daemon-spawn`/`daemon-restart` do NOT
+/// match (they are short-lived CLI calls, never the port holder), and neither
+/// do other legion subcommands (`recall`, `post`, ...).
 fn cmdline_is_legion_daemon(cmdline: &str) -> bool {
-    // Lower-case once so the check is case-insensitive across platforms.
-    let lower = cmdline.to_lowercase();
-    // Must contain the binary name "legion" and one of the daemon subcommands.
-    // "legion daemon", "legion serve" (legacy), and the built path
-    // "/path/to/legion daemon" all pass; unrelated processes named "legion"
-    // without a daemon arg do not.
-    lower.contains("legion")
-        && (lower.contains(" daemon") || lower.contains("/daemon") || lower.contains(" serve"))
+    let mut tokens = cmdline.split_whitespace();
+    // argv[0]: the program. Its basename must be exactly "legion".
+    let prog = match tokens.next() {
+        Some(p) => p,
+        None => return false,
+    };
+    let base = prog.rsplit('/').next().unwrap_or(prog);
+    if !base.eq_ignore_ascii_case("legion") {
+        return false;
+    }
+    // argv[1]: the subcommand must be exactly "daemon" or "serve".
+    match tokens.next() {
+        Some(sub) => sub.eq_ignore_ascii_case("daemon") || sub.eq_ignore_ascii_case("serve"),
+        None => false,
+    }
 }
 
 /// Decide whether a port holder should be killed.
@@ -906,6 +916,23 @@ mod tests {
         assert!(
             !cmdline_is_legion_daemon("legion post --repo legion"),
             "legion post must not be identified as a daemon"
+        );
+        // Substring-match false positive that the structural argv[0]+subcommand
+        // check must reject: contains both "legion" and "serve" but argv[0] is
+        // node, not legion. This was the pre-push review's HIGH-1 example.
+        assert!(
+            !cmdline_is_legion_daemon("node serve --legion-mode"),
+            "a non-legion argv[0] must never match, even if later args mention legion/serve"
+        );
+        // daemon-spawn / daemon-restart are short-lived CLI calls, never the
+        // port holder; the exact-subcommand match must not treat them as the daemon.
+        assert!(
+            !cmdline_is_legion_daemon("legion daemon-spawn"),
+            "daemon-spawn is a CLI call, not the daemon"
+        );
+        assert!(
+            !cmdline_is_legion_daemon("legion daemon-restart"),
+            "daemon-restart is a CLI call, not the daemon"
         );
     }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -83,6 +83,12 @@ pub enum LegionError {
     )]
     SignalNoteTooLong { len: usize, max: usize },
 
+    #[error(
+        "--repo and --to must differ: '{repo}' is the authoring repo context, not the recipient. \
+         To signal {repo}, use: legion signal --repo <your-repo> --to {repo} ..."
+    )]
+    SignalSelfAddressed { repo: String },
+
     #[error("watch config error: {0}")]
     WatchConfig(String),
 

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -275,10 +275,10 @@ pub(super) fn handle_tool_call(
             // Guard: repo is the authoring context; to is the routing target.
             // When they are the same (case-insensitive) the signal is silently
             // dropped by the poll query, so reject it here the same way the
-            // CLI arm does (#673 fix 1). Broadcasts are exempt.
-            let to_lower = to.to_lowercase();
-            let is_broadcast = matches!(to_lower.as_str(), "all" | "everyone");
-            if !is_broadcast && repo.to_lowercase() == to_lower {
+            // CLI arm does (#673 fix 1). Broadcasts (bare "all", "everyone",
+            // or @-prefixed forms) are exempt. is_self_address is shared with
+            // the CLI guard so the sentinel set cannot drift.
+            if crate::signal::is_self_address(std::slice::from_ref(&repo), &to) {
                 return Err(LegionError::McpInvalidArgument(format!(
                     "--repo and --to must differ: '{}' is the authoring repo context, not the \
                      recipient. To signal {}, use a different --repo value.",
@@ -650,6 +650,73 @@ mod tests {
         assert!(
             text.contains("repo is required"),
             "expected 'repo is required' in error text, got: {text}"
+        );
+    }
+
+    #[test]
+    fn legion_signal_rejects_self_address_via_shared_guard() {
+        // The MCP guard now calls crate::signal::is_self_address (same as the
+        // CLI guard). Sending repo="legion" to="legion" must be rejected.
+        let (db, dir) = mcp_test_dir();
+        drop(db);
+
+        let tx = make_tx();
+        let req = make_request(
+            "tools/call",
+            Some(json!({
+                "name": "legion_signal",
+                "arguments": {
+                    "repo": "legion",
+                    "to": "legion",
+                    "verb": "review",
+                    "status": "approved"
+                }
+            })),
+        );
+
+        let resp = dispatch(&req, dir.path(), "0.6.0", &tx, None, None).expect("response");
+        assert_eq!(
+            resp["result"]["isError"], true,
+            "self-address signal must be rejected"
+        );
+        let text = resp["result"]["content"][0]["text"].as_str().unwrap_or("");
+        assert!(
+            text.contains("legion"),
+            "error must name the conflicting repo: {text}"
+        );
+    }
+
+    #[test]
+    fn legion_signal_allows_broadcast_with_at_prefix() {
+        // "@all" with a leading @ must be treated as a broadcast, not a
+        // self-address, by the shared is_self_address guard.
+        let (db, dir) = mcp_test_dir();
+        drop(db);
+
+        let tx = make_tx();
+        let req = make_request(
+            "tools/call",
+            Some(json!({
+                "name": "legion_signal",
+                "arguments": {
+                    "repo": "legion",
+                    "to": "@all",
+                    "verb": "announce",
+                    "note": "broadcast test"
+                }
+            })),
+        );
+
+        let resp = dispatch(&req, dir.path(), "0.6.0", &tx, None, None).expect("response");
+        // The signal itself should succeed (not be rejected as self-address).
+        // It may fail for other reasons (e.g., missing required fields on the
+        // verb) but must NOT fail with a self-address error.
+        let text = resp["result"]["content"][0]["text"].as_str().unwrap_or("");
+        let is_self_address_error =
+            text.contains("authoring repo context") || text.contains("--repo and --to must differ");
+        assert!(
+            !is_self_address_error,
+            "@all broadcast must not be rejected as a self-address: {text}"
         );
     }
 

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -272,6 +272,20 @@ pub(super) fn handle_tool_call(
             let note = get_str("note");
             let details_str = get_str("details");
 
+            // Guard: repo is the authoring context; to is the routing target.
+            // When they are the same (case-insensitive) the signal is silently
+            // dropped by the poll query, so reject it here the same way the
+            // CLI arm does (#673 fix 1). Broadcasts are exempt.
+            let to_lower = to.to_lowercase();
+            let is_broadcast = matches!(to_lower.as_str(), "all" | "everyone");
+            if !is_broadcast && repo.to_lowercase() == to_lower {
+                return Err(LegionError::McpInvalidArgument(format!(
+                    "--repo and --to must differ: '{}' is the authoring repo context, not the \
+                     recipient. To signal {}, use a different --repo value.",
+                    repo, repo
+                )));
+            }
+
             // One compose/validate entry point shared with the CLI signal
             // arm (#612): details wire parsing, the #587 required-fields
             // gate, and the note length cap all live in signal::compose.

--- a/src/signal.rs
+++ b/src/signal.rs
@@ -16,6 +16,28 @@ pub fn validate_note(note: &str) -> error::Result<()> {
     Ok(())
 }
 
+/// Decide whether a signal address is a self-address collision.
+///
+/// Returns `true` when `to` names any of the authoring repos (case-insensitive)
+/// AND is not a broadcast sentinel ("all" / "everyone"). Broadcast sentinels are
+/// always exempt -- they route through a fan-out path that ignores the author
+/// filter. A single leading `@` is stripped from `to` before comparison so a
+/// caller passing "@all" or "@legion" is handled the same as the bare forms.
+///
+/// Shared by both the CLI (`cli/signal.rs`) and MCP (`mcp/tools.rs`) signal
+/// guards so the sentinel set and stripping logic cannot drift between surfaces.
+pub(crate) fn is_self_address(repos: &[String], to: &str) -> bool {
+    // Strip one leading '@' so callers passing "@all" or "@legion" are
+    // handled identically to the bare "all" / "legion" forms.
+    let bare = to.strip_prefix('@').unwrap_or(to);
+    let lower = bare.to_lowercase();
+    // Broadcast sentinels are never self-addresses; they fan out to everyone.
+    if matches!(lower.as_str(), "all" | "everyone") {
+        return false;
+    }
+    repos.iter().any(|r| r.to_lowercase() == lower)
+}
+
 /// A parsed signal from a bullpen post.
 ///
 /// Signals follow the format: `@recipient verb:status {key: value, key: value}`
@@ -653,6 +675,83 @@ mod tests {
     fn validate_note_accepts_short_notes() {
         assert!(validate_note("short note").is_ok());
         assert!(validate_note(&"a".repeat(MAX_SIGNAL_NOTE_LENGTH)).is_ok());
+    }
+
+    // -- is_self_address (shared CLI + MCP guard) ---------------------------
+
+    #[test]
+    fn is_self_address_rejects_same_repo() {
+        assert!(
+            is_self_address(&["legion".to_string()], "legion"),
+            "exact match must be detected as self-address"
+        );
+    }
+
+    #[test]
+    fn is_self_address_rejects_case_insensitive() {
+        assert!(
+            is_self_address(&["legion".to_string()], "Legion"),
+            "case mismatch must still be caught"
+        );
+        assert!(
+            is_self_address(&["Legion".to_string()], "legion"),
+            "repo-side case mismatch must still be caught"
+        );
+    }
+
+    #[test]
+    fn is_self_address_allows_different_repo() {
+        assert!(
+            !is_self_address(&["legion".to_string()], "huttspawn"),
+            "a signal to a different repo must not be flagged"
+        );
+    }
+
+    #[test]
+    fn is_self_address_allows_broadcast_all() {
+        assert!(
+            !is_self_address(&["legion".to_string()], "all"),
+            "broadcast 'all' must never be flagged"
+        );
+        assert!(
+            !is_self_address(&["legion".to_string()], "everyone"),
+            "broadcast 'everyone' must never be flagged"
+        );
+    }
+
+    #[test]
+    fn is_self_address_allows_broadcast_case_insensitive() {
+        assert!(
+            !is_self_address(&["legion".to_string()], "ALL"),
+            "broadcast 'ALL' must never be flagged"
+        );
+        assert!(
+            !is_self_address(&["legion".to_string()], "Everyone"),
+            "broadcast 'Everyone' must never be flagged"
+        );
+    }
+
+    #[test]
+    fn is_self_address_strips_leading_at_for_broadcast() {
+        // Callers passing "@all" or "@everyone" must be treated as broadcasts,
+        // not self-addresses. The leading '@' is stripped before comparison.
+        assert!(
+            !is_self_address(&["legion".to_string()], "@all"),
+            "@all with leading @ must be treated as a broadcast"
+        );
+        assert!(
+            !is_self_address(&["legion".to_string()], "@everyone"),
+            "@everyone with leading @ must be treated as a broadcast"
+        );
+    }
+
+    #[test]
+    fn is_self_address_strips_leading_at_for_self_check() {
+        // A caller passing "@legion" is the same as passing "legion".
+        assert!(
+            is_self_address(&["legion".to_string()], "@legion"),
+            "@legion with leading @ must still be caught as self-address"
+        );
     }
 
     #[test]

--- a/src/watch/locks.rs
+++ b/src/watch/locks.rs
@@ -195,9 +195,15 @@ impl SessionLockTracker {
     /// Idempotent: a missing file is not an error. Removes only the
     /// `.session` file; the `.lock` file (watch-spawned) is untouched.
     ///
-    /// Available for explicit cleanup; the passive path is `active_pid`
-    /// deleting stale files opportunistically when it reads a dead PID.
-    #[allow(dead_code)] // public API completion -- no production call site yet
+    /// Called from two sites:
+    /// - `record_session_end` (stop-hook fast path) when a wake-attempt row
+    ///   exists for the ending session -- the repo name is resolved from the
+    ///   row so the right `.session` file is removed.
+    /// - `legion watch session-end` (interactive path) when no wake-attempt
+    ///   row exists -- the repo is passed directly from the CLI argument.
+    ///
+    /// The passive path is `active_pid` deleting stale files opportunistically
+    /// when it reads a dead PID.
     pub fn release_interactive(&self, repo: &str) -> Result<()> {
         let path = self.session_path(repo);
         match std::fs::remove_file(&path) {

--- a/src/watch/mod.rs
+++ b/src/watch/mod.rs
@@ -246,6 +246,11 @@ impl WatchLoop {
             .drive_submit_confirmation(&self.db, &self.config);
         self.tracker
             .reap_finished(Some(&self.db), Some(&self.session_locks));
+        // #673 fix 4: reap `running` wake_attempts whose backing pid is dead.
+        // These rows accumulate after crash/restart (pid-alive check only runs
+        // on the AgentTracker's live children; a row whose pid was never
+        // tracked by *this* daemon instance is invisible to the tracker).
+        reap_dead_pid_attempts(&self.db, &self.host, self.log_prefix);
         if let Err(e) = self.db.heartbeat_persona_leases(&self.host, self.lease_ttl) {
             eprintln!("{} lease heartbeat error: {e}", self.log_prefix);
         }
@@ -383,6 +388,57 @@ impl WatchLoop {
             "{} reconcile: auto-cancelled {cancelled} shipped-pending card(s), {failed} failed",
             self.log_prefix
         );
+    }
+}
+
+/// Reap `running` wake_attempts whose backing pid is dead (#673 fix 4).
+///
+/// `list_local_orphans` returns every in-flight row owned by this host.
+/// For each one that has a `spawned_pid`, we probe liveness with
+/// `process_alive`. A dead pid means the agent exited without the stop
+/// hook firing (crash, OOM, operator kill) -- mark the row `failed` via
+/// `record_wake_attempt_outcome` so it does not persist indefinitely.
+///
+/// Rows without a `spawned_pid` (queued/claimed/spawning without a
+/// recorded pid yet) are left alone -- they are still transitioning and
+/// the pid has not been stamped yet.
+///
+/// An error from the DB scan is logged and swallowed; the reaper must
+/// never abort the health tick.
+fn reap_dead_pid_attempts(db: &Database, host: &str, log_prefix: &str) {
+    let orphans = match db.list_local_orphans(host) {
+        Ok(v) => v,
+        Err(e) => {
+            eprintln!("{log_prefix} dead-pid reaper: scan error: {e}");
+            return;
+        }
+    };
+
+    for attempt in orphans {
+        let pid = match attempt.spawned_pid {
+            Some(p) => p,
+            None => continue, // no pid yet; skip
+        };
+
+        if process_alive(pid) {
+            continue; // still running; leave it alone
+        }
+
+        eprintln!(
+            "{log_prefix} dead-pid reaper: attempt {} (repo {}, pid {}) is not alive -- marking failed",
+            attempt.attempt_id, attempt.repo_name, pid
+        );
+
+        if let Err(e) = db.record_wake_attempt_outcome(
+            &attempt.attempt_id,
+            "error",
+            "dead-pid: process not found at reaper scan",
+        ) {
+            eprintln!(
+                "{log_prefix} dead-pid reaper: failed to mark {} as failed: {e}",
+                attempt.attempt_id
+            );
+        }
     }
 }
 
@@ -900,6 +956,134 @@ mod tests {
         assert!(
             !pid_path.exists(),
             "dropping the guard must release the pid lock"
+        );
+    }
+
+    // -- FIX 4: dead-pid reaper (#673) ----------------------------------------
+
+    /// A `running` wake_attempt with a dead pid is marked failed by
+    /// `reap_dead_pid_attempts`. A live-pid row is left alone.
+    #[cfg(unix)]
+    #[test]
+    fn reap_dead_pid_attempts_marks_dead_pid_failed_and_leaves_live_pid() {
+        let (db, _index, _dir) = test_storage();
+
+        // Spawn a real process, record its pid, then wait for it to die.
+        let mut child = std::process::Command::new("true")
+            .spawn()
+            .expect("spawn true");
+        let dead_pid = child.id();
+        child.wait().expect("wait for child");
+
+        // Insert a running attempt with the dead pid.
+        let dead_id = uuid::Uuid::now_v7().to_string();
+        db.enqueue_wake_attempt(&dead_id, "test-persona", "test-repo", &[])
+            .expect("enqueue dead-pid attempt");
+        db.try_claim_wake_attempt(&dead_id, "test-host")
+            .expect("claim dead-pid attempt");
+        db.transition_wake_attempt(
+            &dead_id,
+            crate::wake_attempts::WakeAttemptState::Claimed,
+            crate::wake_attempts::WakeAttemptState::Spawning,
+        )
+        .expect("spawning");
+        db.set_wake_attempt_pid(&dead_id, dead_pid)
+            .expect("set dead pid");
+        db.transition_wake_attempt(
+            &dead_id,
+            crate::wake_attempts::WakeAttemptState::Spawning,
+            crate::wake_attempts::WakeAttemptState::Running,
+        )
+        .expect("running");
+
+        // Insert a second running attempt with our own (live) pid.
+        let live_id = uuid::Uuid::now_v7().to_string();
+        db.enqueue_wake_attempt(&live_id, "test-persona", "test-repo", &[])
+            .expect("enqueue live-pid attempt");
+        db.try_claim_wake_attempt(&live_id, "test-host")
+            .expect("claim live-pid attempt");
+        db.transition_wake_attempt(
+            &live_id,
+            crate::wake_attempts::WakeAttemptState::Claimed,
+            crate::wake_attempts::WakeAttemptState::Spawning,
+        )
+        .expect("spawning live");
+        db.set_wake_attempt_pid(&live_id, std::process::id())
+            .expect("set live pid");
+        db.transition_wake_attempt(
+            &live_id,
+            crate::wake_attempts::WakeAttemptState::Spawning,
+            crate::wake_attempts::WakeAttemptState::Running,
+        )
+        .expect("running live");
+
+        // Run the reaper.
+        reap_dead_pid_attempts(&db, "test-host", "[test]");
+
+        // Dead-pid row must be in a terminal (failed) state.
+        let dead_row = db
+            .get_wake_attempt(&dead_id)
+            .expect("get dead row")
+            .expect("row exists");
+        assert_eq!(
+            dead_row.state.as_str(),
+            "failed",
+            "dead-pid attempt must be marked failed; got state: {}",
+            dead_row.state.as_str()
+        );
+
+        // Live-pid row must still be running.
+        let live_row = db
+            .get_wake_attempt(&live_id)
+            .expect("get live row")
+            .expect("row exists");
+        assert_eq!(
+            live_row.state.as_str(),
+            "running",
+            "live-pid attempt must remain in running state; got: {}",
+            live_row.state.as_str()
+        );
+    }
+
+    /// A `running` wake_attempt with no spawned_pid is left alone by the reaper
+    /// (it is still transitioning and has not been assigned a pid yet).
+    #[test]
+    fn reap_dead_pid_attempts_skips_rows_without_pid() {
+        let (db, _index, _dir) = test_storage();
+
+        // Insert a running attempt without calling set_wake_attempt_pid.
+        // Use direct SQL to get to running without a pid (rare in practice,
+        // but the reaper must handle it defensively).
+        let attempt_id = uuid::Uuid::now_v7().to_string();
+        db.enqueue_wake_attempt(&attempt_id, "test-persona", "test-repo", &[])
+            .expect("enqueue");
+        db.try_claim_wake_attempt(&attempt_id, "test-host")
+            .expect("claim");
+        // Transition to spawning and then running without setting a pid.
+        db.transition_wake_attempt(
+            &attempt_id,
+            crate::wake_attempts::WakeAttemptState::Claimed,
+            crate::wake_attempts::WakeAttemptState::Spawning,
+        )
+        .expect("spawning");
+        db.transition_wake_attempt(
+            &attempt_id,
+            crate::wake_attempts::WakeAttemptState::Spawning,
+            crate::wake_attempts::WakeAttemptState::Running,
+        )
+        .expect("running");
+
+        // Run the reaper -- must not crash and must leave the row alone.
+        reap_dead_pid_attempts(&db, "test-host", "[test]");
+
+        let row = db
+            .get_wake_attempt(&attempt_id)
+            .expect("get row")
+            .expect("row exists");
+        assert_eq!(
+            row.state.as_str(),
+            "running",
+            "no-pid running row must be left in running state"
         );
     }
 }

--- a/src/watch/spawn.rs
+++ b/src/watch/spawn.rs
@@ -110,13 +110,35 @@ impl SpawnMode {
 /// Idempotent: missing rows return `Ok(())` because the hook may fire
 /// for operator-attended sessions that watch never spawned (no wake row
 /// -> still Ok; no lock -> release is a no-op).
-pub fn record_session_end(db: &Database, attempt_id: &str, data_dir: &Path) -> Result<()> {
+///
+/// `repo_hint` is used on the interactive path (#673 fix 2): when no
+/// wake_attempts row exists for `attempt_id` (interactive / operator
+/// session), the `.session` file for `repo_hint` is removed so the
+/// active-session gate is cleared. Ignored when the row is found
+/// (the repo is resolved from the row instead).
+pub fn record_session_end(
+    db: &Database,
+    attempt_id: &str,
+    repo_hint: Option<&str>,
+    data_dir: &Path,
+) -> Result<()> {
     match db.mark_wake_attempt_exit_observed(attempt_id) {
         Ok(()) => {}
         Err(LegionError::WakeAttemptNotFound(_)) => {
-            // No wake row for this attempt_id -- operator-attended session
-            // or a hook firing before the daemon wrote the row. Nothing to
-            // release; return Ok so the stop hook never blocks Claude Code.
+            // No wake row for this attempt_id -- operator-attended (interactive)
+            // session or a hook firing before the daemon wrote the row.
+            // Still clean up the .session file if the caller provided a repo
+            // name, so the gate is cleared for the next wake cycle (#673 fix 2).
+            if let Some(repo) = repo_hint {
+                let session_locks =
+                    SessionLockTracker::new(data_dir, default_session_lock_ttl_secs());
+                if let Err(e) = session_locks.release_interactive(repo) {
+                    eprintln!(
+                        "[legion watch] session-end: failed to release .session for {}: {}",
+                        repo, e
+                    );
+                }
+            }
             return Ok(());
         }
         Err(e) => return Err(e),
@@ -134,6 +156,18 @@ pub fn record_session_end(db: &Database, attempt_id: &str, data_dir: &Path) -> R
             if let Err(e) = session_locks.release(&attempt.repo_name) {
                 eprintln!(
                     "[legion watch] session-end: failed to release lock for {}: {}",
+                    attempt.repo_name, e
+                );
+            }
+            // Remove the interactive .session file as well (#673 fix 2).
+            // The wake-spawned path does not write a .session file (only
+            // interactive sessions do), but releasing it here is idempotent
+            // -- missing file is not an error. This closes the gap where a
+            // wake-spawned session that also happens to have an operator-held
+            // .session could leave a stale file behind.
+            if let Err(e) = session_locks.release_interactive(&attempt.repo_name) {
+                eprintln!(
+                    "[legion watch] session-end: failed to release .session for {}: {}",
                     attempt.repo_name, e
                 );
             }
@@ -429,5 +463,60 @@ mod tests {
             assert!(!spawned.turn_started());
             let _ = spawned.kill();
         }
+    }
+
+    // -- record_session_end (#673 fix 2) ------------------------------------
+
+    /// `record_session_end` with a repo_hint and no wake_attempts row
+    /// (interactive/operator path) must remove the `.session` file.
+    #[test]
+    fn session_end_removes_session_file_on_interactive_path() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let data_dir = dir.path();
+
+        // Write a .session file to simulate an active interactive session.
+        let locks = SessionLockTracker::new(data_dir, default_session_lock_ttl_secs());
+        locks
+            .record_interactive("myrepo", std::process::id())
+            .expect("record_interactive");
+
+        // Verify the .session file exists before the call.
+        let session_file = data_dir.join("sessions").join("myrepo.session");
+        assert!(
+            session_file.exists(),
+            "precondition: .session file must exist before session-end"
+        );
+
+        // Open a fresh DB -- no wake_attempts row exists.
+        let db_path = data_dir.join("legion.db");
+        let db = crate::db::Database::open(&db_path).expect("open db");
+
+        // Call with an attempt_id that has no matching row and a repo_hint.
+        let result = record_session_end(&db, "nonexistent-attempt-id", Some("myrepo"), data_dir);
+        assert!(
+            result.is_ok(),
+            "record_session_end must return Ok on missing wake attempt"
+        );
+
+        // The .session file must be gone.
+        assert!(
+            !session_file.exists(),
+            ".session file must be removed on the interactive path when repo_hint is provided"
+        );
+    }
+
+    /// When no wake_attempts row exists AND no repo_hint is provided,
+    /// `record_session_end` returns Ok but does not crash.
+    #[test]
+    fn session_end_no_repo_hint_is_ok_with_no_wake_row() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db_path = dir.path().join("legion.db");
+        let db = crate::db::Database::open(&db_path).expect("open db");
+
+        let result = record_session_end(&db, "nonexistent-attempt-id", None, dir.path());
+        assert!(
+            result.is_ok(),
+            "record_session_end must return Ok even with no row and no repo_hint"
+        );
     }
 }

--- a/src/watch/spawn.rs
+++ b/src/watch/spawn.rs
@@ -153,21 +153,13 @@ pub fn record_session_end(
 
     match db.get_wake_attempt(attempt_id) {
         Ok(Some(attempt)) => {
+            // Wake-spawned path: release the .lock file so the wake gate clears.
+            // Do NOT call release_interactive here -- the wake-spawned path never
+            // writes a .session file, so deleting one here would remove a live
+            // interactive session's lock, reopening the #583 duplicate-wake window.
             if let Err(e) = session_locks.release(&attempt.repo_name) {
                 eprintln!(
                     "[legion watch] session-end: failed to release lock for {}: {}",
-                    attempt.repo_name, e
-                );
-            }
-            // Remove the interactive .session file as well (#673 fix 2).
-            // The wake-spawned path does not write a .session file (only
-            // interactive sessions do), but releasing it here is idempotent
-            // -- missing file is not an error. This closes the gap where a
-            // wake-spawned session that also happens to have an operator-held
-            // .session could leave a stale file behind.
-            if let Err(e) = session_locks.release_interactive(&attempt.repo_name) {
-                eprintln!(
-                    "[legion watch] session-end: failed to release .session for {}: {}",
                     attempt.repo_name, e
                 );
             }
@@ -517,6 +509,57 @@ mod tests {
         assert!(
             result.is_ok(),
             "record_session_end must return Ok even with no row and no repo_hint"
+        );
+    }
+
+    /// The wake-spawned branch (found-row path) must NOT delete an existing
+    /// `.session` file for the same repo. The wake daemon never writes a
+    /// `.session`; deleting one here would evict a live interactive session's
+    /// lock, reopening the #583 duplicate-wake window.
+    ///
+    /// Simulates: watch spawned a session (wake_attempts row written by the DB
+    /// migration seed below), an interactive session is also open (.session
+    /// file written), stop-hook fires via `record_session_end`. After the call
+    /// the `.session` must still exist.
+    #[test]
+    fn session_end_found_row_does_not_delete_interactive_session_file() {
+        use crate::db::Database;
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let data_dir = dir.path();
+
+        // Write an interactive .session file to simulate an operator-attended
+        // session for "myrepo" that is open concurrently with a wake-spawned
+        // session.
+        let locks = SessionLockTracker::new(data_dir, default_session_lock_ttl_secs());
+        locks
+            .record_interactive("myrepo", std::process::id())
+            .expect("record_interactive");
+
+        let session_file = data_dir.join("sessions").join("myrepo.session");
+        assert!(
+            session_file.exists(),
+            "precondition: .session file must exist before the test"
+        );
+
+        // Insert a wake_attempts row so record_session_end takes the
+        // found-row (wake-spawned) path.
+        let db_path = data_dir.join("legion.db");
+        let db = Database::open(&db_path).expect("open db");
+        let attempt_id = uuid::Uuid::now_v7().to_string();
+        db.enqueue_wake_attempt(&attempt_id, "myrepo-persona", "myrepo", &[])
+            .expect("enqueue wake attempt");
+
+        let result = record_session_end(&db, &attempt_id, Some("myrepo"), data_dir);
+        assert!(
+            result.is_ok(),
+            "record_session_end must return Ok on the found-row path"
+        );
+
+        // The .session file for the interactive session must be untouched.
+        assert!(
+            session_file.exists(),
+            "the wake-spawned path must NOT delete the interactive .session file"
         );
     }
 }


### PR DESCRIPTION
## Summary

Four wake/daemon robustness fixes surfaced while investigating an apparent wake failure that turned out to be a test error (a signal sent `--repo X --to X`, which `board.rs:626` self-excludes). The core wake path is healthy -- verified end-to-end live: a directed `question` from `legion` to an idle `veneer` spawned the agent, PTY-confirmed the submit, and the agent replied. These four are the genuine defects found along the way.

## Acceptance criteria mapping

### 1. `legion signal --repo X --to X` is refused, not silently dropped
The poll query self-excludes a repo's own posts (`src/db/board.rs:626`, `AND r.repo != ?`), so a self-addressed signal never reaches the daemon. A new `is_self_address` pure helper (case-insensitive, broadcasts `all`/`everyone` exempt) guards `handle_signal` before the DB is opened and returns the typed `SignalSelfAddressed` error, whose message names the repo and the correct `--repo`/`--to` usage. The same guard is mirrored in the MCP `legion_signal` tool (`McpInvalidArgument`). This is the exact trap that caused the investigation's false alarm.
Evidence: `src/cli/signal.rs` `is_self_address` + guard; `src/error.rs` variant; `src/mcp/tools.rs`; six unit tests (`self_address_guard_*`, `self_address_error_variant_names_the_repo`).

### 2. `.session` is removed when an interactive session ends
Two parts. Rust: `release_interactive` (was dead code) is wired into `record_session_end`, which gains a `repo_hint` -- on the interactive (no-wake-row) path it removes the `.session` for that repo; `legion watch session-end` gains `--repo`. Wiring: a new **SessionEnd hook** (`plugin/hooks/session-end.sh`, registered in `hooks.json`) calls `legion watch session-end --attempt-id ${ID:-} --repo $REPO` on real session termination -- the correct point (Stop fires per-turn and would falsely end a live session). This clears the lock immediately instead of waiting for the daemon to passively reap a dead pid, closing the pid-recycle window where a recycled pid reads as a false active session and suppresses a wake.
Evidence: `src/watch/spawn.rs` `record_session_end(repo_hint)`; `src/watch/locks.rs` (`#[allow(dead_code)]` removed); `src/cli/watch.rs` `--repo`; `plugin/hooks/session-end.sh` + `hooks.json`; tests `session_end_removes_session_file_on_interactive_path`, `session_end_no_repo_hint_is_ok_with_no_wake_row`.

### 3. `legion daemon-restart` recovers a wedged daemon
Observed live: a daemon whose pidfile was stale still held the port, so pidfile-based stop no-op'd and spawn refused, requiring a manual kill. `restart_detached` now checks `port_available` after the stop and, if the port is still held, calls `kill_orphaned_daemon_on_port`, which only kills the holder when `cmdline_is_legion_daemon` confirms it (requires "legion" + a daemon subcommand) -- an unrelated process on the port is never touched.
Evidence: `src/daemon.rs` `process_cmdline` / `cmdline_is_legion_daemon` / `kill_orphaned_daemon_on_port` / `restart_detached`; tests prove the cmdline guard rejects `node`, `python`, and `legion recall`/`post`.

### 4. Dead-pid `running` wake_attempts are reaped
Rows stuck `running` whose backing pid is dead (the 06-15 platform rows that survived a restart) now get reaped: `reap_dead_pid_attempts` runs each cycle, scans `list_local_orphans` (host-scoped), and marks any row whose `spawned_pid` is no longer alive as failed via `record_wake_attempt_outcome`. Rows without a pid yet are left alone; scan errors are logged and swallowed so the tick never aborts.
Evidence: `src/watch/mod.rs` `reap_dead_pid_attempts`; tests `reap_dead_pid_attempts_marks_dead_pid_failed_and_leaves_live_pid`, `reap_dead_pid_attempts_skips_rows_without_pid`.

### 5. Tests cover each; clippy/fmt/test green
1122 tests pass; `cargo clippy --all-targets -- -D warnings` clean; `cargo fmt -- --check` clean; `hooks.json` valid; `session-end.sh` shellcheck-clean.
Evidence: agent build report + my re-run of clippy/shellcheck/jq after the hook commit.

### 6. Simplify + review passes; PR linked
The simplify gate caught a real HIGH on the first pass -- fix 2's `.session` cleanup was unreachable (the Rust accepted `--repo` but no hook passed it, and Stop is the wrong event) -- recorded as issues (gate 019ee942), fixed by adding the SessionEnd hook in commit 34de4e2, then re-recorded clean (gate 019ee946). Found-fixed-reclean. PR references #673; branch feat/673-wake-daemon-robustness.
Evidence: simplify gates 019ee942 (issues) -> 019ee946 (clean); commit 34de4e2.

## Not done

The SessionEnd hook's live firing was not empirically verified mid-session (it requires actually terminating a Claude session to observe) -- the hook is idempotent and fail-open so a mis-fire cannot wedge shutdown, but its on-termination behavior should be confirmed in production. The MCP self-address check is inlined rather than sharing `is_self_address` across the cli/mcp module boundary -- judged acceptable (small site-appropriate checks, stable 2-item sentinel set), noted so a future third broadcast sentinel updates both sites. No change to the (healthy) core wake spawn path.