### PR TITLE
feat(#700): legion document set-status verb for the publish flow

### DIFF
--- a/src/cli/document.rs
+++ b/src/cli/document.rs
@@ -70,6 +70,16 @@ pub(crate) enum DocumentAction {
     },
     /// Mark a document archived.
     Archive { id: String },
+    /// Set a document's lifecycle status (e.g. publish: draft -> published).
+    /// The dashboard Publish/Approve button calls this; the localhost
+    /// operator session is the human gate, so it is a direct flag set.
+    SetStatus {
+        /// Document id.
+        id: String,
+        /// New lifecycle status (e.g. "published", "draft").
+        #[arg(long)]
+        to: String,
+    },
     /// Validate a JSON instance against a landed schema document (#526).
     /// Checks the dependency-free subset: type, required, properties,
     /// items, enum. Exits non-zero with one error per violation.
@@ -230,6 +240,10 @@ pub(crate) fn handle(action: DocumentAction) -> error::Result<()> {
                 doc.id,
                 doc.archived_at.as_deref().unwrap_or("?")
             );
+        }
+        DocumentAction::SetStatus { id, to } => {
+            let doc = database.set_document_status(&id, &to)?;
+            println!("{} status -> {}", doc.id, doc.status);
         }
         DocumentAction::Validate { schema, file } => {
             let doc = database.get_document(&schema)?.ok_or_else(|| {

--- a/src/documents.rs
+++ b/src/documents.rs
@@ -323,6 +323,34 @@ impl Database {
             LegionError::WorkSource(format!("document '{id}' vanished after archive"))
         })
     }
+
+    /// Set a document's lifecycle status (e.g. `draft` -> `published`).
+    /// Updates the `status` column and `updated_at`, returns the updated
+    /// Document. This is the operator publish/approve action surfaced by
+    /// the dashboard: the localhost session is the human gate, so there is
+    /// no status-machine or adoption-gate enforcement here -- it is a
+    /// direct flag set on the column the list/view read from.
+    ///
+    /// Note: the JSON payload may carry its own `meta.status` copy; this
+    /// only writes the hoisted column, which is the source of truth for
+    /// `list`/`view` filtering and the dashboard badge.
+    pub fn set_document_status(&self, id: &str, status: &str) -> Result<Document> {
+        let now = Utc::now().to_rfc3339();
+        let rows = self.conn.execute(
+            "UPDATE documents \
+             SET status = ?1, updated_at = ?2 \
+             WHERE id = ?3 AND deleted_at IS NULL",
+            params![status, &now, id],
+        )?;
+        if rows == 0 {
+            return Err(LegionError::WorkSource(format!(
+                "document '{id}' not found"
+            )));
+        }
+        self.get_document(id)?.ok_or_else(|| {
+            LegionError::WorkSource(format!("document '{id}' vanished after set-status"))
+        })
+    }
 }
 
 /// Summary extracted from a validated schema payload, used to compose
@@ -699,6 +727,31 @@ mod tests {
     fn archive_nonexistent_returns_error() {
         let db = test_db();
         let err = db.archive_document("FR-NOPE").unwrap_err();
+        assert!(err.to_string().contains("not found"));
+    }
+
+    #[test]
+    fn set_document_status_flips_the_flag() {
+        let db = test_db();
+        let mut m = sample_meta("requirement", "mail");
+        m.id = Some("FR-PUB");
+        m.status = Some("draft");
+        db.insert_document(&m, "{}").unwrap();
+
+        let updated = db
+            .set_document_status("FR-PUB", "published")
+            .expect("set-status");
+        assert_eq!(updated.status, "published");
+
+        // Persisted, not just returned.
+        let fetched = db.get_document("FR-PUB").expect("get").expect("some");
+        assert_eq!(fetched.status, "published");
+    }
+
+    #[test]
+    fn set_document_status_nonexistent_returns_error() {
+        let db = test_db();
+        let err = db.set_document_status("FR-NOPE", "published").unwrap_err();
         assert!(err.to_string().contains("not found"));
     }
 


### PR DESCRIPTION
## Summary

Adds `legion document set-status <id> --to <status>`, the missing mutation primitive for a
landed document's lifecycle status. `legion document` could create/view/list/archive/validate
but never change a status after insert, so the dashboard's publish/approve flow (`draft ->
published`) had no backend. This lands the CLI verb and its db method; the serve endpoint is a
separate follow-up.

## Acceptance criteria mapping

### 1. `set-status <id> --to <status>` sets the status column, bumps updated_at, prints the new status
The db method `set_document_status` (src/documents.rs) runs a scoped `UPDATE documents SET
status = ?1, updated_at = ?2 WHERE id = ?3 AND deleted_at IS NULL`, then re-fetches and returns
the updated `Document`. The CLI arm (src/cli/document.rs, `DocumentAction::SetStatus`) calls it
and prints `"{id} status -> {status}"` from the returned row, so the printed value is the
persisted column, not the input argument. `updated_at` is set to `Utc::now()` in the same
statement.
Evidence: manual run against a real doc printed `019f1aa7-... status -> published`; unit test `set_document_status_flips_the_flag` asserts `updated.status == "published"`.

### 2. Setting status on a nonexistent id returns a not-found error (non-zero exit)
The method checks the `UPDATE` affected-row count: `rows == 0` returns
`LegionError::WorkSource("document '{id}' not found")`, which propagates through the CLI handler
as a non-zero exit. This mirrors the existing `archive_document` not-found contract, so behavior
is consistent across the two mutating verbs.
Evidence: unit test `set_document_status_nonexistent_returns_error` asserts the error string contains "not found"; manual run of `set-status nonexistent-id-xyz` printed the work-source not-found error.

### 3. The change is persisted, not just returned
The method returns the value from a fresh `get_document(id)` re-fetch after the UPDATE commits,
rather than constructing a Document in memory -- so a returned `published` status is proof the
row was written. The happy-path test additionally re-reads via a second `get_document` call to
prove persistence independent of the method's own return value.
Evidence: `set_document_status_flips_the_flag` calls `db.get_document("FR-PUB")` after set-status and asserts `fetched.status == "published"`.

### 4. No status-machine / adoption-gate enforcement; the localhost operator is the human gate
The method takes an arbitrary `status: &str` and writes it directly -- no allowed-status set, no
draft->proposed->adopted transition validation, no LEGION_AUTO_WAKE operator-signal check. This
is deliberate: the dashboard is served on localhost and the person clicking Publish is the human
gate, so a status-machine would add enforcement the surface does not need. The rationale (and the
column-vs-payload `meta.status` source-of-truth note) is written into the method's doc comment so
the tradeoff is documented, not hidden.
Evidence: doc comment on `fn set_document_status` in src/documents.rs states the localhost-operator-gate rationale and names the column as source of truth.

## Not done

- The serve endpoint (`POST /api/documents/:id/status`) that the dashboard button will call --
  separate follow-up under the same dashboard effort.
- Reconciling the JSON payload's `meta.status` copy with the hoisted column -- left as a
  documented divergence; the column is the source of truth for list/view/filter.
- A closed status vocabulary / enum -- the `documents.status` column stays free `TEXT` as it has
  been since the table's migration; constraining it is a table-wide change out of scope here.