### PR TITLE
fix(#682): retry plugin spawn on ETXTBSY (Text file busy) under parallel tests

### DIFF
--- a/src/worksource/mod.rs
+++ b/src/worksource/mod.rs
@@ -13,10 +13,10 @@ pub use prs::*;
 
 use std::io::Read;
 use std::path::{Path, PathBuf};
-use std::process::{Command, Stdio};
+use std::process::{Child, Command, Stdio};
 use std::sync::{Mutex, OnceLock};
 use std::thread;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use wait_timeout::ChildExt;
 
@@ -173,6 +173,51 @@ fn call_plugin(plugin_path: &Path, args: &[&str], env: &[(&str, &str)]) -> Resul
     call_plugin_inner(plugin_path, args, env, resolve_plugin_timeout())
 }
 
+/// The exec-time errno returned when the target file is open for writing by any
+/// process: `ETXTBSY`, which is 26 on both Linux and macOS -- the only platforms
+/// this exec path runs on.
+const ETXTBSY: i32 = 26;
+
+/// Hard wall-clock cap on `ETXTBSY` spawn retries. The condition clears in
+/// milliseconds in practice, so this bound exists only to guarantee the retry
+/// loop cannot hang on a genuinely stuck writer.
+const ETXTBSY_RETRY_BUDGET: Duration = Duration::from_secs(2);
+
+/// Backoff between `ETXTBSY` spawn retries.
+const ETXTBSY_RETRY_BACKOFF: Duration = Duration::from_millis(20);
+
+/// Spawn `cmd`, retrying on `ETXTBSY` within a bounded budget.
+///
+/// `execve` returns `ETXTBSY` when the binary is open for writing anywhere --
+/// e.g. a plugin just written or updated while a writer still holds the fd, or,
+/// under parallel test execution, a sibling process that inherited the write fd
+/// in its fork/exec window. The condition is transient, so a bounded retry
+/// succeeds where a single attempt spuriously fails. Any non-`ETXTBSY` spawn
+/// error returns immediately.
+fn spawn_with_etxtbsy_retry(cmd: &mut Command) -> std::io::Result<Child> {
+    let deadline = Instant::now() + ETXTBSY_RETRY_BUDGET;
+    let mut logged = false;
+    loop {
+        match cmd.spawn() {
+            Ok(child) => return Ok(child),
+            Err(e) if e.raw_os_error() == Some(ETXTBSY) && Instant::now() < deadline => {
+                // Log once: a plugin that genuinely needs retries to spawn is a
+                // signal worth seeing, but the per-iteration retry is silent so a
+                // tight backoff cannot flood stderr.
+                if !logged {
+                    eprintln!(
+                        "[legion worksource] plugin spawn hit ETXTBSY (file busy) -- retrying for up to {}s",
+                        ETXTBSY_RETRY_BUDGET.as_secs()
+                    );
+                    logged = true;
+                }
+                thread::sleep(ETXTBSY_RETRY_BACKOFF);
+            }
+            Err(e) => return Err(e),
+        }
+    }
+}
+
 fn call_plugin_inner(
     plugin_path: &Path,
     args: &[&str],
@@ -198,8 +243,7 @@ fn call_plugin_inner(
         cmd.process_group(0);
     }
 
-    let mut child = cmd
-        .spawn()
+    let mut child = spawn_with_etxtbsy_retry(&mut cmd)
         .map_err(|e| LegionError::WorkSource(format!("failed to run plugin: {e}")))?;
 
     // Reader threads must be spawned BEFORE we wait. If the plugin emits
@@ -501,6 +545,39 @@ mod tests {
             let (_tmp, path) = write_stub("#!/bin/bash\necho hello\n");
             let out = call_plugin_inner(&path, &[], &[], Some(Duration::from_secs(2)))
                 .expect("stub should succeed");
+            assert_eq!(out, "hello\n");
+        }
+
+        #[test]
+        fn retries_past_etxtbsy_until_writer_closes() {
+            // Holding a writable fd open to the stub makes execve() of it return
+            // ETXTBSY -- the exact transient condition that flaked CI. A single
+            // spawn would fail; the bounded retry must succeed once the writer
+            // releases the fd. A background thread closes it after a short delay.
+            use std::fs::OpenOptions;
+            use std::sync::{Arc, Mutex};
+
+            let (_tmp, path) = write_stub("#!/bin/bash\necho hello\n");
+            let writer = OpenOptions::new()
+                .write(true)
+                .open(&path)
+                .expect("open stub for writing");
+            let writer = Arc::new(Mutex::new(Some(writer)));
+
+            let releaser = {
+                let writer = Arc::clone(&writer);
+                thread::spawn(move || {
+                    // 120ms sits well inside the 2s retry budget and 3s call
+                    // timeout, so the retry has ample room to outlast the hold.
+                    thread::sleep(Duration::from_millis(120));
+                    // Drop the File, closing the writable fd so exec can proceed.
+                    *writer.lock().expect("lock writer") = None;
+                })
+            };
+
+            let out = call_plugin_inner(&path, &[], &[], Some(Duration::from_secs(3)))
+                .expect("must retry past ETXTBSY and succeed once the writer closes");
+            releaser.join().expect("join releaser");
             assert_eq!(out, "hello\n");
         }
 


### PR DESCRIPTION
Fixes #682.

## Summary

worksource exec tests intermittently failed CI with `failed to run plugin: Text file busy
(os error 26)` -- ETXTBSY on `execve`, returned when the target file is open for writing by
any process. Observed on the main push CI for #680 across all three OS test jobs while the
same code passed on the PR branch: a race, not a defect in the change under test. Under
parallel test execution a sibling test that forks (the timeout stubs run `sleep`) inherits a
writable fd to another test's freshly-written `stub` in its fork/exec window, so the owning
test's `exec` races the inherited fd. It clears in milliseconds.

## Acceptance criteria mapping

### 1. call_plugin_inner retries spawn on ETXTBSY within a bounded budget; non-ETXTBSY spawn errors still fail immediately
`call_plugin_inner` now spawns via `spawn_with_etxtbsy_retry`, which loops on `cmd.spawn()`:
`ETXTBSY` (errno 26, named const) within the deadline sleeps `ETXTBSY_RETRY_BACKOFF` (20ms)
and retries; any other error returns immediately via the `Err(e) => return Err(e)` arm, and
the caller still maps it to the same `LegionError::WorkSource("failed to run plugin: ...")`.
Evidence: `src/worksource/mod.rs` `spawn_with_etxtbsy_retry`; `call_plugin_inner` spawn site
now calls it. A first-retry stderr line surfaces the rare event without flooding on the tight
backoff.

### 2. A deterministic test holds a writable fd open, then releases it, and asserts the call retries past ETXTBSY and succeeds
`retries_past_etxtbsy_until_writer_closes` opens the stub with `OpenOptions::write(true)` (which
makes `execve` return ETXTBSY), spawns a thread that drops the handle after 120ms, then calls
`call_plugin_inner` and asserts it returns `"hello\n"`. A single spawn would fail; the retry
must outlast the 120ms hold. Deterministic -- it forces the exact condition rather than relying
on parallel-scheduling luck.
Evidence: `src/worksource/mod.rs` test `retries_past_etxtbsy_until_writer_closes`; the module's
~1.0s runtime confirms the retry-until-close path is exercised.

### 3. The retry is bounded (cannot hang) and does not change the happy path or timeout behavior
The loop is bounded by `ETXTBSY_RETRY_BUDGET` (2s wall-clock): once `Instant::now() >= deadline`
the ETXTBSY arm's guard fails and the error propagates, so it cannot hang. A successful first
spawn returns immediately (happy path unchanged), and the retry wraps only `spawn` -- the
timeout/wait/reader-thread/kill logic after spawn is untouched.
Evidence: `src/worksource/mod.rs` `ETXTBSY_RETRY_BUDGET` deadline guard; the spawn site is the
only change, the post-spawn body is identical; existing `terminates_on_timeout`/`returns_*`
tests pass unchanged.

### 4. Full suite + clippy --all-targets + fmt green
Suite 1135 + 195 pass; the worksource module ran clean across repeated invocations.
`cargo clippy --all-targets -- -D warnings` clean; `cargo fmt -- --check` clean.
Evidence: local runs; CI will confirm on this branch.

## Not done

- No production hardening of the OTHER fork/exec sites (this is the only one that execs a
  potentially-just-written file; the rest exec stable binaries on PATH).
- No switch to `serial_test` or a global exec mutex -- the retry is narrower and also hardens
  the production exec path, where serializing tests would not help.
- The retry tolerates only ETXTBSY; other transient spawn errors (EAGAIN, etc.) are out of
  scope and still fail fast, by design.