### PR TITLE
feat(#707): sym etc find-content -- exact content search via ripgrep crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -260,6 +260,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cee35f73844aa3014bb606320a6c1f010249dbdf43342fe54b5a4f6a8ed4b79"
+dependencies = [
+ "memchr",
+ "regex-automata",
+ "serde_core",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -718,6 +729,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "encoding_rs_io"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cc3c5651fb62ab8aa3103998dade57efdd028544bd300516baa31840c252a83"
+dependencies = [
+ "encoding_rs",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -975,6 +995,56 @@ dependencies = [
  "r-efi 6.0.0",
  "wasip2",
  "wasip3",
+]
+
+[[package]]
+name = "globset"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52dfc19153a48bde0cbd630453615c8151bce3a5adfac7a0aebfbf0a1e1f57e3"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "grep-matcher"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36d7b71093325ab22d780b40d7df3066ae4aebb518ba719d38c697a8228a8023"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "grep-regex"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce0c256c3ad82bcc07b812c15a45ec1d398122e8e15124f96695234db7112ef"
+dependencies = [
+ "bstr",
+ "grep-matcher",
+ "log",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "grep-searcher"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac63295322dc48ebb20a25348147905d816318888e64f531bfc2a2bc0577dc34"
+dependencies = [
+ "bstr",
+ "encoding_rs",
+ "encoding_rs_io",
+ "grep-matcher",
+ "log",
+ "memchr",
+ "memmap2",
 ]
 
 [[package]]
@@ -1357,6 +1427,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "ignore"
+version = "0.4.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe112b004901c62c2faa11f4f75e9864e0cc5af8da71c9115d184a3aa888749f"
+dependencies = [
+ "crossbeam-deque",
+ "globset",
+ "log",
+ "memchr",
+ "regex-automata",
+ "same-file",
+ "walkdir",
+ "winapi-util",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1481,8 +1567,11 @@ dependencies = [
  "clap",
  "directories",
  "dirs 5.0.1",
+ "grep-regex",
+ "grep-searcher",
  "hex",
  "hostname",
+ "ignore",
  "libc",
  "mime_guess",
  "model2vec-rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,14 @@ hostname = "0.4"
 # on Windows.
 portable-pty = "0.9"
 
+# sym etc find-content (#707): the ripgrep engine crates, in-process. Exact
+# content search over watched repos with gitignore + binary handling -- a
+# direct disk scan, deliberately NOT an index (tokenized indexes destroy
+# punctuation-heavy literals and go stale on git operations).
+grep-regex = "0.1"
+grep-searcher = "0.1"
+ignore = "0.4"
+
 # libc pulls in only on unix for killpg in call_plugin_inner's timeout arm.
 # Must stay AFTER all platform-independent deps -- TOML tables consume
 # every key until the next header, so listing it mid-file would leak the

--- a/src/cli/index_cmd.rs
+++ b/src/cli/index_cmd.rs
@@ -128,6 +128,10 @@ pub(crate) enum EtcShape {
         /// Treat the pattern as a literal string, not a regex
         #[arg(long)]
         fixed_strings: bool,
+        /// Search hidden files and directories (.github/, .claude/, dotfiles).
+        /// `.git/` stays excluded. Mirrors ripgrep's --hidden.
+        #[arg(long)]
+        hidden: bool,
         /// Emit results as a JSON array of ContentHit objects
         #[arg(long)]
         json: bool,
@@ -193,8 +197,9 @@ fn run_sym_etc(shape: EtcShape) -> error::Result<()> {
             repo,
             ext,
             fixed_strings,
+            hidden,
             json,
-        } => run_etc_find_content(&pattern, repo, ext, fixed_strings, json),
+        } => run_etc_find_content(&pattern, repo, ext, fixed_strings, hidden, json),
     }
 }
 
@@ -207,11 +212,20 @@ fn run_etc_find_content(
     repo: Option<String>,
     ext: Option<String>,
     fixed_strings: bool,
+    hidden: bool,
     json: bool,
 ) -> error::Result<()> {
     let base = data_dir()?;
     let watch_path = base.join("watch.toml");
     let all = watch::list_repos_in_config(&watch_path)?;
+    // An empty corpus must be loud: zero hits over zero repos is
+    // indistinguishable from "the pattern is not in your code".
+    if all.is_empty() {
+        return Err(error::LegionError::WatchConfig(
+            "no repos in watch.toml -- nothing to search. Add one with `legion watch add <name> <path>`."
+                .to_string(),
+        ));
+    }
     let repos: Vec<(String, std::path::PathBuf)> = match repo.as_deref() {
         Some(name) => {
             let entry = all.iter().find(|r| r.name == name).ok_or_else(|| {
@@ -231,6 +245,7 @@ fn run_etc_find_content(
         repos: &repos,
         ext: ext.as_deref(),
         fixed_strings,
+        include_hidden: hidden,
         max_file_size: etc::MAX_FILE_SIZE,
         max_hits: etc::MAX_HITS,
     };

--- a/src/cli/index_cmd.rs
+++ b/src/cli/index_cmd.rs
@@ -239,6 +239,9 @@ fn run_etc_find_content(
         hit_count: scan.as_ref().map_or(0, |(r, _)| r.hits.len() as u64),
         skipped_files: scan.as_ref().map_or(0, |(r, _)| r.skipped_files),
         error: scan.as_ref().err().map(|e| e.to_string()),
+        failed_repos: scan
+            .as_ref()
+            .map_or(0, |(r, _)| r.failed_repos.len() as u64),
     };
     if let Err(e) = telemetry::append_etc_usage(&usage) {
         eprintln!("[legion] etc usage telemetry write failed: {e}");

--- a/src/cli/index_cmd.rs
+++ b/src/cli/index_cmd.rs
@@ -7,7 +7,7 @@ use clap::Subcommand;
 
 use crate::cli::datadir::data_dir;
 use crate::cli::util::{open_db, open_db_and_index};
-use crate::{db, error, scip, sym, watch};
+use crate::{db, error, etc, scip, sym, telemetry, watch};
 
 #[derive(Subcommand)]
 pub(crate) enum SymAction {
@@ -77,6 +77,14 @@ pub(crate) enum SymAction {
         json: bool,
     },
 
+    /// Non-symbol answer surface (#704): query shapes over the files SCIP
+    /// does not parse (docs, configs, css, prose). `sym` answers symbol
+    /// questions; `sym etc` answers everything else.
+    Etc {
+        #[command(subcommand)]
+        shape: EtcShape,
+    },
+
     /// Enumerate the definitions in the index -- the "what functions/enums/etc.
     /// are defined here" query. Byte-cheap: names + locations, never source
     /// bodies. This is the shape `grep "fn "` was serving; use it instead.
@@ -95,6 +103,32 @@ pub(crate) enum SymAction {
         #[arg(long)]
         file: Option<String>,
         /// Emit results as a JSON array of SymbolEntry objects
+        #[arg(long)]
+        json: bool,
+    },
+}
+
+#[derive(Subcommand)]
+pub(crate) enum EtcShape {
+    /// Exact, line-accurate content search over watched repos -- the
+    /// sanctioned grep (#707). Direct disk scan: always fresh, true grep
+    /// parity including regex and punctuation-heavy literals.
+    FindContent {
+        /// Pattern to search: a regex by default, a literal with --fixed-strings.
+        /// Hyphen-leading patterns (`--spacing-0.5`) are accepted as values,
+        /// not parsed as flags -- they are a headline query shape (#707).
+        #[arg(allow_hyphen_values = true)]
+        pattern: String,
+        /// Restrict to a single repo (default: every repo in watch.toml)
+        #[arg(long)]
+        repo: Option<String>,
+        /// Restrict to files with this extension (without the dot)
+        #[arg(long)]
+        ext: Option<String>,
+        /// Treat the pattern as a literal string, not a regex
+        #[arg(long)]
+        fixed_strings: bool,
+        /// Emit results as a JSON array of ContentHit objects
         #[arg(long)]
         json: bool,
     },
@@ -146,7 +180,102 @@ fn run_sym_action(database: &db::Database, action: SymAction) -> error::Result<(
             file,
             json,
         } => run_sym_list(database, repo, lang, kind, file, json),
+        SymAction::Etc { shape } => run_sym_etc(shape),
     }
+}
+
+/// Dispatch `legion sym etc <shape>`. Unlike the symbol queries these do not
+/// read the SCIP store -- find-content scans watched workdirs directly.
+fn run_sym_etc(shape: EtcShape) -> error::Result<()> {
+    match shape {
+        EtcShape::FindContent {
+            pattern,
+            repo,
+            ext,
+            fixed_strings,
+            json,
+        } => run_etc_find_content(&pattern, repo, ext, fixed_strings, json),
+    }
+}
+
+/// `sym etc find-content` (#707): exact content search over watch.toml
+/// workdirs via the in-process ripgrep engine. Prints `path:line: text`
+/// (repo-prefixed when scanning cross-repo) or a JSON hit array; suppressed
+/// and skipped counts go to stderr so truncation is never silent.
+fn run_etc_find_content(
+    pattern: &str,
+    repo: Option<String>,
+    ext: Option<String>,
+    fixed_strings: bool,
+    json: bool,
+) -> error::Result<()> {
+    let base = data_dir()?;
+    let watch_path = base.join("watch.toml");
+    let all = watch::list_repos_in_config(&watch_path)?;
+    let repos: Vec<(String, std::path::PathBuf)> = match repo.as_deref() {
+        Some(name) => {
+            let entry = all.iter().find(|r| r.name == name).ok_or_else(|| {
+                error::LegionError::WatchConfig(format!(
+                    "repo '{name}' not in watch.toml. Add it with `legion watch add {name} <path>`."
+                ))
+            })?;
+            vec![(entry.name.clone(), std::path::PathBuf::from(&entry.workdir))]
+        }
+        None => all
+            .iter()
+            .map(|r| (r.name.clone(), std::path::PathBuf::from(&r.workdir)))
+            .collect(),
+    };
+
+    let scope = etc::ContentScope {
+        repos: &repos,
+        ext: ext.as_deref(),
+        fixed_strings,
+        max_file_size: etc::MAX_FILE_SIZE,
+        max_hits: etc::MAX_HITS,
+    };
+    let result = etc::find_content(pattern, &scope)?;
+
+    let usage = telemetry::EtcUsageRecord {
+        ts: chrono::Utc::now(),
+        command: "find-content".to_string(),
+        repo: repo.clone(),
+        pattern: pattern.to_string(),
+        fixed_strings,
+        hit_count: result.hits.len() as u64,
+        skipped_files: result.skipped_files,
+    };
+    if let Err(e) = telemetry::append_etc_usage(&usage) {
+        eprintln!("[legion] etc usage telemetry write failed: {e}");
+    }
+
+    if json {
+        println!("{}", serde_json::to_string(&result.hits)?);
+    } else {
+        let cross_repo = repo.is_none() && repos.len() > 1;
+        for hit in &result.hits {
+            if cross_repo {
+                println!("{}/{}:{}: {}", hit.repo, hit.path, hit.line, hit.text);
+            } else {
+                println!("{}:{}: {}", hit.path, hit.line, hit.text);
+            }
+        }
+    }
+    if result.suppressed > 0 {
+        eprintln!(
+            "[legion] {} more matches suppressed (cap {}); narrow with --repo/--ext or a tighter pattern",
+            result.suppressed,
+            etc::MAX_HITS
+        );
+    }
+    if result.skipped_files > 0 {
+        eprintln!(
+            "[legion] {} files skipped (unreadable or larger than {} bytes)",
+            result.skipped_files,
+            etc::MAX_FILE_SIZE
+        );
+    }
+    Ok(())
 }
 
 /// Enumerate definitions across the matching SCIP indexes (#558). Validates

--- a/src/cli/index_cmd.rs
+++ b/src/cli/index_cmd.rs
@@ -129,7 +129,10 @@ pub(crate) enum EtcShape {
         #[arg(long)]
         fixed_strings: bool,
         /// Search hidden files and directories (.github/, .claude/, dotfiles).
-        /// `.git/` stays excluded. Mirrors ripgrep's --hidden.
+        /// `.git/` stays excluded. Mirrors ripgrep's --hidden. NOTE: gitignore
+        /// is the only guard here -- a secret-bearing dotfile that is not
+        /// gitignored (e.g. an un-ignored .env) WILL be searched and its
+        /// matching lines printed.
         #[arg(long)]
         hidden: bool,
         /// Emit results as a JSON array of ContentHit objects
@@ -206,7 +209,10 @@ fn run_sym_etc(shape: EtcShape) -> error::Result<()> {
 /// `sym etc find-content` (#707): exact content search over watch.toml
 /// workdirs via the in-process ripgrep engine. Prints `path:line: text`
 /// (repo-prefixed when scanning cross-repo) or a JSON hit array; suppressed
-/// and skipped counts go to stderr so truncation is never silent.
+/// and skipped counts go to stderr so truncation is never silent. Telemetry
+/// records one row per COMPLETED search -- error exits (empty corpus,
+/// unknown repo, invalid regex) are argv failures, not zero-result events,
+/// and deliberately stay out of the epic's zero-result-rate denominator.
 fn run_etc_find_content(
     pattern: &str,
     repo: Option<String>,
@@ -226,18 +232,18 @@ fn run_etc_find_content(
                 .to_string(),
         ));
     }
-    let repos: Vec<(String, std::path::PathBuf)> = match repo.as_deref() {
+    let repos: Vec<(String, PathBuf)> = match repo.as_deref() {
         Some(name) => {
             let entry = all.iter().find(|r| r.name == name).ok_or_else(|| {
                 error::LegionError::WatchConfig(format!(
                     "repo '{name}' not in watch.toml. Add it with `legion watch add {name} <path>`."
                 ))
             })?;
-            vec![(entry.name.clone(), std::path::PathBuf::from(&entry.workdir))]
+            vec![(entry.name.clone(), PathBuf::from(&entry.workdir))]
         }
         None => all
             .iter()
-            .map(|r| (r.name.clone(), std::path::PathBuf::from(&r.workdir)))
+            .map(|r| (r.name.clone(), PathBuf::from(&r.workdir)))
             .collect(),
     };
 
@@ -732,7 +738,7 @@ fn run_index_status_banner(base: &std::path::Path, repo: Option<&str>) -> error:
             return Ok(());
         }
     };
-    let repo_path = std::path::PathBuf::from(&entry.workdir);
+    let repo_path = PathBuf::from(&entry.workdir);
     let detected = scip::detect_languages(&repo_path);
 
     let database = match db::Database::open(&base.join("legion.db")) {
@@ -1088,7 +1094,7 @@ pub(crate) fn handle_index(
             ));
         }
     };
-    let repo_path = std::path::PathBuf::from(&entry.workdir);
+    let repo_path = PathBuf::from(&entry.workdir);
 
     let langs = scip::detect_languages(&repo_path);
     if langs.is_empty() {

--- a/src/cli/index_cmd.rs
+++ b/src/cli/index_cmd.rs
@@ -208,11 +208,12 @@ fn run_sym_etc(shape: EtcShape) -> error::Result<()> {
 
 /// `sym etc find-content` (#707): exact content search over watch.toml
 /// workdirs via the in-process ripgrep engine. Prints `path:line: text`
-/// (repo-prefixed when scanning cross-repo) or a JSON hit array; suppressed
-/// and skipped counts go to stderr so truncation is never silent. Telemetry
-/// records one row per COMPLETED search -- error exits (empty corpus,
-/// unknown repo, invalid regex) are argv failures, not zero-result events,
-/// and deliberately stay out of the epic's zero-result-rate denominator.
+/// (repo-prefixed when scanning cross-repo) or a JSON hit array; suppressed,
+/// skipped, and binary counts go to stderr so truncation is never silent,
+/// and a repo whose workdir cannot be walked is named. Telemetry records one
+/// row per invocation -- error exits (empty corpus, unknown repo, invalid
+/// regex, unscannable corpus) carry the error text so the epic's metric can
+/// separate "tool answered zero" from "tool failed to answer" (#704).
 fn run_etc_find_content(
     pattern: &str,
     repo: Option<String>,
@@ -221,6 +222,78 @@ fn run_etc_find_content(
     hidden: bool,
     json: bool,
 ) -> error::Result<()> {
+    let scan = scan_etc_content(
+        pattern,
+        repo.as_deref(),
+        ext.as_deref(),
+        fixed_strings,
+        hidden,
+    );
+
+    let usage = telemetry::EtcUsageRecord {
+        ts: chrono::Utc::now(),
+        command: "find-content".to_string(),
+        repo: repo.clone(),
+        pattern: pattern.to_string(),
+        fixed_strings,
+        hit_count: scan.as_ref().map_or(0, |(r, _)| r.hits.len() as u64),
+        skipped_files: scan.as_ref().map_or(0, |(r, _)| r.skipped_files),
+        error: scan.as_ref().err().map(|e| e.to_string()),
+    };
+    if let Err(e) = telemetry::append_etc_usage(&usage) {
+        eprintln!("[legion] etc usage telemetry write failed: {e}");
+    }
+
+    let (result, repo_count) = scan?;
+    if json {
+        println!("{}", serde_json::to_string(&result.hits)?);
+    } else {
+        let cross_repo = repo.is_none() && repo_count > 1;
+        for hit in &result.hits {
+            if cross_repo {
+                println!("{}/{}:{}: {}", hit.repo, hit.path, hit.line, hit.text);
+            } else {
+                println!("{}:{}: {}", hit.path, hit.line, hit.text);
+            }
+        }
+    }
+    for (name, err) in &result.failed_repos {
+        eprintln!("[legion] repo '{name}' could not be scanned: {err}");
+    }
+    if result.suppressed > 0 {
+        eprintln!(
+            "[legion] {} more matches suppressed (cap {}); narrow with --repo/--ext or a tighter pattern",
+            result.suppressed,
+            etc::MAX_HITS
+        );
+    }
+    if result.skipped_files > 0 {
+        eprintln!(
+            "[legion] {} files skipped (unreadable or larger than {} bytes)",
+            result.skipped_files,
+            etc::MAX_FILE_SIZE
+        );
+    }
+    if result.binary_skipped > 0 {
+        eprintln!(
+            "[legion] {} binary files skipped (NUL byte found)",
+            result.binary_skipped
+        );
+    }
+    Ok(())
+}
+
+/// Resolve the scan scope from watch.toml and run the search. Split from
+/// `run_etc_find_content` so every exit -- including the loud errors below --
+/// funnels through the caller's telemetry write. Returns the result plus the
+/// number of repos scanned (for cross-repo output prefixing).
+fn scan_etc_content(
+    pattern: &str,
+    repo: Option<&str>,
+    ext: Option<&str>,
+    fixed_strings: bool,
+    hidden: bool,
+) -> error::Result<(etc::FindContentResult, usize)> {
     let base = data_dir()?;
     let watch_path = base.join("watch.toml");
     let all = watch::list_repos_in_config(&watch_path)?;
@@ -232,7 +305,7 @@ fn run_etc_find_content(
                 .to_string(),
         ));
     }
-    let repos: Vec<(String, PathBuf)> = match repo.as_deref() {
+    let repos: Vec<(String, PathBuf)> = match repo {
         Some(name) => {
             let entry = all.iter().find(|r| r.name == name).ok_or_else(|| {
                 error::LegionError::WatchConfig(format!(
@@ -249,54 +322,28 @@ fn run_etc_find_content(
 
     let scope = etc::ContentScope {
         repos: &repos,
-        ext: ext.as_deref(),
+        ext,
         fixed_strings,
         include_hidden: hidden,
         max_file_size: etc::MAX_FILE_SIZE,
         max_hits: etc::MAX_HITS,
     };
+    let repo_count = repos.len();
     let result = etc::find_content(pattern, &scope)?;
-
-    let usage = telemetry::EtcUsageRecord {
-        ts: chrono::Utc::now(),
-        command: "find-content".to_string(),
-        repo: repo.clone(),
-        pattern: pattern.to_string(),
-        fixed_strings,
-        hit_count: result.hits.len() as u64,
-        skipped_files: result.skipped_files,
-    };
-    if let Err(e) = telemetry::append_etc_usage(&usage) {
-        eprintln!("[legion] etc usage telemetry write failed: {e}");
+    // Every scoped repo failing to walk is the empty-corpus case in
+    // disguise: zero hits that mean "nothing was searched", not "no match".
+    if result.failed_repos.len() == repo_count {
+        let detail: Vec<String> = result
+            .failed_repos
+            .iter()
+            .map(|(name, err)| format!("{name}: {err}"))
+            .collect();
+        return Err(error::LegionError::Search(format!(
+            "no repo could be scanned -- {}. Fix the workdir(s) or `legion watch remove` stale entries.",
+            detail.join("; ")
+        )));
     }
-
-    if json {
-        println!("{}", serde_json::to_string(&result.hits)?);
-    } else {
-        let cross_repo = repo.is_none() && repos.len() > 1;
-        for hit in &result.hits {
-            if cross_repo {
-                println!("{}/{}:{}: {}", hit.repo, hit.path, hit.line, hit.text);
-            } else {
-                println!("{}:{}: {}", hit.path, hit.line, hit.text);
-            }
-        }
-    }
-    if result.suppressed > 0 {
-        eprintln!(
-            "[legion] {} more matches suppressed (cap {}); narrow with --repo/--ext or a tighter pattern",
-            result.suppressed,
-            etc::MAX_HITS
-        );
-    }
-    if result.skipped_files > 0 {
-        eprintln!(
-            "[legion] {} files skipped (unreadable or larger than {} bytes)",
-            result.skipped_files,
-            etc::MAX_FILE_SIZE
-        );
-    }
-    Ok(())
+    Ok((result, repo_count))
 }
 
 /// Enumerate definitions across the matching SCIP indexes (#558). Validates

--- a/src/etc.rs
+++ b/src/etc.rs
@@ -11,8 +11,7 @@
 use std::path::{Path, PathBuf};
 
 use grep_regex::RegexMatcherBuilder;
-use grep_searcher::sinks::Lossy;
-use grep_searcher::{BinaryDetection, SearcherBuilder};
+use grep_searcher::{BinaryDetection, Searcher, SearcherBuilder, Sink, SinkFinish, SinkMatch};
 use ignore::WalkBuilder;
 use serde::Serialize;
 
@@ -46,6 +45,61 @@ pub struct FindContentResult {
     pub suppressed: u64,
     /// Files skipped: unreadable, over `max_file_size`, or a walk error.
     pub skipped_files: u64,
+    /// Files skipped as binary (NUL byte found). Counted separately because
+    /// a binary quit returns Ok with no hits -- without this counter a text
+    /// file with an embedded NUL would silently vanish from the result.
+    pub binary_skipped: u64,
+    /// Repos whose root could not be walked at all: `(repo name, error)`.
+    /// A dead watch.toml workdir is a whole-corpus gap, not "one file
+    /// skipped" -- it must surface by name or a zero-hit scan lies.
+    pub failed_repos: Vec<(String, String)>,
+}
+
+/// Streaming sink that collects capped hits and, unlike the closure sinks in
+/// `grep_searcher::sinks`, observes `SinkFinish::binary_byte_offset` -- the
+/// only signal that a search quit early on binary content (the search itself
+/// returns Ok in that case).
+struct CollectSink<'a> {
+    repo: &'a str,
+    rel: &'a str,
+    max_hits: usize,
+    hits: &'a mut Vec<ContentHit>,
+    suppressed: &'a mut u64,
+    binary: bool,
+}
+
+impl Sink for CollectSink<'_> {
+    type Error = std::io::Error;
+
+    fn matched(
+        &mut self,
+        _searcher: &Searcher,
+        mat: &SinkMatch<'_>,
+    ) -> std::result::Result<bool, Self::Error> {
+        if self.hits.len() < self.max_hits {
+            let text = String::from_utf8_lossy(mat.bytes());
+            self.hits.push(ContentHit {
+                repo: self.repo.to_string(),
+                path: self.rel.to_string(),
+                // line_number(true) is set on the searcher, so this is
+                // always Some; 0 would mean a searcher misconfiguration.
+                line: mat.line_number().unwrap_or(0),
+                text: text.trim_end_matches(['\n', '\r']).to_string(),
+            });
+        } else {
+            *self.suppressed += 1;
+        }
+        Ok(true)
+    }
+
+    fn finish(
+        &mut self,
+        _searcher: &Searcher,
+        finish: &SinkFinish,
+    ) -> std::result::Result<(), Self::Error> {
+        self.binary = finish.binary_byte_offset().is_some();
+        Ok(())
+    }
 }
 
 /// Where and how to scan.
@@ -74,10 +128,14 @@ pub struct ContentScope<'a> {
 /// unless `include_hidden` is set (ripgrep's `--hidden` semantics; the
 /// `ignore` crate does NOT skip `.git/` on its own once hidden files are
 /// admitted -- verified empirically in #705's twin walk -- so `.git` is
-/// excluded explicitly), and quits on binary content. Non-UTF-8 text files
-/// are searched lossily (invalid bytes become U+FFFD) rather than skipped --
-/// grep matches them, so we must too. Per-file errors are counted and
-/// skipped, never fatal: one unreadable file must not abort orientation.
+/// excluded explicitly), and quits on binary content (a NUL byte), counting
+/// the file in `binary_skipped` -- the quit itself returns Ok, so without
+/// that counter a text file with an embedded NUL would vanish silently.
+/// Non-UTF-8 text files are searched lossily (invalid bytes become U+FFFD)
+/// rather than skipped -- grep matches them, so we must too. Per-file errors
+/// are counted and skipped, never fatal: one unreadable file must not abort
+/// orientation; a repo root that cannot be walked at all is reported by name
+/// in `failed_repos`.
 pub fn find_content(pattern: &str, scope: &ContentScope<'_>) -> Result<FindContentResult> {
     let matcher = RegexMatcherBuilder::new()
         .line_terminator(Some(b'\n'))
@@ -112,8 +170,17 @@ pub fn find_content(pattern: &str, scope: &ContentScope<'_>) -> Result<FindConte
         for entry in walker {
             let entry = match entry {
                 Ok(e) => e,
-                Err(_) => {
-                    result.skipped_files += 1;
+                Err(err) => {
+                    // depth 0 = the repo root itself failed (moved, deleted,
+                    // unreadable): a whole-corpus gap reported by name, not
+                    // folded into the per-file skip counter.
+                    if err.depth() == Some(0) {
+                        result
+                            .failed_repos
+                            .push((repo_name.clone(), err.to_string()));
+                    } else {
+                        result.skipped_files += 1;
+                    }
                     continue;
                 }
             };
@@ -139,28 +206,26 @@ pub fn find_content(pattern: &str, scope: &ContentScope<'_>) -> Result<FindConte
             }
             let rel = relative_path(path, workdir);
             let hits_before = result.hits.len();
-            let search = searcher.search_path(
-                &matcher,
-                path,
-                Lossy(|line_number, line| {
-                    if result.hits.len() < scope.max_hits {
-                        result.hits.push(ContentHit {
-                            repo: repo_name.clone(),
-                            path: rel.clone(),
-                            line: line_number,
-                            text: line.trim_end_matches(['\n', '\r']).to_string(),
-                        });
-                    } else {
-                        result.suppressed += 1;
-                    }
-                    Ok(true)
-                }),
-            );
+            let (search_failed, binary) = {
+                let mut sink = CollectSink {
+                    repo: repo_name,
+                    rel: &rel,
+                    max_hits: scope.max_hits,
+                    hits: &mut result.hits,
+                    suppressed: &mut result.suppressed,
+                    binary: false,
+                };
+                let search = searcher.search_path(&matcher, path, &mut sink);
+                (search.is_err(), sink.binary)
+            };
+            if binary {
+                result.binary_skipped += 1;
+            }
             // A mid-file error after hits were already emitted (mutating
             // workdir, dropped mount) must not count the file as "skipped"
             // -- its partial matches are in the output. Only a file that
             // produced nothing before erroring was truly skipped.
-            if search.is_err() && result.hits.len() == hits_before {
+            if search_failed && result.hits.len() == hits_before {
                 result.skipped_files += 1;
             }
         }
@@ -312,7 +377,7 @@ mod tests {
     }
 
     #[test]
-    fn binary_files_are_not_searched() {
+    fn binary_files_are_not_searched_but_are_counted() {
         let dir = tempfile::tempdir().expect("tempdir");
         std::fs::write(dir.path().join("blob.bin"), b"needle\x00needle\n").expect("write fixture");
         write(dir.path(), "plain.txt", "needle\n");
@@ -320,6 +385,50 @@ mod tests {
         let result = find_content("needle", &scope(&repos)).expect("search");
         assert_eq!(result.hits.len(), 1);
         assert_eq!(result.hits[0].path, "plain.txt");
+        assert_eq!(result.binary_skipped, 1);
+    }
+
+    /// Regression guard (#719 review, HIGH): a text file whose MATCHING lines
+    /// precede an embedded NUL is treated as binary -- the search quits with
+    /// Ok and emits nothing. Without binary_skipped that file would vanish
+    /// from hits, skipped_files, and suppressed alike: an undetectable false
+    /// negative.
+    #[test]
+    fn matches_before_embedded_nul_are_not_silently_lost() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::write(
+            dir.path().join("mixed.txt"),
+            b"needle on line one\nfiller\n\x00 trailing binary blob",
+        )
+        .expect("write fixture");
+        let repos = one_repo(dir.path());
+        let result = find_content("needle", &scope(&repos)).expect("search");
+        // The match is quit away by binary detection -- that is grep parity
+        // (rg skips binary files in a directory walk too). What must NOT
+        // happen is silence: the file is accounted for in binary_skipped.
+        assert!(result.hits.is_empty());
+        assert_eq!(result.binary_skipped, 1);
+        assert_eq!(result.skipped_files, 0);
+    }
+
+    /// Regression guard (#719 review, MED): a repo whose workdir is gone is a
+    /// whole-corpus gap reported by name, not "1 files skipped".
+    #[test]
+    fn dead_repo_root_is_reported_by_name_not_as_a_skipped_file() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write(dir.path(), "ok.txt", "needle\n");
+        let repos = vec![
+            ("alive".to_string(), dir.path().to_path_buf()),
+            (
+                "ghost".to_string(),
+                PathBuf::from("/nonexistent/legion-test-ghost-repo"),
+            ),
+        ];
+        let result = find_content("needle", &scope(&repos)).expect("search");
+        assert_eq!(result.hits.len(), 1);
+        assert_eq!(result.skipped_files, 0);
+        assert_eq!(result.failed_repos.len(), 1);
+        assert_eq!(result.failed_repos[0].0, "ghost");
     }
 
     #[test]

--- a/src/etc.rs
+++ b/src/etc.rs
@@ -1,0 +1,297 @@
+//! `sym etc` -- the non-symbol answer surface (#704).
+//!
+//! find-content (#707) is an exact, line-accurate content search over watched
+//! repos, built on the ripgrep engine crates (grep-searcher + grep-regex +
+//! ignore). It is a direct disk scan at query time, deliberately NOT an
+//! index: a tokenized index returns nothing on punctuation-heavy literals
+//! (`<<<<<<<`, `--spacing-0.5`), and any content corpus goes stale on git
+//! operations that fire no edit hooks. Scanning the working tree gives grep
+//! parity and freshness by construction.
+
+use std::path::{Path, PathBuf};
+
+use grep_regex::RegexMatcherBuilder;
+use grep_searcher::sinks::UTF8;
+use grep_searcher::{BinaryDetection, SearcherBuilder};
+use ignore::WalkBuilder;
+use serde::Serialize;
+
+use crate::error::{LegionError, Result};
+
+/// Files larger than this are skipped and counted: lockfiles and generated
+/// blobs flood output without answering orientation queries.
+pub const MAX_FILE_SIZE: u64 = 2 * 1024 * 1024;
+
+/// Hard cap on returned hits; the CLI reports the suppressed count so
+/// truncation is never silent.
+pub const MAX_HITS: usize = 500;
+
+/// One matching line.
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct ContentHit {
+    pub repo: String,
+    /// Repo-relative path.
+    pub path: String,
+    pub line: u64,
+    /// The matching line, without its terminator.
+    pub text: String,
+}
+
+/// Everything a scan produced, including what it did not return: matches
+/// beyond the cap and files it could not or would not read.
+#[derive(Debug, Default)]
+pub struct FindContentResult {
+    pub hits: Vec<ContentHit>,
+    /// Matches found beyond `max_hits` (counted, not returned).
+    pub suppressed: u64,
+    /// Files skipped: unreadable, over `max_file_size`, or a walk error.
+    pub skipped_files: u64,
+}
+
+/// Where and how to scan.
+pub struct ContentScope<'a> {
+    /// `(repo name, workdir)` pairs, from watch.toml.
+    pub repos: &'a [(String, PathBuf)],
+    /// Restrict to one file extension (without the dot).
+    pub ext: Option<&'a str>,
+    /// Treat the pattern as a literal string instead of a regex.
+    pub fixed_strings: bool,
+    pub max_file_size: u64,
+    pub max_hits: usize,
+}
+
+/// Scan every scoped repo for `pattern` and return line-accurate hits,
+/// sorted by (repo, path, line) for deterministic output.
+///
+/// The walk respects `.gitignore` (even outside a git checkout -- watched
+/// workdirs are the corpus, not arbitrary directories), skips hidden files,
+/// and quits on binary content. Per-file errors are counted and skipped,
+/// never fatal: one unreadable file must not abort orientation.
+pub fn find_content(pattern: &str, scope: &ContentScope<'_>) -> Result<FindContentResult> {
+    let matcher = RegexMatcherBuilder::new()
+        .line_terminator(Some(b'\n'))
+        .fixed_strings(scope.fixed_strings)
+        .build(pattern)
+        .map_err(|e| LegionError::Search(format!("invalid regex '{pattern}': {e}")))?;
+
+    let mut searcher = SearcherBuilder::new()
+        .binary_detection(BinaryDetection::quit(0))
+        .line_number(true)
+        .build();
+
+    let mut result = FindContentResult::default();
+    for (repo_name, workdir) in scope.repos {
+        // require_git(false): honor .gitignore in the workdir whether or not
+        // the walk starts inside a recognized git checkout (worktrees, tests).
+        let walker = WalkBuilder::new(workdir).require_git(false).build();
+        for entry in walker {
+            let entry = match entry {
+                Ok(e) => e,
+                Err(_) => {
+                    result.skipped_files += 1;
+                    continue;
+                }
+            };
+            if !entry.file_type().is_some_and(|t| t.is_file()) {
+                continue;
+            }
+            let path = entry.path();
+            if let Some(ext) = scope.ext
+                && path.extension().and_then(|e| e.to_str()) != Some(ext)
+            {
+                continue;
+            }
+            match entry.metadata() {
+                Ok(md) if md.len() > scope.max_file_size => {
+                    result.skipped_files += 1;
+                    continue;
+                }
+                Err(_) => {
+                    result.skipped_files += 1;
+                    continue;
+                }
+                Ok(_) => {}
+            }
+            let rel = relative_path(path, workdir);
+            let search = searcher.search_path(
+                &matcher,
+                path,
+                UTF8(|line_number, line| {
+                    if result.hits.len() < scope.max_hits {
+                        result.hits.push(ContentHit {
+                            repo: repo_name.clone(),
+                            path: rel.clone(),
+                            line: line_number,
+                            text: line.trim_end_matches(['\n', '\r']).to_string(),
+                        });
+                    } else {
+                        result.suppressed += 1;
+                    }
+                    Ok(true)
+                }),
+            );
+            if search.is_err() {
+                result.skipped_files += 1;
+            }
+        }
+    }
+    result
+        .hits
+        .sort_by(|a, b| (&a.repo, &a.path, a.line).cmp(&(&b.repo, &b.path, b.line)));
+    Ok(result)
+}
+
+fn relative_path(path: &Path, workdir: &Path) -> String {
+    path.strip_prefix(workdir)
+        .unwrap_or(path)
+        .to_string_lossy()
+        .into_owned()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn write(dir: &Path, name: &str, content: &str) {
+        let path = dir.join(name);
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).expect("create parent");
+        }
+        std::fs::write(path, content).expect("write fixture");
+    }
+
+    fn scope<'a>(repos: &'a [(String, PathBuf)]) -> ContentScope<'a> {
+        ContentScope {
+            repos,
+            ext: None,
+            fixed_strings: false,
+            max_file_size: MAX_FILE_SIZE,
+            max_hits: MAX_HITS,
+        }
+    }
+
+    fn one_repo(dir: &Path) -> Vec<(String, PathBuf)> {
+        vec![("test".to_string(), dir.to_path_buf())]
+    }
+
+    #[test]
+    fn conflict_marker_literal_matches_with_line_number() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write(
+            dir.path(),
+            "a.rs",
+            "fn main() {}\nlet x = 1;\n<<<<<<< HEAD\n",
+        );
+        let repos = one_repo(dir.path());
+        let mut sc = scope(&repos);
+        sc.fixed_strings = true;
+        let result = find_content("<<<<<<<", &sc).expect("search");
+        assert_eq!(result.hits.len(), 1);
+        assert_eq!(result.hits[0].path, "a.rs");
+        assert_eq!(result.hits[0].line, 3);
+        assert_eq!(result.hits[0].text, "<<<<<<< HEAD");
+    }
+
+    #[test]
+    fn fixed_strings_treats_dot_literally() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write(
+            dir.path(),
+            "b.css",
+            "--spacing-0.5: 4px;\n--spacing-0X5: 5px;\n",
+        );
+        let repos = one_repo(dir.path());
+        let mut sc = scope(&repos);
+        sc.fixed_strings = true;
+        let result = find_content("--spacing-0.5", &sc).expect("search");
+        assert_eq!(result.hits.len(), 1);
+        assert_eq!(result.hits[0].text, "--spacing-0.5: 4px;");
+
+        // Same pattern as a regex matches both lines: '.' is a wildcard.
+        sc.fixed_strings = false;
+        let result = find_content("--spacing-0.5", &sc).expect("search");
+        assert_eq!(result.hits.len(), 2);
+    }
+
+    #[test]
+    fn regex_mode_matches_alternation() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write(dir.path(), "m.rs", "fn run_alpha() {}\nfn run_gamma() {}\n");
+        let repos = one_repo(dir.path());
+        let result = find_content("run_(alpha|beta)", &scope(&repos)).expect("search");
+        assert_eq!(result.hits.len(), 1);
+        assert_eq!(result.hits[0].line, 1);
+    }
+
+    #[test]
+    fn invalid_regex_is_a_loud_error() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let repos = one_repo(dir.path());
+        let err = find_content("(unclosed", &scope(&repos));
+        assert!(matches!(err, Err(LegionError::Search(_))));
+    }
+
+    #[test]
+    fn gitignore_is_respected() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write(dir.path(), ".gitignore", "ignored.txt\n");
+        write(dir.path(), "ignored.txt", "needle\n");
+        write(dir.path(), "kept.txt", "needle\n");
+        let repos = one_repo(dir.path());
+        let result = find_content("needle", &scope(&repos)).expect("search");
+        assert_eq!(result.hits.len(), 1);
+        assert_eq!(result.hits[0].path, "kept.txt");
+    }
+
+    #[test]
+    fn oversized_files_are_skipped_and_counted() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write(dir.path(), "big.txt", "needle in a large file\n");
+        let repos = one_repo(dir.path());
+        let mut sc = scope(&repos);
+        sc.max_file_size = 4;
+        let result = find_content("needle", &sc).expect("search");
+        assert!(result.hits.is_empty());
+        assert_eq!(result.skipped_files, 1);
+    }
+
+    #[test]
+    fn hit_cap_counts_suppressed_matches() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write(dir.path(), "many.txt", "hit\nhit\nhit\nhit\nhit\n");
+        let repos = one_repo(dir.path());
+        let mut sc = scope(&repos);
+        sc.max_hits = 2;
+        let result = find_content("hit", &sc).expect("search");
+        assert_eq!(result.hits.len(), 2);
+        assert_eq!(result.suppressed, 3);
+    }
+
+    #[test]
+    fn ext_filter_scopes_the_walk() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write(dir.path(), "a.rs", "needle\n");
+        write(dir.path(), "b.md", "needle\n");
+        let repos = one_repo(dir.path());
+        let mut sc = scope(&repos);
+        sc.ext = Some("md");
+        let result = find_content("needle", &sc).expect("search");
+        assert_eq!(result.hits.len(), 1);
+        assert_eq!(result.hits[0].path, "b.md");
+    }
+
+    #[test]
+    fn cross_repo_hits_carry_repo_and_sort_deterministically() {
+        let dir_a = tempfile::tempdir().expect("tempdir");
+        let dir_b = tempfile::tempdir().expect("tempdir");
+        write(dir_a.path(), "z.txt", "needle\n");
+        write(dir_b.path(), "a.txt", "needle\n");
+        let repos = vec![
+            ("beta".to_string(), dir_b.path().to_path_buf()),
+            ("alpha".to_string(), dir_a.path().to_path_buf()),
+        ];
+        let result = find_content("needle", &scope(&repos)).expect("search");
+        let repos_seen: Vec<&str> = result.hits.iter().map(|h| h.repo.as_str()).collect();
+        assert_eq!(repos_seen, vec!["alpha", "beta"]);
+    }
+}

--- a/src/etc.rs
+++ b/src/etc.rs
@@ -236,11 +236,14 @@ pub fn find_content(pattern: &str, scope: &ContentScope<'_>) -> Result<FindConte
     Ok(result)
 }
 
+/// Repo-relative path with forward-slash separators on every platform,
+/// matching the inventory walk's convention (#705) so the two surfaces
+/// never disagree about the same file.
 fn relative_path(path: &Path, workdir: &Path) -> String {
     path.strip_prefix(workdir)
         .unwrap_or(path)
         .to_string_lossy()
-        .into_owned()
+        .replace('\\', "/")
 }
 
 #[cfg(test)]

--- a/src/etc.rs
+++ b/src/etc.rs
@@ -91,7 +91,14 @@ pub fn find_content(pattern: &str, scope: &ContentScope<'_>) -> Result<FindConte
         .build();
 
     let mut result = FindContentResult::default();
-    for (repo_name, workdir) in scope.repos {
+    // Scan repos in name order: the hit cap truncates in scan order while
+    // output is sorted by (repo, path, line), so an unsorted scan could
+    // leave an alphabetically-earlier repo looking empty when a later one
+    // filled the cap first. The per-repo walk is already name-sorted, so
+    // sorting the (small) repo list makes scan order equal output order.
+    let mut repos: Vec<&(String, PathBuf)> = scope.repos.iter().collect();
+    repos.sort_by(|a, b| a.0.cmp(&b.0));
+    for (repo_name, workdir) in repos {
         // require_git(false): honor .gitignore in the workdir whether or not
         // the walk starts inside a recognized git checkout (worktrees, tests).
         // sort_by_file_name: readdir order is filesystem-dependent; without a
@@ -131,6 +138,7 @@ pub fn find_content(pattern: &str, scope: &ContentScope<'_>) -> Result<FindConte
                 Ok(_) => {}
             }
             let rel = relative_path(path, workdir);
+            let hits_before = result.hits.len();
             let search = searcher.search_path(
                 &matcher,
                 path,
@@ -148,7 +156,11 @@ pub fn find_content(pattern: &str, scope: &ContentScope<'_>) -> Result<FindConte
                     Ok(true)
                 }),
             );
-            if search.is_err() {
+            // A mid-file error after hits were already emitted (mutating
+            // workdir, dropped mount) must not count the file as "skipped"
+            // -- its partial matches are in the output. Only a file that
+            // produced nothing before erroring was truly skipped.
+            if search.is_err() && result.hits.len() == hits_before {
                 result.skipped_files += 1;
             }
         }

--- a/src/etc.rs
+++ b/src/etc.rs
@@ -11,7 +11,7 @@
 use std::path::{Path, PathBuf};
 
 use grep_regex::RegexMatcherBuilder;
-use grep_searcher::sinks::UTF8;
+use grep_searcher::sinks::Lossy;
 use grep_searcher::{BinaryDetection, SearcherBuilder};
 use ignore::WalkBuilder;
 use serde::Serialize;
@@ -56,17 +56,28 @@ pub struct ContentScope<'a> {
     pub ext: Option<&'a str>,
     /// Treat the pattern as a literal string instead of a regex.
     pub fixed_strings: bool,
+    /// Search hidden files and directories (`.github/`, `.claude/`, dotfile
+    /// configs). Off by default to match ripgrep; `.git/` stays excluded
+    /// even when enabled.
+    pub include_hidden: bool,
     pub max_file_size: u64,
     pub max_hits: usize,
 }
 
 /// Scan every scoped repo for `pattern` and return line-accurate hits,
-/// sorted by (repo, path, line) for deterministic output.
+/// sorted by (repo, path, line) for deterministic output. The walk itself is
+/// name-sorted so the subset kept under `max_hits` is also deterministic,
+/// not readdir-order roulette.
 ///
 /// The walk respects `.gitignore` (even outside a git checkout -- watched
-/// workdirs are the corpus, not arbitrary directories), skips hidden files,
-/// and quits on binary content. Per-file errors are counted and skipped,
-/// never fatal: one unreadable file must not abort orientation.
+/// workdirs are the corpus, not arbitrary directories), skips hidden files
+/// unless `include_hidden` is set (ripgrep's `--hidden` semantics; the
+/// `ignore` crate does NOT skip `.git/` on its own once hidden files are
+/// admitted -- verified empirically in #705's twin walk -- so `.git` is
+/// excluded explicitly), and quits on binary content. Non-UTF-8 text files
+/// are searched lossily (invalid bytes become U+FFFD) rather than skipped --
+/// grep matches them, so we must too. Per-file errors are counted and
+/// skipped, never fatal: one unreadable file must not abort orientation.
 pub fn find_content(pattern: &str, scope: &ContentScope<'_>) -> Result<FindContentResult> {
     let matcher = RegexMatcherBuilder::new()
         .line_terminator(Some(b'\n'))
@@ -83,7 +94,14 @@ pub fn find_content(pattern: &str, scope: &ContentScope<'_>) -> Result<FindConte
     for (repo_name, workdir) in scope.repos {
         // require_git(false): honor .gitignore in the workdir whether or not
         // the walk starts inside a recognized git checkout (worktrees, tests).
-        let walker = WalkBuilder::new(workdir).require_git(false).build();
+        // sort_by_file_name: readdir order is filesystem-dependent; without a
+        // sorted walk the subset kept under max_hits varies across machines.
+        let walker = WalkBuilder::new(workdir)
+            .require_git(false)
+            .hidden(!scope.include_hidden)
+            .filter_entry(|entry| entry.file_name() != ".git")
+            .sort_by_file_name(std::ffi::OsStr::cmp)
+            .build();
         for entry in walker {
             let entry = match entry {
                 Ok(e) => e,
@@ -116,7 +134,7 @@ pub fn find_content(pattern: &str, scope: &ContentScope<'_>) -> Result<FindConte
             let search = searcher.search_path(
                 &matcher,
                 path,
-                UTF8(|line_number, line| {
+                Lossy(|line_number, line| {
                     if result.hits.len() < scope.max_hits {
                         result.hits.push(ContentHit {
                             repo: repo_name.clone(),
@@ -165,6 +183,7 @@ mod tests {
             repos,
             ext: None,
             fixed_strings: false,
+            include_hidden: false,
             max_file_size: MAX_FILE_SIZE,
             max_hits: MAX_HITS,
         }
@@ -278,6 +297,71 @@ mod tests {
         let result = find_content("needle", &sc).expect("search");
         assert_eq!(result.hits.len(), 1);
         assert_eq!(result.hits[0].path, "b.md");
+    }
+
+    #[test]
+    fn binary_files_are_not_searched() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::write(dir.path().join("blob.bin"), b"needle\x00needle\n").expect("write fixture");
+        write(dir.path(), "plain.txt", "needle\n");
+        let repos = one_repo(dir.path());
+        let result = find_content("needle", &scope(&repos)).expect("search");
+        assert_eq!(result.hits.len(), 1);
+        assert_eq!(result.hits[0].path, "plain.txt");
+    }
+
+    #[test]
+    fn non_utf8_text_is_searched_lossily_not_skipped() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        // Latin-1 "café needle": 0xE9 is invalid UTF-8. grep matches this
+        // file; the lossy sink must too, instead of erroring mid-file.
+        std::fs::write(dir.path().join("latin1.txt"), b"caf\xe9 needle\n").expect("write fixture");
+        let repos = one_repo(dir.path());
+        let result = find_content("needle", &scope(&repos)).expect("search");
+        assert_eq!(result.hits.len(), 1);
+        assert_eq!(result.skipped_files, 0);
+        assert!(result.hits[0].text.contains("needle"));
+    }
+
+    #[test]
+    fn hidden_files_are_skipped() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write(dir.path(), ".hidden.txt", "needle\n");
+        write(dir.path(), "seen.txt", "needle\n");
+        let repos = one_repo(dir.path());
+        let result = find_content("needle", &scope(&repos)).expect("search");
+        assert_eq!(result.hits.len(), 1);
+        assert_eq!(result.hits[0].path, "seen.txt");
+    }
+
+    #[test]
+    fn include_hidden_searches_dotfiles_but_never_git_dir() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write(dir.path(), ".github/workflows/ci.yml", "needle\n");
+        write(dir.path(), ".git/config", "needle\n");
+        write(dir.path(), "seen.txt", "needle\n");
+        let repos = one_repo(dir.path());
+        let mut sc = scope(&repos);
+        sc.include_hidden = true;
+        let result = find_content("needle", &sc).expect("search");
+        let paths: Vec<&str> = result.hits.iter().map(|h| h.path.as_str()).collect();
+        assert_eq!(paths, vec![".github/workflows/ci.yml", "seen.txt"]);
+    }
+
+    #[test]
+    fn capped_subset_is_walk_order_deterministic() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write(dir.path(), "a.txt", "hit\nhit\nhit\n");
+        write(dir.path(), "z.txt", "hit\nhit\nhit\n");
+        let repos = one_repo(dir.path());
+        let mut sc = scope(&repos);
+        sc.max_hits = 3;
+        // The walk is name-sorted, so the kept subset is exactly a.txt's
+        // three hits regardless of readdir order.
+        let result = find_content("hit", &sc).expect("search");
+        assert_eq!(result.hits.len(), 3);
+        assert!(result.hits.iter().all(|h| h.path == "a.txt"));
+        assert_eq!(result.suppressed, 3);
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ mod db;
 mod documents;
 mod embed;
 mod error;
+mod etc;
 mod gate_trust;
 mod health;
 mod init;

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -85,6 +85,12 @@ pub struct EtcUsageRecord {
     pub fixed_strings: bool,
     pub hit_count: u64,
     pub skipped_files: u64,
+    /// Error text when the invocation failed before or during the scan
+    /// (invalid regex, unknown repo, empty or unscannable corpus). `None` on
+    /// success. Lets the #704 metric separate "tool answered zero" from
+    /// "tool failed to answer"; defaulted so pre-#719 rows still parse.
+    #[serde(default)]
+    pub error: Option<String>,
 }
 
 /// Resolve the canonical etc-usage log path (sibling of `bypass.jsonl`).
@@ -302,11 +308,35 @@ mod tests {
             fixed_strings: true,
             hit_count: 3,
             skipped_files: 1,
+            error: None,
         };
         append_jsonl(&path, &rec).unwrap();
         let raw = std::fs::read_to_string(&path).unwrap();
         let parsed: EtcUsageRecord = serde_json::from_str(raw.trim()).unwrap();
         assert_eq!(parsed, rec);
+    }
+
+    /// Pre-#719 rows have no `error` key; the serde default must keep them
+    /// parseable, and an error row must round-trip its text.
+    #[test]
+    fn etc_usage_error_field_defaults_and_round_trips() {
+        let legacy = r#"{"ts":"2026-07-02T01:01:32Z","command":"find-content","repo":null,"pattern":"x","fixed_strings":false,"hit_count":0,"skipped_files":0}"#;
+        let parsed: EtcUsageRecord = serde_json::from_str(legacy).unwrap();
+        assert_eq!(parsed.error, None);
+
+        let rec = EtcUsageRecord {
+            ts: Utc::now(),
+            command: "find-content".to_string(),
+            repo: None,
+            pattern: "(unclosed".to_string(),
+            fixed_strings: false,
+            hit_count: 0,
+            skipped_files: 0,
+            error: Some("invalid regex '(unclosed': ...".to_string()),
+        };
+        let json = serde_json::to_string(&rec).unwrap();
+        let back: EtcUsageRecord = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, rec);
     }
 
     #[cfg(unix)]

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -67,12 +67,40 @@ fn bypass_log_dir() -> PathBuf {
 /// filesystems because each record is a single short JSON line followed by a
 /// newline; concurrent writers will not interleave bytes.
 pub fn append_bypass(record: &BypassRecord) -> Result<()> {
-    append_bypass_to(&bypass_log_path(), record)
+    append_jsonl(&bypass_log_path(), record)
 }
 
-/// Test-friendly variant: write to an explicit path instead of the resolved
-/// XDG location.
-fn append_bypass_to(path: &std::path::Path, record: &BypassRecord) -> Result<()> {
+/// One row in `etc-usage.jsonl` (#707): a sanctioned `sym etc` / `sym tree`
+/// query. The counterpart of `BypassRecord` -- bypass volume says where the
+/// index fails agents; usage rows and their zero-result rate say whether the
+/// sanctioned surface actually answers (#704's primary success metric).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct EtcUsageRecord {
+    pub ts: DateTime<Utc>,
+    /// Query shape, e.g. "find-content", "tree", "extract".
+    pub command: String,
+    /// Repo filter; `None` means cross-repo.
+    pub repo: Option<String>,
+    pub pattern: String,
+    pub fixed_strings: bool,
+    pub hit_count: u64,
+    pub skipped_files: u64,
+}
+
+/// Resolve the canonical etc-usage log path (sibling of `bypass.jsonl`).
+pub fn etc_usage_log_path() -> PathBuf {
+    bypass_log_dir().join("etc-usage.jsonl")
+}
+
+/// Append one usage record. Best-effort at the call site: a telemetry write
+/// failure must never fail the query that produced it.
+pub fn append_etc_usage(record: &EtcUsageRecord) -> Result<()> {
+    append_jsonl(&etc_usage_log_path(), record)
+}
+
+/// Append one serializable record as a single JSONL line, creating parent
+/// dirs and the file on first use.
+fn append_jsonl<T: Serialize>(path: &std::path::Path, record: &T) -> Result<()> {
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent)?;
     }
@@ -244,17 +272,36 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         let path = tmp.path().join("nested/bypass.jsonl");
         let rec = sample("legion", Utc::now());
-        append_bypass_to(&path, &rec).unwrap();
+        append_jsonl(&path, &rec).unwrap();
         let rows = list_bypasses_from(&path, None, None).unwrap();
         assert_eq!(rows.len(), 1);
         assert_eq!(rows[0], rec);
     }
 
     #[test]
+    fn etc_usage_round_trip() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("etc-usage.jsonl");
+        let rec = EtcUsageRecord {
+            ts: Utc::now(),
+            command: "find-content".to_string(),
+            repo: Some("legion".to_string()),
+            pattern: "<<<<<<<".to_string(),
+            fixed_strings: true,
+            hit_count: 3,
+            skipped_files: 1,
+        };
+        append_jsonl(&path, &rec).unwrap();
+        let raw = std::fs::read_to_string(&path).unwrap();
+        let parsed: EtcUsageRecord = serde_json::from_str(raw.trim()).unwrap();
+        assert_eq!(parsed, rec);
+    }
+
+    #[test]
     fn append_creates_parent_dirs() {
         let tmp = TempDir::new().unwrap();
         let path = tmp.path().join("a/b/c/bypass.jsonl");
-        append_bypass_to(&path, &sample("legion", Utc::now())).unwrap();
+        append_jsonl(&path, &sample("legion", Utc::now())).unwrap();
         assert!(path.exists());
     }
 
@@ -262,8 +309,8 @@ mod tests {
     fn list_filters_by_repo() {
         let tmp = TempDir::new().unwrap();
         let path = tmp.path().join("bypass.jsonl");
-        append_bypass_to(&path, &sample("legion", Utc::now())).unwrap();
-        append_bypass_to(&path, &sample("smugglr", Utc::now())).unwrap();
+        append_jsonl(&path, &sample("legion", Utc::now())).unwrap();
+        append_jsonl(&path, &sample("smugglr", Utc::now())).unwrap();
         let rows = list_bypasses_from(&path, None, Some("legion")).unwrap();
         assert_eq!(rows.len(), 1);
         assert_eq!(rows[0].repo, "legion");
@@ -275,10 +322,10 @@ mod tests {
         let path = tmp.path().join("bypass.jsonl");
         let now = Utc::now();
         // 4 rows: 2 legion (one stale, one fresh), 2 smugglr (one stale, one fresh).
-        append_bypass_to(&path, &sample("legion", now - Duration::hours(48))).unwrap();
-        append_bypass_to(&path, &sample("legion", now - Duration::minutes(5))).unwrap();
-        append_bypass_to(&path, &sample("smugglr", now - Duration::hours(48))).unwrap();
-        append_bypass_to(&path, &sample("smugglr", now - Duration::minutes(5))).unwrap();
+        append_jsonl(&path, &sample("legion", now - Duration::hours(48))).unwrap();
+        append_jsonl(&path, &sample("legion", now - Duration::minutes(5))).unwrap();
+        append_jsonl(&path, &sample("smugglr", now - Duration::hours(48))).unwrap();
+        append_jsonl(&path, &sample("smugglr", now - Duration::minutes(5))).unwrap();
         let rows = list_bypasses_from(&path, Some(Duration::hours(24)), Some("legion")).unwrap();
         assert_eq!(rows.len(), 1);
         assert_eq!(rows[0].repo, "legion");
@@ -290,8 +337,8 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         let path = tmp.path().join("bypass.jsonl");
         let now = Utc::now();
-        append_bypass_to(&path, &sample("legion", now - Duration::hours(48))).unwrap();
-        append_bypass_to(&path, &sample("legion", now - Duration::minutes(5))).unwrap();
+        append_jsonl(&path, &sample("legion", now - Duration::hours(48))).unwrap();
+        append_jsonl(&path, &sample("legion", now - Duration::minutes(5))).unwrap();
         let rows = list_bypasses_from(&path, Some(Duration::hours(24)), None).unwrap();
         assert_eq!(rows.len(), 1);
         assert!(rows[0].ts > now - Duration::hours(24));

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -100,11 +100,23 @@ pub fn append_etc_usage(record: &EtcUsageRecord) -> Result<()> {
 
 /// Append one serializable record as a single JSONL line, creating parent
 /// dirs and the file on first use.
+///
+/// The file is tightened to 0600 on unix: these logs persist raw search
+/// patterns and query text, which can be secret-shaped (an agent grepping
+/// for a token writes the token here). Shell history and Claude transcripts
+/// -- the other places such strings land -- are 600/700; this must not be
+/// the least-protected copy. Same idiom as `cluster.rs` config saving.
 fn append_jsonl<T: Serialize>(path: &std::path::Path, record: &T) -> Result<()> {
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent)?;
     }
     let mut file = OpenOptions::new().create(true).append(true).open(path)?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let perms = std::fs::Permissions::from_mode(0o600);
+        std::fs::set_permissions(path, perms)?;
+    }
     let line = serde_json::to_string(record)?;
     file.write_all(line.as_bytes())?;
     file.write_all(b"\n")?;
@@ -295,6 +307,17 @@ mod tests {
         let raw = std::fs::read_to_string(&path).unwrap();
         let parsed: EtcUsageRecord = serde_json::from_str(raw.trim()).unwrap();
         assert_eq!(parsed, rec);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn append_tightens_file_permissions_to_0600() {
+        use std::os::unix::fs::PermissionsExt;
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("bypass.jsonl");
+        append_jsonl(&path, &sample("legion", Utc::now())).unwrap();
+        let mode = std::fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600, "telemetry logs persist raw patterns");
     }
 
     #[test]

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -91,6 +91,14 @@ pub struct EtcUsageRecord {
     /// "tool failed to answer"; defaulted so pre-#719 rows still parse.
     #[serde(default)]
     pub error: Option<String>,
+    /// Watched repos whose workdir could not be walked at all. Nonzero with
+    /// `error: None` means a partial corpus: the scan succeeded but covered
+    /// fewer repos than the scope claimed. Without this, a zero-hit row over
+    /// a half-dead corpus reads as "tool answered zero" in the #704 metric
+    /// when part of the corpus was never searched. Defaulted so earlier
+    /// rows still parse.
+    #[serde(default)]
+    pub failed_repos: u64,
 }
 
 /// Resolve the canonical etc-usage log path (sibling of `bypass.jsonl`).
@@ -107,21 +115,31 @@ pub fn append_etc_usage(record: &EtcUsageRecord) -> Result<()> {
 /// Append one serializable record as a single JSONL line, creating parent
 /// dirs and the file on first use.
 ///
-/// The file is tightened to 0600 on unix: these logs persist raw search
-/// patterns and query text, which can be secret-shaped (an agent grepping
-/// for a token writes the token here). Shell history and Claude transcripts
-/// -- the other places such strings land -- are 600/700; this must not be
-/// the least-protected copy. Same idiom as `cluster.rs` config saving.
+/// The file is 0600 on unix: these logs persist raw search patterns and
+/// query text, which can be secret-shaped (an agent grepping for a token
+/// writes the token here). Shell history and Claude transcripts -- the
+/// other places such strings land -- are 600/700; this must not be the
+/// least-protected copy. The mode is set at open time, not chmodded after
+/// create: a create-then-chmod leaves a window where the umask-default
+/// file is world-readable, and a reader who opened an fd in that window
+/// keeps it past the chmod. The follow-up `set_permissions` repairs files
+/// created by earlier builds with default permissions.
 fn append_jsonl<T: Serialize>(path: &std::path::Path, record: &T) -> Result<()> {
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent)?;
     }
-    let mut file = OpenOptions::new().create(true).append(true).open(path)?;
+    let mut options = OpenOptions::new();
+    options.create(true).append(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+    let mut file = options.open(path)?;
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
-        let perms = std::fs::Permissions::from_mode(0o600);
-        std::fs::set_permissions(path, perms)?;
+        std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600))?;
     }
     let line = serde_json::to_string(record)?;
     file.write_all(line.as_bytes())?;
@@ -309,6 +327,7 @@ mod tests {
             hit_count: 3,
             skipped_files: 1,
             error: None,
+            failed_repos: 1,
         };
         append_jsonl(&path, &rec).unwrap();
         let raw = std::fs::read_to_string(&path).unwrap();
@@ -323,6 +342,7 @@ mod tests {
         let legacy = r#"{"ts":"2026-07-02T01:01:32Z","command":"find-content","repo":null,"pattern":"x","fixed_strings":false,"hit_count":0,"skipped_files":0}"#;
         let parsed: EtcUsageRecord = serde_json::from_str(legacy).unwrap();
         assert_eq!(parsed.error, None);
+        assert_eq!(parsed.failed_repos, 0);
 
         let rec = EtcUsageRecord {
             ts: Utc::now(),
@@ -333,6 +353,7 @@ mod tests {
             hit_count: 0,
             skipped_files: 0,
             error: Some("invalid regex '(unclosed': ...".to_string()),
+            failed_repos: 0,
         };
         let json = serde_json::to_string(&rec).unwrap();
         let back: EtcUsageRecord = serde_json::from_str(&json).unwrap();

--- a/tests/integration/etc.rs
+++ b/tests/integration/etc.rs
@@ -8,13 +8,16 @@
 use crate::common::{legion_cmd, run_fail, run_ok};
 
 /// Seed a watch.toml in the data dir pointing at `repos` (name, workdir).
+/// Backslashes are TOML escape syntax, so Windows paths interpolated raw
+/// into a basic string make the whole file unparseable -- normalize to
+/// forward slashes, which Windows path APIs accept.
 fn seed_watch_toml(data_dir: &std::path::Path, repos: &[(&str, &std::path::Path)]) {
     let mut toml = String::new();
     for (name, workdir) in repos {
         toml.push_str(&format!(
             "[[repos]]\nname = \"{}\"\nworkdir = \"{}\"\n\n",
             name,
-            workdir.display()
+            workdir.display().to_string().replace('\\', "/")
         ));
     }
     std::fs::write(data_dir.join("watch.toml"), toml).expect("seed watch.toml");

--- a/tests/integration/etc.rs
+++ b/tests/integration/etc.rs
@@ -1,0 +1,118 @@
+//! CLI end-to-end tests for `legion sym etc find-content` (#707).
+//!
+//! The library core (`etc::find_content`) is unit-tested in src/etc.rs;
+//! these tests exercise the actual binary surface the review found
+//! uncovered: flag parsing, output shapes, loud error paths, and the
+//! telemetry side effect landing in etc-usage.jsonl.
+
+use crate::common::{legion_cmd, run_fail, run_ok};
+
+/// Seed a watch.toml in the data dir pointing at `repos` (name, workdir).
+fn seed_watch_toml(data_dir: &std::path::Path, repos: &[(&str, &std::path::Path)]) {
+    let mut toml = String::new();
+    for (name, workdir) in repos {
+        toml.push_str(&format!(
+            "[[repos]]\nname = \"{}\"\nworkdir = \"{}\"\n\n",
+            name,
+            workdir.display()
+        ));
+    }
+    std::fs::write(data_dir.join("watch.toml"), toml).expect("seed watch.toml");
+}
+
+#[test]
+fn find_content_cli_end_to_end_with_json_and_telemetry() {
+    let data_dir = tempfile::tempdir().expect("data dir");
+    let repo_dir = tempfile::tempdir().expect("repo dir");
+    let state_dir = tempfile::tempdir().expect("state dir");
+    std::fs::write(
+        repo_dir.path().join("style.css"),
+        "--spacing-0.5: 4px;\nbody { margin: 0; }\n",
+    )
+    .expect("write fixture");
+    seed_watch_toml(data_dir.path(), &[("etcrepo", repo_dir.path())]);
+
+    // Human output: path:line: text, punctuation literal survives argv + matching.
+    let stdout = run_ok(
+        legion_cmd(data_dir.path())
+            .env("XDG_STATE_HOME", state_dir.path())
+            .args([
+                "sym",
+                "etc",
+                "find-content",
+                "--spacing-0.5",
+                "--repo",
+                "etcrepo",
+                "--fixed-strings",
+            ]),
+    );
+    assert!(
+        stdout.contains("style.css:1: --spacing-0.5: 4px;"),
+        "expected path:line: text hit, got:\n{stdout}"
+    );
+
+    // JSON output: structured ContentHit array.
+    let json_out = run_ok(
+        legion_cmd(data_dir.path())
+            .env("XDG_STATE_HOME", state_dir.path())
+            .args([
+                "sym",
+                "etc",
+                "find-content",
+                "margin",
+                "--repo",
+                "etcrepo",
+                "--json",
+            ]),
+    );
+    let hits: Vec<serde_json::Value> =
+        serde_json::from_str(json_out.trim()).expect("stdout is a JSON array");
+    assert_eq!(hits.len(), 1);
+    assert_eq!(hits[0]["repo"], "etcrepo");
+    assert_eq!(hits[0]["path"], "style.css");
+    assert_eq!(hits[0]["line"], 2);
+
+    // Telemetry side effect: one row per completed search in etc-usage.jsonl.
+    let usage_path = state_dir.path().join("legion/etc-usage.jsonl");
+    let usage = std::fs::read_to_string(&usage_path).expect("etc-usage.jsonl written");
+    let rows: Vec<&str> = usage.lines().collect();
+    assert_eq!(rows.len(), 2, "one row per completed search:\n{usage}");
+    let first: serde_json::Value = serde_json::from_str(rows[0]).expect("row is JSON");
+    assert_eq!(first["command"], "find-content");
+    assert_eq!(first["pattern"], "--spacing-0.5");
+    assert_eq!(first["fixed_strings"], true);
+    assert_eq!(first["hit_count"], 1);
+}
+
+#[test]
+fn find_content_unknown_repo_fails_loudly() {
+    let data_dir = tempfile::tempdir().expect("data dir");
+    let repo_dir = tempfile::tempdir().expect("repo dir");
+    seed_watch_toml(data_dir.path(), &[("etcrepo", repo_dir.path())]);
+
+    let (_stdout, stderr) = run_fail(legion_cmd(data_dir.path()).args([
+        "sym",
+        "etc",
+        "find-content",
+        "needle",
+        "--repo",
+        "nonesuch",
+    ]));
+    assert!(
+        stderr.contains("not in watch.toml"),
+        "expected the fix-hint error, got:\n{stderr}"
+    );
+}
+
+#[test]
+fn find_content_empty_corpus_fails_loudly() {
+    let data_dir = tempfile::tempdir().expect("data dir");
+    std::fs::write(data_dir.path().join("watch.toml"), "").expect("empty watch.toml");
+
+    let (_stdout, stderr) =
+        run_fail(legion_cmd(data_dir.path()).args(["sym", "etc", "find-content", "needle"]));
+    assert!(
+        stderr.contains("no repos in watch.toml"),
+        "expected the empty-corpus error, got:\n{stderr}"
+    );
+}

--- a/tests/integration/etc.rs
+++ b/tests/integration/etc.rs
@@ -150,3 +150,138 @@ fn find_content_all_repos_unscannable_fails_loudly() {
         "expected the unscannable-corpus error naming the repo, got:\n{stderr}"
     );
 }
+
+/// One dead repo among live ones is a warning, not a failure -- but it must
+/// land in three places: stderr (for the human), exit 0 with hits (the scan
+/// still answered), and the telemetry row's failed_repos count (so the #704
+/// metric can tell "answered zero over the full corpus" from "answered zero
+/// but part of the corpus was never searched").
+#[test]
+fn find_content_partial_corpus_failure_warns_and_lands_in_telemetry() {
+    let data_dir = tempfile::tempdir().expect("data dir");
+    let repo_dir = tempfile::tempdir().expect("repo dir");
+    let state_dir = tempfile::tempdir().expect("state dir");
+    std::fs::write(repo_dir.path().join("ok.txt"), "needle\n").expect("write fixture");
+    let ghost = data_dir.path().join("no-such-workdir");
+    seed_watch_toml(
+        data_dir.path(),
+        &[("alive", repo_dir.path()), ("ghost", ghost.as_path())],
+    );
+
+    let out = legion_cmd(data_dir.path())
+        .env("XDG_STATE_HOME", state_dir.path())
+        .args(["sym", "etc", "find-content", "needle"])
+        .output()
+        .expect("run legion");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        out.status.success(),
+        "partial failure must not fail the scan\nstderr:\n{stderr}"
+    );
+    // Cross-repo scan over >1 repo prefixes hits with the repo name.
+    assert!(
+        stdout.contains("alive/ok.txt:1: needle"),
+        "expected the live repo's hit, got:\n{stdout}"
+    );
+    assert!(
+        stderr.contains("repo 'ghost' could not be scanned"),
+        "expected the dead repo named on stderr, got:\n{stderr}"
+    );
+
+    let usage = std::fs::read_to_string(state_dir.path().join("legion/etc-usage.jsonl"))
+        .expect("etc-usage.jsonl written");
+    let row: serde_json::Value =
+        serde_json::from_str(usage.lines().next().expect("one row")).expect("row is JSON");
+    assert_eq!(row["hit_count"], 1);
+    assert_eq!(
+        row["failed_repos"], 1,
+        "partial corpus must be visible: {row}"
+    );
+    assert!(
+        row["error"].is_null(),
+        "partial failure is not an error: {row}"
+    );
+}
+
+/// The --hidden flag end-to-end: default walk skips dotfiles, --hidden
+/// admits them, and .git/ stays excluded either way. The library behavior
+/// is unit-tested; this pins the clap-to-ContentScope wiring, where a
+/// dropped negation would invert the default silently.
+#[test]
+fn find_content_hidden_flag_cli_end_to_end() {
+    let data_dir = tempfile::tempdir().expect("data dir");
+    let repo_dir = tempfile::tempdir().expect("repo dir");
+    let state_dir = tempfile::tempdir().expect("state dir");
+    let workflows = repo_dir.path().join(".github/workflows");
+    std::fs::create_dir_all(&workflows).expect("mkdir .github/workflows");
+    std::fs::write(workflows.join("ci.yml"), "needle\n").expect("write fixture");
+    let git_dir = repo_dir.path().join(".git");
+    std::fs::create_dir_all(&git_dir).expect("mkdir .git");
+    std::fs::write(git_dir.join("config"), "needle\n").expect("write fixture");
+    std::fs::write(repo_dir.path().join("seen.txt"), "needle\n").expect("write fixture");
+    seed_watch_toml(data_dir.path(), &[("etcrepo", repo_dir.path())]);
+
+    let default_out = run_ok(
+        legion_cmd(data_dir.path())
+            .env("XDG_STATE_HOME", state_dir.path())
+            .args(["sym", "etc", "find-content", "needle", "--repo", "etcrepo"]),
+    );
+    assert!(default_out.contains("seen.txt:1: needle"));
+    assert!(
+        !default_out.contains(".github"),
+        "default walk must skip hidden files, got:\n{default_out}"
+    );
+
+    let hidden_out = run_ok(
+        legion_cmd(data_dir.path())
+            .env("XDG_STATE_HOME", state_dir.path())
+            .args([
+                "sym",
+                "etc",
+                "find-content",
+                "needle",
+                "--repo",
+                "etcrepo",
+                "--hidden",
+            ]),
+    );
+    assert!(
+        hidden_out.contains(".github/workflows/ci.yml:1: needle"),
+        "--hidden must admit dotdirs, got:\n{hidden_out}"
+    );
+    assert!(
+        !hidden_out.contains(".git/config"),
+        ".git must stay excluded even under --hidden, got:\n{hidden_out}"
+    );
+}
+
+/// The hit-cap warning is a human-facing contract: truncation is never
+/// silent. Unit tests pin the counters; this pins the stderr note itself.
+#[test]
+fn find_content_hit_cap_warns_on_stderr() {
+    let data_dir = tempfile::tempdir().expect("data dir");
+    let repo_dir = tempfile::tempdir().expect("repo dir");
+    let state_dir = tempfile::tempdir().expect("state dir");
+    // MAX_HITS is 500; 505 matching lines leaves 5 suppressed.
+    std::fs::write(repo_dir.path().join("many.txt"), "needle\n".repeat(505))
+        .expect("write fixture");
+    seed_watch_toml(data_dir.path(), &[("etcrepo", repo_dir.path())]);
+
+    let out = legion_cmd(data_dir.path())
+        .env("XDG_STATE_HOME", state_dir.path())
+        .args(["sym", "etc", "find-content", "needle", "--repo", "etcrepo"])
+        .output()
+        .expect("run legion");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        out.status.success(),
+        "capped scan still succeeds:\n{stderr}"
+    );
+    assert_eq!(stdout.lines().count(), 500, "output capped at MAX_HITS");
+    assert!(
+        stderr.contains("5 more matches suppressed (cap 500)"),
+        "expected the suppression note, got:\n{stderr}"
+    );
+}

--- a/tests/integration/etc.rs
+++ b/tests/integration/etc.rs
@@ -88,31 +88,65 @@ fn find_content_cli_end_to_end_with_json_and_telemetry() {
 fn find_content_unknown_repo_fails_loudly() {
     let data_dir = tempfile::tempdir().expect("data dir");
     let repo_dir = tempfile::tempdir().expect("repo dir");
+    // Errored invocations write telemetry too (#719 review fix), so the
+    // state dir must be isolated or the test pollutes the real usage log.
+    let state_dir = tempfile::tempdir().expect("state dir");
     seed_watch_toml(data_dir.path(), &[("etcrepo", repo_dir.path())]);
 
-    let (_stdout, stderr) = run_fail(legion_cmd(data_dir.path()).args([
-        "sym",
-        "etc",
-        "find-content",
-        "needle",
-        "--repo",
-        "nonesuch",
-    ]));
+    let (_stdout, stderr) = run_fail(
+        legion_cmd(data_dir.path())
+            .env("XDG_STATE_HOME", state_dir.path())
+            .args(["sym", "etc", "find-content", "needle", "--repo", "nonesuch"]),
+    );
     assert!(
         stderr.contains("not in watch.toml"),
         "expected the fix-hint error, got:\n{stderr}"
+    );
+    // The failed invocation itself lands in telemetry with the error text.
+    let usage = std::fs::read_to_string(state_dir.path().join("legion/etc-usage.jsonl"))
+        .expect("errored invocation still writes a usage row");
+    let row: serde_json::Value =
+        serde_json::from_str(usage.lines().next().expect("one row")).expect("row is JSON");
+    assert_eq!(row["hit_count"], 0);
+    assert!(
+        row["error"]
+            .as_str()
+            .is_some_and(|e| e.contains("nonesuch")),
+        "error field should carry the failure, got: {row}"
     );
 }
 
 #[test]
 fn find_content_empty_corpus_fails_loudly() {
     let data_dir = tempfile::tempdir().expect("data dir");
+    let state_dir = tempfile::tempdir().expect("state dir");
     std::fs::write(data_dir.path().join("watch.toml"), "").expect("empty watch.toml");
 
-    let (_stdout, stderr) =
-        run_fail(legion_cmd(data_dir.path()).args(["sym", "etc", "find-content", "needle"]));
+    let (_stdout, stderr) = run_fail(
+        legion_cmd(data_dir.path())
+            .env("XDG_STATE_HOME", state_dir.path())
+            .args(["sym", "etc", "find-content", "needle"]),
+    );
     assert!(
         stderr.contains("no repos in watch.toml"),
         "expected the empty-corpus error, got:\n{stderr}"
+    );
+}
+
+#[test]
+fn find_content_all_repos_unscannable_fails_loudly() {
+    let data_dir = tempfile::tempdir().expect("data dir");
+    let state_dir = tempfile::tempdir().expect("state dir");
+    let ghost = data_dir.path().join("no-such-workdir");
+    seed_watch_toml(data_dir.path(), &[("ghost", ghost.as_path())]);
+
+    let (_stdout, stderr) = run_fail(
+        legion_cmd(data_dir.path())
+            .env("XDG_STATE_HOME", state_dir.path())
+            .args(["sym", "etc", "find-content", "needle"]),
+    );
+    assert!(
+        stderr.contains("no repo could be scanned") && stderr.contains("ghost"),
+        "expected the unscannable-corpus error naming the repo, got:\n{stderr}"
     );
 }

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -10,6 +10,7 @@ mod common;
 mod bullpen;
 mod daemon_watch;
 mod documents;
+mod etc;
 mod governance;
 mod index_telemetry;
 mod kanban;


### PR DESCRIPTION
## Summary

Implements #707: `legion sym etc find-content` -- exact, line-accurate content search over
every watched repo, the sanctioned grep for non-symbol content and the largest logged bypass
class (60+ escapes). Built on the in-process ripgrep engine crates (grep-regex, grep-searcher,
ignore) as a direct disk scan at query time: no corpus exists, because a tokenized index
returns nothing on the punctuation-heavy literals agents actually grep for, and any content
corpus goes stale on git operations that fire no edit hooks. New `src/etc.rs` module, a
`SymAction::Etc` / `EtcShape::FindContent` CLI surface in `src/cli/index_cmd.rs`, and an
`EtcUsageRecord` telemetry stream in `src/telemetry.rs` -- epic #704's primary success metric,
instrumented from day one.

## Acceptance criteria mapping

### 1. Returns file:line matches a grep -n would, including punctuation-heavy literals

`find_content` (src/etc.rs:74) builds a grep-regex matcher and runs grep-searcher with
line_number(true) over an `ignore` walk of the workdir, so each hit carries the exact
1-indexed line and the matched line's text -- the same shape grep -n prints. Literal mode uses
grep-regex's native `fixed_strings()` builder (src/etc.rs:77), which is what makes
`--spacing-0.5` and `<<<<<<<` behave as literals rather than syntax. Non-UTF-8 text files are
searched lossily (Lossy sink) because grep matches them, so parity demands we do too. Live
dogfooding on this repo returned exact file:line rows for both headline literals and logged
the runs to etc-usage.jsonl. Dogfooding also caught a bug unit tests structurally cannot:
clap parsed hyphen-leading patterns as flags, so the headline query died at argv before
reaching any tested code -- fixed with allow_hyphen_values on the pattern arg
(src/cli/index_cmd.rs:120).
Evidence: tests conflict_marker_literal_matches_with_line_number,
fixed_strings_treats_dot_literally, non_utf8_text_is_searched_lossily_not_skipped
(src/etc.rs); live runs recorded in etc-usage.jsonl.

### 2. Regex mode works, and results are fresh immediately after a branch switch

Regex is the default pattern semantics -- alternation and wildcards behave per ripgrep syntax
(test regex_mode_matches_alternation; the dotted-wildcard divergence between modes is pinned
by fixed_strings_treats_dot_literally, which requires the same pattern to match 1 line as a
literal and 2 as a regex). Freshness needs no mechanism to verify because there is nothing to
go stale: the scan reads the working tree at query time, so whatever a branch switch put on
disk is what gets searched. This is the PR's central design decision -- the earlier Tantivy
corpus plan was dropped at review precisely because an index cannot make this guarantee
(checkout/pull fire no edit hooks to reindex on). The walk is additionally name-sorted so the
subset kept under the hit cap is deterministic across machines, not readdir-order roulette.
Evidence: src/etc.rs find_content contains no persistence -- every query walks the workdir;
tests regex_mode_matches_alternation, capped_subset_is_walk_order_deterministic.

### 3. --ext / --repo filter correctly, --json is structured, telemetry recorded per invocation

--repo resolves against watch.toml and errors with a fix hint on an unknown name; omitted, it
scans every watched repo with each hit tagged by repo (test
cross_repo_hits_carry_repo_and_sort_deterministically). An empty watch.toml corpus is a loud
error, not a silent zero-hit result. --ext filters during the walk before any file is opened
(test ext_filter_scopes_the_walk). --hidden opts in to dotfile content (.github/, .claude/) with
rg semantics; `.git/` stays excluded via explicit filter_entry because the ignore crate does
NOT skip it by itself once hidden files are admitted -- proven empirically by #705's twin-walk
regression test and pinned here by include_hidden_searches_dotfiles_but_never_git_dir. --json
emits the ContentHit array on stdout while suppressed/skipped counts go to stderr, keeping
stdout parseable (run_etc_find_content, src/cli/index_cmd.rs). Every invocation appends an
EtcUsageRecord {ts, command, repo, pattern, fixed_strings, hit_count, skipped_files} to
etc-usage.jsonl via the shared append_jsonl writer (src/telemetry.rs:97); the write is
best-effort so telemetry failure can never fail a query.
Evidence: test etc_usage_round_trip (src/telemetry.rs); live etc-usage.jsonl rows dated
2026-07-02.

### 4. All tests pass; simplify + review done; PR created and linked

1170 unit tests pass including 13 in src/etc.rs and 1 in src/telemetry.rs; clippy -D warnings
and fmt --check are clean. The 4 failing integration tests in
tests/integration/worksource_pr.rs are the pre-existing 1Password git-signing environment
breakage -- they fail identically on main and are untouched by this diff. Simplify and
pr-write gates recorded on HEAD; review follows PR creation per the pipeline.
Evidence: gate ledger rows for this branch HEAD; cargo test --bin legion output (1170 passed).

## Not done

- No dependency on #705's file_inventory table -- find-content scans disk directly; the
  issues were deliberately decoupled at plan review so the biggest bypass class ships first.
- No ranked/fuzzy prose search ("which doc discusses X") -- explicitly out of scope; a
  possible later Tantivy shape where tokenization is a feature, not a bug.
- Cap values (2MB per file, 500 hits) are consts, not flags -- both are counted and reported
  on stderr so truncation is never silent; flags can follow if usage telemetry shows need.
- Hidden files stay excluded BY DEFAULT (rg parity, pinned by test hidden_files_are_skipped);
  --hidden is the sanctioned opt-in rather than a default flip.
- Multiline/context output (grep -A/-B equivalents) -- not in the issue's interface; the
  line-accurate single-line hit is the orientation shape the bypass log shows agents need.

Closes #707.