### PR TITLE
fix(#678): frame request wakes as must-complete, not just must-reply

### DIFF
--- a/src/watch/signals.rs
+++ b/src/watch/signals.rs
@@ -121,10 +121,16 @@ pub fn build_wake_prompt(repo_name: &str, signals: &[(String, String, String)]) 
     };
 
     append_section(
-        "REQUIRES A REPLY -- these are directed questions or requests. \
-         You MUST reply to each one, even if the reply is \"no\", \"can't help\", \
-         or \"handing to X\". Silence on a directed question is ghosting, not \
-         acknowledgment. A short refusal is a valid reply; no reply is not.",
+        "REQUIRES A REPLY -- these are directed questions and requests. Each one \
+         needs a real response before you stop, not just an acknowledgment. \
+         If it ASKS something, answer it -- a short answer or a clear \"no\" / \
+         \"can't help\" / \"handing to X\" is fine. If it asks you to DO something \
+         (a task, request, or handoff with a deliverable), COMPLETE the work and \
+         report the result; or, if you cannot, reply explicitly with the blocker \
+         or a decline and the reason. A bare \"received\" / \"on it\" / \"ack\" that \
+         stops without doing the asked work is ghosting, not a reply -- and so is \
+         silence. Do not end your turn until each item below is either \
+         done-and-reported or explicitly declined/blocked.",
         &must_reply,
         PENDING_REPLY_CAP,
     );
@@ -335,6 +341,38 @@ mod tests {
         assert!(prompt.contains("@all announce: shipped"));
         assert!(prompt.contains("from kelex"));
         assert!(prompt.contains("from rafters"));
+    }
+
+    #[test]
+    fn build_wake_prompt_frames_requests_as_must_complete() {
+        // #678: a request that asks for a deliverable must be framed as
+        // do-the-work-before-you-stop, not just reply -- otherwise a woken
+        // agent satisfies the prompt with a bare ack and stops without
+        // producing the deliverable (the kessel/veneer ack-and-stop seen in
+        // the #676 coordination test).
+        let signals = vec![(
+            "id-req".to_string(),
+            "@kessel request:open -- read your repo and post your conventions".to_string(),
+            "legion".to_string(),
+        )];
+
+        let prompt = build_wake_prompt("kessel", &signals);
+
+        // The reply-required section must spell out the do-the-work path and
+        // forbid ack-and-stop, so the framing survives prompt edits.
+        assert!(prompt.contains("REQUIRES A REPLY"));
+        assert!(
+            prompt.contains("COMPLETE the work"),
+            "request framing must tell the agent to complete the work, not just reply"
+        );
+        assert!(
+            prompt.contains("done-and-reported or explicitly declined/blocked"),
+            "framing must require a real outcome before the turn ends"
+        );
+        assert!(
+            prompt.contains("ghosting"),
+            "a bare ack that stops must be named as ghosting"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Fixes #678.

## Summary

A single-turn broadcast wake did not reliably drive delegated work to completion. The
`REQUIRES A REPLY` section of `build_wake_prompt` told the woken agent to "reply" -- which a
bare ack satisfies -- so a `request` that asked for a deliverable produced an acknowledgment,
not the deliverable. In the #676 coordination test, kessel and veneer woke, ran one turn, and
stopped without producing their conventions section; only smugglr (1/4) completed the task.

The fix reframes the reply-required section so a request that asks for work must be COMPLETED
(or explicitly declined/blocked with a reason) before the turn ends, and names a bare
"received"/"on it"/"ack" that stops without doing the work as ghosting. `build_wake_prompt` is
the single source for both the PTY-injected wake prompt (`gates.rs:225`) and the SessionStart
pending-replies banner (`cli/signal.rs:185`), so the framing lands on both surfaces from one
change. This is a behavioral lever (prompt framing), chosen over a stop-hook re-prompt loop to
avoid wake-loop risk -- see Not done.

## Acceptance criteria mapping

### 1. A request-verb broadcast that asks for a deliverable reliably produces the deliverable + answer:done, or an explicit blocked/declined reply -- not silent ack-and-stop
The reply-required section in `build_wake_prompt` (`src/watch/signals.rs`) now distinguishes
answer-a-question from do-the-work: "If it asks you to DO something (a task, request, or
handoff with a deliverable), COMPLETE the work and report the result; or, if you cannot, reply
explicitly with the blocker or a decline and the reason ... Do not end your turn until each
item below is either done-and-reported or explicitly declined/blocked." This is the exact
ack-and-stop failure from #676, now forbidden by the prompt the woken agent acts on.
Evidence: `src/watch/signals.rs` `build_wake_prompt` reply-required `append_section`; test
`build_wake_prompt_frames_requests_as_must_complete` asserts the do-the-work framing, the
done-or-declined outcome requirement, and the ghosting label are present.

### 2. Measured: re-run the #676-style test and get >= 3/4 (excluding wedge) completing or explicitly declining
The mechanism is in place; the empirical measurement is a live re-test, not a unit test -- it
requires the new prompt deployed to the running daemon and a real `@rust`-style broadcast. I
will run that validation after this merges/releases and report the completion rate; if framing
alone does not reach >= 3/4, the escalation is the stop-hook completion gate noted below. The
unit test locks the framing in so the lever cannot silently regress before that measurement.
Evidence: `build_wake_prompt_frames_requests_as_must_complete` (framing present);
post-deploy live re-test to follow (the #676 broadcast protocol).

### 3. No change to receipt-only wakes (informational verbs still just ack)
The informational `append_section` and its "Silence is acknowledgment ... empty acknowledgments
... trigger wake storms" guard are unchanged in the diff -- only the reply-required section was
rewritten. The must_reply/informational partition (`signal_requires_reply`) is untouched, so an
informational verb still routes to the silence-is-acknowledgment bucket.
Evidence: `src/watch/signals.rs` informational `append_section` is byte-identical in the diff;
existing tests `build_wake_prompt_splits_questions_from_announcements`,
`build_wake_prompt_routes_by_verb_only`, and the informational-cap tests pass unchanged.

## Not done

- No stop-hook re-prompt / completion gate. Re-injecting a prompt when the deliverable is
  absent is more robust but carries wake-loop risk (a session that cannot complete would be
  re-prompted indefinitely). Framing is the lower-risk first lever; the re-prompt gate is the
  escalation if the AC2 live re-test shows framing alone is insufficient.
- No verb-level bucket split (e.g. routing `question` vs `request` to different sections). The
  single reply-required section now covers both paths in its prose; a structural split would be
  added only if the framing proves too coarse in practice.
- No change to the wake gate, the verb canon, or the informational path.