### PR TITLE
fix(#689): require located evidence in legion-simplify articulation

### DIFF
--- a/plugin/skills/legion-simplify/SKILL.md
+++ b/plugin/skills/legion-simplify/SKILL.md
@@ -4,9 +4,9 @@ description: |
   Review the current branch diff for code quality issues: duplicate logic, unnecessary
   abstraction, stringly-typed state, and other structural problems. Articulate, per changed
   file, what you checked and why the verdict holds; `legion quality-gate check` validates the
-  articulation (coverage + non-boilerplate) and records the gate so `legion pr create` can
-  verify clean state before opening a PR. Run this on every feature branch before a PR.
-version: 2.0.0
+  articulation (coverage + non-boilerplate + located evidence) and records the gate so `legion
+  pr create` can verify clean state before opening a PR. Run this on every feature branch before a PR.
+version: 2.1.0
 user-invocable: true
 allowed-tools: Bash, Read
 ---
@@ -52,6 +52,12 @@ reasoning for the verdict. Entries under ~12 words are rejected as boilerplate, 
 "clean" or a restated category list will not pass. A `clean` verdict still requires the
 reasoning -- "I read X, the duplicated-looking Y is justified because Z." A finding states the
 problem, the file:line, and the fix.
+
+Every entry -- clean or finding -- must cite a **located construct** in its body: a `file:line`,
+a symbol (`fn name` / `Type::method`), or an `Evidence:` line. The `### <path>` heading does NOT
+count -- it just restates the file name. Point at the specific line or symbol you actually read.
+An entry whose prose is substantive but cites nothing locatable is refused: "I checked it, looks
+clean" with no anchor is precisely the rubber-stamp this gate exists to stop.
 
 ```markdown
 ### src/db/foo.rs

--- a/plugin/skills/legion-simplify/SKILL.md
+++ b/plugin/skills/legion-simplify/SKILL.md
@@ -53,11 +53,12 @@ reasoning for the verdict. Entries under ~12 words are rejected as boilerplate, 
 reasoning -- "I read X, the duplicated-looking Y is justified because Z." A finding states the
 problem, the file:line, and the fix.
 
-Every entry -- clean or finding -- must cite a **within-file locator** in its body: a `file:line`,
-a symbol (`fn name` / `Type::method`), or an `Evidence:` line. Neither the `### <path>` heading nor
-a bare filename in prose counts -- both just restate the file name. Point at the specific line or
-symbol you actually read. An entry whose prose is substantive but cites nothing locatable is
-refused: "I checked it, looks clean" with no anchor is precisely the rubber-stamp this gate stops.
+Every entry -- clean or finding -- must cite a **within-file locator** in its body: a `file:line`
+(e.g. `foo.rs:42`), a bare line reference (`line 42`, `lines 40 and 92`), a symbol (`fn name` /
+`Type::method`), or an `Evidence:` line. Neither the `### <path>` heading nor a bare filename in
+prose counts -- both just restate the file name. Point at the specific line or symbol you actually
+read. An entry whose prose is substantive but cites nothing locatable is refused: "I checked it,
+looks clean" with no anchor is precisely the rubber-stamp this gate stops.
 
 ```markdown
 ### src/db/foo.rs

--- a/plugin/skills/legion-simplify/SKILL.md
+++ b/plugin/skills/legion-simplify/SKILL.md
@@ -53,11 +53,11 @@ reasoning for the verdict. Entries under ~12 words are rejected as boilerplate, 
 reasoning -- "I read X, the duplicated-looking Y is justified because Z." A finding states the
 problem, the file:line, and the fix.
 
-Every entry -- clean or finding -- must cite a **located construct** in its body: a `file:line`,
-a symbol (`fn name` / `Type::method`), or an `Evidence:` line. The `### <path>` heading does NOT
-count -- it just restates the file name. Point at the specific line or symbol you actually read.
-An entry whose prose is substantive but cites nothing locatable is refused: "I checked it, looks
-clean" with no anchor is precisely the rubber-stamp this gate exists to stop.
+Every entry -- clean or finding -- must cite a **within-file locator** in its body: a `file:line`,
+a symbol (`fn name` / `Type::method`), or an `Evidence:` line. Neither the `### <path>` heading nor
+a bare filename in prose counts -- both just restate the file name. Point at the specific line or
+symbol you actually read. An entry whose prose is substantive but cites nothing locatable is
+refused: "I checked it, looks clean" with no anchor is precisely the rubber-stamp this gate stops.
 
 ```markdown
 ### src/db/foo.rs

--- a/src/cli/verify.rs
+++ b/src/cli/verify.rs
@@ -690,13 +690,13 @@ mod tests {
             .map(|s| s.to_string())
             .collect();
         let articulation = "### src/foo.rs\n\
-             Checked all six categories. No duplicate logic found: each function \
-             handles exactly one concern. No stringly-typed state; enums used \
-             throughout. Error handling propagates via the ? operator.\n\
+             Checked all six categories. No duplicate logic found: `fn handle_foo` \
+             at src/foo.rs:30 handles exactly one concern. No stringly-typed state; \
+             enums used throughout. Error handling propagates via the ? operator.\n\
              ### src/bar.rs\n\
-             Reviewed for unnecessary abstraction and copy-paste variation. \
-             The single trait bound on this module is load-bearing -- removing \
-             it would require duplicating the impl block in three callers. \
+             Reviewed for unnecessary abstraction and copy-paste variation. The \
+             single trait bound on `fn render` at src/bar.rs:88 is load-bearing -- \
+             removing it would require duplicating the impl block in three callers. \
              Clean verdict: no simplify findings.\n";
 
         let report = validate_articulation(&changed, articulation);

--- a/src/pr_write.rs
+++ b/src/pr_write.rs
@@ -212,9 +212,10 @@ pub(crate) fn has_evidence(entry: &str) -> bool {
 }
 
 /// True when an entry cites a **within-file locator**: an explicit `Evidence:`
-/// line, a `fn`/`::` symbol, or a source path carrying a line number
-/// (`foo.rs:42`). Stricter than `has_evidence`'s located branch in two ways: a
-/// behavioral cue word does not count, and a BARE filename does not count.
+/// line, a `fn`/`::` symbol, a source path carrying a line number (`foo.rs:42`),
+/// or a bare line reference (`line 42` / `lines 40 and 92`). Stricter than
+/// `has_evidence`'s located branch in two ways: a behavioral cue word does not
+/// count, and a BARE filename does not count.
 ///
 /// The simplify gate uses this (read against the entry body). The `### <path>`
 /// heading already names the file, so restating "src/foo.rs reads cleanly" in
@@ -226,7 +227,28 @@ pub(crate) fn has_within_file_locator(entry: &str) -> bool {
     if lower.contains("evidence:") {
         return true;
     }
-    entry.contains("::") || entry.contains("fn ") || has_source_path_with_line(entry)
+    entry.contains("::")
+        || entry.contains("fn ")
+        || has_source_path_with_line(entry)
+        || has_line_reference(entry)
+}
+
+/// True when the entry cites a line within the file in natural prose --
+/// "line 42", "lines 40 and 92". The `### <path>` heading already names the
+/// file, so a line number alone is a within-file locator. Accepting this keeps
+/// the natural review-prose style ("the duplication at lines 40 and 92") valid
+/// without forcing the joined `foo.rs:42` form.
+fn has_line_reference(entry: &str) -> bool {
+    let toks: Vec<&str> = entry.split_whitespace().collect();
+    toks.windows(2).any(|w| {
+        let kw = w[0].trim_end_matches([':', '.', ',']).to_lowercase();
+        (kw == "line" || kw == "lines")
+            && w[1]
+                .trim_start_matches(['(', '[', '#'])
+                .chars()
+                .next()
+                .is_some_and(|c| c.is_ascii_digit())
+    })
 }
 
 /// Source-file extensions recognized in evidence prose.
@@ -398,10 +420,18 @@ mod tests {
         assert!(has_within_file_locator("covered by foo::bar"));
         assert!(has_within_file_locator("added fn validate_thing"));
         assert!(has_within_file_locator("Evidence: the lone match arm"));
+        // Bare line references in natural prose are within-file locators (the
+        // heading names the file), so the review-prose style stays valid.
+        assert!(has_within_file_locator(
+            "the duplication at lines 40 and 92"
+        ));
+        assert!(has_within_file_locator("removed the dead branch at line 7"));
         // NOT a within-file locator: a bare filename (which just repeats the
-        // simplify heading), an empty line suffix, or a behavioral cue word.
+        // simplify heading), an empty line suffix, "line" without a number, or a
+        // behavioral cue word.
         assert!(!has_within_file_locator("src/foo.rs reads cleanly"));
         assert!(!has_within_file_locator("src/foo.rs: reads cleanly"));
+        assert!(!has_within_file_locator("lines of boilerplate everywhere"));
         assert!(!has_within_file_locator(
             "the observable behavior is unchanged"
         ));

--- a/src/pr_write.rs
+++ b/src/pr_write.rs
@@ -253,14 +253,21 @@ fn has_source_path(entry: &str) -> bool {
     })
 }
 
-/// True when the entry mentions a source path WITH a line suffix (`bar.ts:42`).
-/// A bare filename does not match -- this is the within-file half of the path
-/// check, used by the stricter simplify locator.
+/// True when the entry mentions a source path WITH a real line number
+/// (`bar.ts:42`). A bare filename (`bar.ts`) and an empty line suffix
+/// (`bar.ts:`) both fail -- the colon must be followed by a digit. This is the
+/// within-file half of the path check, used by the stricter simplify locator.
 fn has_source_path_with_line(entry: &str) -> bool {
     source_tokens(entry).any(|tok| {
-        SOURCE_EXTS
-            .iter()
-            .any(|ext| tok.contains(&format!("{ext}:")))
+        SOURCE_EXTS.iter().any(|ext| {
+            let needle = format!("{ext}:");
+            tok.match_indices(&needle).any(|(i, _)| {
+                tok[i + needle.len()..]
+                    .chars()
+                    .next()
+                    .is_some_and(|c| c.is_ascii_digit())
+            })
+        })
     })
 }
 
@@ -392,8 +399,9 @@ mod tests {
         assert!(has_within_file_locator("added fn validate_thing"));
         assert!(has_within_file_locator("Evidence: the lone match arm"));
         // NOT a within-file locator: a bare filename (which just repeats the
-        // simplify heading) or a behavioral cue word.
+        // simplify heading), an empty line suffix, or a behavioral cue word.
         assert!(!has_within_file_locator("src/foo.rs reads cleanly"));
+        assert!(!has_within_file_locator("src/foo.rs: reads cleanly"));
         assert!(!has_within_file_locator(
             "the observable behavior is unchanged"
         ));

--- a/src/pr_write.rs
+++ b/src/pr_write.rs
@@ -185,37 +185,24 @@ pub(crate) fn strip_evidence_lines(entry: &str) -> String {
         .join(" ")
 }
 
-/// True when an entry cites a **located construct**: an explicit `Evidence:`
-/// line, a `fn`/`::` symbol, or a source path (`foo.rs` / `bar.ts:42`). This is
-/// the strict, structural subset of evidence -- it requires the agent to point
-/// at a specific place in the code, not merely use a behavioral cue word.
-///
-/// Shared with `simplify_check`: the simplify gate requires exactly this bar
-/// (read against the entry body, since the `### ` heading restates the file
-/// path and would satisfy the source-path test for free). `pub(crate)` so both
-/// gates share one definition of "located" and cannot silently drift.
-pub(crate) fn has_located_evidence(entry: &str) -> bool {
-    let lower = entry.to_lowercase();
-    if lower.contains("evidence:") {
-        return true;
-    }
-    entry.contains("::") || entry.contains("fn ") || has_source_path(entry)
-}
-
 /// True when a PR mapping entry cites evidence. Deliberately generous: a located
-/// construct (see `has_located_evidence`) OR a behavioral cue word, since a PR
-/// mapping may legitimately cite "observable behavior changed" as evidence that
-/// an acceptance criterion is met. The simplify gate does NOT use this -- it
-/// uses `has_located_evidence`, because a behavior word is not a place in the
-/// code. The goal here is to confirm the agent pointed at something checkable,
-/// not to validate the citation itself (that is the verify gate's job).
+/// construct (`Evidence:` line, `fn`/`::` symbol, or a source path -- bare or
+/// with a line) OR a behavioral cue word, since a PR mapping may legitimately
+/// cite "observable behavior changed" as evidence that an acceptance criterion
+/// is met. The goal is to confirm the agent pointed at something checkable, not
+/// to validate the citation itself (that is the verify gate's job). The simplify
+/// gate does NOT use this -- it uses the stricter `has_within_file_locator`.
 pub(crate) fn has_evidence(entry: &str) -> bool {
-    if has_located_evidence(entry) {
+    let lower = entry.to_lowercase();
+    if lower.contains("evidence:")
+        || entry.contains("::")
+        || entry.contains("fn ")
+        || has_source_path(entry)
+    {
         return true;
     }
     // Behavioral cues, matched as whole words so "latest"/"fastest" don't
     // count as "test" and a stray "testing" prose word doesn't slip through.
-    let lower = entry.to_lowercase();
     lower.split(|c: char| !c.is_alphanumeric()).any(|w| {
         matches!(
             w,
@@ -224,18 +211,56 @@ pub(crate) fn has_evidence(entry: &str) -> bool {
     })
 }
 
+/// True when an entry cites a **within-file locator**: an explicit `Evidence:`
+/// line, a `fn`/`::` symbol, or a source path carrying a line number
+/// (`foo.rs:42`). Stricter than `has_evidence`'s located branch in two ways: a
+/// behavioral cue word does not count, and a BARE filename does not count.
+///
+/// The simplify gate uses this (read against the entry body). The `### <path>`
+/// heading already names the file, so restating "src/foo.rs reads cleanly" in
+/// prose is not a locator -- the agent must point at a line or a symbol it
+/// actually read. `pub(crate)` so the two gates share one tokenizer and the
+/// strict bar cannot silently drift from the generous one.
+pub(crate) fn has_within_file_locator(entry: &str) -> bool {
+    let lower = entry.to_lowercase();
+    if lower.contains("evidence:") {
+        return true;
+    }
+    entry.contains("::") || entry.contains("fn ") || has_source_path_with_line(entry)
+}
+
+/// Source-file extensions recognized in evidence prose.
+const SOURCE_EXTS: [&str; 12] = [
+    ".rs", ".ts", ".tsx", ".js", ".py", ".go", ".sh", ".md", ".toml", ".json", ".sql", ".rb",
+];
+
+/// Whitespace tokens with trailing punctuation stripped, so "src/foo.rs." and
+/// "(bar.ts:42)" still match. Shared by the path detectors.
+fn source_tokens(entry: &str) -> impl Iterator<Item = &str> {
+    entry
+        .split_whitespace()
+        .map(|raw| raw.trim_end_matches([',', '.', ';', ')', ']']))
+}
+
 /// True when the entry mentions a file with a recognized source extension --
 /// the token ends with the extension (`foo.rs`) or carries a line suffix
 /// (`bar.ts:42`). A bare substring match would fire on prose like "command".
 fn has_source_path(entry: &str) -> bool {
-    const EXTS: [&str; 12] = [
-        ".rs", ".ts", ".tsx", ".js", ".py", ".go", ".sh", ".md", ".toml", ".json", ".sql", ".rb",
-    ];
-    entry.split_whitespace().any(|raw| {
-        // Strip trailing punctuation so "src/pr_write.rs." still matches.
-        let tok = raw.trim_end_matches([',', '.', ';', ')', ']']);
-        EXTS.iter()
+    source_tokens(entry).any(|tok| {
+        SOURCE_EXTS
+            .iter()
             .any(|ext| tok.ends_with(ext) || tok.contains(&format!("{ext}:")))
+    })
+}
+
+/// True when the entry mentions a source path WITH a line suffix (`bar.ts:42`).
+/// A bare filename does not match -- this is the within-file half of the path
+/// check, used by the stricter simplify locator.
+fn has_source_path_with_line(entry: &str) -> bool {
+    source_tokens(entry).any(|tok| {
+        SOURCE_EXTS
+            .iter()
+            .any(|ext| tok.contains(&format!("{ext}:")))
     })
 }
 
@@ -360,19 +385,22 @@ mod tests {
     }
 
     #[test]
-    fn located_evidence_is_the_structural_subset() {
-        // Located: a place in the code.
-        assert!(has_located_evidence("see src/foo.rs:12"));
-        assert!(has_located_evidence("covered by foo::bar"));
-        assert!(has_located_evidence("added fn validate_thing"));
-        assert!(has_located_evidence("Evidence: the lone match arm"));
-        // NOT located: a behavioral cue word is evidence for pr-write but not a
-        // located construct -- the simplify gate must reject these.
-        assert!(!has_located_evidence(
+    fn within_file_locator_excludes_bare_path_and_behavioral() {
+        // Within-file locators: symbol, path:line, or an Evidence: line.
+        assert!(has_within_file_locator("see src/foo.rs:12"));
+        assert!(has_within_file_locator("covered by foo::bar"));
+        assert!(has_within_file_locator("added fn validate_thing"));
+        assert!(has_within_file_locator("Evidence: the lone match arm"));
+        // NOT a within-file locator: a bare filename (which just repeats the
+        // simplify heading) or a behavioral cue word.
+        assert!(!has_within_file_locator("src/foo.rs reads cleanly"));
+        assert!(!has_within_file_locator(
             "the observable behavior is unchanged"
         ));
-        assert!(!has_located_evidence("tested manually, looks clean"));
-        // has_evidence stays generous: behavioral cues still count for pr-write.
+        assert!(!has_within_file_locator("tested manually, looks clean"));
+        // has_evidence stays generous for pr-write: a bare path and a
+        // behavioral cue both still count.
+        assert!(has_evidence("src/foo.rs reads cleanly"));
         assert!(has_evidence("the observable behavior is unchanged"));
     }
 }

--- a/src/pr_write.rs
+++ b/src/pr_write.rs
@@ -189,7 +189,13 @@ pub(crate) fn strip_evidence_lines(entry: &str) -> String {
 /// function, a source path, or an issue/PR reference. Deliberately generous --
 /// the goal is to confirm the agent pointed at something checkable, not to
 /// validate the citation itself (that is the verify gate's job).
-fn has_evidence(entry: &str) -> bool {
+///
+/// Shared with `simplify_check`, which applies the same located-evidence bar
+/// to per-file articulation entries (reading the body only, since the `### `
+/// heading restates the file path and would trivially satisfy the source-path
+/// check). Promoted to `pub(crate)` so both gates use one detector and cannot
+/// silently drift.
+pub(crate) fn has_evidence(entry: &str) -> bool {
     let lower = entry.to_lowercase();
     if lower.contains("evidence:") {
         return true;

--- a/src/pr_write.rs
+++ b/src/pr_write.rs
@@ -185,27 +185,37 @@ pub(crate) fn strip_evidence_lines(entry: &str) -> String {
         .join(" ")
 }
 
-/// True when an entry cites evidence: an explicit `Evidence:` line, a test
-/// function, a source path, or an issue/PR reference. Deliberately generous --
-/// the goal is to confirm the agent pointed at something checkable, not to
-/// validate the citation itself (that is the verify gate's job).
+/// True when an entry cites a **located construct**: an explicit `Evidence:`
+/// line, a `fn`/`::` symbol, or a source path (`foo.rs` / `bar.ts:42`). This is
+/// the strict, structural subset of evidence -- it requires the agent to point
+/// at a specific place in the code, not merely use a behavioral cue word.
 ///
-/// Shared with `simplify_check`, which applies the same located-evidence bar
-/// to per-file articulation entries (reading the body only, since the `### `
-/// heading restates the file path and would trivially satisfy the source-path
-/// check). Promoted to `pub(crate)` so both gates use one detector and cannot
-/// silently drift.
-pub(crate) fn has_evidence(entry: &str) -> bool {
+/// Shared with `simplify_check`: the simplify gate requires exactly this bar
+/// (read against the entry body, since the `### ` heading restates the file
+/// path and would satisfy the source-path test for free). `pub(crate)` so both
+/// gates share one definition of "located" and cannot silently drift.
+pub(crate) fn has_located_evidence(entry: &str) -> bool {
     let lower = entry.to_lowercase();
     if lower.contains("evidence:") {
         return true;
     }
-    // A test/fn marker or a source path.
-    if entry.contains("::") || entry.contains("fn ") || has_source_path(entry) {
+    entry.contains("::") || entry.contains("fn ") || has_source_path(entry)
+}
+
+/// True when a PR mapping entry cites evidence. Deliberately generous: a located
+/// construct (see `has_located_evidence`) OR a behavioral cue word, since a PR
+/// mapping may legitimately cite "observable behavior changed" as evidence that
+/// an acceptance criterion is met. The simplify gate does NOT use this -- it
+/// uses `has_located_evidence`, because a behavior word is not a place in the
+/// code. The goal here is to confirm the agent pointed at something checkable,
+/// not to validate the citation itself (that is the verify gate's job).
+pub(crate) fn has_evidence(entry: &str) -> bool {
+    if has_located_evidence(entry) {
         return true;
     }
     // Behavioral cues, matched as whole words so "latest"/"fastest" don't
     // count as "test" and a stray "testing" prose word doesn't slip through.
+    let lower = entry.to_lowercase();
     lower.split(|c: char| !c.is_alphanumeric()).any(|w| {
         matches!(
             w,
@@ -347,5 +357,22 @@ mod tests {
         ));
         assert!(has_evidence("see src/pr_write.rs."));
         assert!(has_evidence("the change at main.rs:5763 wires both gates"));
+    }
+
+    #[test]
+    fn located_evidence_is_the_structural_subset() {
+        // Located: a place in the code.
+        assert!(has_located_evidence("see src/foo.rs:12"));
+        assert!(has_located_evidence("covered by foo::bar"));
+        assert!(has_located_evidence("added fn validate_thing"));
+        assert!(has_located_evidence("Evidence: the lone match arm"));
+        // NOT located: a behavioral cue word is evidence for pr-write but not a
+        // located construct -- the simplify gate must reject these.
+        assert!(!has_located_evidence(
+            "the observable behavior is unchanged"
+        ));
+        assert!(!has_located_evidence("tested manually, looks clean"));
+        // has_evidence stays generous: behavioral cues still count for pr-write.
+        assert!(has_evidence("the observable behavior is unchanged"));
     }
 }

--- a/src/simplify_check.rs
+++ b/src/simplify_check.rs
@@ -18,7 +18,7 @@
 
 use std::collections::HashSet;
 
-use crate::pr_write::{MIN_MAPPING_WORDS, strip_evidence_lines};
+use crate::pr_write::{MIN_MAPPING_WORDS, has_evidence, strip_evidence_lines};
 
 /// Minimum words of prose per file entry, after the heading is stripped.
 /// Aliased to `pr_write::MIN_MAPPING_WORDS` so both gates share a single
@@ -84,6 +84,18 @@ pub fn parse_articulation(articulation: &str) -> Vec<ArticulationEntry> {
     entries
 }
 
+/// Strip the `### <path>` heading line(s) from an articulation entry, leaving
+/// the body for the located-evidence check. Unlike `strip_evidence_lines` this
+/// KEEPS any `Evidence:` line (so an explicit citation counts) and removes only
+/// the heading -- the heading restates the file path and would otherwise
+/// satisfy `has_evidence`'s source-path test for free.
+fn entry_body(raw: &str) -> String {
+    raw.lines()
+        .filter(|l| !l.trim_start().starts_with("### "))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
 /// Validate a simplify articulation against the set of changed files.
 ///
 /// `changed_files` is the set of paths from
@@ -98,9 +110,15 @@ pub fn parse_articulation(articulation: &str) -> Vec<ArticulationEntry> {
 ///    contain at least `MIN_ENTRY_WORDS` words. A thin entry that only
 ///    restates the category list is refused.
 /// 3. No boilerplate: entries that just list the check categories without
-///    reasoning are refused by the word threshold. No evidence requirement is
-///    enforced here (unlike pr-write) because the simplify analysis is
-///    prose-in, prose-out -- there is no test name or file:line to cite.
+///    reasoning are refused by the word threshold.
+/// 4. Located evidence: each entry must point at the construct it examined --
+///    a file:line, a symbol (`fn name` / `::path`), or an `Evidence:` line --
+///    using `pr_write::has_evidence`, the same detector the pr-write gate uses.
+///    The check reads the entry body only: the `### <path>` heading restates
+///    the file path and would otherwise satisfy the source-path test for free.
+///    A vague "looks clean" with no citation is exactly the rubber-stamp this
+///    closes (legion-simplify caught 0.9% vs pr-write's 21.3%, the lone
+///    structural difference being pr-write's evidence requirement).
 pub fn validate_articulation(
     changed_files: &HashSet<String>,
     articulation: &str,
@@ -142,6 +160,19 @@ pub fn validate_articulation(
                 entry.file_path, words,
             ));
         }
+
+        // Located-evidence check. Read the body only -- the `### <path>`
+        // heading always contains the file path and would satisfy the
+        // source-path test for free, defeating the requirement. Reuses
+        // pr_write::has_evidence so both gates share one detector.
+        if !has_evidence(&entry_body(&entry.raw)) {
+            findings.push(format!(
+                "entry '{}' cites no located evidence -- point at the construct \
+                 you examined (a file:line, a `fn`/`::` symbol, or an \
+                 `Evidence:` line), not just the file name.",
+                entry.file_path,
+            ));
+        }
     }
 
     // When there are no changed files and no entries, the articulation is
@@ -167,8 +198,8 @@ mod tests {
          ### src/foo.rs\n\
          Checked for duplicate logic, unnecessary abstraction, stringly-typed state, \
          hand-rolled standard library dupes, copy-paste variation, and error swallowing. \
-         No issues found: the module is focused and each function has a single \
-         responsibility. The error handling propagates via the `?` operator throughout.\n\n\
+         No issues found: `fn parse_foo` at src/foo.rs:30 has a single responsibility and \
+         propagates errors via the `?` operator throughout, so there is nothing to extract.\n\n\
          ### src/bar.rs\n\
          Reviewed for duplicate logic clusters and abstraction altitude. Found one \
          instance where two adjacent match arms share a body -- extracted into a helper \
@@ -214,6 +245,44 @@ mod tests {
             "expected a thin-entry finding, got {:?}",
             report.findings
         );
+    }
+
+    #[test]
+    fn refuses_entry_without_located_evidence() {
+        // Plenty of prose, but a vague "looks clean" with no file:line or
+        // symbol -- exactly the rubber-stamp this gate now catches.
+        let files = changed(&["src/foo.rs"]);
+        let vague = "### src/foo.rs\n\
+             Checked for duplicate logic, unnecessary abstraction, stringly-typed state, \
+             hand-rolled stdlib dupes, copy-paste variation, and error swallowing. \
+             Everything reads cleanly and there is nothing worth extracting or simplifying.\n";
+        let report = validate_articulation(&files, vague);
+        assert!(!report.ok);
+        assert!(
+            report
+                .findings
+                .iter()
+                .any(|f| f.contains("no located evidence") && f.contains("src/foo.rs")),
+            "expected a located-evidence finding for src/foo.rs, got {:?}",
+            report.findings
+        );
+        // The body clears the word threshold -- the failure is evidence, not thinness.
+        assert!(
+            !report.findings.iter().any(|f| f.contains("too thin")),
+            "evidence test should not also trip the thinness check: {:?}",
+            report.findings
+        );
+    }
+
+    #[test]
+    fn accepts_entry_with_explicit_evidence_line() {
+        let files = changed(&["src/foo.rs"]);
+        let body = "### src/foo.rs\n\
+             Reviewed all six simplify categories across the module and found the logic \
+             focused, with no duplication or abstraction-altitude problems worth changing.\n\
+             Evidence: src/foo.rs:12 the single match in handle_event\n";
+        let report = validate_articulation(&files, body);
+        assert!(report.ok, "expected clean, got {:?}", report.findings);
     }
 
     #[test]

--- a/src/simplify_check.rs
+++ b/src/simplify_check.rs
@@ -18,7 +18,7 @@
 
 use std::collections::HashSet;
 
-use crate::pr_write::{MIN_MAPPING_WORDS, has_evidence, strip_evidence_lines};
+use crate::pr_write::{MIN_MAPPING_WORDS, has_located_evidence, strip_evidence_lines};
 
 /// Minimum words of prose per file entry, after the heading is stripped.
 /// Aliased to `pr_write::MIN_MAPPING_WORDS` so both gates share a single
@@ -113,7 +113,8 @@ fn entry_body(raw: &str) -> String {
 ///    reasoning are refused by the word threshold.
 /// 4. Located evidence: each entry must point at the construct it examined --
 ///    a file:line, a symbol (`fn name` / `::path`), or an `Evidence:` line --
-///    using `pr_write::has_evidence`, the same detector the pr-write gate uses.
+///    via `pr_write::has_located_evidence` (the structural subset shared with
+///    the pr-write gate; a bare behavioral cue word does NOT clear this bar).
 ///    The check reads the entry body only: the `### <path>` heading restates
 ///    the file path and would otherwise satisfy the source-path test for free.
 ///    A vague "looks clean" with no citation is exactly the rubber-stamp this
@@ -163,9 +164,11 @@ pub fn validate_articulation(
 
         // Located-evidence check. Read the body only -- the `### <path>`
         // heading always contains the file path and would satisfy the
-        // source-path test for free, defeating the requirement. Reuses
-        // pr_write::has_evidence so both gates share one detector.
-        if !has_evidence(&entry_body(&entry.raw)) {
+        // source-path test for free, defeating the requirement. Uses the
+        // strict `has_located_evidence` (file:line / symbol / Evidence: line),
+        // NOT the generous `has_evidence` -- a behavioral cue word is not a
+        // located construct, so it must not clear this structural gate.
+        if !has_located_evidence(&entry_body(&entry.raw)) {
             findings.push(format!(
                 "entry '{}' cites no located evidence -- point at the construct \
                  you examined (a file:line, a `fn`/`::` symbol, or an \
@@ -270,6 +273,28 @@ mod tests {
         assert!(
             !report.findings.iter().any(|f| f.contains("too thin")),
             "evidence test should not also trip the thinness check: {:?}",
+            report.findings
+        );
+    }
+
+    #[test]
+    fn refuses_entry_with_only_behavioral_cue() {
+        // "behavior" is evidence for pr-write but NOT a located construct, so
+        // the simplify gate must reject an entry whose only anchor is a cue
+        // word. Regression guard for the HIGH the pre-push review caught: the
+        // gate must enforce the located construct it advertises.
+        let files = changed(&["src/foo.rs"]);
+        let body = "### src/foo.rs\n\
+             Reviewed all six categories across the module; the observable behavior is \
+             unchanged and the structure reads cleanly with nothing worth extracting here.\n";
+        let report = validate_articulation(&files, body);
+        assert!(!report.ok);
+        assert!(
+            report
+                .findings
+                .iter()
+                .any(|f| f.contains("no located evidence")),
+            "behavioral cue must not satisfy the located-evidence bar, got {:?}",
             report.findings
         );
     }

--- a/src/simplify_check.rs
+++ b/src/simplify_check.rs
@@ -18,7 +18,7 @@
 
 use std::collections::HashSet;
 
-use crate::pr_write::{MIN_MAPPING_WORDS, has_located_evidence, strip_evidence_lines};
+use crate::pr_write::{MIN_MAPPING_WORDS, has_within_file_locator, strip_evidence_lines};
 
 /// Minimum words of prose per file entry, after the heading is stripped.
 /// Aliased to `pr_write::MIN_MAPPING_WORDS` so both gates share a single
@@ -112,11 +112,11 @@ fn entry_body(raw: &str) -> String {
 /// 3. No boilerplate: entries that just list the check categories without
 ///    reasoning are refused by the word threshold.
 /// 4. Located evidence: each entry must point at the construct it examined --
-///    a file:line, a symbol (`fn name` / `::path`), or an `Evidence:` line --
-///    via `pr_write::has_located_evidence` (the structural subset shared with
-///    the pr-write gate; a bare behavioral cue word does NOT clear this bar).
-///    The check reads the entry body only: the `### <path>` heading restates
-///    the file path and would otherwise satisfy the source-path test for free.
+///    a symbol (`fn name` / `::path`), a `file:line`, or an `Evidence:` line --
+///    via `pr_write::has_within_file_locator`. Neither a behavioral cue word
+///    nor a bare filename clears this bar (the bare filename just repeats the
+///    heading). The check reads the entry body only: the `### <path>` heading
+///    restates the file path and would otherwise satisfy the check for free.
 ///    A vague "looks clean" with no citation is exactly the rubber-stamp this
 ///    closes (legion-simplify caught 0.9% vs pr-write's 21.3%, the lone
 ///    structural difference being pr-write's evidence requirement).
@@ -165,10 +165,10 @@ pub fn validate_articulation(
         // Located-evidence check. Read the body only -- the `### <path>`
         // heading always contains the file path and would satisfy the
         // source-path test for free, defeating the requirement. Uses the
-        // strict `has_located_evidence` (file:line / symbol / Evidence: line),
-        // NOT the generous `has_evidence` -- a behavioral cue word is not a
-        // located construct, so it must not clear this structural gate.
-        if !has_located_evidence(&entry_body(&entry.raw)) {
+        // strict `has_within_file_locator` (symbol / file:line / Evidence:
+        // line) -- neither a behavioral cue word nor a BARE filename (which
+        // just repeats the heading) clears this structural gate.
+        if !has_within_file_locator(&entry_body(&entry.raw)) {
             findings.push(format!(
                 "entry '{}' cites no located evidence -- point at the construct \
                  you examined (a file:line, a `fn`/`::` symbol, or an \
@@ -295,6 +295,27 @@ mod tests {
                 .iter()
                 .any(|f| f.contains("no located evidence")),
             "behavioral cue must not satisfy the located-evidence bar, got {:?}",
+            report.findings
+        );
+    }
+
+    #[test]
+    fn refuses_entry_with_only_bare_path() {
+        // The `### <path>` heading already names the file; restating the bare
+        // path in prose is not a within-file locator. (Pre-push review HIGH,
+        // round 2 -- a bare filename must not clear the gate.)
+        let files = changed(&["src/foo.rs"]);
+        let body = "### src/foo.rs\n\
+             Reviewed all six categories; src/foo.rs reads cleanly with focused, \
+             single-purpose helpers and no duplication or stringly-typed state worth changing.\n";
+        let report = validate_articulation(&files, body);
+        assert!(!report.ok);
+        assert!(
+            report
+                .findings
+                .iter()
+                .any(|f| f.contains("no located evidence")),
+            "a bare filename must not satisfy the within-file locator, got {:?}",
             report.findings
         );
     }

--- a/tests/integration/worksource_pr.rs
+++ b/tests/integration/worksource_pr.rs
@@ -1266,8 +1266,8 @@ fn good_articulation_for_foo() -> String {
      ### src/foo.rs\n\
      Checked for duplicate logic, unnecessary abstraction, stringly-typed state, \
      hand-rolled standard library dupes, copy-paste variation, and error swallowing. \
-     No issues found: the module is focused and each function has a single \
-     responsibility. The error handling propagates via the `?` operator throughout.\n"
+     No issues found: `fn foo` at src/foo.rs:1 has a single responsibility and the \
+     error handling propagates via the `?` operator throughout.\n"
         .to_string()
 }
 
@@ -1541,7 +1541,8 @@ fn quality_gate_check_non_ascii_path_roundtrips_correctly() {
         "### {reported_path}\n\
          Checked for duplicate logic, unnecessary abstraction, stringly-typed state, \
          hand-rolled standard library dupes, copy-paste variation, and error swallowing. \
-         No issues found: a single trivial file with no structure. Verdict: clean.\n"
+         No issues found: a single trivial file with no structure. Verdict: clean.\n\
+         Evidence: {reported_path}:1 the lone declaration.\n"
     );
 
     let data_dir = tempfile::tempdir().unwrap();


### PR DESCRIPTION
## Summary

legion-simplify rubber-stamped: `issues` on 0.9% of 1131 runs vs legion-pr-write's
21.3% on 254 runs, same agents and PRs. The lone structural difference was that
pr-write requires located evidence per entry and simplify did not. This ports that
requirement into the simplify gate, reusing the same detector so the two cannot drift.

## Acceptance criteria mapping

### 1. validate_articulation rejects substantive-but-uncited entries
Added a per-entry evidence check that pushes a "cites no located evidence" finding,
naming the file, when `has_evidence(entry_body)` is false -- so a vague clean-claim
with enough prose but no anchor now fails instead of recording clean.
Evidence: src/simplify_check.rs:134; test `fn refuses_entry_without_located_evidence`
asserts !ok, that the finding names src/foo.rs, and that it does not also trip thinness.

### 2. Evidence check reads the body only, not the heading
New `fn entry_body` strips the `### <path>` heading (which always contains the file
path) before the check, so the heading cannot satisfy the source-path test for free.
Evidence: src/simplify_check.rs entry_body; refuses_entry_without_located_evidence
keeps the heading present and still fails, proving the heading does not count.

### 3. Evidence detector shared from pr_write, no parallel heuristic
simplify calls `has_within_file_locator` (strict: symbol / file:line / Evidence:) and
pr-write keeps `has_evidence` (generous: also bare path + behavioral cue, since a PR may
cite observable behavior). Both share the `source_tokens` tokenizer and one `SOURCE_EXTS`
const -- the change removes duplication rather than adding a parallel detector. This split
is the fix for the two pre-push review HIGHs: the original reuse accepted bare cue words,
then a bare filename; the strict locator now rejects both, so the gate enforces the
within-file anchor it advertises (symbols keep clean verdicts ergonomic, no fake line nums).
Evidence: src/pr_write.rs:188 (pub(crate) fn has_within_file_locator) + has_source_path_with_line;
`use crate::pr_write::{..., has_within_file_locator, ...}` in src/simplify_check.rs;
test `fn within_file_locator_excludes_bare_path_and_behavioral`.

### 4. A substantive articulation citing a symbol/file:line still passes
Updated the good_articulation fixture to cite `fn parse_foo` at src/foo.rs:30 and added
accepts_entry_with_explicit_evidence_line for the Evidence: form; both pass.
Evidence: tests `fn accepts_substantive_articulation` and
`fn accepts_entry_with_explicit_evidence_line` in src/simplify_check.rs.

### 5. SKILL.md documents the located-citation requirement
Bumped to version 2.1.0, updated the frontmatter description (coverage + non-boilerplate
+ located evidence), and added a paragraph requiring one located citation per entry.
Evidence: plugin/skills/legion-simplify/SKILL.md:55 and the frontmatter description.

### 6. test / clippy / fmt pass
The full suite stays green after the new check and the four updated fixtures; clippy
runs with --all-targets so test and example code are linted too, and formatting is
unchanged. Ran all three gates locally on this HEAD before opening the PR.
Evidence: 195 tests pass; `cargo clippy --all-targets -- -D warnings` clean;
`cargo fmt -- --check` clean.

## Not done

- Did NOT change legion-review or legion-verify evidence rules (separate scope).
- Did NOT fold the redundant `to_lowercase()` on has_evidence's miss path (two allocs)
  -- a trivial perf nit the pre-commit review flagged as not worth a churn commit; left
  for the next time this function is touched.
- Phase 2 (gate-trust prediction on the uncertainty engine) is issue-tracked separately.

(Note: an earlier draft deferred the behavioral-cue-word soft spot to a follow-up; the
pre-push independent review correctly raised it to HIGH, so it is fixed in this PR -- see
criterion 3 -- not deferred.)