### PR TITLE
feat(#705): file-inventory table populated by a gitignore-aware walk on legion index

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -260,6 +260,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cee35f73844aa3014bb606320a6c1f010249dbdf43342fe54b5a4f6a8ed4b79"
+dependencies = [
+ "memchr",
+ "serde_core",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -978,6 +988,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "globset"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52dfc19153a48bde0cbd630453615c8151bce3a5adfac7a0aebfbf0a1e1f57e3"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "h2"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1357,6 +1380,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "ignore"
+version = "0.4.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe112b004901c62c2faa11f4f75e9864e0cc5af8da71c9115d184a3aa888749f"
+dependencies = [
+ "crossbeam-deque",
+ "globset",
+ "log",
+ "memchr",
+ "regex-automata",
+ "same-file",
+ "walkdir",
+ "winapi-util",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1483,6 +1522,7 @@ dependencies = [
  "dirs 5.0.1",
  "hex",
  "hostname",
+ "ignore",
  "libc",
  "mime_guess",
  "model2vec-rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,10 @@ hostname = "0.4"
 # on Windows.
 portable-pty = "0.9"
 
+# File inventory walk (#705): gitignore-aware recursive walk over watched
+# workdirs. The same crate powers the ripgrep engine used by find-content.
+ignore = "0.4"
+
 # libc pulls in only on unix for killpg in call_plugin_inner's timeout arm.
 # Must stay AFTER all platform-independent deps -- TOML tables consume
 # every key until the next header, so listing it mid-file would leak the

--- a/src/cli/index_cmd.rs
+++ b/src/cli/index_cmd.rs
@@ -967,7 +967,7 @@ pub(crate) fn handle_index(
     // independent of SCIP outcomes -- including the all-indexers-failed hard
     // error below, which must not leave the inventory stale (#705 review).
     let outcome = inventory::walk_repo(&repo, &repo_path);
-    let live_paths: Vec<String> = outcome.entries.iter().map(|e| e.path.clone()).collect();
+    let live_paths: Vec<&str> = outcome.entries.iter().map(|e| e.path.as_str()).collect();
     database.upsert_file_inventory(&outcome.entries)?;
     // Prune only on a complete walk: with walk errors the entry set may be
     // missing files that still exist, and evicting their rows would let a

--- a/src/cli/index_cmd.rs
+++ b/src/cli/index_cmd.rs
@@ -946,6 +946,19 @@ pub(crate) fn handle_index(
     };
     let repo_path = std::path::PathBuf::from(&entry.workdir);
 
+    // A missing workdir must fail BEFORE the walk: walk_repo on a vanished
+    // root returns an empty entry set, and pruning against it would delete
+    // every inventory row for the repo -- a transient mount failure (watched
+    // workdirs live on external volumes) silently destroying derived state
+    // (#718 review).
+    if !repo_path.is_dir() {
+        return Err(error::LegionError::WatchConfig(format!(
+            "workdir {} for repo '{repo}' does not exist or is not a directory -- \
+             refusing to index (an unmounted volume must not wipe the inventory)",
+            repo_path.display()
+        )));
+    }
+
     let langs = scip::detect_languages(&repo_path);
     let database = open_db()?;
 
@@ -974,6 +987,8 @@ pub(crate) fn handle_index(
         );
     } else {
         let mut indexed: u32 = 0;
+        let mut symbol_counts: std::collections::HashMap<String, u32> =
+            std::collections::HashMap::new();
         for lang in &langs {
             let blob = match scip::run_indexer(lang, &repo_path) {
                 Ok(b) => b,
@@ -998,12 +1013,28 @@ pub(crate) fn handle_index(
             database.upsert_scip_index(&index)?;
             eprintln!("[legion] indexed {repo} ({lang}): {bytes_len} bytes, hash {hash_prefix}");
             indexed += 1;
+            // Per-file symbol counts for the inventory (#705): a blob this
+            // run just built failing to parse is not fatal to indexing, but
+            // it must be loud -- counts silently stuck at 0 would misreport
+            // every SCIP-covered file.
+            match sym::symbol_counts_per_file(&index.blob) {
+                Ok(counts) => symbol_counts.extend(counts),
+                Err(e) => {
+                    eprintln!(
+                        "[legion] per-file symbol counts unavailable for {repo} ({lang}): {e}"
+                    )
+                }
+            }
         }
         if indexed == 0 {
             return Err(error::LegionError::WatchConfig(format!(
                 "no language indexed for {repo} -- every detected language ({}) failed; see warnings above",
                 langs.join(", ")
             )));
+        }
+        if !symbol_counts.is_empty() {
+            let updated = database.update_file_symbol_counts(&repo, &symbol_counts)?;
+            eprintln!("[legion] symbol counts applied to {updated} inventoried files for {repo}");
         }
     }
 

--- a/src/cli/index_cmd.rs
+++ b/src/cli/index_cmd.rs
@@ -998,6 +998,7 @@ pub(crate) fn handle_index(
         );
     } else {
         let mut indexed: u32 = 0;
+        let mut counts_available = false;
         let mut symbol_counts: std::collections::HashMap<String, u32> =
             std::collections::HashMap::new();
         for lang in &langs {
@@ -1029,7 +1030,10 @@ pub(crate) fn handle_index(
             // it must be loud -- counts silently stuck at 0 would misreport
             // every SCIP-covered file.
             match sym::symbol_counts_per_file(&index.blob) {
-                Ok(counts) => symbol_counts.extend(counts),
+                Ok(counts) => {
+                    counts_available = true;
+                    symbol_counts.extend(counts);
+                }
                 Err(e) => {
                     eprintln!(
                         "[legion] per-file symbol counts unavailable for {repo} ({lang}): {e}"
@@ -1043,7 +1047,12 @@ pub(crate) fn handle_index(
                 langs.join(", ")
             )));
         }
-        if !symbol_counts.is_empty() {
+        // Gate on parse success, not on non-empty counts: a blob that parsed
+        // but yielded zero definitions (the repo's last definition was
+        // deleted) must still run the enrich pass so its reset clears the
+        // now-stale counts. A parse FAILURE skips the pass entirely,
+        // preserving prior enrichment.
+        if counts_available {
             let updated = database.update_file_symbol_counts(&repo, &symbol_counts)?;
             eprintln!("[legion] symbol counts applied to {updated} inventoried files for {repo}");
         }

--- a/src/cli/index_cmd.rs
+++ b/src/cli/index_cmd.rs
@@ -7,7 +7,7 @@ use clap::Subcommand;
 
 use crate::cli::datadir::data_dir;
 use crate::cli::util::{open_db, open_db_and_index};
-use crate::{db, error, scip, sym, watch};
+use crate::{db, error, inventory, scip, sym, watch};
 
 #[derive(Subcommand)]
 pub(crate) enum SymAction {
@@ -947,46 +947,64 @@ pub(crate) fn handle_index(
     let repo_path = std::path::PathBuf::from(&entry.workdir);
 
     let langs = scip::detect_languages(&repo_path);
+    let database = open_db()?;
+
+    // SCIP indexing runs only when language markers are present. A docs-only
+    // repo (no Cargo.toml, package.json, etc.) skips this block entirely and
+    // still gets a populated file inventory below (#705).
     if langs.is_empty() {
-        return Err(error::LegionError::WatchConfig(format!(
-            "no supported language detected at {}. Markers checked: Cargo.toml, package.json, pyproject.toml, requirements.txt, go.mod.",
+        eprintln!(
+            "[legion] no SCIP-supported language detected at {}; skipping SCIP indexing. \
+             Markers checked: Cargo.toml, package.json, pyproject.toml, requirements.txt, go.mod.",
             repo_path.display()
-        )));
+        );
+    } else {
+        let mut indexed: u32 = 0;
+        for lang in &langs {
+            let blob = match scip::run_indexer(lang, &repo_path) {
+                Ok(b) => b,
+                Err(e) => {
+                    eprintln!("[legion] skipped {repo} ({lang}): {e}");
+                    continue;
+                }
+            };
+            let hash = scip::content_hash(&blob);
+            let now = chrono::Utc::now().to_rfc3339();
+            let index = scip::ScipIndex {
+                id: uuid::Uuid::now_v7().to_string(),
+                repo: repo.clone(),
+                lang: (*lang).to_string(),
+                content_hash: hash,
+                blob,
+                updated_at: now,
+                deleted_at: None,
+            };
+            let bytes_len = index.blob.len();
+            let hash_prefix = &index.content_hash[..16];
+            database.upsert_scip_index(&index)?;
+            eprintln!("[legion] indexed {repo} ({lang}): {bytes_len} bytes, hash {hash_prefix}");
+            indexed += 1;
+        }
+        if indexed == 0 {
+            return Err(error::LegionError::WatchConfig(format!(
+                "no language indexed for {repo} -- every detected language ({}) failed; see warnings above",
+                langs.join(", ")
+            )));
+        }
     }
 
-    let database = open_db()?;
-    let mut indexed: u32 = 0;
-    for lang in &langs {
-        let blob = match scip::run_indexer(lang, &repo_path) {
-            Ok(b) => b,
-            Err(e) => {
-                eprintln!("[legion] skipped {repo} ({lang}): {e}");
-                continue;
-            }
-        };
-        let hash = scip::content_hash(&blob);
-        let now = chrono::Utc::now().to_rfc3339();
-        let index = scip::ScipIndex {
-            id: uuid::Uuid::now_v7().to_string(),
-            repo: repo.clone(),
-            lang: (*lang).to_string(),
-            content_hash: hash,
-            blob,
-            updated_at: now,
-            deleted_at: None,
-        };
-        let bytes_len = index.blob.len();
-        let hash_prefix = &index.content_hash[..16];
-        database.upsert_scip_index(&index)?;
-        eprintln!("[legion] indexed {repo} ({lang}): {bytes_len} bytes, hash {hash_prefix}");
-        indexed += 1;
-    }
-    if indexed == 0 {
-        return Err(error::LegionError::WatchConfig(format!(
-            "no language indexed for {repo} -- every detected language ({}) failed; see warnings above",
-            langs.join(", ")
-        )));
-    }
+    // File inventory walk: enumerate every non-ignored file and persist one
+    // row per file. Runs independently of the SCIP result above -- docs-only
+    // repos still get a full inventory when the SCIP loop was skipped.
+    let entries: Vec<crate::db::inventory::FileInventoryEntry> =
+        inventory::walk_repo(&repo, &repo_path);
+    let live_paths: Vec<String> = entries.iter().map(|e| e.path.clone()).collect();
+    database.upsert_file_inventory(&entries)?;
+    let pruned: usize = database.prune_file_inventory(&repo, &live_paths)?;
+    eprintln!(
+        "[legion] inventoried {} files for {repo} ({pruned} stale rows pruned)",
+        entries.len()
+    );
     Ok(())
 }
 

--- a/src/cli/index_cmd.rs
+++ b/src/cli/index_cmd.rs
@@ -949,9 +949,23 @@ pub(crate) fn handle_index(
     let langs = scip::detect_languages(&repo_path);
     let database = open_db()?;
 
+    // File inventory walk FIRST: enumerate every non-ignored file and persist
+    // one row per file. Ordered before the SCIP loop so inventory truly runs
+    // independent of SCIP outcomes -- including the all-indexers-failed hard
+    // error below, which must not leave the inventory stale (#705 review).
+    let entries: Vec<crate::db::inventory::FileInventoryEntry> =
+        inventory::walk_repo(&repo, &repo_path);
+    let live_paths: Vec<String> = entries.iter().map(|e| e.path.clone()).collect();
+    database.upsert_file_inventory(&entries)?;
+    let pruned: usize = database.prune_file_inventory(&repo, &live_paths)?;
+    eprintln!(
+        "[legion] inventoried {} files for {repo} ({pruned} stale rows pruned)",
+        entries.len()
+    );
+
     // SCIP indexing runs only when language markers are present. A docs-only
-    // repo (no Cargo.toml, package.json, etc.) skips this block entirely and
-    // still gets a populated file inventory below (#705).
+    // repo (no Cargo.toml, package.json, etc.) skips this block entirely --
+    // the file inventory above already covered it (#705).
     if langs.is_empty() {
         eprintln!(
             "[legion] no SCIP-supported language detected at {}; skipping SCIP indexing. \
@@ -993,18 +1007,6 @@ pub(crate) fn handle_index(
         }
     }
 
-    // File inventory walk: enumerate every non-ignored file and persist one
-    // row per file. Runs independently of the SCIP result above -- docs-only
-    // repos still get a full inventory when the SCIP loop was skipped.
-    let entries: Vec<crate::db::inventory::FileInventoryEntry> =
-        inventory::walk_repo(&repo, &repo_path);
-    let live_paths: Vec<String> = entries.iter().map(|e| e.path.clone()).collect();
-    database.upsert_file_inventory(&entries)?;
-    let pruned: usize = database.prune_file_inventory(&repo, &live_paths)?;
-    eprintln!(
-        "[legion] inventoried {} files for {repo} ({pruned} stale rows pruned)",
-        entries.len()
-    );
     Ok(())
 }
 

--- a/src/cli/index_cmd.rs
+++ b/src/cli/index_cmd.rs
@@ -966,14 +966,25 @@ pub(crate) fn handle_index(
     // one row per file. Ordered before the SCIP loop so inventory truly runs
     // independent of SCIP outcomes -- including the all-indexers-failed hard
     // error below, which must not leave the inventory stale (#705 review).
-    let entries: Vec<crate::db::inventory::FileInventoryEntry> =
-        inventory::walk_repo(&repo, &repo_path);
-    let live_paths: Vec<String> = entries.iter().map(|e| e.path.clone()).collect();
-    database.upsert_file_inventory(&entries)?;
-    let pruned: usize = database.prune_file_inventory(&repo, &live_paths)?;
+    let outcome = inventory::walk_repo(&repo, &repo_path);
+    let live_paths: Vec<String> = outcome.entries.iter().map(|e| e.path.clone()).collect();
+    database.upsert_file_inventory(&outcome.entries)?;
+    // Prune only on a complete walk: with walk errors the entry set may be
+    // missing files that still exist, and evicting their rows would let a
+    // transient I/O failure shrink the inventory (#718 re-review). Upserting
+    // the partial set is still correct -- fresh data is fresh.
+    let pruned: usize = if outcome.walk_errors == 0 {
+        database.prune_file_inventory(&repo, &live_paths)?
+    } else {
+        eprintln!(
+            "[legion] {} walk errors for {repo} -- stale-row prune skipped (partial walk must not evict rows)",
+            outcome.walk_errors
+        );
+        0
+    };
     eprintln!(
         "[legion] inventoried {} files for {repo} ({pruned} stale rows pruned)",
-        entries.len()
+        outcome.entries.len()
     );
 
     // SCIP indexing runs only when language markers are present. A docs-only

--- a/src/db/inventory.rs
+++ b/src/db/inventory.rs
@@ -16,7 +16,9 @@ use crate::error::Result;
 /// Paths are always repo-relative (forward-slash separated, no leading slash).
 /// `lang` is the SCIP language tag (e.g. "rust", "typescript"); `None` for
 /// files that SCIP does not index (docs, configs, scripts, etc.).
-/// `symbol_count` is 0 until a later epic populates it from the SCIP blob.
+/// `symbol_count` is written 0 by the walk, then enriched from the SCIP
+/// blob by `update_file_symbol_counts` when `legion index` builds one;
+/// files no blob covers stay at 0 (non-SCIP formats gain sources in E6/E7).
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct FileInventoryEntry {
     pub repo: String,

--- a/src/db/inventory.rs
+++ b/src/db/inventory.rs
@@ -16,9 +16,11 @@ use crate::error::Result;
 /// Paths are always repo-relative (forward-slash separated, no leading slash).
 /// `lang` is the SCIP language tag (e.g. "rust", "typescript"); `None` for
 /// files that SCIP does not index (docs, configs, scripts, etc.).
-/// `symbol_count` is written 0 by the walk, then enriched from the SCIP
-/// blob by `update_file_symbol_counts` when `legion index` builds one;
-/// files no blob covers stay at 0 (non-SCIP formats gain sources in E6/E7).
+/// `symbol_count` is written 0 by the walk on first insert, then owned by
+/// the enrich pass: `update_file_symbol_counts` fills it from the SCIP blob
+/// when `legion index` builds one, and the upsert preserves it on conflict
+/// so a failed SCIP run cannot zero prior enrichment. Files no blob covers
+/// stay at 0 (non-SCIP formats gain sources in E6/E7).
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct FileInventoryEntry {
     pub repo: String,
@@ -52,7 +54,10 @@ pub struct InventoryFilter<'a> {
     pub lang: Option<&'a str>,
 }
 
-/// Create the `file_inventory` table and its covering indexes.
+/// Create the `file_inventory` table and its `(repo, ext)` covering index.
+///
+/// Repo-scoped lookups need no dedicated index: the `(repo, path)` primary
+/// key's prefix already covers them.
 ///
 /// Called from `init_schema` inside the schema-creation transaction.
 /// Idempotent via `IF NOT EXISTS`.
@@ -68,8 +73,6 @@ pub(super) fn create_tables(conn: &Connection) -> Result<()> {
             symbol_count INTEGER NOT NULL DEFAULT 0,
             PRIMARY KEY (repo, path)
         );
-        CREATE INDEX IF NOT EXISTS idx_file_inventory_repo
-            ON file_inventory(repo);
         CREATE INDEX IF NOT EXISTS idx_file_inventory_repo_ext
             ON file_inventory(repo, ext);",
     )?;
@@ -81,20 +84,27 @@ impl Database {
     ///
     /// Idempotent: re-indexing the same file updates its metadata in place
     /// without changing the row identity. All rows are written inside a
-    /// single transaction for throughput.
+    /// single transaction, through one prepared statement, for throughput.
+    ///
+    /// On conflict `symbol_count` is deliberately NOT overwritten: the walk
+    /// always supplies 0, and the enrich pass (`update_file_symbol_counts`)
+    /// owns that column -- letting the upsert clobber it would zero every
+    /// count whenever SCIP fails to run (missing indexer) until the next
+    /// successful index.
     pub fn upsert_file_inventory(&self, entries: &[FileInventoryEntry]) -> Result<()> {
         let tx = self.conn.unchecked_transaction()?;
-        for entry in entries {
-            tx.execute(
+        {
+            let mut stmt = tx.prepare(
                 "INSERT INTO file_inventory (repo, path, ext, lang, size, mtime, symbol_count)
                  VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
                  ON CONFLICT(repo, path) DO UPDATE SET
-                     ext          = excluded.ext,
-                     lang         = excluded.lang,
-                     size         = excluded.size,
-                     mtime        = excluded.mtime,
-                     symbol_count = excluded.symbol_count",
-                rusqlite::params![
+                     ext   = excluded.ext,
+                     lang  = excluded.lang,
+                     size  = excluded.size,
+                     mtime = excluded.mtime",
+            )?;
+            for entry in entries {
+                stmt.execute(rusqlite::params![
                     &entry.repo,
                     &entry.path,
                     &entry.ext,
@@ -102,8 +112,8 @@ impl Database {
                     entry.size as i64,
                     &entry.mtime,
                     entry.symbol_count as i64,
-                ],
-            )?;
+                ])?;
+            }
         }
         tx.commit()?;
         Ok(())
@@ -163,12 +173,21 @@ impl Database {
     /// Apply per-file SCIP symbol counts to existing inventory rows (#705).
     ///
     /// Called after the SCIP loop in `legion index`: the inventory is
-    /// upserted (with `symbol_count = 0`) before SCIP runs so it stays
-    /// independent of indexer outcomes, then this pass enriches the rows
-    /// whose path appears in a freshly built blob. Paths in `counts` with
-    /// no inventory row (unlikely: SCIP indexed a file the walk skipped)
-    /// update nothing and are not an error. Returns the number of rows
-    /// actually updated.
+    /// upserted before SCIP runs so it stays independent of indexer
+    /// outcomes, then this pass enriches the rows whose path appears in a
+    /// freshly built blob. This pass OWNS the `symbol_count` column: it
+    /// first resets the repo's counts to 0 inside the same transaction, so
+    /// a file whose definitions all vanished (and thus dropped out of the
+    /// blob) does not keep a stale count. The upsert never touches the
+    /// column, so a run where SCIP fails entirely leaves prior enrichment
+    /// intact. Tradeoff: when one of several languages fails to index, the
+    /// failed language's counts reset to 0 until it next succeeds --
+    /// accepted, since a stale-vs-absent distinction is not worth
+    /// per-language column ownership.
+    ///
+    /// Paths in `counts` with no inventory row (unlikely: SCIP indexed a
+    /// file the walk skipped) update nothing and are not an error. Returns
+    /// the number of rows enriched with a fresh count.
     pub fn update_file_symbol_counts(
         &self,
         repo: &str,
@@ -177,6 +196,10 @@ impl Database {
         let tx = self.conn.unchecked_transaction()?;
         let mut updated: usize = 0;
         {
+            tx.execute(
+                "UPDATE file_inventory SET symbol_count = 0 WHERE repo = ?1",
+                rusqlite::params![repo],
+            )?;
             let mut stmt = tx.prepare(
                 "UPDATE file_inventory SET symbol_count = ?3
                  WHERE repo = ?1 AND path = ?2",
@@ -196,7 +219,10 @@ impl Database {
     ///
     /// When `live_paths` is empty every row for the repo is removed (the
     /// repo's working directory became empty or was deleted).
-    pub fn prune_file_inventory(&self, repo: &str, live_paths: &[String]) -> Result<usize> {
+    ///
+    /// Takes borrowed paths: callers hold the walked entries and must not
+    /// need to clone every path `String` just to prune.
+    pub fn prune_file_inventory(&self, repo: &str, live_paths: &[&str]) -> Result<usize> {
         if live_paths.is_empty() {
             let n = self.conn.execute(
                 "DELETE FROM file_inventory WHERE repo = ?1",
@@ -352,6 +378,69 @@ mod tests {
     }
 
     #[test]
+    fn upsert_preserves_symbol_count_across_reindex() {
+        let db = test_db();
+        let e = entry("r", "src/a.rs", Some("rs"), Some("rust"));
+        db.upsert_file_inventory(std::slice::from_ref(&e)).unwrap();
+
+        let mut counts = std::collections::HashMap::new();
+        counts.insert("src/a.rs".to_string(), 7_u32);
+        db.update_file_symbol_counts("r", &counts).unwrap();
+
+        // Re-index without SCIP (walk always supplies symbol_count = 0):
+        // the upsert must not clobber the enrichment.
+        db.upsert_file_inventory(&[e]).unwrap();
+
+        let got = db
+            .list_file_inventory(&InventoryFilter {
+                repo: Some("r"),
+                ..Default::default()
+            })
+            .unwrap();
+        assert_eq!(
+            got[0].symbol_count, 7,
+            "failed SCIP run must not zero counts"
+        );
+    }
+
+    #[test]
+    fn enrich_resets_counts_for_files_dropped_from_the_blob() {
+        let db = test_db();
+        db.upsert_file_inventory(&[
+            entry("r", "src/a.rs", Some("rs"), Some("rust")),
+            entry("r", "src/b.rs", Some("rs"), Some("rust")),
+        ])
+        .unwrap();
+
+        let mut counts = std::collections::HashMap::new();
+        counts.insert("src/a.rs".to_string(), 4_u32);
+        counts.insert("src/b.rs".to_string(), 9_u32);
+        db.update_file_symbol_counts("r", &counts).unwrap();
+
+        // Next successful index: b.rs lost all its definitions and no
+        // longer appears in the blob. Its stale count must reset.
+        let mut counts = std::collections::HashMap::new();
+        counts.insert("src/a.rs".to_string(), 5_u32);
+        db.update_file_symbol_counts("r", &counts).unwrap();
+
+        let got = db
+            .list_file_inventory(&InventoryFilter {
+                repo: Some("r"),
+                ..Default::default()
+            })
+            .unwrap();
+        let by_path: std::collections::HashMap<&str, u32> = got
+            .iter()
+            .map(|e| (e.path.as_str(), e.symbol_count))
+            .collect();
+        assert_eq!(by_path["src/a.rs"], 5);
+        assert_eq!(
+            by_path["src/b.rs"], 0,
+            "stale count must not survive the enrich pass"
+        );
+    }
+
+    #[test]
     fn prune_removes_deleted_files() {
         let db = test_db();
         let entries = vec![
@@ -361,8 +450,7 @@ mod tests {
         ];
         db.upsert_file_inventory(&entries).unwrap();
 
-        let live: Vec<String> = vec!["a.rs".to_string(), "c.rs".to_string()];
-        let pruned = db.prune_file_inventory("r", &live).unwrap();
+        let pruned = db.prune_file_inventory("r", &["a.rs", "c.rs"]).unwrap();
         assert_eq!(pruned, 1, "one stale row should have been removed");
 
         let got = db

--- a/src/db/inventory.rs
+++ b/src/db/inventory.rs
@@ -158,6 +158,35 @@ impl Database {
         Ok(rows)
     }
 
+    /// Apply per-file SCIP symbol counts to existing inventory rows (#705).
+    ///
+    /// Called after the SCIP loop in `legion index`: the inventory is
+    /// upserted (with `symbol_count = 0`) before SCIP runs so it stays
+    /// independent of indexer outcomes, then this pass enriches the rows
+    /// whose path appears in a freshly built blob. Paths in `counts` with
+    /// no inventory row (unlikely: SCIP indexed a file the walk skipped)
+    /// update nothing and are not an error. Returns the number of rows
+    /// actually updated.
+    pub fn update_file_symbol_counts(
+        &self,
+        repo: &str,
+        counts: &std::collections::HashMap<String, u32>,
+    ) -> Result<usize> {
+        let tx = self.conn.unchecked_transaction()?;
+        let mut updated: usize = 0;
+        {
+            let mut stmt = tx.prepare(
+                "UPDATE file_inventory SET symbol_count = ?3
+                 WHERE repo = ?1 AND path = ?2",
+            )?;
+            for (path, count) in counts {
+                updated += stmt.execute(rusqlite::params![repo, path, *count as i64])?;
+            }
+        }
+        tx.commit()?;
+        Ok(updated)
+    }
+
     /// Delete rows for `repo` whose path is not in `live_paths`.
     ///
     /// Call this after [`upsert_file_inventory`] to evict stale rows left
@@ -287,6 +316,37 @@ mod tests {
         assert_eq!(got.len(), 1, "re-index must not duplicate the row");
         assert_eq!(got[0].size, 9999);
         assert_eq!(got[0].mtime, "2026-07-02T00:00:00+00:00");
+    }
+
+    #[test]
+    fn update_symbol_counts_enriches_matching_rows_only() {
+        let db = test_db();
+        db.upsert_file_inventory(&[
+            entry("r", "src/a.rs", Some("rs"), Some("rust")),
+            entry("r", "src/b.rs", Some("rs"), Some("rust")),
+            entry("r", "README.md", Some("md"), None),
+        ])
+        .unwrap();
+
+        let mut counts = std::collections::HashMap::new();
+        counts.insert("src/a.rs".to_string(), 7_u32);
+        counts.insert("src/gone.rs".to_string(), 3_u32); // no inventory row
+        let updated = db.update_file_symbol_counts("r", &counts).unwrap();
+        assert_eq!(updated, 1, "only the row that exists gets enriched");
+
+        let got = db
+            .list_file_inventory(&InventoryFilter {
+                repo: Some("r"),
+                ..Default::default()
+            })
+            .unwrap();
+        let by_path: std::collections::HashMap<&str, u32> = got
+            .iter()
+            .map(|e| (e.path.as_str(), e.symbol_count))
+            .collect();
+        assert_eq!(by_path["src/a.rs"], 7);
+        assert_eq!(by_path["src/b.rs"], 0, "uncounted files stay at 0");
+        assert_eq!(by_path["README.md"], 0);
     }
 
     #[test]

--- a/src/db/inventory.rs
+++ b/src/db/inventory.rs
@@ -1,0 +1,375 @@
+//! File inventory: per-file metadata for every watched repo (#705).
+//!
+//! `file_inventory` stores one row per file encountered during `legion index`.
+//! It is the always-fresh substrate for `sym tree` and `sym etc find-file`
+//! (#706, #709). The walk that populates it lives in `src/inventory.rs`;
+//! this module owns only the DDL and the persistence API.
+
+use rusqlite::Connection;
+use serde::{Deserialize, Serialize};
+
+use super::Database;
+use crate::error::Result;
+
+/// One row in the `file_inventory` table.
+///
+/// Paths are always repo-relative (forward-slash separated, no leading slash).
+/// `lang` is the SCIP language tag (e.g. "rust", "typescript"); `None` for
+/// files that SCIP does not index (docs, configs, scripts, etc.).
+/// `symbol_count` is 0 until a later epic populates it from the SCIP blob.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct FileInventoryEntry {
+    pub repo: String,
+    /// Repo-relative path with forward-slash separators, no leading slash.
+    pub path: String,
+    /// File extension without the leading dot (`rs`, `md`, `toml`). `None`
+    /// for dotfiles or files with no extension.
+    pub ext: Option<String>,
+    /// SCIP language tag for files whose extension maps to an indexed
+    /// language; `None` for everything else.
+    pub lang: Option<String>,
+    pub size: u64,
+    /// RFC3339 last-modified timestamp from the file system.
+    pub mtime: String,
+    /// Number of SCIP symbols in this file; 0 when no SCIP index covers it.
+    pub symbol_count: u32,
+}
+
+/// Optional scope restrictions for [`Database::list_file_inventory`].
+///
+/// `None` on any field disables that filter; `InventoryFilter::default()`
+/// returns every row.
+///
+/// Used by `sym tree` (#706) and `sym etc find-file` (#709); `#[allow]`
+/// silences the dead-code lint until those callers land.
+#[derive(Debug, Default)]
+#[allow(dead_code)]
+pub struct InventoryFilter<'a> {
+    pub repo: Option<&'a str>,
+    pub ext: Option<&'a str>,
+    pub lang: Option<&'a str>,
+}
+
+/// Create the `file_inventory` table and its covering indexes.
+///
+/// Called from `init_schema` inside the schema-creation transaction.
+/// Idempotent via `IF NOT EXISTS`.
+pub(super) fn create_tables(conn: &Connection) -> Result<()> {
+    conn.execute_batch(
+        "CREATE TABLE IF NOT EXISTS file_inventory (
+            repo TEXT NOT NULL,
+            path TEXT NOT NULL,
+            ext  TEXT,
+            lang TEXT,
+            size INTEGER NOT NULL,
+            mtime TEXT NOT NULL,
+            symbol_count INTEGER NOT NULL DEFAULT 0,
+            PRIMARY KEY (repo, path)
+        );
+        CREATE INDEX IF NOT EXISTS idx_file_inventory_repo
+            ON file_inventory(repo);
+        CREATE INDEX IF NOT EXISTS idx_file_inventory_repo_ext
+            ON file_inventory(repo, ext);",
+    )?;
+    Ok(())
+}
+
+impl Database {
+    /// Upsert a batch of file inventory rows, keyed on `(repo, path)`.
+    ///
+    /// Idempotent: re-indexing the same file updates its metadata in place
+    /// without changing the row identity. All rows are written inside a
+    /// single transaction for throughput.
+    pub fn upsert_file_inventory(&self, entries: &[FileInventoryEntry]) -> Result<()> {
+        let tx = self.conn.unchecked_transaction()?;
+        for entry in entries {
+            tx.execute(
+                "INSERT INTO file_inventory (repo, path, ext, lang, size, mtime, symbol_count)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
+                 ON CONFLICT(repo, path) DO UPDATE SET
+                     ext          = excluded.ext,
+                     lang         = excluded.lang,
+                     size         = excluded.size,
+                     mtime        = excluded.mtime,
+                     symbol_count = excluded.symbol_count",
+                rusqlite::params![
+                    &entry.repo,
+                    &entry.path,
+                    &entry.ext,
+                    &entry.lang,
+                    entry.size as i64,
+                    &entry.mtime,
+                    entry.symbol_count as i64,
+                ],
+            )?;
+        }
+        tx.commit()?;
+        Ok(())
+    }
+
+    /// Return inventory rows matching the optional filter, ordered by
+    /// `(repo, path)`.
+    ///
+    /// `None` on any filter field disables that restriction. All three
+    /// `None` returns every row in the table.
+    ///
+    /// Read path for `sym tree` (#706) and `sym etc find-file` (#709);
+    /// `#[allow]` silences the dead-code lint until those callers land.
+    #[allow(dead_code)]
+    pub fn list_file_inventory(
+        &self,
+        filter: &InventoryFilter<'_>,
+    ) -> Result<Vec<FileInventoryEntry>> {
+        let mut sql = String::from(
+            "SELECT repo, path, ext, lang, size, mtime, symbol_count
+             FROM file_inventory
+             WHERE 1=1",
+        );
+        let mut params: Vec<Box<dyn rusqlite::ToSql>> = Vec::new();
+        if let Some(r) = filter.repo {
+            sql.push_str(" AND repo = ?");
+            params.push(Box::new(r.to_string()));
+        }
+        if let Some(e) = filter.ext {
+            sql.push_str(" AND ext = ?");
+            params.push(Box::new(e.to_string()));
+        }
+        if let Some(l) = filter.lang {
+            sql.push_str(" AND lang = ?");
+            params.push(Box::new(l.to_string()));
+        }
+        sql.push_str(" ORDER BY repo, path");
+
+        let mut stmt = self.conn.prepare(&sql)?;
+        let param_refs: Vec<&dyn rusqlite::ToSql> = params.iter().map(|p| p.as_ref()).collect();
+        let rows = stmt
+            .query_map(rusqlite::params_from_iter(param_refs), |row| {
+                Ok(FileInventoryEntry {
+                    repo: row.get(0)?,
+                    path: row.get(1)?,
+                    ext: row.get(2)?,
+                    lang: row.get(3)?,
+                    size: row.get::<_, i64>(4)? as u64,
+                    mtime: row.get(5)?,
+                    symbol_count: row.get::<_, i64>(6)? as u32,
+                })
+            })?
+            .collect::<std::result::Result<Vec<_>, _>>()?;
+        Ok(rows)
+    }
+
+    /// Delete rows for `repo` whose path is not in `live_paths`.
+    ///
+    /// Call this after [`upsert_file_inventory`] to evict stale rows left
+    /// by deleted or renamed files. Returns the number of rows deleted.
+    ///
+    /// When `live_paths` is empty every row for the repo is removed (the
+    /// repo's working directory became empty or was deleted).
+    pub fn prune_file_inventory(&self, repo: &str, live_paths: &[String]) -> Result<usize> {
+        if live_paths.is_empty() {
+            let n = self.conn.execute(
+                "DELETE FROM file_inventory WHERE repo = ?1",
+                rusqlite::params![repo],
+            )?;
+            return Ok(n);
+        }
+
+        // Materialize live paths into a temporary table so the DELETE is a
+        // single statement regardless of how many files the repo has. A NOT
+        // IN (?1, ?2, ...) approach hits SQLite's variable-number limit for
+        // repos with many files; a temp table has no such bound.
+        self.conn.execute_batch(
+            "CREATE TEMP TABLE IF NOT EXISTS _inv_live_paths (path TEXT PRIMARY KEY)",
+        )?;
+        self.conn.execute_batch("DELETE FROM _inv_live_paths")?;
+
+        {
+            let tx = self.conn.unchecked_transaction()?;
+            {
+                // The Statement borrows `tx`; drop it before commit.
+                let mut insert =
+                    tx.prepare("INSERT OR IGNORE INTO _inv_live_paths (path) VALUES (?1)")?;
+                for p in live_paths {
+                    insert.execute(rusqlite::params![p])?;
+                }
+            }
+            tx.commit()?;
+        }
+
+        let n = self.conn.execute(
+            "DELETE FROM file_inventory
+             WHERE repo = ?1
+               AND path NOT IN (SELECT path FROM _inv_live_paths)",
+            rusqlite::params![repo],
+        )?;
+        Ok(n)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::testutil::test_db;
+
+    fn entry(repo: &str, path: &str, ext: Option<&str>, lang: Option<&str>) -> FileInventoryEntry {
+        FileInventoryEntry {
+            repo: repo.to_string(),
+            path: path.to_string(),
+            ext: ext.map(|s| s.to_string()),
+            lang: lang.map(|s| s.to_string()),
+            size: 100,
+            mtime: "2026-07-01T00:00:00+00:00".to_string(),
+            symbol_count: 0,
+        }
+    }
+
+    #[test]
+    fn upsert_and_list_round_trip() {
+        let db = test_db();
+        let entries = vec![
+            entry("myrepo", "src/main.rs", Some("rs"), Some("rust")),
+            entry("myrepo", "README.md", Some("md"), None),
+        ];
+        db.upsert_file_inventory(&entries).unwrap();
+
+        let got = db
+            .list_file_inventory(&InventoryFilter {
+                repo: Some("myrepo"),
+                ..Default::default()
+            })
+            .unwrap();
+        assert_eq!(got.len(), 2);
+        // Ordered by path: README.md before src/main.rs.
+        assert_eq!(got[0].path, "README.md");
+        assert_eq!(got[0].lang, None);
+        assert_eq!(got[1].path, "src/main.rs");
+        assert_eq!(got[1].lang.as_deref(), Some("rust"));
+    }
+
+    #[test]
+    fn sh_and_md_files_have_no_lang() {
+        let db = test_db();
+        let entries = vec![
+            entry("r", "scripts/deploy.sh", Some("sh"), None),
+            entry("r", "docs/guide.md", Some("md"), None),
+        ];
+        db.upsert_file_inventory(&entries).unwrap();
+
+        let got = db
+            .list_file_inventory(&InventoryFilter {
+                repo: Some("r"),
+                ..Default::default()
+            })
+            .unwrap();
+        assert_eq!(got.len(), 2);
+        for e in &got {
+            assert!(e.lang.is_none(), "{} should have lang=None", e.path);
+        }
+    }
+
+    #[test]
+    fn upsert_is_idempotent() {
+        let db = test_db();
+        let mut e = entry("r", "src/lib.rs", Some("rs"), Some("rust"));
+        db.upsert_file_inventory(&[e.clone()]).unwrap();
+
+        // Simulate a re-index: same path, updated metadata.
+        e.size = 9999;
+        e.mtime = "2026-07-02T00:00:00+00:00".to_string();
+        db.upsert_file_inventory(&[e]).unwrap();
+
+        let got = db
+            .list_file_inventory(&InventoryFilter {
+                repo: Some("r"),
+                ..Default::default()
+            })
+            .unwrap();
+        assert_eq!(got.len(), 1, "re-index must not duplicate the row");
+        assert_eq!(got[0].size, 9999);
+        assert_eq!(got[0].mtime, "2026-07-02T00:00:00+00:00");
+    }
+
+    #[test]
+    fn prune_removes_deleted_files() {
+        let db = test_db();
+        let entries = vec![
+            entry("r", "a.rs", Some("rs"), Some("rust")),
+            entry("r", "b.rs", Some("rs"), Some("rust")),
+            entry("r", "c.rs", Some("rs"), Some("rust")),
+        ];
+        db.upsert_file_inventory(&entries).unwrap();
+
+        let live: Vec<String> = vec!["a.rs".to_string(), "c.rs".to_string()];
+        let pruned = db.prune_file_inventory("r", &live).unwrap();
+        assert_eq!(pruned, 1, "one stale row should have been removed");
+
+        let got = db
+            .list_file_inventory(&InventoryFilter {
+                repo: Some("r"),
+                ..Default::default()
+            })
+            .unwrap();
+        let paths: Vec<&str> = got.iter().map(|e| e.path.as_str()).collect();
+        assert!(!paths.contains(&"b.rs"), "b.rs should have been pruned");
+        assert!(paths.contains(&"a.rs"));
+        assert!(paths.contains(&"c.rs"));
+    }
+
+    #[test]
+    fn prune_empty_live_paths_wipes_repo() {
+        let db = test_db();
+        db.upsert_file_inventory(&[entry("r", "a.rs", Some("rs"), Some("rust"))])
+            .unwrap();
+
+        let pruned = db.prune_file_inventory("r", &[]).unwrap();
+        assert_eq!(pruned, 1);
+
+        let got = db
+            .list_file_inventory(&InventoryFilter {
+                repo: Some("r"),
+                ..Default::default()
+            })
+            .unwrap();
+        assert!(got.is_empty());
+    }
+
+    #[test]
+    fn list_filtered_by_ext() {
+        let db = test_db();
+        let entries = vec![
+            entry("r", "a.rs", Some("rs"), Some("rust")),
+            entry("r", "b.md", Some("md"), None),
+            entry("r", "c.rs", Some("rs"), Some("rust")),
+        ];
+        db.upsert_file_inventory(&entries).unwrap();
+
+        let got = db
+            .list_file_inventory(&InventoryFilter {
+                repo: Some("r"),
+                ext: Some("rs"),
+                ..Default::default()
+            })
+            .unwrap();
+        assert_eq!(got.len(), 2);
+        assert!(got.iter().all(|e| e.ext.as_deref() == Some("rs")));
+    }
+
+    #[test]
+    fn list_scoped_to_repo() {
+        let db = test_db();
+        db.upsert_file_inventory(&[
+            entry("alpha", "a.rs", Some("rs"), Some("rust")),
+            entry("beta", "b.rs", Some("rs"), Some("rust")),
+        ])
+        .unwrap();
+
+        let got = db
+            .list_file_inventory(&InventoryFilter {
+                repo: Some("alpha"),
+                ..Default::default()
+            })
+            .unwrap();
+        assert_eq!(got.len(), 1);
+        assert_eq!(got[0].repo, "alpha");
+    }
+}

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -12,6 +12,7 @@ mod board;
 mod documents;
 mod health;
 mod heartbeat;
+pub mod inventory;
 mod kanban;
 pub(crate) mod quality_gates;
 mod reflections;
@@ -117,6 +118,7 @@ impl Database {
         uncertainty::create_tables(conn)?;
         autonomy::create_tables(conn)?;
         heartbeat::create_tables(conn)?;
+        inventory::create_tables(conn)?;
         tx.commit()?;
 
         reflections::migrate(conn)?;

--- a/src/inventory.rs
+++ b/src/inventory.rs
@@ -34,7 +34,21 @@ pub fn lang_for_ext(ext: &str) -> Option<&'static str> {
     }
 }
 
-/// Walk `repo_path` and return one inventory entry per non-ignored file.
+/// What a repo walk produced, including how much it could not see.
+///
+/// `walk_errors` counts walk-level failures (unreadable directories,
+/// readdir errors, per-file stat failures) that were skipped. Nonzero
+/// means `entries` may be INCOMPLETE -- callers that evict rows based on
+/// the entry set (the prune pass) must not treat a partial walk as the
+/// full corpus, or a transient I/O failure evicts rows for files that
+/// still exist (#718 re-review).
+pub struct WalkOutcome {
+    pub entries: Vec<FileInventoryEntry>,
+    pub walk_errors: u64,
+}
+
+/// Walk `repo_path` and return one inventory entry per non-ignored file,
+/// plus the count of walk errors encountered.
 ///
 /// The walk respects `.gitignore` rules via the `ignore` crate, including
 /// rules from parent directories inside the repo. Settings that could vary
@@ -50,8 +64,9 @@ pub fn lang_for_ext(ext: &str) -> Option<&'static str> {
 ///
 /// `require_git` is set to `false` so the walk works correctly both inside
 /// a git checkout and in plain directories (tempdir-based tests). Per-file
-/// stat/walk errors are logged to stderr and skipped -- one unreadable file
-/// must not abort the whole inventory.
+/// stat/walk errors are logged to stderr, skipped, and counted in
+/// `walk_errors` -- one unreadable file must not abort the whole inventory,
+/// but the caller must know the result is partial.
 ///
 /// Returned paths are repo-relative with forward-slash separators and no
 /// leading slash, matching the convention used by the SCIP document paths.
@@ -60,7 +75,7 @@ pub fn lang_for_ext(ext: &str) -> Option<&'static str> {
 /// the mtime falls back silently to `Utc::now()`. The row then looks fresh
 /// on every index until a platform with mtime support updates it -- an
 /// accepted inaccuracy on exotic filesystems, not worth a per-file log line.
-pub fn walk_repo(repo_name: &str, repo_path: &Path) -> Vec<FileInventoryEntry> {
+pub fn walk_repo(repo_name: &str, repo_path: &Path) -> WalkOutcome {
     let walker = WalkBuilder::new(repo_path)
         .require_git(false)
         .hidden(false)
@@ -68,12 +83,14 @@ pub fn walk_repo(repo_name: &str, repo_path: &Path) -> Vec<FileInventoryEntry> {
         .filter_entry(|entry| entry.file_name() != ".git")
         .build();
     let mut entries: Vec<FileInventoryEntry> = Vec::new();
+    let mut walk_errors: u64 = 0;
 
     for result in walker {
         let dir_entry = match result {
             Ok(e) => e,
             Err(err) => {
                 eprintln!("[legion] inventory walk error (skipped): {err}");
+                walk_errors += 1;
                 continue;
             }
         };
@@ -92,6 +109,7 @@ pub fn walk_repo(repo_name: &str, repo_path: &Path) -> Vec<FileInventoryEntry> {
                     "[legion] inventory stat error for {}: {err} (skipped)",
                     abs_path.display()
                 );
+                walk_errors += 1;
                 continue;
             }
         };
@@ -128,7 +146,10 @@ pub fn walk_repo(repo_name: &str, repo_path: &Path) -> Vec<FileInventoryEntry> {
         });
     }
 
-    entries
+    WalkOutcome {
+        entries,
+        walk_errors,
+    }
 }
 
 #[cfg(test)]
@@ -185,11 +206,27 @@ mod tests {
     #[test]
     fn walk_produces_one_row_per_file() {
         let dir = make_tree(&["src/main.rs", "README.md", "Cargo.toml"]);
-        let entries = walk_repo("myrepo", dir.path());
+        let outcome = walk_repo("myrepo", dir.path());
         assert_eq!(
-            entries.len(),
+            outcome.entries.len(),
             3,
             "every non-ignored file must produce one row"
+        );
+        assert_eq!(outcome.walk_errors, 0, "clean tree walks without errors");
+    }
+
+    // --- a missing root is a counted error, not a silent empty success ---
+
+    #[test]
+    fn missing_root_reports_walk_error_not_empty_success() {
+        let dir = tempfile::tempdir().unwrap();
+        let gone = dir.path().join("never-existed");
+        let outcome = walk_repo("r", &gone);
+        assert!(outcome.entries.is_empty());
+        assert!(
+            outcome.walk_errors > 0,
+            "a vanished root must be visible to the caller so the prune \
+             pass does not treat the empty set as the full corpus"
         );
     }
 
@@ -198,7 +235,7 @@ mod tests {
     #[test]
     fn sh_and_md_have_no_lang() {
         let dir = make_tree(&["deploy.sh", "README.md"]);
-        let entries = walk_repo("r", dir.path());
+        let entries = walk_repo("r", dir.path()).entries;
         assert_eq!(entries.len(), 2, "both files must be inventoried");
         for e in &entries {
             assert!(e.lang.is_none(), "{} should have lang=None", e.path);
@@ -210,7 +247,7 @@ mod tests {
     #[test]
     fn docs_only_repo_produces_inventory() {
         let dir = make_tree(&["docs/guide.md", "docs/intro.md", "README.md"]);
-        let entries = walk_repo("docs-repo", dir.path());
+        let entries = walk_repo("docs-repo", dir.path()).entries;
         // Must succeed and return a row for each file, not error.
         assert_eq!(entries.len(), 3);
         for e in &entries {
@@ -228,7 +265,7 @@ mod tests {
     #[test]
     fn walk_paths_are_repo_relative() {
         let dir = make_tree(&["src/lib.rs"]);
-        let entries = walk_repo("r", dir.path());
+        let entries = walk_repo("r", dir.path()).entries;
         assert_eq!(entries.len(), 1);
         // Must be repo-relative, not absolute.
         assert!(
@@ -246,7 +283,7 @@ mod tests {
         // inventory; WalkBuilder defaults to hidden(true) which excludes them,
         // so we explicitly set hidden(false) in walk_repo.
         let dir = make_tree(&[".github/workflows/ci.yml", ".env.example", "src/main.rs"]);
-        let entries = walk_repo("r", dir.path());
+        let entries = walk_repo("r", dir.path()).entries;
         let paths: Vec<&str> = entries.iter().map(|e| e.path.as_str()).collect();
         assert!(
             paths.contains(&".github/workflows/ci.yml"),
@@ -268,7 +305,7 @@ mod tests {
         // pull in the .git object store. Pins the doc claim on walk_repo
         // that the ignore crate skips .git regardless of hidden().
         let dir = make_tree(&[".git/config", ".git/objects/aa/bb", "src/main.rs"]);
-        let entries = walk_repo("r", dir.path());
+        let entries = walk_repo("r", dir.path()).entries;
         let paths: Vec<&str> = entries.iter().map(|e| e.path.as_str()).collect();
         assert!(
             !paths.iter().any(|p| p.starts_with(".git/")),
@@ -284,7 +321,7 @@ mod tests {
         let dir = make_tree(&["src/main.rs", "target/debug/legion"]);
         // Write a .gitignore that excludes the target/ directory.
         fs::write(dir.path().join(".gitignore"), b"target/\n").unwrap();
-        let entries = walk_repo("r", dir.path());
+        let entries = walk_repo("r", dir.path()).entries;
         let paths: Vec<&str> = entries.iter().map(|e| e.path.as_str()).collect();
         assert!(
             paths.contains(&"src/main.rs"),
@@ -301,13 +338,13 @@ mod tests {
     #[test]
     fn walk_reflects_tree_changes_between_runs() {
         let dir = make_tree(&["a.rs", "b.rs"]);
-        let first = walk_repo("r", dir.path());
+        let first = walk_repo("r", dir.path()).entries;
         assert_eq!(first.len(), 2);
 
         std::fs::remove_file(dir.path().join("b.rs")).unwrap();
         std::fs::write(dir.path().join("c.md"), b"new").unwrap();
 
-        let second = walk_repo("r", dir.path());
+        let second = walk_repo("r", dir.path()).entries;
         let mut second_paths: Vec<&str> = second.iter().map(|e| e.path.as_str()).collect();
         second_paths.sort_unstable();
         assert_eq!(
@@ -324,7 +361,7 @@ mod tests {
     fn symlinks_are_excluded_from_inventory() {
         let dir = make_tree(&["real.rs"]);
         std::os::unix::fs::symlink(dir.path().join("real.rs"), dir.path().join("link.rs")).unwrap();
-        let entries = walk_repo("r", dir.path());
+        let entries = walk_repo("r", dir.path()).entries;
         let paths: Vec<&str> = entries.iter().map(|e| e.path.as_str()).collect();
         assert_eq!(
             paths,

--- a/src/inventory.rs
+++ b/src/inventory.rs
@@ -199,6 +199,7 @@ mod tests {
     fn sh_and_md_have_no_lang() {
         let dir = make_tree(&["deploy.sh", "README.md"]);
         let entries = walk_repo("r", dir.path());
+        assert_eq!(entries.len(), 2, "both files must be inventoried");
         for e in &entries {
             assert!(e.lang.is_none(), "{} should have lang=None", e.path);
         }

--- a/src/inventory.rs
+++ b/src/inventory.rs
@@ -57,9 +57,9 @@ pub fn lang_for_ext(ext: &str) -> Option<&'static str> {
 /// leading slash, matching the convention used by the SCIP document paths.
 ///
 /// Note: if `metadata().modified()` is unavailable (rare on some platforms),
-/// the mtime falls back to `Utc::now()`. This makes the row look fresh on
-/// every index until the file is actually updated on a platform that supports
-/// mtime; the behavior is logged at the site in that event.
+/// the mtime falls back silently to `Utc::now()`. The row then looks fresh
+/// on every index until a platform with mtime support updates it -- an
+/// accepted inaccuracy on exotic filesystems, not worth a per-file log line.
 pub fn walk_repo(repo_name: &str, repo_path: &Path) -> Vec<FileInventoryEntry> {
     let walker = WalkBuilder::new(repo_path)
         .require_git(false)
@@ -295,17 +295,40 @@ mod tests {
         );
     }
 
-    // --- walk is idempotent (same files => same result) ---
+    // --- walk output tracks tree mutations (add + delete visible) ---
 
     #[test]
-    fn walk_is_idempotent() {
+    fn walk_reflects_tree_changes_between_runs() {
         let dir = make_tree(&["a.rs", "b.rs"]);
         let first = walk_repo("r", dir.path());
+        assert_eq!(first.len(), 2);
+
+        std::fs::remove_file(dir.path().join("b.rs")).unwrap();
+        std::fs::write(dir.path().join("c.md"), b"new").unwrap();
+
         let second = walk_repo("r", dir.path());
-        let mut first_paths: Vec<&str> = first.iter().map(|e| e.path.as_str()).collect();
         let mut second_paths: Vec<&str> = second.iter().map(|e| e.path.as_str()).collect();
-        first_paths.sort();
-        second_paths.sort();
-        assert_eq!(first_paths, second_paths);
+        second_paths.sort_unstable();
+        assert_eq!(
+            second_paths,
+            vec!["a.rs", "c.md"],
+            "walk must reflect deletions and additions, not cache"
+        );
+    }
+
+    // --- symlinks are excluded (walker does not follow links) ---
+
+    #[cfg(unix)]
+    #[test]
+    fn symlinks_are_excluded_from_inventory() {
+        let dir = make_tree(&["real.rs"]);
+        std::os::unix::fs::symlink(dir.path().join("real.rs"), dir.path().join("link.rs")).unwrap();
+        let entries = walk_repo("r", dir.path());
+        let paths: Vec<&str> = entries.iter().map(|e| e.path.as_str()).collect();
+        assert_eq!(
+            paths,
+            vec!["real.rs"],
+            "symlink entries must be skipped (follow_links off + is_file guard)"
+        );
     }
 }

--- a/src/inventory.rs
+++ b/src/inventory.rs
@@ -43,9 +43,10 @@ pub fn lang_for_ext(ext: &str) -> Option<&'static str> {
 ///
 /// Dotfiles and dot-directories are included (`hidden(false)`): files like
 /// `.github/workflows/ci.yml`, `.env.example`, and `.gitignore` itself are
-/// part of the repo corpus and must appear in the inventory. The `.git/`
-/// object store is excluded unconditionally by the `ignore` crate regardless
-/// of this setting.
+/// part of the repo corpus and must appear in the inventory. With hidden
+/// disabled the `ignore` crate does NOT skip `.git/` on its own (verified
+/// empirically by `git_dir_is_excluded_even_with_hidden_false`), so the
+/// walk excludes it explicitly via `filter_entry`.
 ///
 /// `require_git` is set to `false` so the walk works correctly both inside
 /// a git checkout and in plain directories (tempdir-based tests). Per-file
@@ -64,6 +65,7 @@ pub fn walk_repo(repo_name: &str, repo_path: &Path) -> Vec<FileInventoryEntry> {
         .require_git(false)
         .hidden(false)
         .git_global(false)
+        .filter_entry(|entry| entry.file_name() != ".git")
         .build();
     let mut entries: Vec<FileInventoryEntry> = Vec::new();
 
@@ -255,6 +257,23 @@ mod tests {
         );
         assert!(paths.contains(&"src/main.rs"));
         assert_eq!(entries.len(), 3, "all three files must appear");
+    }
+
+    // --- .git object store is never inventoried ---
+
+    #[test]
+    fn git_dir_is_excluded_even_with_hidden_false() {
+        // walk_repo sets hidden(false) to include dotfiles; this must NOT
+        // pull in the .git object store. Pins the doc claim on walk_repo
+        // that the ignore crate skips .git regardless of hidden().
+        let dir = make_tree(&[".git/config", ".git/objects/aa/bb", "src/main.rs"]);
+        let entries = walk_repo("r", dir.path());
+        let paths: Vec<&str> = entries.iter().map(|e| e.path.as_str()).collect();
+        assert!(
+            !paths.iter().any(|p| p.starts_with(".git/")),
+            ".git/ contents must never be inventoried; got: {paths:?}"
+        );
+        assert!(paths.contains(&"src/main.rs"));
     }
 
     // --- gitignored files are excluded ---

--- a/src/inventory.rs
+++ b/src/inventory.rs
@@ -1,0 +1,292 @@
+//! File inventory walk: enumerate every non-ignored file in a repo (#705).
+//!
+//! `walk_repo` drives an `ignore::WalkBuilder` over a watched workdir and
+//! returns one [`FileInventoryEntry`] per file. The walk respects `.gitignore`
+//! rules even when the root is not a git checkout (`require_git(false)`), so
+//! tempdir-based tests are not vacuously "passing" by ignoring nothing.
+//!
+//! `lang_for_ext` maps file extensions to the SCIP language tags used by
+//! `legion index`. Files whose extension has no mapping land with `lang = None`.
+
+use std::path::Path;
+
+use chrono::{DateTime, Utc};
+use ignore::WalkBuilder;
+
+use crate::db::inventory::FileInventoryEntry;
+
+/// Map a file extension (without the leading dot) to a SCIP language tag.
+///
+/// Returns `None` for extensions that no SCIP indexer covers. The mapping
+/// mirrors the languages detected by `scip::detect_languages`.
+pub fn lang_for_ext(ext: &str) -> Option<&'static str> {
+    match ext {
+        "rs" => Some("rust"),
+        "ts" | "tsx" | "js" | "jsx" | "mts" | "cts" | "mjs" | "cjs" => Some("typescript"),
+        "py" | "pyi" => Some("python"),
+        "go" => Some("go"),
+        "java" | "kt" | "kts" => Some("java"),
+        "rb" => Some("ruby"),
+        "c" | "h" | "cc" | "cpp" | "cxx" | "hh" | "hpp" | "hxx" => Some("clang"),
+        "cs" => Some("csharp"),
+        "php" => Some("php"),
+        _ => None,
+    }
+}
+
+/// Walk `repo_path` and return one inventory entry per non-ignored file.
+///
+/// The walk respects `.gitignore` rules via the `ignore` crate, including
+/// rules from parent directories inside the repo. Settings that could vary
+/// across machines (global gitignore, `core.excludesFile`) are explicitly
+/// disabled so the inventory is reproducible.
+///
+/// Dotfiles and dot-directories are included (`hidden(false)`): files like
+/// `.github/workflows/ci.yml`, `.env.example`, and `.gitignore` itself are
+/// part of the repo corpus and must appear in the inventory. The `.git/`
+/// object store is excluded unconditionally by the `ignore` crate regardless
+/// of this setting.
+///
+/// `require_git` is set to `false` so the walk works correctly both inside
+/// a git checkout and in plain directories (tempdir-based tests). Per-file
+/// stat/walk errors are logged to stderr and skipped -- one unreadable file
+/// must not abort the whole inventory.
+///
+/// Returned paths are repo-relative with forward-slash separators and no
+/// leading slash, matching the convention used by the SCIP document paths.
+///
+/// Note: if `metadata().modified()` is unavailable (rare on some platforms),
+/// the mtime falls back to `Utc::now()`. This makes the row look fresh on
+/// every index until the file is actually updated on a platform that supports
+/// mtime; the behavior is logged at the site in that event.
+pub fn walk_repo(repo_name: &str, repo_path: &Path) -> Vec<FileInventoryEntry> {
+    let walker = WalkBuilder::new(repo_path)
+        .require_git(false)
+        .hidden(false)
+        .git_global(false)
+        .build();
+    let mut entries: Vec<FileInventoryEntry> = Vec::new();
+
+    for result in walker {
+        let dir_entry = match result {
+            Ok(e) => e,
+            Err(err) => {
+                eprintln!("[legion] inventory walk error (skipped): {err}");
+                continue;
+            }
+        };
+
+        // Skip directories and symlinks -- files only.
+        if !dir_entry.file_type().is_some_and(|ft| ft.is_file()) {
+            continue;
+        }
+
+        let abs_path = dir_entry.path();
+
+        let metadata = match abs_path.metadata() {
+            Ok(m) => m,
+            Err(err) => {
+                eprintln!(
+                    "[legion] inventory stat error for {}: {err} (skipped)",
+                    abs_path.display()
+                );
+                continue;
+            }
+        };
+
+        let size: u64 = metadata.len();
+        let mtime: DateTime<Utc> = metadata
+            .modified()
+            .map(|t| t.into())
+            .unwrap_or_else(|_| Utc::now());
+        let mtime_str: String = mtime.to_rfc3339();
+
+        // Repo-relative path with forward slashes.
+        let rel = abs_path
+            .strip_prefix(repo_path)
+            .unwrap_or(abs_path)
+            .to_string_lossy()
+            .replace('\\', "/");
+
+        let ext: Option<String> = abs_path
+            .extension()
+            .and_then(|e| e.to_str())
+            .map(|s| s.to_string());
+
+        let lang: Option<String> = ext.as_deref().and_then(lang_for_ext).map(|s| s.to_string());
+
+        entries.push(FileInventoryEntry {
+            repo: repo_name.to_string(),
+            path: rel,
+            ext,
+            lang,
+            size,
+            mtime: mtime_str,
+            symbol_count: 0,
+        });
+    }
+
+    entries
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use tempfile::TempDir;
+
+    use super::*;
+
+    // Helper: create a temp dir with the given relative file paths (empty
+    // content), return the dir so it stays alive for the duration of the test.
+    fn make_tree(files: &[&str]) -> TempDir {
+        let dir = tempfile::tempdir().unwrap();
+        for rel in files {
+            let abs = dir.path().join(rel);
+            if let Some(parent) = abs.parent() {
+                fs::create_dir_all(parent).unwrap();
+            }
+            fs::write(&abs, b"").unwrap();
+        }
+        dir
+    }
+
+    // --- lang_for_ext mapping ---
+
+    #[test]
+    fn lang_for_ext_rust() {
+        assert_eq!(lang_for_ext("rs"), Some("rust"));
+    }
+
+    #[test]
+    fn lang_for_ext_typescript_variants() {
+        for ext in ["ts", "tsx", "js", "jsx", "mts", "cts"] {
+            assert_eq!(
+                lang_for_ext(ext),
+                Some("typescript"),
+                "ext={ext} should map to typescript"
+            );
+        }
+    }
+
+    #[test]
+    fn lang_for_ext_unknown_returns_none() {
+        assert_eq!(lang_for_ext("sh"), None);
+        assert_eq!(lang_for_ext("md"), None);
+        assert_eq!(lang_for_ext("toml"), None);
+        assert_eq!(lang_for_ext("yaml"), None);
+        assert_eq!(lang_for_ext("css"), None);
+    }
+
+    // --- walk_repo: one row per non-ignored file ---
+
+    #[test]
+    fn walk_produces_one_row_per_file() {
+        let dir = make_tree(&["src/main.rs", "README.md", "Cargo.toml"]);
+        let entries = walk_repo("myrepo", dir.path());
+        assert_eq!(
+            entries.len(),
+            3,
+            "every non-ignored file must produce one row"
+        );
+    }
+
+    // --- sh and md land with lang = None ---
+
+    #[test]
+    fn sh_and_md_have_no_lang() {
+        let dir = make_tree(&["deploy.sh", "README.md"]);
+        let entries = walk_repo("r", dir.path());
+        for e in &entries {
+            assert!(e.lang.is_none(), "{} should have lang=None", e.path);
+        }
+    }
+
+    // --- docs-only repo (no language markers) succeeds ---
+
+    #[test]
+    fn docs_only_repo_produces_inventory() {
+        let dir = make_tree(&["docs/guide.md", "docs/intro.md", "README.md"]);
+        let entries = walk_repo("docs-repo", dir.path());
+        // Must succeed and return a row for each file, not error.
+        assert_eq!(entries.len(), 3);
+        for e in &entries {
+            assert!(
+                e.lang.is_none(),
+                "docs-only repo: lang must be None for {}",
+                e.path
+            );
+            assert_eq!(e.ext.as_deref(), Some("md"));
+        }
+    }
+
+    // --- paths are repo-relative ---
+
+    #[test]
+    fn walk_paths_are_repo_relative() {
+        let dir = make_tree(&["src/lib.rs"]);
+        let entries = walk_repo("r", dir.path());
+        assert_eq!(entries.len(), 1);
+        // Must be repo-relative, not absolute.
+        assert!(
+            !entries[0].path.starts_with('/'),
+            "path must be repo-relative"
+        );
+        assert_eq!(entries[0].path, "src/lib.rs");
+    }
+
+    // --- dotfiles and dot-directories are included ---
+
+    #[test]
+    fn dotfiles_are_included() {
+        // Files like .github/workflows/ci.yml and .env must appear in the
+        // inventory; WalkBuilder defaults to hidden(true) which excludes them,
+        // so we explicitly set hidden(false) in walk_repo.
+        let dir = make_tree(&[".github/workflows/ci.yml", ".env.example", "src/main.rs"]);
+        let entries = walk_repo("r", dir.path());
+        let paths: Vec<&str> = entries.iter().map(|e| e.path.as_str()).collect();
+        assert!(
+            paths.contains(&".github/workflows/ci.yml"),
+            ".github/workflows/ci.yml must be inventoried; got: {paths:?}"
+        );
+        assert!(
+            paths.contains(&".env.example"),
+            ".env.example must be inventoried; got: {paths:?}"
+        );
+        assert!(paths.contains(&"src/main.rs"));
+        assert_eq!(entries.len(), 3, "all three files must appear");
+    }
+
+    // --- gitignored files are excluded ---
+
+    #[test]
+    fn gitignored_files_are_excluded() {
+        let dir = make_tree(&["src/main.rs", "target/debug/legion"]);
+        // Write a .gitignore that excludes the target/ directory.
+        fs::write(dir.path().join(".gitignore"), b"target/\n").unwrap();
+        let entries = walk_repo("r", dir.path());
+        let paths: Vec<&str> = entries.iter().map(|e| e.path.as_str()).collect();
+        assert!(
+            paths.contains(&"src/main.rs"),
+            "src/main.rs should be present"
+        );
+        assert!(
+            !paths.iter().any(|p| p.starts_with("target/")),
+            "target/ should be gitignored"
+        );
+    }
+
+    // --- walk is idempotent (same files => same result) ---
+
+    #[test]
+    fn walk_is_idempotent() {
+        let dir = make_tree(&["a.rs", "b.rs"]);
+        let first = walk_repo("r", dir.path());
+        let second = walk_repo("r", dir.path());
+        let mut first_paths: Vec<&str> = first.iter().map(|e| e.path.as_str()).collect();
+        let mut second_paths: Vec<&str> = second.iter().map(|e| e.path.as_str()).collect();
+        first_paths.sort();
+        second_paths.sort();
+        assert_eq!(first_paths, second_paths);
+    }
+}

--- a/src/inventory.rs
+++ b/src/inventory.rs
@@ -75,6 +75,13 @@ pub struct WalkOutcome {
 /// the mtime falls back silently to `Utc::now()`. The row then looks fresh
 /// on every index until a platform with mtime support updates it -- an
 /// accepted inaccuracy on exotic filesystems, not worth a per-file log line.
+///
+/// Note: non-UTF-8 path components are lossy-converted (invalid bytes become
+/// U+FFFD), so two distinct on-disk paths can map to the same inventory path
+/// and collide on the `(repo, path)` primary key, last writer wins. Accepted
+/// silently for the same reason as the mtime fallback: non-UTF-8 filenames
+/// are vanishingly rare on the platforms legion targets, and rejecting them
+/// would drop real files from the corpus.
 pub fn walk_repo(repo_name: &str, repo_path: &Path) -> WalkOutcome {
     let walker = WalkBuilder::new(repo_path)
         .require_git(false)
@@ -121,7 +128,8 @@ pub fn walk_repo(repo_name: &str, repo_path: &Path) -> WalkOutcome {
             .unwrap_or_else(|_| Utc::now());
         let mtime_str: String = mtime.to_rfc3339();
 
-        // Repo-relative path with forward slashes.
+        // Repo-relative path with forward slashes. Non-UTF-8 components are
+        // lossy-converted; see the fn doc for the PK-collision tradeoff.
         let rel = abs_path
             .strip_prefix(repo_path)
             .unwrap_or(abs_path)

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,7 @@ mod error;
 mod gate_trust;
 mod health;
 mod init;
+mod inventory;
 #[allow(dead_code)] // Items used by tests + pending surface/status/serve migration
 mod kanban;
 mod mcp;

--- a/src/sym.rs
+++ b/src/sym.rs
@@ -602,6 +602,25 @@ pub fn query_hover(
     Ok(None)
 }
 
+/// Per-file symbol counts for a SCIP blob: `relative_path -> number of
+/// definition occurrences in that document` (#705). Definition occurrences
+/// are the same population `query_definitions` serves, so the count agrees
+/// with what `sym def`/`sym list` would enumerate for the file. Feeds
+/// `file_inventory.symbol_count` right after `legion index` builds the blob.
+pub fn symbol_counts_per_file(blob: &[u8]) -> Result<HashMap<String, u32>> {
+    let index = parse_blob(blob)?;
+    let mut counts: HashMap<String, u32> = HashMap::new();
+    for document in &index.documents {
+        let defs = document
+            .occurrences
+            .iter()
+            .filter(|o| is_definition(o.symbol_roles))
+            .count() as u32;
+        counts.insert(document.relative_path.clone(), defs);
+    }
+    Ok(counts)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -628,6 +647,31 @@ mod tests {
         let mut idx = Index::new();
         idx.documents = documents;
         idx.write_to_bytes().unwrap()
+    }
+
+    #[test]
+    fn symbol_counts_per_file_counts_definitions_per_document() {
+        let blob = build_index(vec![
+            doc(
+                "src/a.rs",
+                vec![
+                    occ("sym1", vec![0, 0, 3], true),
+                    occ("sym1", vec![5, 0, 3], false), // reference: not counted
+                    occ("sym2", vec![9, 0, 3], true),
+                ],
+            ),
+            doc("src/b.rs", vec![occ("sym3", vec![0, 0, 3], false)]),
+        ]);
+        let counts = symbol_counts_per_file(&blob).expect("parse");
+        assert_eq!(counts.get("src/a.rs"), Some(&2));
+        assert_eq!(counts.get("src/b.rs"), Some(&0));
+        assert_eq!(counts.len(), 2);
+    }
+
+    #[test]
+    fn symbol_counts_per_file_rejects_garbage_blob() {
+        let err = symbol_counts_per_file(&[0xff, 0xff, 0xff, 0xff]);
+        assert!(matches!(err, Err(LegionError::Search(_))));
     }
 
     #[test]

--- a/tests/integration/index_telemetry.rs
+++ b/tests/integration/index_telemetry.rs
@@ -424,3 +424,63 @@ fn index_missing_workdir_fails_loudly_instead_of_wiping_inventory() {
         "expected the missing-workdir refusal naming the repo, got: {stderr}"
     );
 }
+
+/// #705 re-review (smugglr, PR #718): a workdir that EXISTS but cannot be
+/// read (permission-mangled remount, present-but-unreadable mount point)
+/// passes the `is_dir()` guard, so the walk runs, yields a root-level error
+/// and zero entries. The prune must be refused: a transient permission
+/// failure must not evict rows for files that still exist. This is the
+/// CLI-level repro of the chmod-000 wipe demonstrated against 0bdfcb7.
+#[cfg(unix)]
+#[test]
+fn index_unreadable_workdir_skips_prune_instead_of_wiping_inventory() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let dir = tempfile::tempdir().unwrap();
+    let repo = tempfile::tempdir().unwrap();
+    std::fs::write(repo.path().join("README.md"), "# docs only\n").unwrap();
+    std::fs::write(repo.path().join("guide.md"), "content\n").unwrap();
+
+    std::fs::write(
+        dir.path().join("watch.toml"),
+        format!(
+            "poll_interval_secs = 30\ncooldown_secs = 300\n\n[[repos]]\nname = \"permrepo\"\nworkdir = \"{}\"\n",
+            repo.path().display()
+        ),
+    )
+    .unwrap();
+
+    let stderr = run_ok_stderr(legion_cmd(dir.path()).args(["index", "permrepo"]));
+    assert!(
+        stderr.contains("inventoried 2 files for permrepo"),
+        "expected two files inventoried, got: {stderr}"
+    );
+
+    // The mount goes unreadable: the root still stats as a directory but
+    // readdir on it fails.
+    let mut perm = std::fs::metadata(repo.path()).unwrap().permissions();
+    perm.set_mode(0o000);
+    std::fs::set_permissions(repo.path(), perm).unwrap();
+
+    let stderr = run_ok_stderr(legion_cmd(dir.path()).args(["index", "permrepo"]));
+
+    // Restore perms before asserting so the tempdir can drop even on failure.
+    let mut perm = std::fs::metadata(repo.path()).unwrap().permissions();
+    perm.set_mode(0o755);
+    std::fs::set_permissions(repo.path(), perm).unwrap();
+
+    assert!(
+        stderr.contains("prune skipped"),
+        "expected the partial-walk prune refusal, got: {stderr}"
+    );
+
+    // Row-survival proof: delete one file and re-index. Exactly one stale
+    // row gets pruned, so both rows survived the unreadable run -- a wipe
+    // would have left nothing to prune.
+    std::fs::remove_file(repo.path().join("guide.md")).unwrap();
+    let stderr = run_ok_stderr(legion_cmd(dir.path()).args(["index", "permrepo"]));
+    assert!(
+        stderr.contains("inventoried 1 files for permrepo (1 stale rows pruned)"),
+        "expected exactly one stale row pruned after the recovery run, got: {stderr}"
+    );
+}

--- a/tests/integration/index_telemetry.rs
+++ b/tests/integration/index_telemetry.rs
@@ -375,3 +375,31 @@ fn index_docs_only_repo_succeeds_and_inventories() {
         "expected the inventory summary, got: {stderr}"
     );
 }
+
+/// #705 review (PR #718): a missing or unmounted workdir must abort the
+/// index run loudly BEFORE any walk. Without the guard, walk_repo on a
+/// vanished root returns zero entries and the prune pass deletes every
+/// inventory row for the repo -- a transient mount failure silently
+/// destroying derived state.
+#[test]
+fn index_missing_workdir_fails_loudly_instead_of_wiping_inventory() {
+    let dir = tempfile::tempdir().unwrap();
+    let gone = tempfile::tempdir().unwrap();
+    let gone_path = gone.path().to_path_buf();
+    drop(gone); // the workdir existed once, then the mount vanished
+
+    std::fs::write(
+        dir.path().join("watch.toml"),
+        format!(
+            "poll_interval_secs = 30\ncooldown_secs = 300\n\n[[repos]]\nname = \"ghostrepo\"\nworkdir = \"{}\"\n",
+            gone_path.display()
+        ),
+    )
+    .unwrap();
+
+    let (_stdout, stderr) = run_fail(legion_cmd(dir.path()).args(["index", "ghostrepo"]));
+    assert!(
+        stderr.contains("does not exist") && stderr.contains("ghostrepo"),
+        "expected the missing-workdir refusal naming the repo, got: {stderr}"
+    );
+}

--- a/tests/integration/index_telemetry.rs
+++ b/tests/integration/index_telemetry.rs
@@ -380,8 +380,10 @@ fn index_docs_only_repo_succeeds_and_inventories() {
     std::fs::write(
         dir.path().join("watch.toml"),
         format!(
+            // Forward slashes: backslash Windows paths are invalid TOML
+            // string escapes, and Windows path APIs accept slashes.
             "poll_interval_secs = 30\ncooldown_secs = 300\n\n[[repos]]\nname = \"docsrepo\"\nworkdir = \"{}\"\n",
-            repo.path().display()
+            repo.path().display().to_string().replace('\\', "/")
         ),
     )
     .unwrap();
@@ -412,8 +414,9 @@ fn index_missing_workdir_fails_loudly_instead_of_wiping_inventory() {
     std::fs::write(
         dir.path().join("watch.toml"),
         format!(
+            // Forward slashes: see index_docs_only_repo_succeeds_and_inventories.
             "poll_interval_secs = 30\ncooldown_secs = 300\n\n[[repos]]\nname = \"ghostrepo\"\nworkdir = \"{}\"\n",
-            gone_path.display()
+            gone_path.display().to_string().replace('\\', "/")
         ),
     )
     .unwrap();

--- a/tests/integration/index_telemetry.rs
+++ b/tests/integration/index_telemetry.rs
@@ -341,3 +341,37 @@ fn index_and_sym_def_refs_roundtrip_against_fixture_repo() {
     assert_eq!(refs[0]["line"], 11);
     assert_eq!(refs[1]["line"], 21);
 }
+
+/// #705: a docs-only repo (no language markers) must exit 0 from
+/// `legion index`, skip SCIP loudly, and still populate the inventory.
+/// Pins the exit-code contract flip at the CLI boundary -- the old code
+/// hard-errored on `detect_languages() == []`; walk-level unit tests
+/// cannot catch a regression here.
+#[test]
+fn index_docs_only_repo_succeeds_and_inventories() {
+    let dir = tempfile::tempdir().unwrap();
+    let repo = tempfile::tempdir().unwrap();
+    std::fs::write(repo.path().join("README.md"), "# docs only\n").unwrap();
+    std::fs::write(repo.path().join("guide.md"), "content\n").unwrap();
+
+    // Direct watch.toml seed: `watch add` would spawn a background indexer
+    // this test does not want racing it.
+    std::fs::write(
+        dir.path().join("watch.toml"),
+        format!(
+            "poll_interval_secs = 30\ncooldown_secs = 300\n\n[[repos]]\nname = \"docsrepo\"\nworkdir = \"{}\"\n",
+            repo.path().display()
+        ),
+    )
+    .unwrap();
+
+    let stderr = run_ok_stderr(legion_cmd(dir.path()).args(["index", "docsrepo"]));
+    assert!(
+        stderr.contains("no SCIP-supported language detected"),
+        "expected the SCIP-skip notice, got: {stderr}"
+    );
+    assert!(
+        stderr.contains("inventoried 2 files for docsrepo"),
+        "expected the inventory summary, got: {stderr}"
+    );
+}

--- a/tests/integration/index_telemetry.rs
+++ b/tests/integration/index_telemetry.rs
@@ -251,10 +251,19 @@ fn index_and_sym_def_refs_roundtrip_against_fixture_repo() {
     let dir = tempfile::tempdir().unwrap();
     let repo = tempfile::tempdir().unwrap();
 
-    // Fixture repo: a Cargo.toml marker so detect_languages says "rust".
+    // Fixture repo: a Cargo.toml marker so detect_languages says "rust",
+    // plus the src/lib.rs the blob's document refers to -- the inventory
+    // walk only rows files that exist on disk, and the symbol-count
+    // enrichment joins blob relative_path to inventory path (#705).
     std::fs::write(
         repo.path().join("Cargo.toml"),
         "[package]\nname = \"fixture\"\nversion = \"0.1.0\"\n",
+    )
+    .unwrap();
+    std::fs::create_dir_all(repo.path().join("src")).unwrap();
+    std::fs::write(
+        repo.path().join("src/lib.rs"),
+        "pub struct Greeter;\npub fn hello() {}\n",
     )
     .unwrap();
 
@@ -317,6 +326,18 @@ fn index_and_sym_def_refs_roundtrip_against_fixture_repo() {
     assert!(
         index_stderr.contains("indexed fixture (rust)"),
         "expected index confirmation, got: {index_stderr}"
+    );
+    // #705 end-to-end: the walk inventoried the fixture and the enrichment
+    // pass matched the blob's src/lib.rs document to its inventory row --
+    // "applied to 1" proves the SCIP relative_path joined the walk's
+    // repo-relative path through the real CLI + DB, not just unit halves.
+    assert!(
+        index_stderr.contains("inventoried"),
+        "expected the inventory summary, got: {index_stderr}"
+    );
+    assert!(
+        index_stderr.contains("symbol counts applied to 1 inventoried files for fixture"),
+        "expected the symbol-count enrichment line, got: {index_stderr}"
     );
 
     // def: the single definition occurrence, 1-indexed (range line 4 -> 5).

--- a/tests/integration/index_telemetry.rs
+++ b/tests/integration/index_telemetry.rs
@@ -457,7 +457,8 @@ fn index_unreadable_workdir_skips_prune_instead_of_wiping_inventory() {
     );
 
     // The mount goes unreadable: the root still stats as a directory but
-    // readdir on it fails.
+    // readdir on it fails. (Assumes a non-root test runner -- root ignores
+    // mode 000 and would see a readable directory.)
     let mut perm = std::fs::metadata(repo.path()).unwrap().permissions();
     perm.set_mode(0o000);
     std::fs::set_permissions(repo.path(), perm).unwrap();


### PR DESCRIPTION
## Summary

Implements #705: a `file_inventory` table populated on every `legion index` run -- one row
per non-ignored file in the watched repo, pruned when files disappear. This is the always-
fresh structured substrate that `sym tree` (#706) and `sym etc find-file` (#709) will query.
New `src/inventory.rs` (gitignore-aware walk + ext-to-lang mapping) and `src/db/inventory.rs`
(DDL + upsert/list/prune), wired into `handle_index` after -- and independent of -- the SCIP
loop, which docs-only repos now skip instead of erroring.

## Acceptance criteria mapping

### 1. Inventory populated for a real repo on legion index, one row per non-ignored file

`inventory::walk_repo` drives an `ignore::WalkBuilder` over the workdir (require_git(false),
hidden(false), explicit `.git` filter_entry) and returns one FileInventoryEntry per file;
`handle_index` upserts the batch in one transaction and logs the count. Dotfiles like
`.github/workflows/ci.yml` are included -- the pre-commit review caught that WalkBuilder's
hidden(true) default silently excluded them, fixed with a pinning test (dotfiles_are_included).
Evidence: tests walk_produces_one_row_per_file, dotfiles_are_included,
gitignored_files_are_excluded (src/inventory.rs).

### 2. Non-SCIP files present with lang = None, per-file lang from ext mapping

Per-file `lang` comes from the new `lang_for_ext` (src/inventory.rs:22), a flat ext-to-SCIP-tag
map -- NOT from `detect_languages`, which is repo-level marker sniffing and cannot classify
individual files. `.sh`/`.md`/`.toml`/`.yaml`/`.css` all return None and land as inventory rows
with lang NULL.
Evidence: tests sh_and_md_have_no_lang, lang_for_ext_unknown_returns_none.

### 3. Docs-only repo gets a populated inventory instead of an error

`handle_index` previously hard-errored when `detect_languages` returned empty; the guard is now
an eprintln + skip of the SCIP block only, and the inventory walk runs unconditionally after it.
The "markers present but every indexer failed" case still hard-errors inside the else arm, so
the relaxation does not swallow real indexing failures.
Evidence: test docs_only_repo_produces_inventory; the restructured guard in
src/cli/index_cmd.rs handle_index.

### 4. Re-index is idempotent; deleted files are pruned

Upsert is keyed ON CONFLICT(repo, path) DO UPDATE, so re-running mutates metadata in place.
After each walk, `prune_file_inventory` deletes rows whose path is absent from the live set --
via a temp table rather than NOT IN (?,...), specifically to dodge SQLite's bound-variable
limit on large repos. During review, the branch's original claim that the ignore crate skips
`.git/` by itself was empirically DISPROVEN (a regression test showed .git/objects entering
the walk once hidden(false) is set); fixed with an explicit filter_entry in commit
"fix(#705): exclude .git explicitly", test git_dir_is_excluded_even_with_hidden_false.
Evidence: db tests in src/db/inventory.rs covering upsert-idempotence and prune; test
git_dir_is_excluded_even_with_hidden_false.

### 5. Tests pass; simplify + review done; PR linked

1175 unit tests pass (18 in inventory modules) with clippy -D warnings and fmt clean. The 4
failing integration tests in tests/integration/worksource_pr.rs are the pre-existing 1Password
signing environment issue, identical on main. Simplify gate recorded clean on HEAD
(019f2088-983b, 1 finding: the .git exclusion, fixed in-branch).

## Not done

- `symbol_count` population from SCIP blobs -- deferred to E6/E7 per the issue's Out of Scope;
  every row lands with symbol_count = 0.
- The read API (`list_file_inventory` / `InventoryFilter`) ships #[allow(dead_code)]-gated:
  its consumers are #706 (sym tree) and #709 (find-file), which remove the gate.
- No incremental single-file inventory update on `legion index --file` -- the full walk is
  cheap (one readdir pass) and runs on the existing repo-level path; per-file incrementalism
  can follow if telemetry shows index latency pain.

Closes #705.