### PR TITLE
fix(#677): wedge backstop -- reap watch sessions whose turn never completes

### DIFF
--- a/src/watch/config.rs
+++ b/src/watch/config.rs
@@ -598,6 +598,8 @@ workdir = "/tmp"
         assert_eq!(config.submit_retry_max, 12);
         assert_eq!(config.submit_retry_interval_secs, 4);
         assert_eq!(config.submit_confirm_budget_secs, 60);
+        // #677 wedge-backstop budget defaults to 30 minutes when absent.
+        assert_eq!(config.session_budget_secs, 1800);
         // #654 auto-reconcile defaults to hourly when the key is absent.
         assert_eq!(config.reconcile_interval_secs, 3600);
     }

--- a/src/watch/config.rs
+++ b/src/watch/config.rs
@@ -220,6 +220,22 @@ pub struct WatchConfig {
     #[serde(default = "default_submit_confirm_budget_secs")]
     pub submit_confirm_budget_secs: u64,
 
+    /// Hard wall-clock cap (seconds) on a watch-spawned session's total
+    /// lifetime, measured from spawn (#677). The stop hook normally terminates
+    /// a session when its turn completes (typically minutes); a session still
+    /// alive past this cap with no completion signal (`exit_observed_at` unset)
+    /// is wedged -- blocked mid-turn, the stop hook never fired -- and is
+    /// force-reaped: killed, its session lock and persona wake-lease released,
+    /// and its wake_attempt recorded with outcome `session_budget_exceeded`.
+    /// This is the backstop the dead-pid reaper (#673) cannot provide: that
+    /// path only fires once the pid actually exits, but a wedged session's pid
+    /// stays alive indefinitely, leaking the process (and its MCP children) and
+    /// holding the lease against future legit wakes. Must exceed any legitimate
+    /// single turn; default 1800 (30 minutes). Set to `0` to disable the cap
+    /// (not recommended -- a wedge then leaks until the daemon restarts).
+    #[serde(default = "default_session_budget_secs")]
+    pub session_budget_secs: u64,
+
     /// Whether this node serves the web dashboard.
     /// Only one node per network should have this set to true.
     #[serde(default)]
@@ -305,6 +321,10 @@ fn default_submit_confirm_budget_secs() -> u64 {
     60
 }
 
+fn default_session_budget_secs() -> u64 {
+    1800
+}
+
 impl Default for WatchConfig {
     fn default() -> Self {
         Self {
@@ -325,6 +345,7 @@ impl Default for WatchConfig {
             submit_retry_max: default_submit_retry_max(),
             submit_retry_interval_secs: default_submit_retry_interval_secs(),
             submit_confirm_budget_secs: default_submit_confirm_budget_secs(),
+            session_budget_secs: default_session_budget_secs(),
             serve: false,
             cluster: None,
             repos: Vec::new(),

--- a/src/watch/mod.rs
+++ b/src/watch/mod.rs
@@ -244,8 +244,11 @@ impl WatchLoop {
         // that never confirms is failed here and reaped on the same tick.
         self.tracker
             .drive_submit_confirmation(&self.db, &self.config);
-        self.tracker
-            .reap_finished(Some(&self.db), Some(&self.session_locks));
+        self.tracker.reap_finished(
+            Some(&self.db),
+            Some(&self.session_locks),
+            Duration::from_secs(self.config.session_budget_secs),
+        );
         // #673 fix 4: reap `running` wake_attempts whose backing pid is dead.
         // These rows accumulate after crash/restart (pid-alive check only runs
         // on the AgentTracker's live children; a row whose pid was never

--- a/src/watch/spawn.rs
+++ b/src/watch/spawn.rs
@@ -230,10 +230,23 @@ impl SpawnedChild {
     }
 
     /// Terminate the child. Used by `reap_finished` to tear down an idle PTY
-    /// REPL whose turn is complete, and by the spawn-failure cleanup path.
+    /// REPL whose turn is complete, the wedge backstop (#677), and the
+    /// spawn-failure cleanup path.
+    ///
+    /// Both variants reap the killed process so it does not linger as a zombie
+    /// once dropped from tracking: `PtySession` reaps in its `Drop`, and the
+    /// `Print` arm waits here (SIGKILL cannot be caught, so `wait` returns
+    /// promptly). Without the `Print` wait a force-reaped print-mode child would
+    /// leak a zombie for the daemon's lifetime.
     pub fn kill(&mut self) -> Result<()> {
         match self {
-            SpawnedChild::Print(c) => c.kill().map_err(LegionError::Io),
+            SpawnedChild::Print(c) => {
+                c.kill().map_err(LegionError::Io)?;
+                // Reap the just-killed child. Best-effort: a wait error here
+                // does not change that the kill succeeded.
+                let _ = c.wait();
+                Ok(())
+            }
             SpawnedChild::Pty(s) => s.kill(),
         }
     }

--- a/src/watch/tracker.rs
+++ b/src/watch/tracker.rs
@@ -342,9 +342,14 @@ impl AgentTracker {
                     if let Some(ref attempt_id) = tracked.attempt_id
                         && let Err(e) = db.record_wake_attempt_outcome(attempt_id, "error", reason)
                     {
+                        // Name the reason here: on a write failure the row stays
+                        // in-flight, so the same-tick dead-pid reaper settles it
+                        // with a generic "dead-pid" reason instead. Logging the
+                        // specific reason keeps the wedge/submit cause recoverable
+                        // from stderr even when it never reaches the row.
                         eprintln!(
-                            "[legion watch] failed to record terminal outcome {}: {}",
-                            attempt_id, e
+                            "[legion watch] failed to record terminal outcome {} ({}): {}",
+                            attempt_id, reason, e
                         );
                     }
                     return false; // remove from tracking list
@@ -687,8 +692,9 @@ mod tests {
         // exit_observed_at, alive past the session budget, is a wedged session:
         // it must be force-reaped, its session lock and persona lease released,
         // and its wake_attempt settled to Failed with the session_budget_exceeded
-        // outcome -- the eavesdrop case from #676 that the dead-pid reaper misses
-        // because the pid is still alive.
+        // outcome -- the eavesdrop wedge surfaced by the #676 coordination test,
+        // fixed here under #677, that the dead-pid reaper misses because the pid
+        // is still alive.
         let (db, _index, data_dir) = test_storage();
         let locks = SessionLockTracker::new(data_dir.path(), 3600);
 

--- a/src/watch/tracker.rs
+++ b/src/watch/tracker.rs
@@ -94,6 +94,11 @@ pub struct TrackedChild {
     /// `outcome` reason so `reap_finished` records `submit_not_confirmed`
     /// on the wake_attempts row instead of a generic abandon.
     pub submit_failed_reason: Option<String>,
+    /// Set when `reap_finished` force-reaps a session that outlived the
+    /// session budget with no completion signal (#677). Carries the
+    /// `session_budget_exceeded` outcome reason so the wedge is recorded
+    /// distinctly from a submit failure or a generic error.
+    pub budget_exceeded_reason: Option<String>,
 }
 
 pub struct AgentTracker {
@@ -135,6 +140,7 @@ impl AgentTracker {
             submit_retries: 0,
             submit_confirmed: false,
             submit_failed_reason: None,
+            budget_exceeded_reason: None,
         });
     }
 
@@ -152,10 +158,18 @@ impl AgentTracker {
     /// turn is considered complete: the child is killed best-effort and the full
     /// reap path runs. The session lock is released in both cases so the per-repo
     /// wake gate opens immediately rather than waiting for the TTL.
+    ///
+    /// `session_budget` is the wedge backstop (#677): a child that is still
+    /// alive with no completion signal but has outlived this budget (measured
+    /// from spawn) is force-reaped -- killed and run through the full reap path
+    /// with a `session_budget_exceeded` outcome -- so a turn that blocks
+    /// indefinitely cannot leak the process or hold its persona lease forever.
+    /// A zero budget disables the backstop.
     pub fn reap_finished(
         &mut self,
         db: Option<&Database>,
         session_locks: Option<&SessionLockTracker>,
+        session_budget: Duration,
     ) {
         self.children.retain_mut(|tracked| {
             // Determine whether this child should be reaped.
@@ -234,8 +248,46 @@ impl AgentTracker {
                                 return true; // keep tracking; do not leak or open the gate
                             }
                         }
+                    } else if !session_budget.is_zero()
+                        && tracked.spawn_instant.elapsed() >= session_budget
+                    {
+                        // #677: wedge backstop. The child is alive and mid-turn
+                        // but its stop hook never fired (no exit_observed_at)
+                        // within the budget -- the turn is blocked indefinitely.
+                        // The dead-pid reaper (#673) cannot help: the pid is
+                        // still alive. Force-reap so neither the process (nor its
+                        // MCP children) leaks and the persona lease is released.
+                        eprintln!(
+                            "[legion watch] agent for {} exceeded session budget ({}s) with no turn completion -- reaping wedged session",
+                            tracked.repo,
+                            session_budget.as_secs()
+                        );
+                        match tracked.child.kill() {
+                            Ok(()) => {
+                                // Killed: route the outcome to the distinct
+                                // session_budget_exceeded reason and classify as
+                                // error (a wedged turn produced nothing).
+                                tracked.budget_exceeded_reason = Some(format!(
+                                    "session_budget_exceeded ({}s)",
+                                    session_budget.as_secs()
+                                ));
+                                Some(false)
+                            }
+                            Err(e) => {
+                                // Kill failed: the session is STILL ALIVE. Keep it
+                                // tracked and retry next poll rather than dropping
+                                // it -- same reasoning as the idle-REPL path: a
+                                // dropped-but-alive child leaks AND opens the gate.
+                                eprintln!(
+                                    "[legion watch] kill of wedged session for {} failed -- keeping tracked for retry: {}",
+                                    tracked.repo, e
+                                );
+                                return true; // keep tracking; do not leak or open the gate
+                            }
+                        }
                     } else {
-                        // Still genuinely running and no completion signal yet.
+                        // Still genuinely running, within budget, no completion
+                        // signal yet.
                         return true; // keep tracking
                     }
                 }
@@ -275,17 +327,23 @@ impl AgentTracker {
                     }
                 }
 
-                // #649: a child the submit-confirmation loop gave up on
-                // never ran a turn -- there is no session to classify. Record
-                // the wake_attempt outcome with the distinct reason so the
-                // metric trail shows "prompt never submitted" instead of a
-                // generic abandon, and skip the session-outcome row.
-                if let Some(reason) = &tracked.submit_failed_reason {
+                // A child the submit-confirmation loop gave up on (#649,
+                // submit_failed_reason) or one force-reaped past the session
+                // budget (#677, budget_exceeded_reason) produced no real session to
+                // classify. Record the wake_attempt outcome with the distinct
+                // reason so the metric trail shows the specific failure
+                // ("prompt never submitted" / "session_budget_exceeded")
+                // instead of a generic abandon, and skip the session-outcome row.
+                if let Some(reason) = tracked
+                    .submit_failed_reason
+                    .as_ref()
+                    .or(tracked.budget_exceeded_reason.as_ref())
+                {
                     if let Some(ref attempt_id) = tracked.attempt_id
                         && let Err(e) = db.record_wake_attempt_outcome(attempt_id, "error", reason)
                     {
                         eprintln!(
-                            "[legion watch] failed to record submit-failure outcome {}: {}",
+                            "[legion watch] failed to record terminal outcome {}: {}",
                             attempt_id, e
                         );
                     }
@@ -535,7 +593,7 @@ mod tests {
         assert_eq!(tracker.active_count(), 1, "precondition: child is tracked");
 
         // Run the reaper with session_locks provided.
-        tracker.reap_finished(Some(&db), Some(&locks));
+        tracker.reap_finished(Some(&db), Some(&locks), Duration::from_secs(3600));
 
         // The child must have been reaped (removed from tracking).
         assert_eq!(
@@ -599,7 +657,7 @@ mod tests {
         assert_eq!(tracker.active_count(), 1, "precondition: child tracked");
 
         // Reaper: child is live and exit_observed_at is NOT set.
-        tracker.reap_finished(Some(&db), Some(&locks));
+        tracker.reap_finished(Some(&db), Some(&locks), Duration::from_secs(3600));
 
         // Child must still be tracked -- the turn is genuinely in progress.
         assert_eq!(
@@ -615,6 +673,164 @@ mod tests {
         );
 
         // Clean up the long-running child so we don't leak it in the test suite.
+        tracker.children.iter_mut().for_each(|t| {
+            let _ = t.child.kill();
+        });
+    }
+
+    // -- reap_finished: session-budget wedge backstop (#677) ------------------
+
+    #[cfg(unix)]
+    #[test]
+    fn reap_finished_reaps_wedged_session_past_budget() {
+        // A live child (sleep) that is mid-turn (Running) with NO
+        // exit_observed_at, alive past the session budget, is a wedged session:
+        // it must be force-reaped, its session lock and persona lease released,
+        // and its wake_attempt settled to Failed with the session_budget_exceeded
+        // outcome -- the eavesdrop case from #676 that the dead-pid reaper misses
+        // because the pid is still alive.
+        let (db, _index, data_dir) = test_storage();
+        let locks = SessionLockTracker::new(data_dir.path(), 3600);
+
+        let child_proc = std::process::Command::new("sleep")
+            .arg("9999")
+            .spawn()
+            .expect("spawn sleep");
+        let child_pid = child_proc.id();
+
+        // wake_attempts row driven Claimed -> Spawning -> Running so the wedge is
+        // mid-turn (post-submit), exactly like a session that started its turn
+        // and then blocked.
+        let attempt_id = uuid::Uuid::now_v7().to_string();
+        let signal_id = db
+            .insert_reflection("kelex", "@legion question:wedged", "team")
+            .expect("insert signal")
+            .id;
+        db.enqueue_wake_attempt(
+            &attempt_id,
+            "legion",
+            "legion",
+            std::slice::from_ref(&signal_id),
+        )
+        .expect("enqueue");
+        db.try_claim_wake_attempt(&attempt_id, "test-host")
+            .expect("claim");
+        use crate::wake_attempts::WakeAttemptState::{Claimed, Running, Spawning};
+        db.transition_wake_attempt(&attempt_id, Claimed, Spawning)
+            .expect("Claimed->Spawning");
+        db.transition_wake_attempt(&attempt_id, Spawning, Running)
+            .expect("Spawning->Running");
+
+        // Hold a persona lease under the same host the tracked child records, so
+        // we can assert the reap releases it (the load-bearing fix: a wedged
+        // session must not keep blocking future wakes of its persona).
+        assert!(
+            db.try_acquire_persona_lease(
+                "legion",
+                &signal_id,
+                "test-host",
+                Duration::from_secs(3600)
+            )
+            .expect("acquire lease"),
+            "precondition: lease acquired"
+        );
+
+        locks
+            .record_spawn("legion", child_pid)
+            .expect("record spawn");
+
+        let mut tracker = AgentTracker::new();
+        tracker.track(
+            "legion".to_string(),
+            SpawnedChild::Print(child_proc),
+            vec![("legion".to_string(), signal_id.clone())],
+            "test-host".to_string(),
+            uuid::Uuid::now_v7().to_string(),
+            chrono::Utc::now().to_rfc3339(),
+            vec![signal_id.clone()],
+            Some(attempt_id.clone()),
+        );
+
+        // Backdate the monotonic spawn instant so the child reads as 120s old
+        // against a 60s budget -- no sleep needed to cross the threshold.
+        tracker.children[0].spawn_instant = Instant::now() - Duration::from_secs(120);
+
+        tracker.reap_finished(Some(&db), Some(&locks), Duration::from_secs(60));
+
+        assert_eq!(
+            tracker.active_count(),
+            0,
+            "wedged session past budget must be reaped"
+        );
+        assert!(
+            locks.active_pid("legion").is_none(),
+            "session lock must be released after a wedge reap"
+        );
+        let row = db
+            .get_wake_attempt(&attempt_id)
+            .expect("get attempt")
+            .expect("row exists");
+        assert_eq!(row.state, crate::wake_attempts::WakeAttemptState::Failed);
+        assert_eq!(
+            row.outcome.as_deref(),
+            Some("session_budget_exceeded (60s)"),
+            "the distinct wedge reason must land on the row"
+        );
+        assert!(
+            db.list_persona_leases(Some("legion"))
+                .expect("list leases")
+                .is_empty(),
+            "the wedged session's persona lease must be released"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn reap_finished_keeps_wedged_session_when_budget_disabled() {
+        // A zero budget disables the wedge backstop: a live, mid-turn child with
+        // no exit_observed_at stays tracked no matter how old it is, so an
+        // operator who sets session_budget_secs = 0 opts out of force-reaping.
+        let (db, _index, data_dir) = test_storage();
+        let locks = SessionLockTracker::new(data_dir.path(), 3600);
+
+        let child_proc = std::process::Command::new("sleep")
+            .arg("9999")
+            .spawn()
+            .expect("spawn sleep");
+        let attempt_id = uuid::Uuid::now_v7().to_string();
+        let sig = db
+            .insert_reflection("kelex", "@legion question:no-budget", "team")
+            .expect("signal")
+            .id;
+        db.enqueue_wake_attempt(&attempt_id, "legion", "legion", &[sig])
+            .expect("enqueue");
+        locks
+            .record_spawn("legion", child_proc.id())
+            .expect("record spawn");
+
+        let mut tracker = AgentTracker::new();
+        tracker.track(
+            "legion".to_string(),
+            SpawnedChild::Print(child_proc),
+            Vec::new(),
+            "test-host".to_string(),
+            uuid::Uuid::now_v7().to_string(),
+            chrono::Utc::now().to_rfc3339(),
+            Vec::new(),
+            Some(attempt_id),
+        );
+        // Very old child, but budget disabled.
+        tracker.children[0].spawn_instant = Instant::now() - Duration::from_secs(99_999);
+
+        tracker.reap_finished(Some(&db), Some(&locks), Duration::ZERO);
+
+        assert_eq!(
+            tracker.active_count(),
+            1,
+            "a zero budget must disable the wedge backstop"
+        );
+
+        // Clean up the long-running child.
         tracker.children.iter_mut().for_each(|t| {
             let _ = t.child.kill();
         });
@@ -768,7 +984,7 @@ mod tests {
         tracker.children[0].submit_failed_reason =
             Some("submit_not_confirmed (retries=12)".to_string());
 
-        tracker.reap_finished(Some(&db), Some(&locks));
+        tracker.reap_finished(Some(&db), Some(&locks), Duration::from_secs(3600));
 
         assert_eq!(tracker.active_count(), 0, "failed child must be reaped");
         let row = db


### PR DESCRIPTION
Fixes #677 (AC for the lease CLI split to #679).

## Summary

A watch-spawned wake session whose turn never completes was never reaped. The only
termination path was the stop hook setting `exit_observed_at` ("turn complete --
terminating idle REPL"). If the agent blocked mid-turn the hook never fired, so
`reap_finished` sat forever in its still-alive/no-completion branch (`return true`),
leaking the `claude` process and its MCP children and holding the persona wake-lease
against future wakes. The #673 dead-pid reaper cannot help -- the pid is still alive.
This is the eavesdrop seat from the #676 coordination test (blocked 71 minutes).

## Acceptance criteria mapping

### 1. A reaper kills any watch-spawned session exceeding a max-turn wall-clock budget, independent of the stop hook
Added `WatchConfig.session_budget_secs` (default 1800; `0` disables). In `reap_finished`
the still-alive branch now checks `tracked.spawn_instant.elapsed() >= session_budget`
before keeping the child: past budget with no completion signal, it kills the child and
runs the full reap path. This fires precisely when the stop hook did NOT (no
`exit_observed_at`), so it is independent of it. A kill failure keeps the child tracked
for retry rather than leaking + opening the gate, mirroring the idle-REPL path.
Evidence: `src/watch/config.rs` `session_budget_secs` + `default_session_budget_secs`;
`src/watch/tracker.rs` `reap_finished` budget branch; threaded from the health tick in
`src/watch/mod.rs` (`Duration::from_secs(self.config.session_budget_secs)`).

### 2. Reaping a wedged session releases its persona wake-lease
The wedge path falls through to the existing reap body, which calls
`release_persona_lease_if_owner` for every `held_lease` and releases the session lock on
the same path (reopening the per-repo wake gate). The new test asserts the lease is gone
after the reap.
Evidence: `src/watch/tracker.rs` reap body lease-release loop;
`reap_finished_reaps_wedged_session_past_budget` asserts `list_persona_leases(Some("legion"))`
is empty and `active_pid` is `None` after reap.

### 3. `leases list` reflects actual live-lease state (or is reconciled with the release path)
DEFERRED to #679. This is a separate display-vs-state observability concern in the lease
CLI -- `leases list` shows rows the release path reports as "no live lease" -- independent
of the reaper leak this PR fixes. Split out to keep the reaper change focused; #679 carries
its own ACs and test.
Evidence: issue #679 filed with the reproduction (uniform advancing EXPIRES vs
"no live lease found") and acceptance criteria.

### 4. Daemon reaps zombie PTY children
`SpawnedChild::kill` now reaps the killed child so it does not linger as a zombie once
dropped from tracking. `PtySession` already reaps in its `Drop`; the `Print` arm now
`wait`s after `kill` (SIGKILL is uncatchable, so `wait` returns promptly). Without the
`Print` wait a force-reaped print-mode child would leak a zombie for the daemon's lifetime.
Evidence: `src/watch/spawn.rs` `kill` (Print `c.wait()` after `c.kill()`); PTY Drop-reap
proven by `pty::tests::kill_terminates_long_lived_child_and_reader_drains`.

### 5. Test: a session that blocks mid-turn is terminated and its lease freed within the budget
`reap_finished_reaps_wedged_session_past_budget`: a live, Running (mid-turn) child with no
`exit_observed_at`, backdated past a 60s budget, is reaped; asserts lock released, lease
released, and the wake_attempt settled to `Failed` with the distinct
`session_budget_exceeded (60s)` outcome. `reap_finished_keeps_wedged_session_when_budget_disabled`:
a zero budget opts out (a very old child stays tracked).
Evidence: both tests in `src/watch/tracker.rs`; full suite 1134 + 195 pass, clippy
`--all-targets` clean, fmt clean.

## Not done

- No change to the normal stop-hook teardown path -- the budget is a backstop only, firing
  exactly when the hook does not.
- No retry/re-prompt of a wedged turn -- that is the separate #678 wake!=completion concern.
- Lease CLI list/release reconciliation -- #679.
- The wedge outcome (`session_budget_exceeded`) is recorded via the same "no real session to
  classify" path as the #649 `submit_not_confirmed` reason, unified as
  `submit_failed_reason.or(budget_exceeded_reason)`, so the metric trail distinguishes a
  wedge from a submit failure from a generic error.