### PR TITLE
fix(#685): cfg(unix)-gate the ETXTBSY retry, fix vacuous macOS test

### DIFF
--- a/src/worksource/mod.rs
+++ b/src/worksource/mod.rs
@@ -13,10 +13,16 @@ pub use prs::*;
 
 use std::io::Read;
 use std::path::{Path, PathBuf};
-use std::process::{Child, Command, Stdio};
+use std::process::{Command, Stdio};
+// `Child` and `Instant` are used only by the unix-only ETXTBSY retry helper;
+// importing them unconditionally would warn as unused on non-unix targets.
+#[cfg(unix)]
+use std::process::Child;
 use std::sync::{Mutex, OnceLock};
 use std::thread;
-use std::time::{Duration, Instant};
+use std::time::Duration;
+#[cfg(unix)]
+use std::time::Instant;
 
 use wait_timeout::ChildExt;
 
@@ -174,16 +180,21 @@ fn call_plugin(plugin_path: &Path, args: &[&str], env: &[(&str, &str)]) -> Resul
 }
 
 /// The exec-time errno returned when the target file is open for writing by any
-/// process: `ETXTBSY`, which is 26 on both Linux and macOS -- the only platforms
-/// this exec path runs on.
+/// process: `ETXTBSY`, which is 26 on both Linux and macOS. `unix`-only: this is
+/// a POSIX `errno`. On Windows `raw_os_error()` returns Win32 codes where 26 is
+/// `ERROR_SHARING_VIOLATION`, an unrelated condition, so the retry must never run
+/// there -- the helper and its call site are `#[cfg(unix)]`.
+#[cfg(unix)]
 const ETXTBSY: i32 = 26;
 
 /// Hard wall-clock cap on `ETXTBSY` spawn retries. The condition clears in
 /// milliseconds in practice, so this bound exists only to guarantee the retry
 /// loop cannot hang on a genuinely stuck writer.
+#[cfg(unix)]
 const ETXTBSY_RETRY_BUDGET: Duration = Duration::from_secs(2);
 
 /// Backoff between `ETXTBSY` spawn retries.
+#[cfg(unix)]
 const ETXTBSY_RETRY_BACKOFF: Duration = Duration::from_millis(20);
 
 /// Spawn `cmd`, retrying on `ETXTBSY` within a bounded budget.
@@ -193,7 +204,9 @@ const ETXTBSY_RETRY_BACKOFF: Duration = Duration::from_millis(20);
 /// under parallel test execution, a sibling process that inherited the write fd
 /// in its fork/exec window. The condition is transient, so a bounded retry
 /// succeeds where a single attempt spuriously fails. Any non-`ETXTBSY` spawn
-/// error returns immediately.
+/// error returns immediately. `unix`-only: `ETXTBSY` is a POSIX errno (see the
+/// const); the call site uses a plain `spawn()` on non-unix targets.
+#[cfg(unix)]
 fn spawn_with_etxtbsy_retry(cmd: &mut Command) -> std::io::Result<Child> {
     let deadline = Instant::now() + ETXTBSY_RETRY_BUDGET;
     let mut logged = false;
@@ -243,8 +256,14 @@ fn call_plugin_inner(
         cmd.process_group(0);
     }
 
-    let mut child = spawn_with_etxtbsy_retry(&mut cmd)
-        .map_err(|e| LegionError::WorkSource(format!("failed to run plugin: {e}")))?;
+    // ETXTBSY is a POSIX errno, so the retry is unix-only; other targets spawn
+    // directly (matching the `process_group` cfg split above).
+    #[cfg(unix)]
+    let spawn_result = spawn_with_etxtbsy_retry(&mut cmd);
+    #[cfg(not(unix))]
+    let spawn_result = cmd.spawn();
+    let mut child =
+        spawn_result.map_err(|e| LegionError::WorkSource(format!("failed to run plugin: {e}")))?;
 
     // Reader threads must be spawned BEFORE we wait. If the plugin emits
     // more than a pipe buffer of output and nothing is draining, the
@@ -548,6 +567,14 @@ mod tests {
             assert_eq!(out, "hello\n");
         }
 
+        // Linux-only: this test is load-bearing only where `execve` actually
+        // raises ETXTBSY for a file open for writing. Linux does so for the
+        // shebang script; Darwin raises ETXTBSY only for native Mach-O binaries,
+        // not shebang-interpreted scripts, so on macOS the first spawn would
+        // succeed immediately and the test would pass vacuously (the retry path
+        // never runs). On Linux the `.expect()` below is real: without the retry
+        // the first spawn fails with ETXTBSY and the test panics.
+        #[cfg(target_os = "linux")]
         #[test]
         fn retries_past_etxtbsy_until_writer_closes() {
             // Holding a writable fd open to the stub makes execve() of it return


### PR DESCRIPTION
Fixes #685.

## Summary

Review follow-up to #683 (the ETXTBSY retry), which was approved with two MED findings that
landed on main. Both are platform-scoping bugs: the retry is POSIX-specific but was compiled
ungated, and its regression test is load-bearing only on Linux.

## Acceptance criteria mapping

### 1. ETXTBSY const + retry consts + spawn_with_etxtbsy_retry are #[cfg(unix)]
`ETXTBSY` (a POSIX errno), `ETXTBSY_RETRY_BUDGET`, `ETXTBSY_RETRY_BACKOFF`, and
`spawn_with_etxtbsy_retry` are now `#[cfg(unix)]`. On Windows `raw_os_error()` returns Win32
codes where 26 is `ERROR_SHARING_VIOLATION`, so running the retry there would misidentify a
sharing violation as ETXTBSY and burn the 2s budget -- the gate prevents that path from
existing on non-unix. The `Child` and `Instant` imports those items consume are split to
`#[cfg(unix)]` too, so they do not warn as unused on non-unix (`-D warnings` would fail CI).
Evidence: `src/worksource/mod.rs` `#[cfg(unix)]` on the const block, the helper, and the
`use std::process::Child` / `use std::time::Instant` imports.

### 2. The call site uses a #[cfg(not(unix))] plain-spawn fallback
`call_plugin_inner` selects the spawn path by target: `#[cfg(unix)]` calls
`spawn_with_etxtbsy_retry(&mut cmd)`, `#[cfg(not(unix))]` calls `cmd.spawn()`. Both feed the
same `map_err` so the error message is unchanged. This mirrors the existing `#[cfg(unix)]`
`cmd.process_group(0)` split a few lines above -- the established pattern in this function.
Evidence: `src/worksource/mod.rs` `call_plugin_inner` spawn-path cfg split.

### 3. retries_past_etxtbsy_until_writer_closes is #[cfg(target_os = "linux")] with a comment
The test is gated to Linux with a comment explaining the exclusion: Linux raises ETXTBSY on
`execve` of a shebang script held open for writing; Darwin raises it only for native Mach-O
binaries, so on macOS the held fd never triggers the retry and the first spawn succeeds --
the test would pass vacuously. On Linux the existing `.expect()` is load-bearing: without the
retry the first spawn fails with ETXTBSY and the test panics.
Evidence: `src/worksource/mod.rs` `#[cfg(target_os = "linux")]` + comment on the test.

### 4. Full suite + clippy --all-targets + fmt green on all three CI OSes
Local (macOS host): suite green, `cargo clippy --all-targets -- -D warnings` clean, `cargo fmt
-- --check` clean. The Linux retry test and the Windows compile (where the unused-import
warning would have fired before the import split) are confirmed by the CI matrix on this
branch.
Evidence: local runs; the windows-latest + ubuntu-latest + macos-latest CI jobs on this PR.

## Not done

- No change to the retry semantics, budget, backoff, or logging -- only platform scoping.
- No retry-counter threaded out of the helper; the Linux-gated `.expect()` already makes the
  test load-bearing without exposing internals.