### PR TITLE
feat(#698): supervisor restarts daemon on build-id change, not just version drift

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,52 @@
+// Emit LEGION_BUILD_ID at compile time so the running daemon and the local
+// binary can be compared beyond their semver version (#698).
+//
+// The daemon supervisor restarts on version drift, but a rebuild that does
+// NOT bump Cargo.toml -- the common dev case -- keeps the same version and
+// would otherwise go unnoticed (reflection 019f1565). The build id is the
+// git short SHA, with a `-dirty` suffix when the working tree has changes,
+// and `unknown` when git is unavailable (e.g. a crates.io install). The
+// supervisor treats `unknown` as "cannot tell" and falls back to version-
+// only comparison, so a missing id never causes a restart loop.
+//
+// LIMITATION: successive *dirty* rebuilds at the same HEAD yield the same
+// `<sha>-dirty` id, so the supervisor will not catch them. The target case
+// is the committed rebuild; dirty iteration is expected to restart by hand.
+// Note `git status --porcelain` also reports untracked files, so a stray
+// scratch file marks the build `-dirty` even when tracked state is clean --
+// harmless given the by-hand stance, but it widens the dirty surface.
+use std::process::Command;
+
+fn main() {
+    let build_id = git_build_id().unwrap_or_else(|| "unknown".to_string());
+    println!("cargo:rustc-env=LEGION_BUILD_ID={build_id}");
+
+    // logs/HEAD is appended on every HEAD movement (commit, checkout,
+    // reset), so watching it reruns build.rs -- and refreshes the id --
+    // whenever the committed state changes. (Plain .git/HEAD does not
+    // change when a new commit lands on the current branch.)
+    println!("cargo:rerun-if-changed=.git/logs/HEAD");
+}
+
+fn git_build_id() -> Option<String> {
+    let sha_out = Command::new("git")
+        .args(["rev-parse", "--short", "HEAD"])
+        .output()
+        .ok()?;
+    if !sha_out.status.success() {
+        return None;
+    }
+    let sha = String::from_utf8(sha_out.stdout).ok()?.trim().to_string();
+    if sha.is_empty() {
+        return None;
+    }
+
+    let dirty = Command::new("git")
+        .args(["status", "--porcelain"])
+        .output()
+        .ok()
+        .map(|o| !o.stdout.is_empty())
+        .unwrap_or(false);
+
+    Some(if dirty { format!("{sha}-dirty") } else { sha })
+}

--- a/plugin/hooks/_legion-daemon-supervisor.sh
+++ b/plugin/hooks/_legion-daemon-supervisor.sh
@@ -55,6 +55,12 @@ if [ -z "$LOCAL_VERSION" ]; then
   exit 0
 fi
 
+# Local build id (#698): the "(build <id>)" suffix that --version now carries
+# ("legion <version> (build <id>)"). Empty for a pre-#698 binary without the
+# suffix -- then the same-version build-drift check below is skipped and the
+# supervisor falls back to version-only behavior.
+LOCAL_BUILD=$("$LEGION_BIN" --version 2>/dev/null | sed -n 's/.*(build \(.*\))$/\1/p')
+
 # Spawn helper: detach via setsid (Linux) or nohup (mac). Both available
 # on macOS bash; setsid is Linux-only so we try it then fall back.
 spawn_daemon() {
@@ -90,6 +96,25 @@ kill_stale_daemon() {
   fi
 }
 
+# Restart whoever currently answers the port, choosing the remedy by role
+# (#613): a daemon is bounced in place via daemon-restart (which preserves the
+# watch loop); a serve -- or a pre-#613 binary that reports no role -- is
+# killed by pidfile and respawned as a fresh serve. Shared by the version-drift
+# and same-version build-drift (#698) paths.
+restart_by_role() {
+  local role="$1" reason="$2"
+  if [ "$role" = "daemon" ]; then
+    echo "[legion-daemon-supervisor] ${reason}; restarting daemon in place" >> "$LOG"
+    "$LEGION_BIN" daemon-restart >/dev/null 2>>"$LOG"
+  else
+    echo "[legion-daemon-supervisor] ${reason}; replacing" >> "$LOG"
+    if [ -f "$PIDFILE" ]; then
+      kill_stale_daemon "$(cat "$PIDFILE" 2>/dev/null)"
+    fi
+    spawn_daemon "$reason"
+  fi
+}
+
 # Probe /health. Short timeout (2s) since this runs in the SessionStart
 # background path -- waiting longer is just buffering before we accept
 # "not healthy" anyway.
@@ -115,29 +140,33 @@ if [ -z "$DAEMON_VERSION" ]; then
   exit 0
 fi
 
-if [ "$DAEMON_VERSION" = "$LOCAL_VERSION" ]; then
-  # Healthy + matching: silent.
-  exit 0
-fi
-
-# Version mismatch. Who answers the port decides the remedy (#613,
-# absorbed #601): the daemon owns :3131 while it runs, and replacing it
-# with a `legion serve` would silently drop the watch loop. /health now
-# reports a `role` field; a daemon gets bounced in place via
-# daemon-restart (which owns the stop/spawn dance against the daemon's
-# own pidfile). Pre-#613 binaries report no role -- they can only be a
-# `legion serve`, so the kill+spawn path below keeps working for them.
+# Role and build id drive the remedy. Parse both up front: the daemon owns
+# :3131 while it runs, so /health is the only place this info lives.
 DAEMON_ROLE=$(echo "$RESPONSE" | jq -r '.role // empty' 2>/dev/null)
-if [ "$DAEMON_ROLE" = "daemon" ]; then
-  echo "[legion-daemon-supervisor] daemon v${DAEMON_VERSION} != local v${LOCAL_VERSION}; restarting daemon in place" >> "$LOG"
-  "$LEGION_BIN" daemon-restart >/dev/null 2>>"$LOG"
+DAEMON_BUILD=$(echo "$RESPONSE" | jq -r '.build_id // empty' 2>/dev/null)
+
+if [ "$DAEMON_VERSION" = "$LOCAL_VERSION" ]; then
+  # Same version. A rebuild that did not bump Cargo.toml -- the common dev
+  # case -- keeps the version but changes the build id (#698), so version
+  # alone cannot tell the daemon is stale. Bounce when the build ids differ.
+  # Act ONLY when BOTH ids are known and concrete: an "unknown" id (git-less
+  # build) or an empty id (pre-#698 binary, or no build_id in /health) means
+  # "cannot tell" -- fall back to version-only and stay silent rather than
+  # risk a restart loop on indeterminate data.
+  if [ -n "$LOCAL_BUILD" ] && [ -n "$DAEMON_BUILD" ] \
+     && [ "$LOCAL_BUILD" != "unknown" ] && [ "$DAEMON_BUILD" != "unknown" ] \
+     && [ "$LOCAL_BUILD" != "$DAEMON_BUILD" ]; then
+    restart_by_role "$DAEMON_ROLE" \
+      "daemon build ${DAEMON_BUILD} != local build ${LOCAL_BUILD} (same version ${LOCAL_VERSION})"
+    exit 0
+  fi
+  # Same version, same or indeterminate build: healthy, silent.
   exit 0
 fi
 
-# Role "serve" (or absent): kill stale serve, spawn fresh.
-echo "[legion-daemon-supervisor] daemon v${DAEMON_VERSION} != local v${LOCAL_VERSION}; replacing" >> "$LOG"
-if [ -f "$PIDFILE" ]; then
-  kill_stale_daemon "$(cat "$PIDFILE" 2>/dev/null)"
-fi
-spawn_daemon "replaced stale v${DAEMON_VERSION} -> v${LOCAL_VERSION}"
+# Version drift (#613, absorbed #601): replacing a daemon with a `legion
+# serve` would silently drop the watch loop, so a daemon is bounced in place
+# via daemon-restart; a serve -- or a pre-#613 binary with no role -- is
+# killed by pidfile and respawned.
+restart_by_role "$DAEMON_ROLE" "daemon v${DAEMON_VERSION} != local v${LOCAL_VERSION}"
 exit 0

--- a/plugin/hooks/test-daemon-supervisor.sh
+++ b/plugin/hooks/test-daemon-supervisor.sh
@@ -18,6 +18,9 @@ make_plugin_root _legion-daemon-supervisor.sh
 
 mkdir -p "$WORK/scratch"
 export FAKE_VERSION="9.9.9"
+# Local build id (#698): the supervisor reads it from --version's "(build <id>)"
+# suffix and compares against /health's build_id on a version match.
+export FAKE_BUILD="localbuild"
 export FAKE_SPAWN_LOG="$WORK/scratch/spawned.log"
 
 # Redirect /tmp/legion-hook-errors.log to a per-test path: copy the hook to
@@ -40,6 +43,10 @@ case "$mode" in
   refused) exit 7 ;;
   empty) exit 0 ;;
   match) echo '{"status":"ok","version":"9.9.9","role":"serve","started_at":"2026-05-10T00:00:00Z","uptime_secs":10}' ;;
+  match_build_same) echo '{"status":"ok","version":"9.9.9","build_id":"localbuild","role":"daemon","started_at":"2026-05-10T00:00:00Z","uptime_secs":10}' ;;
+  match_build_drift_daemon) echo '{"status":"ok","version":"9.9.9","build_id":"oldbuild","role":"daemon","started_at":"2026-05-10T00:00:00Z","uptime_secs":10}' ;;
+  match_build_drift_serve) echo '{"status":"ok","version":"9.9.9","build_id":"oldbuild","role":"serve","started_at":"2026-05-10T00:00:00Z","uptime_secs":10}' ;;
+  match_build_unknown) echo '{"status":"ok","version":"9.9.9","build_id":"unknown","role":"daemon","started_at":"2026-05-10T00:00:00Z","uptime_secs":10}' ;;
   mismatch) echo '{"status":"ok","version":"1.0.0","started_at":"2026-05-10T00:00:00Z","uptime_secs":10}' ;;
   mismatch_daemon) echo '{"status":"ok","version":"1.0.0","role":"daemon","started_at":"2026-05-10T00:00:00Z","uptime_secs":10}' ;;
   malformed) echo 'not json' ;;
@@ -82,6 +89,54 @@ else
   FAIL=$((FAIL + 1)); echo "  FAIL: log unexpectedly written: $(cat "$TEST_LOG")" >&2
 fi
 
+echo "==> /health version match + build_id absent -> silent no-op (fallback)"
+reset_log
+write_curl_stub match
+bash "$HOOK_PATH"
+wait
+sleep 0.3
+assert_file_absent "no spawn when daemon build_id is absent" "$FAKE_SPAWN_LOG"
+
+echo "==> /health version match + same build_id -> silent no-op"
+reset_log
+write_curl_stub match_build_same
+bash "$HOOK_PATH"
+wait
+sleep 0.3
+assert_file_absent "no spawn when build ids match" "$FAKE_SPAWN_LOG"
+if [ ! -f "$TEST_LOG" ] || [ ! -s "$TEST_LOG" ]; then
+  PASS=$((PASS + 1)); echo "  PASS: log silent on same-build match"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: log unexpectedly written: $(cat "$TEST_LOG")" >&2
+fi
+
+echo "==> /health version match + build drift + role=daemon -> daemon-restart (#698)"
+reset_log
+write_curl_stub match_build_drift_daemon
+bash "$HOOK_PATH"
+wait
+sleep 0.3
+assert_file_contains "daemon bounced on build drift" "$FAKE_SPAWN_LOG" "daemon-restart at"
+assert_file_not_contains "no serve spawned over the daemon" "$FAKE_SPAWN_LOG" "spawned at"
+assert_file_contains "log notes build drift" "$TEST_LOG" "daemon build oldbuild != local build localbuild"
+
+echo "==> /health version match + build drift + role=serve -> replace (#698)"
+reset_log
+write_curl_stub match_build_drift_serve
+bash "$HOOK_PATH"
+wait
+sleep 0.3
+assert_file_contains "serve replaced on build drift" "$FAKE_SPAWN_LOG" "spawned at"
+assert_file_contains "log notes build drift" "$TEST_LOG" "daemon build oldbuild != local build localbuild"
+
+echo "==> /health version match + build_id unknown -> silent no-op (indeterminate)"
+reset_log
+write_curl_stub match_build_unknown
+bash "$HOOK_PATH"
+wait
+sleep 0.3
+assert_file_absent "no spawn when daemon build_id is unknown" "$FAKE_SPAWN_LOG"
+
 echo "==> /health version mismatch -> replace"
 reset_log
 write_curl_stub mismatch
@@ -89,7 +144,7 @@ bash "$HOOK_PATH"
 wait
 sleep 0.3
 assert_file_contains "spawned replacement" "$FAKE_SPAWN_LOG" "spawned at"
-assert_file_contains "log notes replacement" "$TEST_LOG" "replaced stale v1.0.0"
+assert_file_contains "log notes replacement" "$TEST_LOG" "daemon v1.0.0 != local v9.9.9"
 
 echo "==> /health version mismatch with role=daemon -> daemon-restart, never a serve spawn"
 reset_log

--- a/plugin/hooks/tests/testutil.sh
+++ b/plugin/hooks/tests/testutil.sh
@@ -149,6 +149,8 @@ finish_tests() {
 #   FAKE_BROKEN=1            every invocation exits 1 immediately
 #   LEGION_STUB_LOG=<file>   append every invocation's argv (all commands)
 #   FAKE_VERSION             `--version` -> "legion $FAKE_VERSION" (9.9.9)
+#   FAKE_BUILD               when set, `--version` appends " (build $FAKE_BUILD)"
+#                            (the #698 build-id suffix); unset -> no suffix
 #   FAKE_WATCH               `watch list` body ("repo<TAB>/path" lines)
 #   FAKE_STATS="repo:N"      `stats --repo repo` -> "repo: N reflections (...)"
 #                            (anything else -> "no reflections stored yet")
@@ -182,7 +184,14 @@ if [ -n "${LEGION_STUB_LOG:-}" ]; then
 fi
 case "${1:-}" in
   --version)
-    echo "legion ${FAKE_VERSION:-9.9.9}"
+    # FAKE_BUILD (optional) appends the "(build <id>)" suffix the real CLI
+    # carries since #698. Unset -> bare "legion <version>" (pre-#698 shape),
+    # so harnesses that do not care about build id are unaffected.
+    if [ -n "${FAKE_BUILD:-}" ]; then
+      echo "legion ${FAKE_VERSION:-9.9.9} (build ${FAKE_BUILD})"
+    else
+      echo "legion ${FAKE_VERSION:-9.9.9}"
+    fi
     ;;
   watch)
     if [ "${2:-}" = "list" ]; then

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -218,6 +218,10 @@ fn build_health_body(
     serde_json::json!({
         "status": "ok",
         "version": env!("CARGO_PKG_VERSION"),
+        // Build id (git short SHA + dirty flag, or "unknown") so the
+        // supervisor can detect a same-version rebuild (#698). Baked in by
+        // build.rs via LEGION_BUILD_ID.
+        "build_id": env!("LEGION_BUILD_ID"),
         "role": role.as_str(),
         "started_at": started_at.to_rfc3339(),
         "uptime_secs": uptime_secs,
@@ -226,11 +230,13 @@ fn build_health_body(
 
 /// GET /health -- cheap daemon liveness probe (#319).
 ///
-/// Returns `{status, version, started_at, uptime_secs}` with NO database
-/// access so it can be polled aggressively by hooks, the MCP reconnect
-/// path (#320), and the SessionStart auto-spawn supervisor (#321). The
-/// `version` field is baked in at compile time from CARGO_PKG_VERSION so
-/// clients can detect protocol drift after a plugin upgrade.
+/// Returns `{status, version, build_id, role, started_at, uptime_secs}`
+/// with NO database access so it can be polled aggressively by hooks, the
+/// MCP reconnect path (#320), and the SessionStart auto-spawn supervisor
+/// (#321). The `version` field is baked in at compile time from
+/// CARGO_PKG_VERSION so clients can detect protocol drift after a plugin
+/// upgrade; `build_id` (#698) lets the supervisor catch a same-version
+/// rebuild that `version` alone cannot.
 pub async fn health_endpoint(State(state): State<ChannelState>) -> Json<serde_json::Value> {
     Json(build_health_body(
         state.role,
@@ -769,6 +775,17 @@ mod tests {
         let body = build_health_body(ServerRole::Serve, started, now);
         assert_eq!(body["status"], "ok");
         assert_eq!(body["version"], env!("CARGO_PKG_VERSION"));
+        assert_eq!(body["build_id"], env!("LEGION_BUILD_ID"));
+        // build_id is always present and non-empty (build.rs falls back to
+        // "unknown" when git is unavailable), so the supervisor never sees a
+        // missing field.
+        assert!(
+            !body["build_id"]
+                .as_str()
+                .expect("build_id is a string")
+                .is_empty(),
+            "build_id must be non-empty"
+        );
         assert_eq!(body["role"], "serve");
         assert_eq!(body["started_at"], "2026-05-10T12:00:00+00:00");
         assert_eq!(body["uptime_secs"], 90);

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -35,11 +35,23 @@ use self::schedule::ScheduleAction;
 use self::verify::QualityGateAction;
 use self::watch::WatchAction;
 
+/// `legion --version` output, including the build id (#698) so the value
+/// matches what the daemon reports at /health. The semver version stays the
+/// FIRST token after the program name ("legion <version> (build <id>)") so
+/// the supervisor's `legion --version | awk '{print $2}'` version parse is
+/// unaffected; the build id is parsed separately from the parenthetical.
+const LONG_VERSION: &str = concat!(
+    env!("CARGO_PKG_VERSION"),
+    " (build ",
+    env!("LEGION_BUILD_ID"),
+    ")"
+);
+
 #[derive(Parser)]
 #[command(
     name = "legion",
     about = "Agent specialization through deliberate practice",
-    version
+    version = LONG_VERSION
 )]
 pub(crate) struct Cli {
     /// Show informational messages on stderr (quiet by default)


### PR DESCRIPTION
## Summary

The daemon supervisor only restarted on `/health` version drift, so a rebuild that does not bump
`Cargo.toml` -- the everyday dev loop -- kept the same version and left the daemon serving stale
code until a manual restart (reflection `019f1565`). This adds a compile-time build id, surfaces it
on `/health` and `--version`, and teaches the supervisor to bounce the daemon when the version
matches but the build id differs. Closes #698.

## Acceptance criteria mapping

### 1. Build id embedded via build.rs (git short SHA + -dirty; unknown fallback)
New `build.rs` runs `git rev-parse --short HEAD` in `git_build_id()` and appends `-dirty` when
`git status --porcelain` is non-empty; the caller maps a git failure to `"unknown"`, then emits
`cargo:rustc-env=LEGION_BUILD_ID`. `cargo:rerun-if-changed=.git/logs/HEAD` refreshes the id when a
commit lands (plain `.git/HEAD` would not).
Evidence: `build.rs` `fn git_build_id`; built binary reports `(build e8ca0b6-dirty)`.

### 2. /health JSON includes build_id
The pure builder `build_health_body` reads the compile-time `LEGION_BUILD_ID` via `env!` and emits
it as a `build_id` field in the same `serde_json` object that already carries `version`, so the id
ships on every probe with no database access -- the endpoint stays cheap enough for the supervisor
to poll. The shared `channel::router` serves it, so both the daemon and `legion serve` report it.
Evidence: `src/channel.rs` `fn build_health_body`; live probe returned `{"build_id":"e8ca0b6-dirty",...}`.

### 3. legion --version includes the build id with the version token still field 2
`const LONG_VERSION = concat!(CARGO_PKG_VERSION, " (build ", LEGION_BUILD_ID, ")")` feeds
`#[command(version = LONG_VERSION)]`, so output is `legion 0.18.8 (build <id>)` -- the semver stays
the second whitespace token the supervisor parses.
Evidence: `src/cli/mod.rs:43` LONG_VERSION; `legion --version | awk '{print $2}'` yields `0.18.8`.

### 4. Supervisor restarts the daemon on same-version build drift (role-aware)
On a version match the supervisor now parses the local build id from `--version` and the daemon's
from `/health`, and when they differ calls the extracted `restart_by_role` (daemon -> in-place
`daemon-restart`; serve/pre-#613 -> kill-by-pidfile + respawn).
Evidence: `_legion-daemon-supervisor.sh:104` restart_by_role, lines 156-158 the drift guard; test
"build drift + role=daemon -> daemon-restart" passes.

### 5. Unknown or absent build id falls back to version-only comparison
The drift branch fires only when both ids are present, neither is `"unknown"`, and they differ; any
other shape leaves the version-match path silent, so indeterminate data never triggers a restart loop.
Evidence: `_legion-daemon-supervisor.sh:156-158` the compound guard; tests "build_id unknown -> no-op"
and "build_id absent -> no-op" pass.

### 6. Tests cover /health build_id and the supervisor drift + fallback branches
`channel.rs` `health_body_shape` asserts `build_id` equals the env and is non-empty;
`test-daemon-supervisor.sh` adds same-build no-op, drift+daemon, drift+serve, and unknown/absent
fallback; the stub gained an opt-in `FAKE_BUILD` suffix.
Evidence: `src/channel.rs` `fn health_body_shape`; `bash plugin/hooks/test-daemon-supervisor.sh` -> 22 passed.

## Not done

Detecting successive dirty rebuilds at an unchanged HEAD: the `<sha>-dirty` id is stable across them,
so the supervisor will not catch them -- the target is the committed rebuild and dirty iteration
restarts by hand. Documented in `build.rs`, which also notes untracked files trip the dirty flag,
widening that already-by-hand surface. No other scope was deferred.