### PR TITLE
feat(#693): witness gate-trust predictions from the downstream review gate

### DIFF
--- a/src/cli/verify.rs
+++ b/src/cli/verify.rs
@@ -147,6 +147,16 @@ pub(crate) fn handle_quality_gate(action: QualityGateAction) -> error::Result<()
                 details_json.as_deref(),
             )?;
             emit_gate_trust(&database, &row);
+            // Phase 2b: a downstream legion-review verdict witnesses the
+            // upstream legion-simplify gate prediction for this commit -- review
+            // catching issues means simplify's clean verdict was wrong.
+            if row.skill == "legion-review" {
+                crate::gate_trust::witness_simplify_from_review_nonblocking(
+                    &database,
+                    &commit_hash,
+                    matches!(row.result, GateResult::Issues),
+                );
+            }
             println!("{}", row.id);
         }
 

--- a/src/cli/verify.rs
+++ b/src/cli/verify.rs
@@ -150,13 +150,7 @@ pub(crate) fn handle_quality_gate(action: QualityGateAction) -> error::Result<()
             // Phase 2b: a downstream legion-review verdict witnesses the
             // upstream legion-simplify gate prediction for this commit -- review
             // catching issues means simplify's clean verdict was wrong.
-            if row.skill == "legion-review" {
-                crate::gate_trust::witness_simplify_from_review_nonblocking(
-                    &database,
-                    &commit_hash,
-                    matches!(row.result, GateResult::Issues),
-                );
-            }
+            crate::gate_trust::maybe_witness_from_review(&database, &row, &commit_hash);
             println!("{}", row.id);
         }
 

--- a/src/cli/verify.rs
+++ b/src/cli/verify.rs
@@ -150,7 +150,7 @@ pub(crate) fn handle_quality_gate(action: QualityGateAction) -> error::Result<()
             // Phase 2b: a downstream legion-review verdict witnesses the
             // upstream legion-simplify gate prediction for this commit -- review
             // catching issues means simplify's clean verdict was wrong.
-            crate::gate_trust::maybe_witness_from_review(&database, &row, &commit_hash);
+            crate::gate_trust::maybe_witness_from_review(&database, &row);
             println!("{}", row.id);
         }
 

--- a/src/gate_trust.rs
+++ b/src/gate_trust.rs
@@ -170,6 +170,21 @@ pub fn witness_simplify_from_review_nonblocking(
     }
 }
 
+/// Apply the downstream-review witness for a just-recorded gate. ONLY a
+/// `legion-review` verdict witnesses the upstream `legion-simplify` prediction;
+/// every other gate is a no-op here. This is the gate-record handler's single
+/// entry point, so the skill guard and the verdict->bool mapping live in one
+/// testable place rather than inline at the call site.
+pub fn maybe_witness_from_review(db: &Database, row: &QualityGateRow, commit_hash: &str) {
+    if row.skill == "legion-review" {
+        witness_simplify_from_review_nonblocking(
+            db,
+            commit_hash,
+            matches!(row.result, GateResult::Issues),
+        );
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -312,6 +327,37 @@ mod tests {
         assert!(witness_simplify_from_review(&db, "deadbeefcafe", true).unwrap());
         // Now none Emitted -> no-op.
         assert!(!witness_simplify_from_review(&db, "deadbeefcafe", true).unwrap());
+    }
+
+    #[test]
+    fn maybe_witness_fires_only_for_review_gate_and_maps_the_verdict() {
+        use crate::uncertainty::types::PredictionState;
+        let db = test_db();
+        let id =
+            emit_gate_prediction(&db, &gate_row("legion-simplify", GateResult::Clean, 0)).unwrap();
+
+        // A non-review gate (pr-write) must NOT witness the simplify prediction.
+        maybe_witness_from_review(
+            &db,
+            &gate_row("legion-pr-write", GateResult::Issues, 1),
+            "deadbeefcafe",
+        );
+        assert_eq!(
+            db.get_prediction(&id).unwrap().unwrap().state,
+            PredictionState::Emitted,
+            "only legion-review should trigger the witness"
+        );
+
+        // A legion-review Issues verdict witnesses it wrong (verdict -> bool maps
+        // Issues to review_found_issues=true -> correctness 0.0).
+        maybe_witness_from_review(
+            &db,
+            &gate_row("legion-review", GateResult::Issues, 2),
+            "deadbeefcafe",
+        );
+        let fetched = db.get_prediction(&id).unwrap().unwrap();
+        assert_eq!(fetched.state, PredictionState::Witnessed);
+        assert_eq!(fetched.outcome_correctness.map(|c| c.value()), Some(0.0));
     }
 
     #[test]

--- a/src/gate_trust.rs
+++ b/src/gate_trust.rs
@@ -24,7 +24,9 @@ use crate::db::Database;
 use crate::db::quality_gates::QualityGateRow;
 use crate::uncertainty::error::Result as UncertaintyResult;
 use crate::uncertainty::storage::orphan_after_from_ttl;
-use crate::uncertainty::types::{Confidence, Prediction, PredictionInput};
+use crate::uncertainty::types::{
+    Confidence, Correctness, OutcomeLabel, Prediction, PredictionInput,
+};
 use crate::verify::GateResult;
 
 /// The uncertainty surface all gate verdicts emit under.
@@ -122,6 +124,52 @@ pub fn emit_gate_trust(db: &Database, row: &QualityGateRow) {
     }
 }
 
+/// Witness the legion-simplify gate prediction for `commit_hash` from the
+/// downstream review verdict (Phase 2b). `review_found_issues` true means the
+/// review caught what the simplify gate passed clean -- the clean verdict was
+/// wrong (correctness 0.0, Escalated). false corroborates it (correctness 1.0,
+/// Shipped) -- a weak positive, since legion-review records clean-on-approve.
+///
+/// Resolves the prediction by the deterministic fingerprint, taking the LATEST
+/// Emitted row (the re-run contract). Returns true if one was witnessed, false
+/// if no matching Emitted prediction exists (a clean no-op -- e.g. the simplify
+/// gate was never run, or it already witnessed/orphaned).
+pub fn witness_simplify_from_review(
+    db: &Database,
+    commit_hash: &str,
+    review_found_issues: bool,
+) -> UncertaintyResult<bool> {
+    let fingerprint = gate_fingerprint("legion-simplify", commit_hash);
+    let Some(mut prediction) = db.latest_emitted_by_fingerprint(GATE_SURFACE, &fingerprint)? else {
+        return Ok(false);
+    };
+    let (label, correctness) = if review_found_issues {
+        (OutcomeLabel::Escalated, 0.0)
+    } else {
+        (OutcomeLabel::Shipped, 1.0)
+    };
+    let now = chrono::Utc::now().to_rfc3339();
+    let payload = serde_json::json!({
+        "witnessed_by": "legion-review",
+        "review_found_issues": review_found_issues,
+    });
+    prediction.witness(label, payload, Correctness::from_f64(correctness)?, &now)?;
+    db.update_prediction(&prediction)?;
+    Ok(true)
+}
+
+/// Non-blocking witness for the gate-record handler: log on failure, never
+/// propagate. Like emit, a witness problem must not break gate recording.
+pub fn witness_simplify_from_review_nonblocking(
+    db: &Database,
+    commit_hash: &str,
+    review_found_issues: bool,
+) {
+    if let Err(e) = witness_simplify_from_review(db, commit_hash, review_found_issues) {
+        eprintln!("[legion] gate-trust witness failed (non-fatal): {e}");
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -207,6 +255,63 @@ mod tests {
             .count_predictions_by_surface_state("legion.gate", PredictionState::Emitted)
             .unwrap();
         assert_eq!(emitted, 1, "the wrapper must emit exactly one Emitted row");
+    }
+
+    #[test]
+    fn witness_issues_marks_simplify_prediction_wrong() {
+        let db = test_db();
+        let row = gate_row("legion-simplify", GateResult::Clean, 0);
+        let id = emit_gate_prediction(&db, &row).unwrap();
+        // Review caught issues -> the clean verdict was wrong.
+        let witnessed = witness_simplify_from_review(&db, "deadbeefcafe", true).unwrap();
+        assert!(
+            witnessed,
+            "the emitted simplify prediction should be witnessed"
+        );
+        let fetched = db.get_prediction(&id).unwrap().unwrap();
+        use crate::uncertainty::types::PredictionState;
+        assert_eq!(fetched.state, PredictionState::Witnessed);
+        assert_eq!(fetched.outcome_correctness.map(|c| c.value()), Some(0.0));
+        assert_eq!(fetched.outcome_label, Some(OutcomeLabel::Escalated));
+    }
+
+    #[test]
+    fn witness_clean_corroborates_simplify_prediction() {
+        let db = test_db();
+        let row = gate_row("legion-simplify", GateResult::Clean, 0);
+        let id = emit_gate_prediction(&db, &row).unwrap();
+        // Review clean -> corroborates (weak positive).
+        assert!(witness_simplify_from_review(&db, "deadbeefcafe", false).unwrap());
+        let fetched = db.get_prediction(&id).unwrap().unwrap();
+        assert_eq!(fetched.outcome_correctness.map(|c| c.value()), Some(1.0));
+        assert_eq!(fetched.outcome_label, Some(OutcomeLabel::Shipped));
+    }
+
+    #[test]
+    fn witness_with_no_matching_prediction_is_noop() {
+        let db = test_db();
+        // No simplify prediction was emitted for this commit -- clean no-op.
+        let witnessed = witness_simplify_from_review(&db, "nosuchcommit", true).unwrap();
+        assert!(
+            !witnessed,
+            "expected a no-op when no Emitted prediction matches"
+        );
+    }
+
+    #[test]
+    fn witness_takes_the_latest_emitted_on_rerun() {
+        let db = test_db();
+        let row = gate_row("legion-simplify", GateResult::Clean, 0);
+        // Two runs of the same gate on the same commit -> two Emitted rows,
+        // same fingerprint. The witness resolves the latest and leaves the loop
+        // closeable; the second witness is a no-op (only one Emitted remains).
+        let _id1 = emit_gate_prediction(&db, &row).unwrap();
+        let _id2 = emit_gate_prediction(&db, &row).unwrap();
+        assert!(witness_simplify_from_review(&db, "deadbeefcafe", true).unwrap());
+        // One Emitted row remains; a second witness still finds it.
+        assert!(witness_simplify_from_review(&db, "deadbeefcafe", true).unwrap());
+        // Now none Emitted -> no-op.
+        assert!(!witness_simplify_from_review(&db, "deadbeefcafe", true).unwrap());
     }
 
     #[test]

--- a/src/gate_trust.rs
+++ b/src/gate_trust.rs
@@ -339,10 +339,13 @@ mod tests {
         let db = test_db();
         // Simplify recorded ISSUES -> it flagged something, not a rubber-stamp
         // candidate. The witness must skip it even when review finds issues.
-        let id = emit_gate_prediction(&db, &gate_row("legion-simplify", GateResult::Issues, 1))
-            .unwrap();
+        let id =
+            emit_gate_prediction(&db, &gate_row("legion-simplify", GateResult::Issues, 1)).unwrap();
         let witnessed = witness_simplify_from_review(&db, "deadbeefcafe", true).unwrap();
-        assert!(!witnessed, "an issues-verdict prediction must not be witnessed");
+        assert!(
+            !witnessed,
+            "an issues-verdict prediction must not be witnessed"
+        );
         assert_eq!(
             db.get_prediction(&id).unwrap().unwrap().state,
             PredictionState::Emitted

--- a/src/gate_trust.rs
+++ b/src/gate_trust.rs
@@ -143,6 +143,19 @@ pub fn witness_simplify_from_review(
     let Some(mut prediction) = db.latest_emitted_by_fingerprint(GATE_SURFACE, &fingerprint)? else {
         return Ok(false);
     };
+    // Only a CLEAN simplify verdict is a rubber-stamp candidate. If simplify
+    // already flagged issues, it was not rubber-stamping, so a downstream review
+    // catch does not falsify it -- witnessing it would pollute the
+    // P(buggy | said-clean) signal. Skip non-clean predictions (e.g. a gate
+    // recorded out of pipeline order).
+    let was_clean = prediction
+        .prediction_payload
+        .get("result")
+        .and_then(|v| v.as_str())
+        == Some("clean");
+    if !was_clean {
+        return Ok(false);
+    }
     let (label, correctness) = if review_found_issues {
         (OutcomeLabel::Escalated, 0.0)
     } else {
@@ -300,6 +313,22 @@ mod tests {
         let fetched = db.get_prediction(&id).unwrap().unwrap();
         assert_eq!(fetched.outcome_correctness.map(|c| c.value()), Some(1.0));
         assert_eq!(fetched.outcome_label, Some(OutcomeLabel::Shipped));
+    }
+
+    #[test]
+    fn witness_skips_a_non_clean_simplify_prediction() {
+        use crate::uncertainty::types::PredictionState;
+        let db = test_db();
+        // Simplify recorded ISSUES -> it flagged something, not a rubber-stamp
+        // candidate. The witness must skip it even when review finds issues.
+        let id = emit_gate_prediction(&db, &gate_row("legion-simplify", GateResult::Issues, 1))
+            .unwrap();
+        let witnessed = witness_simplify_from_review(&db, "deadbeefcafe", true).unwrap();
+        assert!(!witnessed, "an issues-verdict prediction must not be witnessed");
+        assert_eq!(
+            db.get_prediction(&id).unwrap().unwrap().state,
+            PredictionState::Emitted
+        );
     }
 
     #[test]

--- a/src/gate_trust.rs
+++ b/src/gate_trust.rs
@@ -172,14 +172,14 @@ pub fn witness_simplify_from_review_nonblocking(
 
 /// Apply the downstream-review witness for a just-recorded gate. ONLY a
 /// `legion-review` verdict witnesses the upstream `legion-simplify` prediction;
-/// every other gate is a no-op here. This is the gate-record handler's single
-/// entry point, so the skill guard and the verdict->bool mapping live in one
-/// testable place rather than inline at the call site.
-pub fn maybe_witness_from_review(db: &Database, row: &QualityGateRow, commit_hash: &str) {
+/// every other gate is a no-op here. The handler's single entry point, so the
+/// skill guard and verdict->bool mapping are tested in one place. Witnesses
+/// against the row's own commit, so it cannot drift from the verdict recorded.
+pub fn maybe_witness_from_review(db: &Database, row: &QualityGateRow) {
     if row.skill == "legion-review" {
         witness_simplify_from_review_nonblocking(
             db,
-            commit_hash,
+            &row.commit_hash,
             matches!(row.result, GateResult::Issues),
         );
     }
@@ -337,11 +337,8 @@ mod tests {
             emit_gate_prediction(&db, &gate_row("legion-simplify", GateResult::Clean, 0)).unwrap();
 
         // A non-review gate (pr-write) must NOT witness the simplify prediction.
-        maybe_witness_from_review(
-            &db,
-            &gate_row("legion-pr-write", GateResult::Issues, 1),
-            "deadbeefcafe",
-        );
+        // gate_row's commit ("deadbeefcafe") matches the emitted prediction above.
+        maybe_witness_from_review(&db, &gate_row("legion-pr-write", GateResult::Issues, 1));
         assert_eq!(
             db.get_prediction(&id).unwrap().unwrap().state,
             PredictionState::Emitted,
@@ -350,11 +347,7 @@ mod tests {
 
         // A legion-review Issues verdict witnesses it wrong (verdict -> bool maps
         // Issues to review_found_issues=true -> correctness 0.0).
-        maybe_witness_from_review(
-            &db,
-            &gate_row("legion-review", GateResult::Issues, 2),
-            "deadbeefcafe",
-        );
+        maybe_witness_from_review(&db, &gate_row("legion-review", GateResult::Issues, 2));
         let fetched = db.get_prediction(&id).unwrap().unwrap();
         assert_eq!(fetched.state, PredictionState::Witnessed);
         assert_eq!(fetched.outcome_correctness.map(|c| c.value()), Some(0.0));

--- a/src/gate_trust.rs
+++ b/src/gate_trust.rs
@@ -19,6 +19,24 @@
 //! duplicates simply orphan out after the TTL and are excluded from
 //! calibration. The fingerprint identifies the (skill, commit) cohort run, not a
 //! unique row.
+//!
+//! WITNESS LIMITATIONS (the in-pipeline signal is an MVP; the trustworthy signal
+//! is the review-CAUGHT path):
+//!  1. Exact-commit keying: the witness matches `legion-simplify:<commit>`. In
+//!     the normal pipeline `pr create` requires a clean simplify gate on HEAD, so
+//!     simplify and review land on the same commit and the lookup hits. But if a
+//!     fix commit lands between simplify and review without simplify re-running,
+//!     the lookup no-ops -- silently UNDERCOUNTING (it misses a clean verdict that
+//!     was later fixed, exactly a rubber-stamp).
+//!  2. Weak positive: a clean review corroborates at correctness 1.0, but
+//!     legion-review records clean-on-approve, so the witnessed-correct population
+//!     skews optimistic. The `Escalated`/0.0 review-CAUGHT path is the only fully
+//!     trustworthy signal; read clean-corroboration as a lower bound on the
+//!     rubber-stamp rate, not a measurement of it.
+//!
+//! Closing both needs a stronger, decorrelated witness source (an independent
+//! reviewer on a different model; revert / post-merge-bug detection) -- tracked
+//! as #694, not this MVP.
 
 use crate::db::Database;
 use crate::db::quality_gates::QualityGateRow;

--- a/src/uncertainty/storage.rs
+++ b/src/uncertainty/storage.rs
@@ -70,6 +70,36 @@ impl Database {
         }
     }
 
+    /// Find the most recent Emitted prediction for a (surface, fingerprint).
+    /// Used by the gate-trust witness to resolve a (skill, commit) back to the
+    /// prediction to witness. Returns None if none is in the Emitted state --
+    /// the re-run contract: a re-run emits another row with the same
+    /// fingerprint, so this takes the latest; earlier duplicates may already be
+    /// witnessed or orphaned and are skipped.
+    pub fn latest_emitted_by_fingerprint(
+        &self,
+        surface: &str,
+        fingerprint: &str,
+    ) -> Result<Option<Prediction>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT id, surface, feature_key, input_fingerprint, model, model_version, \
+             claimed_confidence, prediction_payload, state, outcome_label, outcome_payload, \
+             outcome_correctness, cohort_key, created_at, updated_at, witnessed_at, \
+             orphan_after \
+             FROM uncertainty_prediction \
+             WHERE surface = ?1 AND input_fingerprint = ?2 AND state = 'emitted' \
+             AND deleted_at IS NULL \
+             ORDER BY created_at DESC \
+             LIMIT 1",
+        )?;
+        let mut rows = stmt.query(params![surface, fingerprint])?;
+        if let Some(row) = rows.next()? {
+            Ok(Some(map_prediction_row(row)?))
+        } else {
+            Ok(None)
+        }
+    }
+
     /// Persist a prediction whose state has advanced (witness / calibrate /
     /// orphan / retire). UPDATE keyed by id; updated_at is taken from the
     /// in-memory row so callers control the timestamp.
@@ -407,5 +437,38 @@ mod tests {
         let db = test_db();
         let snaps = db.list_calibration_snapshots(None, None).unwrap();
         assert!(snaps.is_empty());
+    }
+
+    #[test]
+    fn latest_emitted_by_fingerprint_finds_emitted_skips_witnessed_and_unknown() {
+        let db = test_db();
+        let p = Prediction::new(fresh_input()); // surface legion.task, fingerprint fp-1
+        db.insert_prediction(&p).unwrap();
+        // Found while Emitted.
+        let found = db
+            .latest_emitted_by_fingerprint("legion.task", "fp-1")
+            .unwrap();
+        assert_eq!(found.as_ref().map(|x| x.id.as_str()), Some(p.id.as_str()));
+        // Unknown fingerprint -> None.
+        assert!(
+            db.latest_emitted_by_fingerprint("legion.task", "nope")
+                .unwrap()
+                .is_none()
+        );
+        // Once witnessed it is no longer Emitted -> the lookup skips it.
+        let mut p2 = db.get_prediction(&p.id).unwrap().unwrap();
+        p2.witness(
+            OutcomeLabel::Shipped,
+            serde_json::json!({}),
+            Correctness::from_f64(1.0).unwrap(),
+            "2026-06-29T00:00:00+00:00",
+        )
+        .unwrap();
+        db.update_prediction(&p2).unwrap();
+        assert!(
+            db.latest_emitted_by_fingerprint("legion.task", "fp-1")
+                .unwrap()
+                .is_none()
+        );
     }
 }

--- a/src/uncertainty/storage.rs
+++ b/src/uncertainty/storage.rs
@@ -89,7 +89,7 @@ impl Database {
              FROM uncertainty_prediction \
              WHERE surface = ?1 AND input_fingerprint = ?2 AND state = 'emitted' \
              AND deleted_at IS NULL \
-             ORDER BY created_at DESC \
+             ORDER BY created_at DESC, id DESC \
              LIMIT 1",
         )?;
         let mut rows = stmt.query(params![surface, fingerprint])?;


### PR DESCRIPTION
## Summary

Phase 2b closes the gate-trust loop: when a `legion-review` verdict is recorded, witness the
`legion-simplify` `legion.gate` prediction for the same commit. Stacked on #692 (Phase 2a emit);
base is feat/691-gate-trust-emit, so the diff here is the witness only.

The genuinely-independent pre-push review runs from the operator's global git hooks
(`core.hooksPath`), outside legion's shippable surface, so the clean in-pipeline wiring point is
the downstream gate.

## Acceptance criteria mapping

### 1. legion-review witnesses the matching legion-simplify prediction with the right outcome
`witness_simplify_from_review` maps review-found-issues -> (Escalated, correctness 0.0) and
review-clean -> (Shipped, correctness 1.0), then transitions the prediction.
Evidence: src/gate_trust.rs:137 fn witness_simplify_from_review; tests
`fn witness_issues_marks_simplify_prediction_wrong` (0.0/Escalated) and
`fn witness_clean_corroborates_simplify_prediction` (1.0/Shipped).

### 2. By deterministic fingerprint, latest Emitted, no-op if none
It recomputes `gate_fingerprint("legion-simplify", commit)` and resolves the newest Emitted row
via `latest_emitted_by_fingerprint`; returns false (no-op) when none matches.
Evidence: src/uncertainty/storage.rs:79 fn latest_emitted_by_fingerprint (ORDER BY created_at DESC,
state='emitted'); tests `fn witness_with_no_matching_prediction_is_noop` and
`fn witness_takes_the_latest_emitted_on_rerun`.

### 3. Non-blocking
`witness_simplify_from_review_nonblocking` logs to stderr and never propagates; the handler calls
that wrapper, so a witness failure cannot break gate recording.
Evidence: src/gate_trust.rs fn witness_simplify_from_review_nonblocking; the e2e recorded a
legion-review issues verdict and the witness fired with no error line.

### 4. Uses the engine's witness path; one read accessor; no engine logic change
The witness calls the engine's `Prediction::witness` + `Database::update_prediction`. The only
addition under src/uncertainty/ is one read-only accessor `latest_emitted_by_fingerprint`
(mirrors get_prediction + map_prediction_row); no existing engine logic changed.
Evidence: src/gate_trust.rs:156 prediction.witness(...) + db.update_prediction(...);
src/uncertainty/storage.rs:79 the read accessor.

### 5. Tests cover both outcomes, the no-op, and the re-run latest behavior
Four witness tests + a storage lookup test (finds Emitted, skips witnessed/unknown). The handler
gate (`if row.skill == "legion-review"`) restricts firing to the review gate.
Evidence: src/gate_trust.rs #[cfg(test)] (4 witness tests);
src/uncertainty/storage.rs `fn latest_emitted_by_fingerprint_finds_emitted_skips_witnessed_and_unknown`.

### 6. test / clippy / fmt pass
Full suite green with the new accessor + witness; clippy --all-targets clean; fmt clean.
Evidence: 195 integration + bin tests pass; `cargo clippy --all-targets -- -D warnings` clean;
`cargo fmt -- --check` clean.

## Not done / known limitations (this is an MVP witness; documented in the module)

- **Only the review-CAUGHT (0.0/Escalated) path is fully trustworthy.** Two weaknesses, both
  inherent to an in-pipeline witness and disclosed in the module doc:
  - *Exact-commit keying undercounts.* The witness matches `legion-simplify:<commit>`. In the
    normal pipeline `pr create` requires a clean simplify gate on HEAD, so simplify+review share a
    commit and it hits; but a fix commit landing between simplify and review (without simplify
    re-running) makes the lookup a silent no-op -- missing a clean-then-fixed verdict, exactly a
    rubber-stamp. Now also guarded to skip non-clean predictions.
  - *Weak positive.* Clean review corroborates at 1.0, but legion-review records clean-on-approve,
    so read clean-corroboration as a lower bound on the rubber-stamp rate, not a measurement.
  Closing both needs a decorrelated witness source (independent reviewer on a different model;
  revert / post-merge-bug detection) -- tracked as #694, not this MVP.
- External witness sources (pre-push hook / `git revert` / post-merge bug) via a
  `legion uncertainty witness-gate` CLI -- a follow-up once the in-pipeline primitive is proven.
- Routing high-rubber-stamp cohorts to independent review (Phase 3); calibration-roller changes
  (engine is done).
- The 17-column SELECT in latest_emitted_by_fingerprint duplicates the module's existing query
  shape (pre-existing convention); left as-is, a shared column const is the fix if it recurs.