### PR TITLE
fix(#714): serde default on ExternalIssue.labels so sub-issue list deserializes

### DIFF
--- a/src/worksource/issues.rs
+++ b/src/worksource/issues.rs
@@ -16,6 +16,11 @@ pub struct ExternalIssue {
     pub number: u64,
     pub title: String,
     pub body: Option<String>,
+    /// Label list. The GitHub sub-issue GraphQL API omits this field entirely
+    /// (it returns only `number`, `url`, `title`, `state`, `body`), so we
+    /// default to an empty vec rather than failing deserialization when the
+    /// field is absent. (#714)
+    #[serde(default)]
     pub labels: Vec<serde_json::Value>,
     pub assignees: Option<Vec<serde_json::Value>>,
     pub state: String,
@@ -469,5 +474,60 @@ mod tests {
             msg.contains("at least one of title or body"),
             "expected validation error message, got: {msg}"
         );
+    }
+
+    /// Regression guard for #714: the GitHub sub-issue GraphQL API returns
+    /// `{ number, url, title, state, body }` -- it omits `labels` entirely.
+    ///
+    /// Without `#[serde(default)]`, serde fails with "missing field `labels`".
+    /// This test deserializes a representative sub-issue payload (no `labels`,
+    /// no `assignees`, no `createdAt`) and asserts that the struct populates
+    /// with sensible defaults rather than erroring.
+    #[test]
+    fn external_issue_deserializes_without_labels_field() {
+        let json = r#"{
+            "number": 705,
+            "url": "https://github.com/runlegion/legion/issues/705",
+            "title": "E1: sym index inventory",
+            "state": "OPEN",
+            "body": "Implement the E1 sub-task."
+        }"#;
+
+        let issue: ExternalIssue =
+            serde_json::from_str(json).expect("should deserialize without labels field");
+
+        assert_eq!(issue.number, 705);
+        assert_eq!(issue.url, "https://github.com/runlegion/legion/issues/705");
+        assert_eq!(issue.title, "E1: sym index inventory");
+        assert_eq!(issue.state, "OPEN");
+        assert!(
+            issue.labels.is_empty(),
+            "labels should default to empty vec, got {:?}",
+            issue.labels
+        );
+        assert!(issue.assignees.is_none());
+        assert!(issue.created_at.is_none());
+    }
+
+    /// Verify that deserialization also works when `labels` IS present (the
+    /// existing `gh issue list` path still works after the default is added).
+    #[test]
+    fn external_issue_deserializes_with_labels_field() {
+        let json = r#"{
+            "number": 42,
+            "url": "https://github.com/runlegion/legion/issues/42",
+            "title": "Some issue",
+            "state": "open",
+            "body": null,
+            "labels": [{"id": "LA_1", "name": "bug"}, {"id": "LA_2", "name": "critical"}],
+            "assignees": [],
+            "createdAt": "2026-06-01T00:00:00Z"
+        }"#;
+
+        let issue: ExternalIssue =
+            serde_json::from_str(json).expect("should deserialize with labels field");
+
+        assert_eq!(issue.labels.len(), 2);
+        assert_eq!(issue.created_at.as_deref(), Some("2026-06-01T00:00:00Z"));
     }
 }


### PR DESCRIPTION
## Summary

`legion sub-issue list` failed on every call with `missing field labels`: the GitHub sub-issue GraphQL API returns only `{number, url, title, state, body}` per child, and `ExternalIssue.labels` was a required `Vec<serde_json::Value>`, so serde refused the whole payload before any row could print. This change adds `#[serde(default)]` to the field so an absent `labels` deserializes to an empty vec -- the correct semantic for an API that simply does not send the field -- without changing the field's type or disturbing the `gh issue list` path, which does supply labels and keeps deserializing exactly as before.

## Acceptance criteria mapping

### 1. `legion sub-issue list` returns the children of #704

The failure was in deserialization, not the query: the GraphQL call succeeded and the payload arrived, but serde rejected it because `labels` was modeled as required while the sub-issue endpoint omits it. With `#[serde(default)]` on `ExternalIssue.labels` (src/worksource/issues.rs:21), the absent field materializes as an empty vec and the rows flow through to output. Verified live against GitHub: `legion sub-issue list --repo legion --parent 704` now prints all nine children, #705 through #713, with their titles and OPEN state.
Evidence: live run output listing #705-#713; src/worksource/issues.rs:21

### 2. Payload-without-labels test passes

`external_issue_deserializes_without_labels_field` pins a representative sub-issue payload containing exactly the five fields the endpoint sends (`number`, `url`, `title`, `state`, `body`) and asserts the struct populates with `labels` empty, `assignees` and `created_at` None -- the regression guard that fails if the default is ever removed. A companion test, `external_issue_deserializes_with_labels_field`, proves the other direction: a payload that does carry `labels` (the `gh issue list` shape) still round-trips with the entries intact, so the fix cannot silently break the existing path.
Evidence: fn external_issue_deserializes_without_labels_field, fn external_issue_deserializes_with_labels_field in src/worksource/issues.rs

### 3. Tests pass; simplify + review done; PR linked

The full worksource test suite passes on the branch (41 tests), and `cargo clippy --all-targets -- -D warnings` plus `cargo fmt -- --check` are both clean. The simplify gate is recorded clean on HEAD (gate 019f208d-0015), this body is the pr-write gate, and the PR is opened via `legion pr create` referencing #714 so the link is structural. Review follows via /legion-review and team review from vault and smugglr.
Evidence: quality-gate row 019f208d-0015-75a2-aa7f-74ba01d922eb on commit 60912ea; cargo test output 41 passed

## Not done

The `labels` field stays `Vec<serde_json::Value>` rather than a typed label struct -- tightening it is orthogonal to this fix and would touch the working `gh issue list` path for no behavioral gain. Error-message quality on deserialization failures (naming endpoint and field) is untouched: it already had that property, and nothing here removes it. No changes to the sub-issue create/link path, which was explicitly out of scope and already working.