### PR TITLE
fix(#682): retry plugin spawn on ETXTBSY -- correct, unix-gated (re-land)

### DIFF
--- a/src/worksource/mod.rs
+++ b/src/worksource/mod.rs
@@ -14,9 +14,15 @@ pub use prs::*;
 use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
+// `Child` and `Instant` are used only by the unix-only ETXTBSY retry helper;
+// importing them unconditionally would warn as unused on non-unix targets.
+#[cfg(unix)]
+use std::process::Child;
 use std::sync::{Mutex, OnceLock};
 use std::thread;
 use std::time::Duration;
+#[cfg(unix)]
+use std::time::Instant;
 
 use wait_timeout::ChildExt;
 
@@ -173,6 +179,58 @@ fn call_plugin(plugin_path: &Path, args: &[&str], env: &[(&str, &str)]) -> Resul
     call_plugin_inner(plugin_path, args, env, resolve_plugin_timeout())
 }
 
+/// The exec-time errno returned when the target file is open for writing by any
+/// process: `ETXTBSY`, which is 26 on both Linux and macOS. `unix`-only: this is
+/// a POSIX `errno`. On Windows `raw_os_error()` returns Win32 codes where 26 is
+/// `ERROR_SHARING_VIOLATION`, an unrelated condition, so the retry must never run
+/// there -- the helper and its call site are `#[cfg(unix)]`.
+#[cfg(unix)]
+const ETXTBSY: i32 = 26;
+
+/// Hard wall-clock cap on `ETXTBSY` spawn retries. The condition clears in
+/// milliseconds in practice, so this bound exists only to guarantee the retry
+/// loop cannot hang on a genuinely stuck writer.
+#[cfg(unix)]
+const ETXTBSY_RETRY_BUDGET: Duration = Duration::from_secs(2);
+
+/// Backoff between `ETXTBSY` spawn retries.
+#[cfg(unix)]
+const ETXTBSY_RETRY_BACKOFF: Duration = Duration::from_millis(20);
+
+/// Spawn `cmd`, retrying on `ETXTBSY` within a bounded budget.
+///
+/// `execve` returns `ETXTBSY` when the binary is open for writing anywhere --
+/// e.g. a plugin just written or updated while a writer still holds the fd, or,
+/// under parallel test execution, a sibling process that inherited the write fd
+/// in its fork/exec window. The condition is transient, so a bounded retry
+/// succeeds where a single attempt spuriously fails. Any non-`ETXTBSY` spawn
+/// error returns immediately. `unix`-only: `ETXTBSY` is a POSIX errno (see the
+/// const); the call site uses a plain `spawn()` on non-unix targets.
+#[cfg(unix)]
+fn spawn_with_etxtbsy_retry(cmd: &mut Command) -> std::io::Result<Child> {
+    let deadline = Instant::now() + ETXTBSY_RETRY_BUDGET;
+    let mut logged = false;
+    loop {
+        match cmd.spawn() {
+            Ok(child) => return Ok(child),
+            Err(e) if e.raw_os_error() == Some(ETXTBSY) && Instant::now() < deadline => {
+                // Log once: a plugin that genuinely needs retries to spawn is a
+                // signal worth seeing, but the per-iteration retry is silent so a
+                // tight backoff cannot flood stderr.
+                if !logged {
+                    eprintln!(
+                        "[legion worksource] plugin spawn hit ETXTBSY (file busy) -- retrying for up to {}s",
+                        ETXTBSY_RETRY_BUDGET.as_secs()
+                    );
+                    logged = true;
+                }
+                thread::sleep(ETXTBSY_RETRY_BACKOFF);
+            }
+            Err(e) => return Err(e),
+        }
+    }
+}
+
 fn call_plugin_inner(
     plugin_path: &Path,
     args: &[&str],
@@ -198,9 +256,14 @@ fn call_plugin_inner(
         cmd.process_group(0);
     }
 
-    let mut child = cmd
-        .spawn()
-        .map_err(|e| LegionError::WorkSource(format!("failed to run plugin: {e}")))?;
+    // ETXTBSY is a POSIX errno, so the retry is unix-only; other targets spawn
+    // directly (matching the `process_group` cfg split above).
+    #[cfg(unix)]
+    let spawn_result = spawn_with_etxtbsy_retry(&mut cmd);
+    #[cfg(not(unix))]
+    let spawn_result = cmd.spawn();
+    let mut child =
+        spawn_result.map_err(|e| LegionError::WorkSource(format!("failed to run plugin: {e}")))?;
 
     // Reader threads must be spawned BEFORE we wait. If the plugin emits
     // more than a pipe buffer of output and nothing is draining, the
@@ -501,6 +564,47 @@ mod tests {
             let (_tmp, path) = write_stub("#!/bin/bash\necho hello\n");
             let out = call_plugin_inner(&path, &[], &[], Some(Duration::from_secs(2)))
                 .expect("stub should succeed");
+            assert_eq!(out, "hello\n");
+        }
+
+        // Linux-only: this test is load-bearing only where `execve` actually
+        // raises ETXTBSY for a file open for writing. Linux does so for the
+        // shebang script; Darwin raises ETXTBSY only for native Mach-O binaries,
+        // not shebang-interpreted scripts, so on macOS the first spawn would
+        // succeed immediately and the test would pass vacuously (the retry path
+        // never runs). On Linux the `.expect()` below is real: without the retry
+        // the first spawn fails with ETXTBSY and the test panics.
+        #[cfg(target_os = "linux")]
+        #[test]
+        fn retries_past_etxtbsy_until_writer_closes() {
+            // Holding a writable fd open to the stub makes execve() of it return
+            // ETXTBSY -- the exact transient condition that flaked CI. A single
+            // spawn would fail; the bounded retry must succeed once the writer
+            // releases the fd. A background thread closes it after a short delay.
+            use std::fs::OpenOptions;
+            use std::sync::{Arc, Mutex};
+
+            let (_tmp, path) = write_stub("#!/bin/bash\necho hello\n");
+            let writer = OpenOptions::new()
+                .write(true)
+                .open(&path)
+                .expect("open stub for writing");
+            let writer = Arc::new(Mutex::new(Some(writer)));
+
+            let releaser = {
+                let writer = Arc::clone(&writer);
+                thread::spawn(move || {
+                    // 120ms sits well inside the 2s retry budget and 3s call
+                    // timeout, so the retry has ample room to outlast the hold.
+                    thread::sleep(Duration::from_millis(120));
+                    // Drop the File, closing the writable fd so exec can proceed.
+                    *writer.lock().expect("lock writer") = None;
+                })
+            };
+
+            let out = call_plugin_inner(&path, &[], &[], Some(Duration::from_secs(3)))
+                .expect("must retry past ETXTBSY and succeed once the writer closes");
+            releaser.join().expect("join releaser");
             assert_eq!(out, "hello\n");
         }
 


### PR DESCRIPTION
Re-land of #682's ETXTBSY spawn-retry after #683 was reverted (#684), with the #685 review
corrections folded in. Closes #685. Supersedes the reverted #683.

## Summary

worksource exec intermittently failed CI with `Text file busy (os error 26)` -- ETXTBSY on
`execve`, returned when the target file is open for writing by any process. Under parallel test
execution a sibling test that forks inherits a writable fd to another test's freshly-written
stub in its fork/exec window. Rather than land the fix and patch it (#683 -> #685), this is the
single correct version.

## Acceptance criteria mapping

### 1. call_plugin_inner retries spawn on ETXTBSY within a bounded budget; non-ETXTBSY spawn errors still fail immediately
`call_plugin_inner` spawns via `spawn_with_etxtbsy_retry`, which loops on `cmd.spawn()`:
ETXTBSY (POSIX errno 26, named const) within a 2s deadline sleeps 20ms and retries; any other
error returns immediately via `Err(e) => return Err(e)`, still mapped to the same
`LegionError::WorkSource`. The const + helper are `#[cfg(unix)]` (ETXTBSY is POSIX; on Windows
error 26 is `ERROR_SHARING_VIOLATION`), and the call site uses a `#[cfg(not(unix))]` plain
`spawn()` fallback matching the existing `process_group` cfg split.
Evidence: `src/worksource/mod.rs` `spawn_with_etxtbsy_retry` + the cfg-split call site.

### 2. A deterministic test holds a writable fd open, then releases it, and asserts the call retries past ETXTBSY and succeeds
`retries_past_etxtbsy_until_writer_closes` opens the stub with `OpenOptions::write(true)` (making
`execve` return ETXTBSY), drops the handle after 120ms from a thread, then asserts
`call_plugin_inner` returns `"hello\n"`. It is `#[cfg(target_os = "linux")]`: Darwin raises
ETXTBSY only for native Mach-O binaries, not shebang scripts, so the test is load-bearing only on
Linux (there the `.expect()` panics without the retry).
Evidence: `src/worksource/mod.rs` test `retries_past_etxtbsy_until_writer_closes` + the cfg gate
and comment.

### 3. The retry is bounded (cannot hang) and does not change the happy path or timeout behavior
`ETXTBSY_RETRY_BUDGET` (2s) bounds the loop: once `Instant::now() >= deadline` the ETXTBSY guard
fails and the error propagates. A successful first spawn returns immediately; the retry wraps only
`spawn`, leaving the timeout/wait/reader-thread/kill logic untouched.
Evidence: `src/worksource/mod.rs` deadline guard; the post-spawn body is unchanged from main.

### 4. Full suite + clippy --all-targets + fmt green on all three CI OSes
Local (macOS): suite green, clippy `--all-targets` clean, fmt clean. The `#[cfg(unix)]` import
split prevents the unused-import warning that would fail `windows-latest` under `-D warnings`; the
Linux retry test runs on `ubuntu-latest`. Confirmed by the CI matrix on this branch.
Evidence: local runs + the three-OS CI jobs on this PR.

## Not done

- No change to retry semantics, budget, backoff, or logging beyond the platform scoping.
- No retry-counter threaded out of the helper; the Linux-gated `.expect()` already makes the test
  load-bearing.
- Other fork/exec sites unchanged (this is the only one that execs a potentially-just-written file).