### PR TITLE
feat(#706): sym tree -- structured cross-repo build-tree query

### DIFF
--- a/src/cli/index_cmd.rs
+++ b/src/cli/index_cmd.rs
@@ -455,7 +455,7 @@ fn run_sym_list(
 /// the issue names (repo, path, ext, lang, size, symbol_count). `mtime` is
 /// deliberately dropped -- `sym tree` answers "what/where", not "when did
 /// it last change".
-#[derive(Debug, Clone, PartialEq, serde::Serialize)]
+#[derive(Debug, serde::Serialize)]
 struct SymTreeEntry {
     repo: String,
     path: String,

--- a/src/cli/index_cmd.rs
+++ b/src/cli/index_cmd.rs
@@ -85,6 +85,31 @@ pub(crate) enum SymAction {
         shape: EtcShape,
     },
 
+    /// Structured, cross-repo view of the file inventory built by `legion
+    /// index` -- the "build tree" shape (#706), the sanctioned replacement
+    /// for `find` / `ls -R` / `tree` / a throwaway `os.walk`. Queries
+    /// `Database::list_file_inventory`; never walks the filesystem at
+    /// query time, so it answers instantly regardless of repo size.
+    Tree {
+        /// Restrict to a single repo (default: cross-repo over every repo
+        /// with inventory rows, each entry tagged with its own `repo` field)
+        #[arg(long)]
+        repo: Option<String>,
+        /// Filter by extension, without the leading dot (e.g. "rs")
+        #[arg(long)]
+        ext: Option<String>,
+        /// Scope to a subtree prefix (e.g. "src/db")
+        #[arg(long)]
+        under: Option<String>,
+        /// Max path depth: number of path segments, counted from --under
+        /// when given, else from the repo root
+        #[arg(long)]
+        depth: Option<u32>,
+        /// Emit results as a JSON array of structured entries
+        #[arg(long)]
+        json: bool,
+    },
+
     /// Enumerate the definitions in the index -- the "what functions/enums/etc.
     /// are defined here" query. Byte-cheap: names + locations, never source
     /// bodies. This is the shape `grep "fn "` was serving; use it instead.
@@ -187,6 +212,13 @@ fn run_sym_action(database: &db::Database, action: SymAction) -> error::Result<(
             file,
             json,
         } => run_sym_list(database, repo, lang, kind, file, json),
+        SymAction::Tree {
+            repo,
+            ext,
+            under,
+            depth,
+            json,
+        } => run_sym_tree(database, repo, ext, under, depth, json),
         SymAction::Etc { shape } => run_sym_etc(shape),
     }
 }
@@ -417,6 +449,435 @@ fn run_sym_list(
         }
     }
     Ok(())
+}
+
+/// One row in `sym tree`'s structured output: the file-inventory columns
+/// the issue names (repo, path, ext, lang, size, symbol_count). `mtime` is
+/// deliberately dropped -- `sym tree` answers "what/where", not "when did
+/// it last change".
+#[derive(Debug, Clone, PartialEq, serde::Serialize)]
+struct SymTreeEntry {
+    repo: String,
+    path: String,
+    ext: Option<String>,
+    lang: Option<String>,
+    size: u64,
+    symbol_count: u32,
+}
+
+impl From<db::inventory::FileInventoryEntry> for SymTreeEntry {
+    fn from(e: db::inventory::FileInventoryEntry) -> Self {
+        Self {
+            repo: e.repo,
+            path: e.path,
+            ext: e.ext,
+            lang: e.lang,
+            size: e.size,
+            symbol_count: e.symbol_count,
+        }
+    }
+}
+
+/// `sym tree` (#706): a structured, cross-repo view of the file inventory
+/// (`Database::list_file_inventory`) -- no filesystem walk at query time.
+/// `--repo` omitted means cross-repo over whatever the inventory table
+/// holds, each entry tagged with its own `repo` field. `--ext` narrows
+/// server-side via the DB filter; `--under`/`--depth` narrow in-process
+/// since neither has a dedicated column. Telemetry records every
+/// invocation -- including error exits -- with the result count, mirroring
+/// `find-content` (#704's primary metric is the zero-result rate across
+/// every sanctioned query shape).
+fn run_sym_tree(
+    database: &db::Database,
+    repo: Option<String>,
+    ext: Option<String>,
+    under: Option<String>,
+    depth: Option<u32>,
+    json: bool,
+) -> error::Result<()> {
+    use std::io::Write;
+
+    let scan = scan_tree(
+        database,
+        repo.as_deref(),
+        ext.as_deref(),
+        under.as_deref(),
+        depth,
+    );
+
+    let usage = telemetry::EtcUsageRecord {
+        ts: chrono::Utc::now(),
+        command: "tree".to_string(),
+        repo: repo.clone(),
+        pattern: describe_tree_scope(ext.as_deref(), under.as_deref(), depth),
+        fixed_strings: false,
+        hit_count: scan.as_ref().map_or(0, |r| r.entries.len() as u64),
+        skipped_files: 0,
+        error: scan.as_ref().err().map(|e| e.to_string()),
+        failed_repos: 0,
+    };
+    if let Err(e) = telemetry::append_etc_usage(&usage) {
+        eprintln!("[legion] etc usage telemetry write failed: {e}");
+    }
+
+    let result = scan?;
+    if let Some(msg) = &result.message {
+        eprintln!("[legion] {msg}");
+    }
+
+    let stdout = std::io::stdout();
+    let mut out = stdout.lock();
+    if json {
+        serde_json::to_writer(&mut out, &result.entries)?;
+        writeln!(out)?;
+    } else {
+        let cross_repo = repo.is_none();
+        for e in &result.entries {
+            let ext_col = e.ext.as_deref().unwrap_or("-");
+            let lang_col = e.lang.as_deref().unwrap_or("-");
+            if cross_repo {
+                writeln!(
+                    out,
+                    "{}/{}\t{ext_col}\t{lang_col}\t{}\t{}",
+                    e.repo, e.path, e.size, e.symbol_count
+                )?;
+            } else {
+                writeln!(
+                    out,
+                    "{}\t{ext_col}\t{lang_col}\t{}\t{}",
+                    e.path, e.size, e.symbol_count
+                )?;
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Result of a `sym tree` scan: the filtered, sorted entries plus an
+/// optional human-facing note for the empty case (either "never indexed"
+/// or "filter matched nothing", distinguished by `compute_uncovered_message`).
+struct TreeScan {
+    entries: Vec<SymTreeEntry>,
+    message: Option<String>,
+}
+
+/// Resolve and filter `sym tree` scope: validate an explicit `--repo`
+/// against watch.toml (the fix-hint error path), query the inventory table
+/// (server-side `--ext`/`--repo` filter), then narrow by `--under`/`--depth`
+/// in-process. Cross-repo (`repo: None`) never touches watch.toml -- the
+/// inventory table is the source of truth once `legion index` has run.
+fn scan_tree(
+    database: &db::Database,
+    repo: Option<&str>,
+    ext: Option<&str>,
+    under: Option<&str>,
+    depth: Option<u32>,
+) -> error::Result<TreeScan> {
+    if let Some(name) = repo {
+        validate_repo_known(name)?;
+    }
+
+    let filter = db::inventory::InventoryFilter {
+        repo,
+        ext,
+        lang: None,
+    };
+    let raw = database.list_file_inventory(&filter)?;
+    let entries = filter_and_scope(raw, under, depth);
+    let message = compute_uncovered_message(database, repo, &entries)?;
+    Ok(TreeScan { entries, message })
+}
+
+/// Error when `name` is not a repo in watch.toml -- the fix hint the issue
+/// requires for an unknown `--repo`.
+fn validate_repo_known(name: &str) -> error::Result<()> {
+    let base = data_dir()?;
+    let watch_path = base.join("watch.toml");
+    let all = watch::list_repos_in_config(&watch_path)?;
+    if !all.iter().any(|r| r.name == name) {
+        return Err(error::LegionError::WatchConfig(format!(
+            "repo '{name}' not in watch.toml. Add it with `legion watch add {name} <path>`."
+        )));
+    }
+    Ok(())
+}
+
+/// Narrow `raw` by `--under` (subtree prefix) and `--depth` (max path
+/// segments), then sort by `(repo, path)`. Pure function of already-fetched
+/// rows so it is unit-testable without a database.
+fn filter_and_scope(
+    raw: Vec<db::inventory::FileInventoryEntry>,
+    under: Option<&str>,
+    depth: Option<u32>,
+) -> Vec<SymTreeEntry> {
+    let mut entries: Vec<SymTreeEntry> = raw
+        .into_iter()
+        .filter(|e| under.is_none_or(|u| under_matches(&e.path, u)))
+        .filter(|e| depth.is_none_or(|d| tree_depth(&e.path, under) <= d as usize))
+        .map(SymTreeEntry::from)
+        .collect();
+    entries.sort_by(|a, b| a.repo.cmp(&b.repo).then(a.path.cmp(&b.path)));
+    entries
+}
+
+/// True when `path` is `under` itself or lives inside it. Boundary-checked
+/// so `src/db` matches `src/db/x.rs` but not the sibling `src/dbfoo.rs`.
+fn under_matches(path: &str, under: &str) -> bool {
+    let u = under.trim_end_matches('/');
+    if u.is_empty() {
+        return true;
+    }
+    path == u || path.starts_with(&format!("{u}/"))
+}
+
+/// Path depth in segments, counted relative to `under` when given (so
+/// `--under src/db --depth 1` returns only the direct children of
+/// `src/db`), else relative to the repo root.
+fn tree_depth(path: &str, under: Option<&str>) -> usize {
+    let rel = match under {
+        Some(u) => {
+            let u = u.trim_end_matches('/');
+            path.strip_prefix(u)
+                .map(|s| s.trim_start_matches('/'))
+                .unwrap_or(path)
+        }
+        None => path,
+    };
+    if rel.is_empty() {
+        0
+    } else {
+        rel.split('/').count()
+    }
+}
+
+/// Empty-result message, distinguishing "this repo has never been indexed"
+/// from "the filter matched nothing" -- the criterion requires the former
+/// to be an explicit "run `legion index <repo>`" hint, not silence. Runs a
+/// second, unfiltered-by-ext query only on the empty path, so the common
+/// non-empty case pays no extra cost.
+fn compute_uncovered_message(
+    database: &db::Database,
+    repo: Option<&str>,
+    entries: &[SymTreeEntry],
+) -> error::Result<Option<String>> {
+    if !entries.is_empty() {
+        return Ok(None);
+    }
+    let baseline = database.list_file_inventory(&db::inventory::InventoryFilter {
+        repo,
+        ext: None,
+        lang: None,
+    })?;
+    Ok(Some(if baseline.is_empty() {
+        match repo {
+            Some(name) => format!("no inventory for '{name}'; run `legion index {name}` first"),
+            None => {
+                "no inventory across any watched repo; run `legion index <repo>` first".to_string()
+            }
+        }
+    } else {
+        "no files match the --ext/--under/--depth filter".to_string()
+    }))
+}
+
+/// Compact telemetry description of the filters used, e.g. "ext=rs,under=src/db,depth=2".
+fn describe_tree_scope(ext: Option<&str>, under: Option<&str>, depth: Option<u32>) -> String {
+    let mut parts = Vec::new();
+    if let Some(e) = ext {
+        parts.push(format!("ext={e}"));
+    }
+    if let Some(u) = under {
+        parts.push(format!("under={u}"));
+    }
+    if let Some(d) = depth {
+        parts.push(format!("depth={d}"));
+    }
+    parts.join(",")
+}
+
+#[cfg(test)]
+mod sym_tree_tests {
+    use super::*;
+
+    fn entry(
+        repo: &str,
+        path: &str,
+        ext: Option<&str>,
+        lang: Option<&str>,
+    ) -> db::inventory::FileInventoryEntry {
+        db::inventory::FileInventoryEntry {
+            repo: repo.to_string(),
+            path: path.to_string(),
+            ext: ext.map(|s| s.to_string()),
+            lang: lang.map(|s| s.to_string()),
+            size: 10,
+            mtime: "2026-07-01T00:00:00+00:00".to_string(),
+            symbol_count: 0,
+        }
+    }
+
+    // --- under_matches ---
+
+    #[test]
+    fn under_matches_exact_and_nested() {
+        assert!(under_matches("src/db", "src/db"));
+        assert!(under_matches("src/db/inventory.rs", "src/db"));
+        assert!(under_matches("src/db/sub/x.rs", "src/db"));
+    }
+
+    #[test]
+    fn under_matches_rejects_sibling_prefix() {
+        // "src/dbfoo.rs" shares the string prefix "src/db" but is not
+        // inside it -- the boundary check must reject it.
+        assert!(!under_matches("src/dbfoo.rs", "src/db"));
+        assert!(!under_matches("src/other/x.rs", "src/db"));
+    }
+
+    #[test]
+    fn under_matches_trailing_slash_is_normalized() {
+        assert!(under_matches("src/db/x.rs", "src/db/"));
+    }
+
+    #[test]
+    fn under_matches_empty_matches_everything() {
+        assert!(under_matches("anything.rs", ""));
+    }
+
+    // --- tree_depth ---
+
+    #[test]
+    fn tree_depth_relative_to_repo_root() {
+        assert_eq!(tree_depth("a.rs", None), 1);
+        assert_eq!(tree_depth("src/a.rs", None), 2);
+        assert_eq!(tree_depth("src/db/a.rs", None), 3);
+    }
+
+    #[test]
+    fn tree_depth_relative_to_under() {
+        assert_eq!(tree_depth("src/db/a.rs", Some("src/db")), 1);
+        assert_eq!(tree_depth("src/db/sub/a.rs", Some("src/db")), 2);
+        // The under path itself: zero remaining segments.
+        assert_eq!(tree_depth("src/db", Some("src/db")), 0);
+    }
+
+    // --- filter_and_scope ---
+
+    #[test]
+    fn filter_and_scope_no_filters_returns_all_sorted() {
+        let raw = vec![
+            entry("r", "b.rs", Some("rs"), Some("rust")),
+            entry("r", "a.rs", Some("rs"), Some("rust")),
+        ];
+        let got = filter_and_scope(raw, None, None);
+        assert_eq!(got.len(), 2);
+        assert_eq!(got[0].path, "a.rs");
+        assert_eq!(got[1].path, "b.rs");
+    }
+
+    #[test]
+    fn filter_and_scope_sorts_by_repo_then_path() {
+        let raw = vec![
+            entry("beta", "a.rs", Some("rs"), Some("rust")),
+            entry("alpha", "z.rs", Some("rs"), Some("rust")),
+        ];
+        let got = filter_and_scope(raw, None, None);
+        assert_eq!(got[0].repo, "alpha");
+        assert_eq!(got[1].repo, "beta");
+    }
+
+    #[test]
+    fn filter_and_scope_under_scopes_subtree() {
+        let raw = vec![
+            entry("r", "src/db/inventory.rs", Some("rs"), Some("rust")),
+            entry("r", "src/other.rs", Some("rs"), Some("rust")),
+            entry("r", "src/dbfoo.rs", Some("rs"), Some("rust")),
+        ];
+        let got = filter_and_scope(raw, Some("src/db"), None);
+        assert_eq!(got.len(), 1);
+        assert_eq!(got[0].path, "src/db/inventory.rs");
+    }
+
+    #[test]
+    fn filter_and_scope_depth_limits_results() {
+        let raw = vec![
+            entry("r", "src/a.rs", Some("rs"), Some("rust")),
+            entry("r", "src/sub/b.rs", Some("rs"), Some("rust")),
+        ];
+        let got = filter_and_scope(raw, Some("src"), Some(1));
+        assert_eq!(got.len(), 1);
+        assert_eq!(got[0].path, "src/a.rs");
+    }
+
+    #[test]
+    fn filter_and_scope_non_symbol_file_has_lang_none() {
+        let raw = vec![entry("r", "README.md", Some("md"), None)];
+        let got = filter_and_scope(raw, None, None);
+        assert_eq!(got.len(), 1);
+        assert_eq!(got[0].lang, None);
+    }
+
+    // --- compute_uncovered_message ---
+
+    #[test]
+    fn message_none_when_entries_present() {
+        let db = crate::db::testutil::test_db();
+        let entries = vec![SymTreeEntry {
+            repo: "r".to_string(),
+            path: "a.rs".to_string(),
+            ext: Some("rs".to_string()),
+            lang: Some("rust".to_string()),
+            size: 1,
+            symbol_count: 0,
+        }];
+        let msg = compute_uncovered_message(&db, Some("r"), &entries).unwrap();
+        assert!(msg.is_none());
+    }
+
+    #[test]
+    fn message_no_inventory_when_repo_never_indexed() {
+        let db = crate::db::testutil::test_db();
+        let msg = compute_uncovered_message(&db, Some("ghost"), &[]).unwrap();
+        assert!(msg.as_deref().is_some_and(
+            |m| m.contains("no inventory for 'ghost'") && m.contains("legion index ghost")
+        ));
+    }
+
+    #[test]
+    fn message_cross_repo_wording_when_repo_none() {
+        let db = crate::db::testutil::test_db();
+        let msg = compute_uncovered_message(&db, None, &[]).unwrap();
+        assert!(
+            msg.as_deref()
+                .is_some_and(|m| m.contains("no inventory across any watched repo"))
+        );
+    }
+
+    #[test]
+    fn message_no_match_when_repo_has_rows_but_filter_empty() {
+        let db = crate::db::testutil::test_db();
+        db.upsert_file_inventory(&[entry("r", "a.rs", Some("rs"), Some("rust"))])
+            .unwrap();
+        let msg = compute_uncovered_message(&db, Some("r"), &[]).unwrap();
+        assert!(
+            msg.as_deref()
+                .is_some_and(|m| m.contains("no files match the --ext/--under/--depth filter"))
+        );
+    }
+
+    // --- describe_tree_scope ---
+
+    #[test]
+    fn describe_tree_scope_empty_when_no_filters() {
+        assert_eq!(describe_tree_scope(None, None, None), "");
+    }
+
+    #[test]
+    fn describe_tree_scope_all_filters() {
+        assert_eq!(
+            describe_tree_scope(Some("rs"), Some("src/db"), Some(2)),
+            "ext=rs,under=src/db,depth=2"
+        );
+    }
 }
 
 /// Read the diff source -- file path or "-" for stdin -- and run impact

--- a/src/db/inventory.rs
+++ b/src/db/inventory.rs
@@ -44,10 +44,8 @@ pub struct FileInventoryEntry {
 /// `None` on any field disables that filter; `InventoryFilter::default()`
 /// returns every row.
 ///
-/// Used by `sym tree` (#706) and `sym etc find-file` (#709); `#[allow]`
-/// silences the dead-code lint until those callers land.
+/// Used by `sym tree` (#706) and `sym etc find-file` (#709).
 #[derive(Debug, Default)]
-#[allow(dead_code)]
 pub struct InventoryFilter<'a> {
     pub repo: Option<&'a str>,
     pub ext: Option<&'a str>,
@@ -125,9 +123,7 @@ impl Database {
     /// `None` on any filter field disables that restriction. All three
     /// `None` returns every row in the table.
     ///
-    /// Read path for `sym tree` (#706) and `sym etc find-file` (#709);
-    /// `#[allow]` silences the dead-code lint until those callers land.
-    #[allow(dead_code)]
+    /// Read path for `sym tree` (#706) and `sym etc find-file` (#709).
     pub fn list_file_inventory(
         &self,
         filter: &InventoryFilter<'_>,

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -19,6 +19,7 @@ mod memory;
 mod mesh;
 mod serve;
 mod spec_gen;
+mod sym_tree;
 mod task;
 mod uncertainty;
 mod usage;

--- a/tests/integration/sym_tree.rs
+++ b/tests/integration/sym_tree.rs
@@ -1,0 +1,217 @@
+//! CLI end-to-end tests for `legion sym tree` (#706).
+//!
+//! The pure filtering/scoping logic (`filter_and_scope`, `under_matches`,
+//! `tree_depth`, `compute_uncovered_message`) is unit-tested in
+//! src/cli/index_cmd.rs; these tests exercise the actual binary surface:
+//! flag parsing, the `Database::list_file_inventory` read path seeded by a
+//! real `legion index` run, cross-repo tagging, and the telemetry side
+//! effect landing in etc-usage.jsonl.
+
+use crate::common::{legion_cmd, run_fail, run_ok, run_ok_stderr};
+
+/// Seed a watch.toml in the data dir pointing at `repos` (name, workdir).
+/// Backslashes are TOML escape syntax, so Windows paths interpolated raw
+/// into a basic string make the whole file unparseable -- normalize to
+/// forward slashes, which Windows path APIs accept.
+fn seed_watch_toml(data_dir: &std::path::Path, repos: &[(&str, &std::path::Path)]) {
+    let mut toml = String::new();
+    for (name, workdir) in repos {
+        toml.push_str(&format!(
+            "[[repos]]\nname = \"{}\"\nworkdir = \"{}\"\n\n",
+            name,
+            workdir.display().to_string().replace('\\', "/")
+        ));
+    }
+    std::fs::write(data_dir.join("watch.toml"), toml).expect("seed watch.toml");
+}
+
+#[test]
+fn tree_cli_end_to_end_with_json_ext_and_telemetry() {
+    let data_dir = tempfile::tempdir().expect("data dir");
+    let repo_dir = tempfile::tempdir().expect("repo dir");
+    let state_dir = tempfile::tempdir().expect("state dir");
+
+    std::fs::create_dir_all(repo_dir.path().join("src/db")).expect("mkdir src/db");
+    std::fs::write(
+        repo_dir.path().join("src/db/inventory.rs"),
+        "pub fn f() {}\n",
+    )
+    .expect("write fixture");
+    std::fs::write(repo_dir.path().join("README.md"), "# hi\n").expect("write fixture");
+    std::fs::write(repo_dir.path().join("deploy.sh"), "#!/bin/sh\n").expect("write fixture");
+    seed_watch_toml(data_dir.path(), &[("treerepo", repo_dir.path())]);
+
+    // Populate the inventory table via a real (docs-only, no SCIP markers)
+    // `legion index` run -- no filesystem walk happens at query time after this.
+    run_ok(legion_cmd(data_dir.path()).args(["index", "treerepo"]));
+
+    // --ext filters server-side to just the .rs file.
+    let json_out = run_ok(
+        legion_cmd(data_dir.path())
+            .env("XDG_STATE_HOME", state_dir.path())
+            .args(["sym", "tree", "--repo", "treerepo", "--ext", "rs", "--json"]),
+    );
+    let entries: Vec<serde_json::Value> =
+        serde_json::from_str(json_out.trim()).expect("stdout is a JSON array");
+    assert_eq!(entries.len(), 1, "only the .rs file should match --ext rs");
+    assert_eq!(entries[0]["repo"], "treerepo");
+    assert_eq!(entries[0]["path"], "src/db/inventory.rs");
+    assert_eq!(entries[0]["ext"], "rs");
+    assert_eq!(entries[0]["lang"], "rust");
+
+    // No --ext: every file appears; non-symbol files carry lang = null.
+    let all_out = run_ok(
+        legion_cmd(data_dir.path())
+            .env("XDG_STATE_HOME", state_dir.path())
+            .args(["sym", "tree", "--repo", "treerepo", "--json"]),
+    );
+    let all: Vec<serde_json::Value> =
+        serde_json::from_str(all_out.trim()).expect("stdout is a JSON array");
+    assert_eq!(all.len(), 3, "every inventoried file must appear: {all:?}");
+    let readme = all
+        .iter()
+        .find(|e| e["path"] == "README.md")
+        .expect("README.md present");
+    assert!(readme["lang"].is_null(), "README.md must have lang=null");
+    let script = all
+        .iter()
+        .find(|e| e["path"] == "deploy.sh")
+        .expect("deploy.sh present");
+    assert!(script["lang"].is_null(), "deploy.sh must have lang=null");
+
+    // Telemetry: one row per invocation, command="tree", with result count.
+    let usage_path = state_dir.path().join("legion/etc-usage.jsonl");
+    let usage = std::fs::read_to_string(&usage_path).expect("etc-usage.jsonl written");
+    let rows: Vec<&str> = usage.lines().collect();
+    assert_eq!(rows.len(), 2, "one row per completed tree query:\n{usage}");
+    let first: serde_json::Value = serde_json::from_str(rows[0]).expect("row is JSON");
+    assert_eq!(first["command"], "tree");
+    assert_eq!(first["repo"], "treerepo");
+    assert_eq!(first["hit_count"], 1);
+    let second: serde_json::Value = serde_json::from_str(rows[1]).expect("row is JSON");
+    assert_eq!(second["hit_count"], 3);
+}
+
+#[test]
+fn tree_under_scopes_to_subtree() {
+    let data_dir = tempfile::tempdir().expect("data dir");
+    let repo_dir = tempfile::tempdir().expect("repo dir");
+    let state_dir = tempfile::tempdir().expect("state dir");
+
+    std::fs::create_dir_all(repo_dir.path().join("src/db")).expect("mkdir");
+    std::fs::write(repo_dir.path().join("src/db/inventory.rs"), "").expect("write fixture");
+    std::fs::write(repo_dir.path().join("src/main.rs"), "").expect("write fixture");
+    // A sibling that shares the string prefix "src/db" but is not inside it.
+    std::fs::write(repo_dir.path().join("src/dbfoo.rs"), "").expect("write fixture");
+    seed_watch_toml(data_dir.path(), &[("treerepo", repo_dir.path())]);
+    run_ok(legion_cmd(data_dir.path()).args(["index", "treerepo"]));
+
+    let json_out = run_ok(
+        legion_cmd(data_dir.path())
+            .env("XDG_STATE_HOME", state_dir.path())
+            .args([
+                "sym", "tree", "--repo", "treerepo", "--under", "src/db", "--json",
+            ]),
+    );
+    let entries: Vec<serde_json::Value> =
+        serde_json::from_str(json_out.trim()).expect("stdout is a JSON array");
+    assert_eq!(
+        entries.len(),
+        1,
+        "--under src/db must exclude the sibling src/dbfoo.rs: {entries:?}"
+    );
+    assert_eq!(entries[0]["path"], "src/db/inventory.rs");
+}
+
+#[test]
+fn tree_no_repo_is_cross_repo_and_tags_each_entry() {
+    let data_dir = tempfile::tempdir().expect("data dir");
+    let alpha_dir = tempfile::tempdir().expect("alpha dir");
+    let beta_dir = tempfile::tempdir().expect("beta dir");
+    let state_dir = tempfile::tempdir().expect("state dir");
+
+    std::fs::write(alpha_dir.path().join("a.rs"), "").expect("write fixture");
+    std::fs::write(beta_dir.path().join("b.rs"), "").expect("write fixture");
+    seed_watch_toml(
+        data_dir.path(),
+        &[("alpha", alpha_dir.path()), ("beta", beta_dir.path())],
+    );
+    run_ok(legion_cmd(data_dir.path()).args(["index", "alpha"]));
+    run_ok(legion_cmd(data_dir.path()).args(["index", "beta"]));
+
+    let json_out = run_ok(
+        legion_cmd(data_dir.path())
+            .env("XDG_STATE_HOME", state_dir.path())
+            .args(["sym", "tree", "--json"]),
+    );
+    let entries: Vec<serde_json::Value> =
+        serde_json::from_str(json_out.trim()).expect("stdout is a JSON array");
+    let repos: std::collections::HashSet<&str> = entries
+        .iter()
+        .map(|e| e["repo"].as_str().unwrap())
+        .collect();
+    assert!(
+        repos.contains("alpha") && repos.contains("beta"),
+        "cross-repo tree must tag entries from every indexed repo: {entries:?}"
+    );
+
+    // Human output prefixes cross-repo lines with the repo name.
+    let human_out = run_ok(
+        legion_cmd(data_dir.path())
+            .env("XDG_STATE_HOME", state_dir.path())
+            .args(["sym", "tree"]),
+    );
+    assert!(human_out.contains("alpha/a.rs"), "got:\n{human_out}");
+    assert!(human_out.contains("beta/b.rs"), "got:\n{human_out}");
+}
+
+#[test]
+fn tree_unknown_repo_fails_loudly() {
+    let data_dir = tempfile::tempdir().expect("data dir");
+    let repo_dir = tempfile::tempdir().expect("repo dir");
+    let state_dir = tempfile::tempdir().expect("state dir");
+    seed_watch_toml(data_dir.path(), &[("treerepo", repo_dir.path())]);
+
+    let (_stdout, stderr) = run_fail(
+        legion_cmd(data_dir.path())
+            .env("XDG_STATE_HOME", state_dir.path())
+            .args(["sym", "tree", "--repo", "nonesuch"]),
+    );
+    assert!(
+        stderr.contains("not in watch.toml"),
+        "expected the fix-hint error, got:\n{stderr}"
+    );
+
+    // The failed invocation itself lands in telemetry with the error text.
+    let usage = std::fs::read_to_string(state_dir.path().join("legion/etc-usage.jsonl"))
+        .expect("errored invocation still writes a usage row");
+    let row: serde_json::Value =
+        serde_json::from_str(usage.lines().next().expect("one row")).expect("row is JSON");
+    assert_eq!(row["command"], "tree");
+    assert_eq!(row["hit_count"], 0);
+    assert!(
+        row["error"]
+            .as_str()
+            .is_some_and(|e| e.contains("nonesuch")),
+        "error field should carry the failure, got: {row}"
+    );
+}
+
+#[test]
+fn tree_uncovered_repo_prints_explicit_message_not_silence() {
+    let data_dir = tempfile::tempdir().expect("data dir");
+    let repo_dir = tempfile::tempdir().expect("repo dir");
+    let state_dir = tempfile::tempdir().expect("state dir");
+    // In watch.toml but never indexed -- zero inventory rows.
+    seed_watch_toml(data_dir.path(), &[("treerepo", repo_dir.path())]);
+
+    let stderr = run_ok_stderr(
+        legion_cmd(data_dir.path())
+            .env("XDG_STATE_HOME", state_dir.path())
+            .args(["sym", "tree", "--repo", "treerepo"]),
+    );
+    assert!(
+        stderr.contains("no inventory for 'treerepo'") && stderr.contains("legion index treerepo"),
+        "expected the explicit no-inventory hint, got:\n{stderr}"
+    );
+}


### PR DESCRIPTION
## Summary

Adds `legion sym tree` -- a structured, cross-repo view of the file inventory built by `legion
index` (#705). This is the "build tree" query shape the epic (#704) exists to replace `find` /
`ls -R` / `tree` / a throwaway `os.walk`: it never walks the filesystem at query time, answers
from `Database::list_file_inventory`, and emits structured `{repo, path, ext, lang, size,
symbol_count}` entries in `--json` mode instead of a flat path list. Filters (`--repo`, `--ext`,
`--under`, `--depth`) narrow server-side (repo/ext) or in-process (under/depth, since neither has
a dedicated inventory column), and every invocation -- success or error -- is recorded in
etc-usage telemetry so the epic's primary metric (zero-result rate) is instrumented from day one.

## Acceptance criteria mapping

### 1. `legion sym tree --repo legion --ext rs --json` returns structured entries matching the tree

Evidence: `tree_cli_end_to_end_with_json_ext_and_telemetry` (tests/integration/sym_tree.rs) seeds
a real repo with a `.rs`, a `.md`, and a `.sh` file, runs a real `legion index` pass, then asserts
`sym tree --repo treerepo --ext rs --json` returns exactly one entry with
`{repo: "treerepo", path: "src/db/inventory.rs", ext: "rs", lang: "rust"}` -- the server-side
`--ext` filter is `InventoryFilter.ext` threaded through `Database::list_file_inventory`
(src/cli/index_cmd.rs `scan_tree`, src/db/inventory.rs `list_file_inventory`). JSON entries are
built by the `SymTreeEntry` struct / `From<FileInventoryEntry>` impl (src/cli/index_cmd.rs:456),
serialized via `serde_json::to_writer` in `run_sym_tree`.

### 2. `--under src/db` scopes correctly; a non-symbol file (`.sh`, `.md`) appears with `lang = null`

Evidence: `tree_under_scopes_to_subtree` seeds `src/db/inventory.rs`, `src/main.rs`, and a
sibling `src/dbfoo.rs` that shares the string prefix but is not inside the subtree; asserts
`--under src/db` returns only `src/db/inventory.rs` -- boundary correctness backed by unit tests
`under_matches_rejects_sibling_prefix` and `under_matches_trailing_slash_is_normalized`
(src/cli/index_cmd.rs `sym_tree_tests`). The `lang = null` behavior for non-symbol files is
asserted in `tree_cli_end_to_end_with_json_ext_and_telemetry`, which checks both `README.md` and
`deploy.sh` carry `lang: null` in the unfiltered `--json` output (their `FileInventoryEntry.lang`
is `None` because the file-inventory walk never attempted symbol extraction on them).

### 3. No `--repo` returns entries across all watched repos, each tagged with its repo

Evidence: `tree_no_repo_is_cross_repo_and_tags_each_entry` indexes two separate repos (`alpha`,
`beta`) into the same data dir, then runs `sym tree --json` with no `--repo` and asserts both
repo names appear in the tagged output, plus asserts the human-readable (non-JSON) path prefixes
each line with its repo name (`alpha/a.rs`, `beta/b.rs`) -- the `cross_repo` branch in
`run_sym_tree` (src/cli/index_cmd.rs) that switches output format based on `repo.is_none()`.
`scan_tree` never touches `watch.toml` in this path since the inventory table itself is the
cross-repo source of truth once indexed (doc comment, src/cli/index_cmd.rs above `scan_tree`).

### 4. Every invocation recorded in telemetry with result count

Evidence: `tree_cli_end_to_end_with_json_ext_and_telemetry` asserts two etc-usage.jsonl rows
land (one per invocation in the test), each carrying `command: "tree"` and the correct
`hit_count` (1 for the filtered query, 3 for the unfiltered one). The error path is covered
separately: `tree_unknown_repo_fails_loudly` asserts a *failed* invocation (unknown `--repo`)
still writes a usage row with `hit_count: 0` and an `error` field containing the failure text --
telemetry fires before the error propagates (`run_sym_tree`, src/cli/index_cmd.rs: usage record
built from `scan.as_ref()`, written via `telemetry::append_etc_usage`, then `scan?` propagates).

### 5. All tests pass; simplify + review done; PR created and linked

Evidence: `cargo test` -- 1222 passed / 0 failed / 2 ignored (unit + lib), 218 passed / 0 failed /
2 ignored (integration), all pre-existing ignores unrelated to this branch. `cargo clippy
--all-targets -- -D warnings` clean. `cargo fmt -- --check` clean. `legion quality-gate check
--skill legion-simplify --result clean` recorded gate `019f2fb0-a7d1-70f1-aef1-dfb63e0d44a3` on
HEAD `cc41650e547607acb8b4173c98e19485e00a28da`. The pre-push hook's automated review returned
PASS (no CRITICAL findings); this PR is linked to issue #706.

## Deliberately not done

- **No CLI/integration test for `--depth`.** It is covered at the unit level
  (`tree_depth_relative_to_repo_root`, `tree_depth_relative_to_under`,
  `filter_and_scope_depth_limits_results`), but no end-to-end test drives `--depth` through the
  real binary the way `--ext`/`--under` are. Flagged by the pre-push review as the one gap worth
  closing before merge; left for a fast follow rather than blocking this PR, since the pure-function
  coverage already pins the depth-counting semantics precisely.
- **`compute_uncovered_message`'s empty-path re-query loads the full inventory table** rather than
  a `LIMIT 1`/count-style existence probe. Only triggers on the zero-result path (not the common
  case), so left as a known inefficiency rather than a correctness issue; noted by the pre-push
  review as a candidate follow-up given the feature's "answers instantly regardless of repo size"
  framing.
- **No end-to-end assertion of the empty-JSON (`[]`) output shape or the filtered-empty message
  through the binary** -- the never-indexed-repo message is covered end-to-end
  (`tree_uncovered_repo_prints_explicit_message_not_silence`), but the "filtered to zero" message
  is only unit-tested (`message_no_match_when_repo_has_rows_but_filter_empty`).
- **Content search (#707) and by-name/role find-file (#709) are out of scope**, per the issue --
  this PR only implements the inventory-backed tree shape.
- **`.depth`/`.under` are not persisted as separate inventory columns**; both are computed
  in-process over the already-fetched rows rather than pushed into the SQL query, since neither
  has a natural column and the row counts involved (single-repo or even multi-repo file
  inventories) do not currently justify a schema change.