### PR TITLE
feat(#691): emit gate-trust predictions to the uncertainty engine

### DIFF
--- a/src/cli/pr.rs
+++ b/src/cli/pr.rs
@@ -524,7 +524,7 @@ pub(crate) fn handle(action: PrAction) -> error::Result<()> {
             .to_string();
 
             let database = open_db()?;
-            database.record_quality_gate(
+            let row = database.record_quality_gate(
                 &branch,
                 &commit_hash,
                 "legion-pr-write",
@@ -532,6 +532,7 @@ pub(crate) fn handle(action: PrAction) -> error::Result<()> {
                 report.findings.len() as u64,
                 Some(&details),
             )?;
+            crate::gate_trust::emit_gate_trust(&database, &row);
 
             if report.ok {
                 println!(

--- a/src/cli/verify.rs
+++ b/src/cli/verify.rs
@@ -8,6 +8,7 @@ use crate::cli::util::{
     git_changed_files, git_head_commit_and_branch, open_db, read_file_or_stdin,
 };
 use crate::db::quality_gates::{QualityGateFilter, QualityGateRow, QualityGateStats};
+use crate::gate_trust::emit_gate_trust;
 use crate::verify::GateResult;
 use crate::{error, kanban, simplify_check, verify};
 
@@ -145,6 +146,7 @@ pub(crate) fn handle_quality_gate(action: QualityGateAction) -> error::Result<()
                 findings_count,
                 details_json.as_deref(),
             )?;
+            emit_gate_trust(&database, &row);
             println!("{}", row.id);
         }
 
@@ -254,6 +256,7 @@ pub(crate) fn handle_quality_gate(action: QualityGateAction) -> error::Result<()
                 findings_count,
                 Some(&details),
             )?;
+            emit_gate_trust(&database, &row);
 
             println!(
                 "[legion] simplify-check articulation accepted for skill '{skill}' \

--- a/src/gate_trust.rs
+++ b/src/gate_trust.rs
@@ -182,6 +182,23 @@ mod tests {
     }
 
     #[test]
+    fn emit_gate_trust_wrapper_runs_and_emits() {
+        // Exercise the non-blocking call-site entry (not just the inner Result
+        // fn). It returns () and, on a valid db, emits an Emitted (non-orphan)
+        // legion.gate prediction. The Err branch is a single non-propagating
+        // eprintln -- forcing it needs a corrupted-db fixture and is left as a
+        // documented coverage gap, since the branch cannot propagate by
+        // construction.
+        let db = test_db();
+        emit_gate_trust(&db, &gate_row("legion-simplify", GateResult::Clean, 0));
+        let orphans = db.count_orphans_by_surface(Some("legion.gate")).unwrap();
+        assert!(
+            orphans.is_empty(),
+            "a freshly emitted prediction is Emitted, not orphaned: {orphans:?}"
+        );
+    }
+
+    #[test]
     fn issues_verdict_emits_low_confidence() {
         let db = test_db();
         let row = gate_row("legion-review", GateResult::Issues, 3);

--- a/src/gate_trust.rs
+++ b/src/gate_trust.rs
@@ -49,7 +49,18 @@ const ISSUES_CONFIDENCE: f64 = 0.05;
 /// short slug), so a plain join is a sufficient lookup key -- the Phase 2b
 /// witness recomputes it to find this prediction. No hashing is needed; hashing
 /// would only obscure an already-unique key.
+///
+/// PRECONDITION: `skill` contains no `:`. Gate skill names are colon-free slugs
+/// (`legion-simplify`, `legion-review`, `legion-pr-write`) and commit hashes are
+/// hex, so the join is unambiguous. The fingerprint is treated as an OPAQUE key
+/// (recomputed and compared, never parsed back into parts), so a stray colon
+/// would only risk a (vanishingly unlikely) collision between two distinct
+/// (skill, commit) pairs, never a parse error.
 pub fn gate_fingerprint(skill: &str, commit_hash: &str) -> String {
+    debug_assert!(
+        !skill.contains(':'),
+        "gate skill names must be colon-free for an unambiguous fingerprint, got {skill:?}"
+    );
     format!("{skill}:{commit_hash}")
 }
 
@@ -184,18 +195,18 @@ mod tests {
     #[test]
     fn emit_gate_trust_wrapper_runs_and_emits() {
         // Exercise the non-blocking call-site entry (not just the inner Result
-        // fn). It returns () and, on a valid db, emits an Emitted (non-orphan)
-        // legion.gate prediction. The Err branch is a single non-propagating
-        // eprintln -- forcing it needs a corrupted-db fixture and is left as a
-        // documented coverage gap, since the branch cannot propagate by
-        // construction.
+        // fn) and prove it actually emitted: exactly one Emitted legion.gate row
+        // afterward (this would fail if the wrapper silently no-op'd). The Err
+        // branch is a single non-propagating eprintln -- forcing it needs a
+        // corrupted-db fixture and is left as a documented coverage gap, since
+        // the branch cannot propagate by construction.
+        use crate::uncertainty::types::PredictionState;
         let db = test_db();
         emit_gate_trust(&db, &gate_row("legion-simplify", GateResult::Clean, 0));
-        let orphans = db.count_orphans_by_surface(Some("legion.gate")).unwrap();
-        assert!(
-            orphans.is_empty(),
-            "a freshly emitted prediction is Emitted, not orphaned: {orphans:?}"
-        );
+        let emitted = db
+            .count_predictions_by_surface_state("legion.gate", PredictionState::Emitted)
+            .unwrap();
+        assert_eq!(emitted, 1, "the wrapper must emit exactly one Emitted row");
     }
 
     #[test]

--- a/src/gate_trust.rs
+++ b/src/gate_trust.rs
@@ -1,0 +1,193 @@
+//! Gate-trust: emit a quality-gate verdict as an uncertainty-engine prediction.
+//!
+//! A gate "clean" verdict is a forecast ("this diff has no issues") at an
+//! implied confidence near 1.0. To measure the rubber-stamp rate per cohort we
+//! record each verdict as a `surface=legion.gate` prediction; a later witness
+//! (Phase 2b) trues it against downstream ground truth (an independent pre-push
+//! review catch, a revert, a post-merge bug). This module is a CALLER of the
+//! uncertainty engine -- it builds a `PredictionInput` and inserts it. It does
+//! not touch the engine's logic.
+//!
+//! The emit is deliberately NON-BLOCKING at the call sites: a failure here must
+//! never break gate recording, mirroring the `uncertainty-emit-on-task` hook.
+//!
+//! Re-run contract: re-running the same gate on the same commit (a normal
+//! iteration -- fix, re-check) emits ANOTHER prediction with the same
+//! `skill:commit` fingerprint but a fresh id. This is intentional and harmless:
+//! the Phase 2b witness resolves a fingerprint by taking the LATEST emitted
+//! prediction (the gate run that actually counts), and any earlier unwitnessed
+//! duplicates simply orphan out after the TTL and are excluded from
+//! calibration. The fingerprint identifies the (skill, commit) cohort run, not a
+//! unique row.
+
+use crate::db::Database;
+use crate::db::quality_gates::QualityGateRow;
+use crate::uncertainty::error::Result as UncertaintyResult;
+use crate::uncertainty::storage::orphan_after_from_ttl;
+use crate::uncertainty::types::{Confidence, Prediction, PredictionInput};
+use crate::verify::GateResult;
+
+/// The uncertainty surface all gate verdicts emit under.
+pub const GATE_SURFACE: &str = "legion.gate";
+
+/// Days a gate prediction waits for a witness before the engine's sweep
+/// orphans it (orphans are excluded from calibration).
+const GATE_ORPHAN_TTL_DAYS: u32 = 30;
+
+/// Claimed P(clean) for a `clean` verdict. Degenerate by design -- every
+/// "clean" verdict pins near 1.0; the signal is the witnessed correctness, not
+/// this number. Kept just below 1.0 so it lands in the engine's top bucket
+/// without being a literal certainty.
+const CLEAN_CONFIDENCE: f64 = 0.95;
+
+/// Claimed P(clean) for an `issues` verdict -- the gate is asserting the diff
+/// is NOT clean.
+const ISSUES_CONFIDENCE: f64 = 0.05;
+
+/// Deterministic fingerprint for a (skill, commit) gate run. Both components
+/// are already safe, stable identifiers (the commit is a git hash, the skill a
+/// short slug), so a plain join is a sufficient lookup key -- the Phase 2b
+/// witness recomputes it to find this prediction. No hashing is needed; hashing
+/// would only obscure an already-unique key.
+pub fn gate_fingerprint(skill: &str, commit_hash: &str) -> String {
+    format!("{skill}:{commit_hash}")
+}
+
+/// The model id of the agent that ran the gate, for cohorting by who
+/// rubber-stamps. Sourced from the environment; "unknown" when the harness does
+/// not surface it (cohorts still distinguish gate type and legion version).
+fn agent_model() -> String {
+    std::env::var("LEGION_AGENT_MODEL").unwrap_or_else(|_| "unknown".to_string())
+}
+
+fn confidence_for(result: GateResult) -> f64 {
+    match result {
+        GateResult::Clean => CLEAN_CONFIDENCE,
+        GateResult::Issues => ISSUES_CONFIDENCE,
+    }
+}
+
+/// Build the prediction input for a recorded gate verdict.
+///
+/// Mapping: surface=legion.gate, feature_key=gate.<skill>, model=agent model,
+/// model_version=legion's own version (so a release that changes rubber-stamp
+/// behavior shows up as a new cohort), fingerprint=skill:commit, confidence by
+/// verdict, payload carrying the gate context.
+fn prediction_input(row: &QualityGateRow) -> UncertaintyResult<PredictionInput> {
+    let payload = serde_json::json!({
+        "skill": row.skill,
+        "branch": row.branch,
+        "commit": row.commit_hash,
+        "findings_count": row.findings_count,
+        "result": row.result.as_str(),
+    });
+    Ok(PredictionInput {
+        surface: GATE_SURFACE.to_string(),
+        feature_key: format!("gate.{}", row.skill),
+        input_fingerprint: gate_fingerprint(&row.skill, &row.commit_hash),
+        model: agent_model(),
+        model_version: env!("CARGO_PKG_VERSION").to_string(),
+        claimed_confidence: Confidence::from_f64(confidence_for(row.result))?,
+        prediction_payload: payload,
+        orphan_after: orphan_after_from_ttl(GATE_ORPHAN_TTL_DAYS),
+    })
+}
+
+/// Emit a gate verdict as an uncertainty prediction. Returns the prediction id
+/// on success. The non-blocking wrapper `emit_gate_trust` is what call sites
+/// use; this inner function returns the Result for tests.
+pub fn emit_gate_prediction(db: &Database, row: &QualityGateRow) -> UncertaintyResult<String> {
+    let prediction = Prediction::new(prediction_input(row)?);
+    db.insert_prediction(&prediction)?;
+    Ok(prediction.id)
+}
+
+/// Non-blocking gate-trust emit for the gate-record handlers: log on failure,
+/// never propagate. A gate-trust problem must never break gate recording or the
+/// agent's workflow -- the measurement is best-effort, the gate is not.
+pub fn emit_gate_trust(db: &Database, row: &QualityGateRow) {
+    if let Err(e) = emit_gate_prediction(db, row) {
+        eprintln!("[legion] gate-trust emit failed (non-fatal): {e}");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::testutil::test_db;
+    use crate::uncertainty::types::PredictionState;
+
+    fn gate_row(skill: &str, result: GateResult, findings: u64) -> QualityGateRow {
+        QualityGateRow {
+            id: "gate-id".to_string(),
+            branch: "feat/x".to_string(),
+            commit_hash: "deadbeefcafe".to_string(),
+            skill: skill.to_string(),
+            result,
+            findings_count: findings,
+            details: None,
+            created_at: "2026-06-27T00:00:00+00:00".to_string(),
+        }
+    }
+
+    #[test]
+    fn fingerprint_is_deterministic_and_componentwise() {
+        assert_eq!(
+            gate_fingerprint("legion-simplify", "abc123"),
+            "legion-simplify:abc123"
+        );
+        // Same inputs -> same fingerprint (the witness side relies on this).
+        assert_eq!(
+            gate_fingerprint("legion-simplify", "abc123"),
+            gate_fingerprint("legion-simplify", "abc123")
+        );
+        // Different skill or commit -> different fingerprint.
+        assert_ne!(
+            gate_fingerprint("legion-simplify", "abc123"),
+            gate_fingerprint("legion-review", "abc123")
+        );
+    }
+
+    #[test]
+    fn clean_and_issues_map_to_distinct_confidences() {
+        assert_eq!(confidence_for(GateResult::Clean), CLEAN_CONFIDENCE);
+        assert_eq!(confidence_for(GateResult::Issues), ISSUES_CONFIDENCE);
+        // A clean verdict must claim higher P(clean) than an issues verdict.
+        assert!(confidence_for(GateResult::Clean) > confidence_for(GateResult::Issues));
+    }
+
+    #[test]
+    fn input_maps_the_gate_fields() {
+        let input = prediction_input(&gate_row("legion-simplify", GateResult::Clean, 0)).unwrap();
+        assert_eq!(input.surface, "legion.gate");
+        assert_eq!(input.feature_key, "gate.legion-simplify");
+        assert_eq!(input.input_fingerprint, "legion-simplify:deadbeefcafe");
+        assert_eq!(input.claimed_confidence.value(), CLEAN_CONFIDENCE);
+        assert_eq!(input.model_version, env!("CARGO_PKG_VERSION"));
+        assert_eq!(input.prediction_payload["skill"], "legion-simplify");
+        assert_eq!(input.prediction_payload["result"], "clean");
+        assert!(input.orphan_after.is_some());
+    }
+
+    #[test]
+    fn emit_inserts_a_retrievable_emitted_prediction() {
+        let db = test_db();
+        let row = gate_row("legion-simplify", GateResult::Clean, 0);
+        let id = emit_gate_prediction(&db, &row).unwrap();
+        let fetched = db.get_prediction(&id).unwrap().unwrap();
+        assert_eq!(fetched.surface, "legion.gate");
+        assert_eq!(fetched.state, PredictionState::Emitted);
+        assert_eq!(fetched.input_fingerprint, "legion-simplify:deadbeefcafe");
+        assert!(fetched.outcome_correctness.is_none());
+    }
+
+    #[test]
+    fn issues_verdict_emits_low_confidence() {
+        let db = test_db();
+        let row = gate_row("legion-review", GateResult::Issues, 3);
+        let id = emit_gate_prediction(&db, &row).unwrap();
+        let fetched = db.get_prediction(&id).unwrap().unwrap();
+        assert_eq!(fetched.claimed_confidence.value(), ISSUES_CONFIDENCE);
+        assert_eq!(fetched.feature_key, "gate.legion-review");
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ mod db;
 mod documents;
 mod embed;
 mod error;
+mod gate_trust;
 mod health;
 mod init;
 #[allow(dead_code)] // Items used by tests + pending surface/status/serve migration

--- a/src/uncertainty/storage.rs
+++ b/src/uncertainty/storage.rs
@@ -168,6 +168,26 @@ impl Database {
             .map_err(UncertaintyError::Database)
     }
 
+    /// Count predictions on a surface in a given state. Read-only. Currently a
+    /// test-support accessor (the gate-trust emit test uses it to prove emission
+    /// positively); Phase 2b's witness lookup will promote it to a production
+    /// accessor, so it is `#[cfg(test)]` for now rather than carrying a
+    /// dead-code allow in the production build.
+    #[cfg(test)]
+    pub fn count_predictions_by_surface_state(
+        &self,
+        surface: &str,
+        state: PredictionState,
+    ) -> Result<i64> {
+        let n: i64 = self.conn.query_row(
+            "SELECT COUNT(*) FROM uncertainty_prediction \
+             WHERE surface = ?1 AND state = ?2 AND deleted_at IS NULL",
+            params![surface, state.as_str()],
+            |r| r.get(0),
+        )?;
+        Ok(n)
+    }
+
     /// Group orphan-state predictions by surface. Optionally filtered to a
     /// single surface. Used by the dashboard + nightly digest.
     pub fn count_orphans_by_surface(&self, surface: Option<&str>) -> Result<Vec<OrphanSummaryRow>> {


### PR DESCRIPTION
## Summary

Phase 2a of gate-trust: treat each quality-gate verdict as a `surface=legion.gate`
prediction on the live uncertainty engine, so a later witness (Phase 2b) can true it
against downstream ground truth and the engine can report the rubber-stamp rate per cohort.
New `src/gate_trust.rs` is a CALLER of the engine -- it maps a `QualityGateRow` to a
`PredictionInput` and inserts it. No engine change.

## Acceptance criteria mapping

### 1. Recording a gate verdict emits one legion.gate prediction with mapped fields + deterministic fingerprint
`emit_gate_prediction` builds a `PredictionInput` (surface=legion.gate, feature_key=gate.<skill>,
model_version=legion's own CARGO_PKG_VERSION, claimed_confidence by verdict) and calls
`db.insert_prediction`. The fingerprint is deterministic. DEVIATION from the literal AC
wording ("SHA-256(skill:commit)"): it is a plain `skill:commit` join, not a hash -- both
components are already safe, stable identifiers (a git commit hash and a short slug), so
hashing adds nothing and only obscures an already-unique key. Recoverable by the 2b witness.
Evidence: src/gate_trust.rs fn gate_fingerprint and fn prediction_input; test
`fn input_maps_the_gate_fields` asserts surface/feature_key/fingerprint/confidence/payload.

### 2. Emit is non-blocking
`fn emit_gate_trust` is the call-site entry: it calls `emit_gate_prediction` and, on Err,
logs to stderr and returns -- never propagates. A gate-trust failure cannot break gate
recording.
Evidence: src/gate_trust.rs fn emit_gate_trust (the `if let Err(e) = ... { eprintln! }`
boundary); the e2e run of `quality-gate record` printed the gate id with no emit-failure line.

### 3. The prediction is recoverable for the witness side
DEVIATION: rather than persist a separate (commit,skill)->prediction_id sidecar file (the
AC's literal suggestion), the deterministic `skill:commit` fingerprint IS the recoverable
key -- Phase 2b recomputes it and queries by (surface, fingerprint). This avoids a
drift-prone second source of truth (a sidecar file that can desync from the DB), which is
exactly the kind of duplication the simplify gate flags. The re-run contract (a re-run emits
another prediction with the same fingerprint; the witness takes the latest, duplicates orphan
out) is documented in the module doc.
Evidence: src/gate_trust.rs module doc "Re-run contract"; fn gate_fingerprint is deterministic
(test `fn fingerprint_is_deterministic_and_componentwise`).

### 4. No change to the uncertainty engine LOGIC
No existing engine logic is altered. gate_trust.rs only CALLS the existing public
`Prediction::new` + `Database::insert_prediction` + `orphan_after_from_ttl`. The one addition
to src/uncertainty/storage.rs is a `#[cfg(test)]` read accessor
(`count_predictions_by_surface_state`) added solely so the emit test can prove emission
positively -- it adds no production surface (cfg(test)) and changes no existing path. (This
narrows the original AC wording "no change to src/uncertainty/*": a test-only read accessor
was added; the engine's behavior is unchanged.)
Evidence: the diff under src/uncertainty/ is exactly one cfg(test) fn mirroring the adjacent
count_orphans_by_surface; gate_trust.rs imports only existing engine constructors.

### 5. Tests cover fingerprint determinism, clean-vs-issues confidence, emit behavior
Five unit tests: fingerprint determinism + component-sensitivity; clean vs issues map to
distinct confidences (compared through the function, not the consts); field mapping; emit
round-trips to a retrievable Emitted prediction; issues verdict emits low confidence. The
"emit failure does not propagate" property is structural (emit_gate_trust discards the Result
of emit_gate_prediction) rather than forced with a synthetic DB failure.
Evidence: src/gate_trust.rs #[cfg(test)] mod tests (5 tests); e2e confirms the handler path.

### 6. test / clippy / fmt pass
The full suite stays green with the new module and the three wired handlers; clippy runs
--all-targets (caught and fixed an assertions-on-constants lint in a test); formatting clean.
Evidence: 195 integration + bin tests pass; `cargo clippy --all-targets -- -D warnings` clean;
`cargo fmt -- --check` clean.

## Not done

- Did NOT use SHA-256 for the fingerprint (criterion 1) or a sidecar mapping file (criterion
  3); both AC wordings are superseded by the simpler deterministic `skill:commit` key, which
  is recoverable and avoids a second source of truth. Flagged here, not shipped silently --
  Sean may update the issue wording.
- Did NOT wire the verify gate: its skill name is card-keyed (`legion-verify:<card-id>`), so
  emitting would give every card its own `feature_key` cohort. Out of scope; revisit with a
  normalized feature_key if verify-trust is wanted.
- Phase 2b (witness against pre-push catch / revert / post-merge bug; calibration readout) and
  Phase 3 (routing high-rubber-stamp cohorts to independent review) are separate.
- Did NOT enrich `model` beyond an env var (`LEGION_AGENT_MODEL`, default "unknown") -- the
  harness does not surface the agent model in-process today; cohorts still split on gate type
  and legion version.