### PR TITLE
feat(#708): sym etc extract -- pull a config/frontmatter field without full read

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1584,6 +1584,7 @@ dependencies = [
  "scip",
  "serde",
  "serde_json",
+ "serde_yaml_ng",
  "sha2",
  "smugglr-core",
  "sysinfo",
@@ -2878,6 +2879,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml_ng"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4db627b98b36d4203a7b458cf3573730f2bb591b28871d916dfa9efabfd41f"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
 name = "serial2"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3668,6 +3682,12 @@ dependencies = [
  "generic-array",
  "subtle",
 ]
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,13 @@ grep-searcher = "0.1"
 # workdirs. The same crate powers the ripgrep engine used by find-content.
 ignore = "0.4"
 
+# sym etc extract (#708): YAML support. serde_yaml is archived and
+# unmaintained (RUSTSEC-2024-0320) -- do not reintroduce it. serde_yaml_ng is
+# a maintained, API-compatible fork: same Value/Deserializer shape, so a
+# parsed document converts into serde_json::Value the same way TOML's does
+# (one dotted-path walker shared across json/toml/yaml/frontmatter).
+serde_yaml_ng = "0.10"
+
 # libc pulls in only on unix for killpg in call_plugin_inner's timeout arm.
 # Must stay AFTER all platform-independent deps -- TOML tables consume
 # every key until the next header, so listing it mid-file would leak the

--- a/src/cli/index_cmd.rs
+++ b/src/cli/index_cmd.rs
@@ -139,6 +139,24 @@ pub(crate) enum EtcShape {
         #[arg(long)]
         json: bool,
     },
+
+    /// Return one field from a JSON/TOML/YAML file, or the YAML frontmatter
+    /// of a `.md`/`.mdx`/`.astro` file, without reading the whole file
+    /// (#708). The bytes an agent wants -- a config value, a frontmatter
+    /// field -- not the surrounding file.
+    Extract {
+        /// Path to the structured file to extract from.
+        path: PathBuf,
+        /// jq-style dotted path: `.`-separated segments walk objects, and a
+        /// purely numeric segment indexes an array (`scripts.build`,
+        /// `keywords.0`, `workspaces.packages.1`). Keys that themselves
+        /// contain a literal `.` are out of scope for v1.
+        #[arg(long)]
+        field: String,
+        /// Emit the value as JSON instead of a bare scalar/lines
+        #[arg(long)]
+        json: bool,
+    },
 }
 
 /// Dispatch `legion sym <action>` against the local index store.
@@ -203,6 +221,7 @@ fn run_sym_etc(shape: EtcShape) -> error::Result<()> {
             hidden,
             json,
         } => run_etc_find_content(&pattern, repo, ext, fixed_strings, hidden, json),
+        EtcShape::Extract { path, field, json } => run_etc_extract(&path, &field, json),
     }
 }
 
@@ -242,6 +261,7 @@ fn run_etc_find_content(
         failed_repos: scan
             .as_ref()
             .map_or(0, |(r, _)| r.failed_repos.len() as u64),
+        format: None,
     };
     if let Err(e) = telemetry::append_etc_usage(&usage) {
         eprintln!("[legion] etc usage telemetry write failed: {e}");
@@ -284,6 +304,61 @@ fn run_etc_find_content(
         );
     }
     Ok(())
+}
+
+/// `sym etc extract` (#708): pull one field out of a config/frontmatter file
+/// without reading the whole thing. Telemetry records one row per
+/// invocation -- `hit_count` is 1 on a resolved field and 0 on a miss or
+/// error, so the epic's zero-result metric covers this shape too. `format`
+/// is detected independently of the extract result (cheap: an extension
+/// check, no extra file read) so a usage row still names the format even
+/// when the field itself was missing.
+fn run_etc_extract(path: &std::path::Path, field: &str, json: bool) -> error::Result<()> {
+    let outcome = etc::extract_field(path, field);
+    let format = etc::detect_format(path)
+        .ok()
+        .map(|f| f.as_str().to_string());
+
+    let usage = telemetry::EtcUsageRecord {
+        ts: chrono::Utc::now(),
+        command: "extract".to_string(),
+        repo: None,
+        pattern: field.to_string(),
+        fixed_strings: false,
+        hit_count: u64::from(outcome.is_ok()),
+        skipped_files: 0,
+        error: outcome.as_ref().err().map(|e| e.to_string()),
+        failed_repos: 0,
+        format,
+    };
+    if let Err(e) = telemetry::append_etc_usage(&usage) {
+        eprintln!("[legion] etc usage telemetry write failed: {e}");
+    }
+
+    let value = outcome?;
+    if json {
+        println!("{}", serde_json::to_string(&value)?);
+    } else {
+        print_extract_value(&value);
+    }
+    Ok(())
+}
+
+/// Print an extracted value the way an agent wants to consume it without
+/// `--json`: a string prints bare (no quotes), an array prints each element
+/// on its own line (flattening nested arrays the same way), and every other
+/// JSON scalar (number/bool/null) or a whole object prints via its compact
+/// JSON form.
+fn print_extract_value(value: &serde_json::Value) {
+    match value {
+        serde_json::Value::String(s) => println!("{s}"),
+        serde_json::Value::Array(items) => {
+            for item in items {
+                print_extract_value(item);
+            }
+        }
+        other => println!("{other}"),
+    }
 }
 
 /// Resolve the scan scope from watch.toml and run the search. Split from

--- a/src/cli/index_cmd.rs
+++ b/src/cli/index_cmd.rs
@@ -590,6 +590,7 @@ fn run_sym_tree(
         skipped_files: 0,
         error: scan.as_ref().err().map(|e| e.to_string()),
         failed_repos: 0,
+        format: None,
     };
     if let Err(e) = telemetry::append_etc_usage(&usage) {
         eprintln!("[legion] etc usage telemetry write failed: {e}");

--- a/src/cli/index_cmd.rs
+++ b/src/cli/index_cmd.rs
@@ -1,7 +1,7 @@
 //! `legion index`/`sym`/`reindex`/`cleanup`/`rename` handlers and the
 //! background indexer plumbing (carved from main.rs, #610).
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use clap::Subcommand;
 
@@ -313,7 +313,7 @@ fn run_etc_find_content(
 /// is detected independently of the extract result (cheap: an extension
 /// check, no extra file read) so a usage row still names the format even
 /// when the field itself was missing.
-fn run_etc_extract(path: &std::path::Path, field: &str, json: bool) -> error::Result<()> {
+fn run_etc_extract(path: &Path, field: &str, json: bool) -> error::Result<()> {
     let outcome = etc::extract_field(path, field);
     let format = etc::detect_format(path)
         .ok()

--- a/src/error.rs
+++ b/src/error.rs
@@ -92,6 +92,9 @@ pub enum LegionError {
     #[error("watch config error: {0}")]
     WatchConfig(String),
 
+    #[error("etc error: {0}")]
+    Etc(String),
+
     #[error("watch already running (pid {0})")]
     WatchAlreadyRunning(u32),
 
@@ -264,6 +267,15 @@ mod tests {
         // the intercept below the generic printer.
         assert_eq!(LegionError::ExitWith(1).to_string(), "");
         assert_eq!(LegionError::ExitWith(2).to_string(), "");
+    }
+
+    #[test]
+    fn error_display_etc() {
+        let err = LegionError::Etc("field 'foo' not found in 'x.json'".to_string());
+        assert_eq!(
+            err.to_string(),
+            "etc error: field 'foo' not found in 'x.json'"
+        );
     }
 
     #[test]

--- a/src/etc.rs
+++ b/src/etc.rs
@@ -253,9 +253,14 @@ fn relative_path(path: &Path, workdir: &Path) -> String {
 }
 
 /// Structured formats `extract` understands, detected from the file
-/// extension. `.md`/`.mdx`/`.astro` route to the YAML frontmatter block, not
-/// the whole file -- extract answers "what does this doc's frontmatter say",
-/// not "search the prose" (that is find-content's job, #707).
+/// extension. `.md`/`.mdx`/`.astro` route to the leading `---`-delimited
+/// block, not the whole file -- extract answers "what does this doc's
+/// frontmatter say", not "search the prose" (that is find-content's job,
+/// #707). Per #708's spec this block is parsed as YAML for all three
+/// extensions; note that a real `.astro` file's fence more often holds a
+/// JS/TS component script than YAML, so `.astro` support here only covers
+/// files whose fence happens to be YAML-shaped (e.g. plain frontmatter
+/// metadata above the component script).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SourceFormat {
     Json,
@@ -397,6 +402,10 @@ fn extract_frontmatter(content: &str, path: &Path) -> Result<String> {
 /// segment looks up an object key. On failure the error names the deepest
 /// segment that DID resolve (`<root>` if none did), so the caller can
 /// correct the path without opening the file.
+///
+/// A numeric segment always tries array-indexing first, so an object with a
+/// literal numeric key (e.g. `{"0": "x"}`) is unreachable by that key --
+/// same v1 scope limitation as keys containing a literal `.`.
 fn walk_field(root: &serde_json::Value, field: &str, path: &Path) -> Result<serde_json::Value> {
     let mut current = root;
     let mut resolved: Vec<&str> = Vec::new();

--- a/src/etc.rs
+++ b/src/etc.rs
@@ -7,6 +7,12 @@
 //! (`<<<<<<<`, `--spacing-0.5`), and any content corpus goes stale on git
 //! operations that fire no edit hooks. Scanning the working tree gives grep
 //! parity and freshness by construction.
+//!
+//! extract (#708) is the complementary shape: return the specific bytes an
+//! agent wants -- a config value, a frontmatter field -- without reading the
+//! whole file. json/toml/yaml, plus the YAML frontmatter block in
+//! `.md`/`.mdx`/`.astro`, all convert into one `serde_json::Value` tree so a
+//! single dotted-path walker serves every format.
 
 use std::path::{Path, PathBuf};
 
@@ -244,6 +250,181 @@ fn relative_path(path: &Path, workdir: &Path) -> String {
         .unwrap_or(path)
         .to_string_lossy()
         .replace('\\', "/")
+}
+
+/// Structured formats `extract` understands, detected from the file
+/// extension. `.md`/`.mdx`/`.astro` route to the YAML frontmatter block, not
+/// the whole file -- extract answers "what does this doc's frontmatter say",
+/// not "search the prose" (that is find-content's job, #707).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SourceFormat {
+    Json,
+    Toml,
+    Yaml,
+    Frontmatter,
+}
+
+impl SourceFormat {
+    /// Stable lowercase name, used as the `format` field in `extract`'s
+    /// usage telemetry.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            SourceFormat::Json => "json",
+            SourceFormat::Toml => "toml",
+            SourceFormat::Yaml => "yaml",
+            SourceFormat::Frontmatter => "frontmatter",
+        }
+    }
+}
+
+/// Detect the structured format from `path`'s extension. Unsupported or
+/// missing extensions are a loud, named error -- extract never guesses at a
+/// format from content sniffing.
+pub fn detect_format(path: &Path) -> Result<SourceFormat> {
+    let ext = path
+        .extension()
+        .and_then(|e| e.to_str())
+        .map(str::to_ascii_lowercase);
+    match ext.as_deref() {
+        Some("json") => Ok(SourceFormat::Json),
+        Some("toml") => Ok(SourceFormat::Toml),
+        Some("yaml") | Some("yml") => Ok(SourceFormat::Yaml),
+        Some("md") | Some("mdx") | Some("astro") => Ok(SourceFormat::Frontmatter),
+        Some(other) => Err(LegionError::Etc(format!(
+            "unsupported format '.{other}' for extract -- handles json, toml, yaml, and YAML \
+             frontmatter in .md/.mdx/.astro"
+        ))),
+        None => Err(LegionError::Etc(format!(
+            "'{}' has no file extension -- cannot detect a format for extract",
+            path.display()
+        ))),
+    }
+}
+
+/// Extract one field from `path` by a jq-style dotted path (#708): `.`
+/// separated segments walk objects, and a purely numeric segment indexes an
+/// array (`scripts.build`, `keywords.0`, `workspaces.packages.1`). The
+/// format is detected from the extension -- json, toml, yaml, or the YAML
+/// frontmatter block of a `.md`/`.mdx`/`.astro` file. A missing field names
+/// the deepest segment that DID resolve, so the caller can correct the path
+/// without opening the file. Keys that themselves contain a literal `.` are
+/// out of scope for v1.
+pub fn extract_field(path: &Path, field: &str) -> Result<serde_json::Value> {
+    if field.trim().is_empty() {
+        return Err(LegionError::Etc("--field must not be empty".to_string()));
+    }
+    let format = detect_format(path)?;
+    let root = parse_source(path, format)?;
+    walk_field(&root, field, path)
+}
+
+/// Read and parse `path` into a generic JSON value per its detected format.
+/// TOML and YAML each parse into their own `Value` type first, then convert
+/// into `serde_json::Value` -- one dotted-path walker (`walk_field`) then
+/// serves every format identically.
+fn parse_source(path: &Path, format: SourceFormat) -> Result<serde_json::Value> {
+    let content = std::fs::read_to_string(path)
+        .map_err(|e| LegionError::Etc(format!("cannot read '{}': {e}", path.display())))?;
+    match format {
+        SourceFormat::Json => serde_json::from_str(&content)
+            .map_err(|e| LegionError::Etc(format!("invalid JSON in '{}': {e}", path.display()))),
+        SourceFormat::Toml => {
+            let value: toml::Value = toml::from_str(&content).map_err(|e| {
+                LegionError::Etc(format!("invalid TOML in '{}': {e}", path.display()))
+            })?;
+            serde_json::to_value(value).map_err(|e| {
+                LegionError::Etc(format!(
+                    "cannot convert TOML to JSON in '{}': {e}",
+                    path.display()
+                ))
+            })
+        }
+        SourceFormat::Yaml => parse_yaml(&content, path),
+        SourceFormat::Frontmatter => {
+            let yaml_text = extract_frontmatter(&content, path)?;
+            parse_yaml(&yaml_text, path)
+        }
+    }
+}
+
+/// Parse a YAML document (or a frontmatter block's text) into JSON. YAML is
+/// handled by `serde_yaml_ng`, a maintained fork of the archived and
+/// unmaintained `serde_yaml` (RUSTSEC-2024-0320) -- API-compatible, so the
+/// rest of the pipeline (deserialize to a `Value`, convert to
+/// `serde_json::Value`) is identical to the TOML path.
+fn parse_yaml(text: &str, path: &Path) -> Result<serde_json::Value> {
+    let value: serde_yaml_ng::Value = serde_yaml_ng::from_str(text)
+        .map_err(|e| LegionError::Etc(format!("invalid YAML in '{}': {e}", path.display())))?;
+    serde_json::to_value(value).map_err(|e| {
+        LegionError::Etc(format!(
+            "cannot convert YAML to JSON in '{}': {e}",
+            path.display()
+        ))
+    })
+}
+
+/// Pull the YAML frontmatter block out of a `.md`/`.mdx`/`.astro` file: the
+/// leading `---` ... `---` (or `...`) delimited section. The prose/component
+/// body after it is out of scope for extract -- that is find-content's job
+/// (#707).
+fn extract_frontmatter(content: &str, path: &Path) -> Result<String> {
+    let mut lines = content.lines();
+    match lines.next() {
+        Some(first) if first.trim_end() == "---" => {}
+        _ => {
+            return Err(LegionError::Etc(format!(
+                "no YAML frontmatter in '{}': file must start with a '---' line",
+                path.display()
+            )));
+        }
+    }
+    let mut yaml_lines = Vec::new();
+    for line in lines {
+        let trimmed = line.trim_end();
+        if trimmed == "---" || trimmed == "..." {
+            return Ok(yaml_lines.join("\n"));
+        }
+        yaml_lines.push(line);
+    }
+    Err(LegionError::Etc(format!(
+        "YAML frontmatter in '{}' has no closing '---' delimiter",
+        path.display()
+    )))
+}
+
+/// Walk `root` along the `.`-separated segments of `field`. A segment that
+/// parses as a plain non-negative integer indexes an array; any other
+/// segment looks up an object key. On failure the error names the deepest
+/// segment that DID resolve (`<root>` if none did), so the caller can
+/// correct the path without opening the file.
+fn walk_field(root: &serde_json::Value, field: &str, path: &Path) -> Result<serde_json::Value> {
+    let mut current = root;
+    let mut resolved: Vec<&str> = Vec::new();
+    for segment in field.split('.') {
+        let next = match segment.parse::<usize>() {
+            Ok(idx) => current.as_array().and_then(|arr| arr.get(idx)),
+            Err(_) => current.as_object().and_then(|obj| obj.get(segment)),
+        };
+        match next {
+            Some(value) => {
+                current = value;
+                resolved.push(segment);
+            }
+            None => {
+                let deepest = if resolved.is_empty() {
+                    "<root>".to_string()
+                } else {
+                    resolved.join(".")
+                };
+                return Err(LegionError::Etc(format!(
+                    "field '{field}' not found in '{}': segment '{segment}' does not resolve \
+                     after '{deepest}' (keys containing a literal '.' are out of scope for extract)",
+                    path.display()
+                )));
+            }
+        }
+    }
+    Ok(current.clone())
 }
 
 #[cfg(test)]
@@ -501,5 +682,257 @@ mod tests {
         let result = find_content("needle", &scope(&repos)).expect("search");
         let repos_seen: Vec<&str> = result.hits.iter().map(|h| h.repo.as_str()).collect();
         assert_eq!(repos_seen, vec!["alpha", "beta"]);
+    }
+
+    // -- extract (#708) --
+
+    #[test]
+    fn extract_json_nested_string_field() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write(
+            dir.path(),
+            "package.json",
+            r#"{"scripts": {"build": "tsc -p ."}}"#,
+        );
+        let value = extract_field(&dir.path().join("package.json"), "scripts.build")
+            .expect("field resolves");
+        assert_eq!(value, serde_json::json!("tsc -p ."));
+    }
+
+    #[test]
+    fn extract_numeric_segment_indexes_array() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write(
+            dir.path(),
+            "package.json",
+            r#"{"keywords": ["cli", "agents", "memory"]}"#,
+        );
+        let value = extract_field(&dir.path().join("package.json"), "keywords.1")
+            .expect("array index resolves");
+        assert_eq!(value, serde_json::json!("agents"));
+    }
+
+    #[test]
+    fn extract_nested_numeric_segment_indexes_array() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write(
+            dir.path(),
+            "pnpm-workspace.json",
+            r#"{"workspaces": {"packages": ["apps/web", "packages/core"]}}"#,
+        );
+        let value = extract_field(
+            &dir.path().join("pnpm-workspace.json"),
+            "workspaces.packages.1",
+        )
+        .expect("nested array index resolves");
+        assert_eq!(value, serde_json::json!("packages/core"));
+    }
+
+    #[test]
+    fn extract_missing_field_names_deepest_resolved_segment() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write(
+            dir.path(),
+            "package.json",
+            r#"{"scripts": {"build": "tsc"}}"#,
+        );
+        let err = extract_field(&dir.path().join("package.json"), "scripts.test")
+            .expect_err("field is missing");
+        let msg = err.to_string();
+        assert!(msg.contains("'test'"), "message was: {msg}");
+        assert!(msg.contains("'scripts'"), "message was: {msg}");
+    }
+
+    #[test]
+    fn extract_missing_top_level_field_names_root() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write(dir.path(), "package.json", r#"{"scripts": {}}"#);
+        let err = extract_field(&dir.path().join("package.json"), "dependencies")
+            .expect_err("field is missing");
+        assert!(err.to_string().contains("<root>"));
+    }
+
+    #[test]
+    fn extract_empty_field_is_a_loud_error() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write(dir.path(), "package.json", r#"{"scripts": {}}"#);
+        let err =
+            extract_field(&dir.path().join("package.json"), "").expect_err("empty field rejected");
+        assert!(err.to_string().contains("must not be empty"));
+    }
+
+    #[test]
+    fn extract_toml_field() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write(
+            dir.path(),
+            "Cargo.toml",
+            "[package]\nname = \"legion\"\nversion = \"0.18.8\"\n",
+        );
+        let value = extract_field(&dir.path().join("Cargo.toml"), "package.name")
+            .expect("toml field resolves");
+        assert_eq!(value, serde_json::json!("legion"));
+    }
+
+    #[test]
+    fn extract_yaml_field() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write(
+            dir.path(),
+            "config.yaml",
+            "database:\n  host: localhost\n  port: 5432\n",
+        );
+        let value = extract_field(&dir.path().join("config.yaml"), "database.port")
+            .expect("yaml field resolves");
+        assert_eq!(value, serde_json::json!(5432));
+    }
+
+    #[test]
+    fn extract_yml_extension_also_parses_as_yaml() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write(dir.path(), "config.yml", "name: legion\n");
+        let value =
+            extract_field(&dir.path().join("config.yml"), "name").expect("yml field resolves");
+        assert_eq!(value, serde_json::json!("legion"));
+    }
+
+    #[test]
+    fn extract_md_frontmatter_field() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write(
+            dir.path(),
+            "post.md",
+            "---\ntitle: Hello World\ntags:\n  - rust\n  - cli\n---\n\n# Body\n\nNot YAML.\n",
+        );
+        let value =
+            extract_field(&dir.path().join("post.md"), "title").expect("frontmatter resolves");
+        assert_eq!(value, serde_json::json!("Hello World"));
+        let tag = extract_field(&dir.path().join("post.md"), "tags.0")
+            .expect("frontmatter array resolves");
+        assert_eq!(tag, serde_json::json!("rust"));
+    }
+
+    #[test]
+    fn extract_mdx_frontmatter_field() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write(
+            dir.path(),
+            "doc.mdx",
+            "---\ntitle: MDX Doc\n---\nimport { Foo } from './foo';\n\n<Foo />\n",
+        );
+        let value =
+            extract_field(&dir.path().join("doc.mdx"), "title").expect("frontmatter resolves");
+        assert_eq!(value, serde_json::json!("MDX Doc"));
+    }
+
+    #[test]
+    fn extract_astro_frontmatter_field() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write(
+            dir.path(),
+            "page.astro",
+            "---\ntitle: Astro Page\ndraft: false\n---\n<h1>{title}</h1>\n",
+        );
+        let value =
+            extract_field(&dir.path().join("page.astro"), "draft").expect("frontmatter resolves");
+        assert_eq!(value, serde_json::json!(false));
+    }
+
+    #[test]
+    fn extract_frontmatter_can_close_with_ellipsis() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write(
+            dir.path(),
+            "post.md",
+            "---\ntitle: Ellipsis Close\n...\nBody.\n",
+        );
+        let value =
+            extract_field(&dir.path().join("post.md"), "title").expect("frontmatter resolves");
+        assert_eq!(value, serde_json::json!("Ellipsis Close"));
+    }
+
+    #[test]
+    fn extract_missing_frontmatter_delimiter_is_a_loud_error() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write(
+            dir.path(),
+            "post.md",
+            "# Just a heading\n\nNo frontmatter.\n",
+        );
+        let err = extract_field(&dir.path().join("post.md"), "title")
+            .expect_err("no frontmatter present");
+        assert!(err.to_string().contains("frontmatter"));
+    }
+
+    #[test]
+    fn extract_unclosed_frontmatter_is_a_loud_error() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write(
+            dir.path(),
+            "post.md",
+            "---\ntitle: Unclosed\nBody with no close.\n",
+        );
+        let err = extract_field(&dir.path().join("post.md"), "title")
+            .expect_err("frontmatter never closes");
+        assert!(err.to_string().contains("closing"));
+    }
+
+    #[test]
+    fn extract_unsupported_extension_is_a_loud_error() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write(dir.path(), "notes.txt", "not structured\n");
+        let err = extract_field(&dir.path().join("notes.txt"), "anything")
+            .expect_err("unsupported format rejected");
+        assert!(err.to_string().contains("unsupported format"));
+    }
+
+    #[test]
+    fn extract_no_extension_is_a_loud_error() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write(dir.path(), "Makefile", "build:\n\tcargo build\n");
+        let err = extract_field(&dir.path().join("Makefile"), "anything")
+            .expect_err("no extension rejected");
+        assert!(err.to_string().contains("no file extension"));
+    }
+
+    #[test]
+    fn extract_invalid_json_is_a_loud_error() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write(dir.path(), "bad.json", "{not valid json");
+        let err = extract_field(&dir.path().join("bad.json"), "anything")
+            .expect_err("invalid json rejected");
+        assert!(err.to_string().contains("invalid JSON"));
+    }
+
+    #[test]
+    fn detect_format_maps_every_supported_extension() {
+        assert_eq!(
+            detect_format(Path::new("x.json")).unwrap(),
+            SourceFormat::Json
+        );
+        assert_eq!(
+            detect_format(Path::new("x.toml")).unwrap(),
+            SourceFormat::Toml
+        );
+        assert_eq!(
+            detect_format(Path::new("x.yaml")).unwrap(),
+            SourceFormat::Yaml
+        );
+        assert_eq!(
+            detect_format(Path::new("x.yml")).unwrap(),
+            SourceFormat::Yaml
+        );
+        assert_eq!(
+            detect_format(Path::new("x.md")).unwrap(),
+            SourceFormat::Frontmatter
+        );
+        assert_eq!(
+            detect_format(Path::new("x.mdx")).unwrap(),
+            SourceFormat::Frontmatter
+        );
+        assert_eq!(
+            detect_format(Path::new("x.astro")).unwrap(),
+            SourceFormat::Frontmatter
+        );
     }
 }

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -74,14 +74,23 @@ pub fn append_bypass(record: &BypassRecord) -> Result<()> {
 /// query. The counterpart of `BypassRecord` -- bypass volume says where the
 /// index fails agents; usage rows and their zero-result rate say whether the
 /// sanctioned surface actually answers (#704's primary success metric).
+///
+/// The schema is shared across query shapes rather than one struct per
+/// shape: `pattern` doubles as `extract`'s dotted `--field` path, and
+/// `hit_count` is 0/1 for a single-value lookup instead of a match count.
+/// `command` is what tells a reader which shape produced a given row.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct EtcUsageRecord {
     pub ts: DateTime<Utc>,
     /// Query shape, e.g. "find-content", "tree", "extract".
     pub command: String,
-    /// Repo filter; `None` means cross-repo.
+    /// Repo filter; `None` means cross-repo. Always `None` for `extract`,
+    /// which takes a direct path rather than a watch.toml repo.
     pub repo: Option<String>,
+    /// The search pattern (`find-content`) or dotted `--field` path
+    /// (`extract`).
     pub pattern: String,
+    /// `find-content` only; always `false` for other shapes.
     pub fixed_strings: bool,
     pub hit_count: u64,
     pub skipped_files: u64,
@@ -99,6 +108,12 @@ pub struct EtcUsageRecord {
     /// rows still parse.
     #[serde(default)]
     pub failed_repos: u64,
+    /// Detected source format for `extract` rows (json/toml/yaml/frontmatter,
+    /// see `etc::SourceFormat`). `None` for `find-content` rows, for an
+    /// `extract` invocation whose path had no recognizable format, and for
+    /// rows logged before #708. Defaulted so earlier rows still parse.
+    #[serde(default)]
+    pub format: Option<String>,
 }
 
 /// Resolve the canonical etc-usage log path (sibling of `bypass.jsonl`).
@@ -328,6 +343,31 @@ mod tests {
             skipped_files: 1,
             error: None,
             failed_repos: 1,
+            format: None,
+        };
+        append_jsonl(&path, &rec).unwrap();
+        let raw = std::fs::read_to_string(&path).unwrap();
+        let parsed: EtcUsageRecord = serde_json::from_str(raw.trim()).unwrap();
+        assert_eq!(parsed, rec);
+    }
+
+    /// `extract` (#708) rows use the same schema: `pattern` carries the
+    /// dotted `--field` path and `format` names the detected source format.
+    #[test]
+    fn etc_usage_extract_round_trip() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("etc-usage.jsonl");
+        let rec = EtcUsageRecord {
+            ts: Utc::now(),
+            command: "extract".to_string(),
+            repo: None,
+            pattern: "scripts.build".to_string(),
+            fixed_strings: false,
+            hit_count: 1,
+            skipped_files: 0,
+            error: None,
+            failed_repos: 0,
+            format: Some("json".to_string()),
         };
         append_jsonl(&path, &rec).unwrap();
         let raw = std::fs::read_to_string(&path).unwrap();
@@ -343,6 +383,7 @@ mod tests {
         let parsed: EtcUsageRecord = serde_json::from_str(legacy).unwrap();
         assert_eq!(parsed.error, None);
         assert_eq!(parsed.failed_repos, 0);
+        assert_eq!(parsed.format, None);
 
         let rec = EtcUsageRecord {
             ts: Utc::now(),
@@ -354,6 +395,33 @@ mod tests {
             skipped_files: 0,
             error: Some("invalid regex '(unclosed': ...".to_string()),
             failed_repos: 0,
+            format: None,
+        };
+        let json = serde_json::to_string(&rec).unwrap();
+        let back: EtcUsageRecord = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, rec);
+    }
+
+    /// Pre-#708 rows (find-content only) have no `format` key; the serde
+    /// default must keep them parseable, and an extract row's format text
+    /// must round-trip.
+    #[test]
+    fn etc_usage_format_field_defaults_and_round_trips() {
+        let legacy = r#"{"ts":"2026-07-02T01:01:32Z","command":"find-content","repo":null,"pattern":"x","fixed_strings":false,"hit_count":0,"skipped_files":0,"error":null,"failed_repos":0}"#;
+        let parsed: EtcUsageRecord = serde_json::from_str(legacy).unwrap();
+        assert_eq!(parsed.format, None);
+
+        let rec = EtcUsageRecord {
+            ts: Utc::now(),
+            command: "extract".to_string(),
+            repo: None,
+            pattern: "database.port".to_string(),
+            fixed_strings: false,
+            hit_count: 0,
+            skipped_files: 0,
+            error: Some("field 'port' not found in 'config.yaml': ...".to_string()),
+            failed_repos: 0,
+            format: Some("yaml".to_string()),
         };
         let json = serde_json::to_string(&rec).unwrap();
         let back: EtcUsageRecord = serde_json::from_str(&json).unwrap();

--- a/tests/integration/etc.rs
+++ b/tests/integration/etc.rs
@@ -1,9 +1,10 @@
-//! CLI end-to-end tests for `legion sym etc find-content` (#707).
+//! CLI end-to-end tests for `legion sym etc find-content` (#707) and
+//! `legion sym etc extract` (#708).
 //!
-//! The library core (`etc::find_content`) is unit-tested in src/etc.rs;
-//! these tests exercise the actual binary surface the review found
-//! uncovered: flag parsing, output shapes, loud error paths, and the
-//! telemetry side effect landing in etc-usage.jsonl.
+//! The library core (`etc::find_content`, `etc::extract_field`) is
+//! unit-tested in src/etc.rs; these tests exercise the actual binary
+//! surface the review found uncovered: flag parsing, output shapes, loud
+//! error paths, and the telemetry side effect landing in etc-usage.jsonl.
 
 use crate::common::{legion_cmd, run_fail, run_ok};
 
@@ -287,4 +288,196 @@ fn find_content_hit_cap_warns_on_stderr() {
         stderr.contains("5 more matches suppressed (cap 500)"),
         "expected the suppression note, got:\n{stderr}"
     );
+}
+
+// -- extract (#708) --
+
+#[test]
+fn extract_cli_default_output_and_telemetry() {
+    let data_dir = tempfile::tempdir().expect("data dir");
+    let repo_dir = tempfile::tempdir().expect("repo dir");
+    let state_dir = tempfile::tempdir().expect("state dir");
+    std::fs::write(
+        repo_dir.path().join("package.json"),
+        r#"{"scripts": {"build": "tsc -p ."}}"#,
+    )
+    .expect("write fixture");
+
+    let stdout = run_ok(
+        legion_cmd(data_dir.path())
+            .env("XDG_STATE_HOME", state_dir.path())
+            .args([
+                "sym",
+                "etc",
+                "extract",
+                repo_dir.path().join("package.json").to_str().unwrap(),
+                "--field",
+                "scripts.build",
+            ]),
+    );
+    // Default output is the bare scalar, not a JSON-quoted string.
+    assert_eq!(stdout.trim(), "tsc -p .");
+
+    let usage = std::fs::read_to_string(state_dir.path().join("legion/etc-usage.jsonl"))
+        .expect("etc-usage.jsonl written");
+    let row: serde_json::Value =
+        serde_json::from_str(usage.lines().next().expect("one row")).expect("row is JSON");
+    assert_eq!(row["command"], "extract");
+    assert_eq!(row["pattern"], "scripts.build");
+    assert_eq!(row["hit_count"], 1);
+    assert_eq!(row["format"], "json");
+    assert!(row["error"].is_null());
+}
+
+#[test]
+fn extract_cli_json_flag_emits_json_value() {
+    let data_dir = tempfile::tempdir().expect("data dir");
+    let repo_dir = tempfile::tempdir().expect("repo dir");
+    let state_dir = tempfile::tempdir().expect("state dir");
+    std::fs::write(
+        repo_dir.path().join("config.yaml"),
+        "database:\n  port: 5432\n",
+    )
+    .expect("write fixture");
+
+    let stdout = run_ok(
+        legion_cmd(data_dir.path())
+            .env("XDG_STATE_HOME", state_dir.path())
+            .args([
+                "sym",
+                "etc",
+                "extract",
+                repo_dir.path().join("config.yaml").to_str().unwrap(),
+                "--field",
+                "database.port",
+                "--json",
+            ]),
+    );
+    let value: serde_json::Value = serde_json::from_str(stdout.trim()).expect("stdout is JSON");
+    assert_eq!(value, serde_json::json!(5432));
+}
+
+#[test]
+fn extract_cli_array_field_prints_one_element_per_line() {
+    let data_dir = tempfile::tempdir().expect("data dir");
+    let repo_dir = tempfile::tempdir().expect("repo dir");
+    let state_dir = tempfile::tempdir().expect("state dir");
+    std::fs::write(
+        repo_dir.path().join("package.json"),
+        r#"{"keywords": ["cli", "agents", "memory"]}"#,
+    )
+    .expect("write fixture");
+
+    let stdout = run_ok(
+        legion_cmd(data_dir.path())
+            .env("XDG_STATE_HOME", state_dir.path())
+            .args([
+                "sym",
+                "etc",
+                "extract",
+                repo_dir.path().join("package.json").to_str().unwrap(),
+                "--field",
+                "keywords",
+            ]),
+    );
+    assert_eq!(
+        stdout.lines().collect::<Vec<_>>(),
+        vec!["cli", "agents", "memory"]
+    );
+}
+
+#[test]
+fn extract_cli_mdx_frontmatter_field() {
+    let data_dir = tempfile::tempdir().expect("data dir");
+    let repo_dir = tempfile::tempdir().expect("repo dir");
+    let state_dir = tempfile::tempdir().expect("state dir");
+    std::fs::write(
+        repo_dir.path().join("doc.mdx"),
+        "---\ntitle: Hello\n---\nimport { Foo } from './foo';\n\n<Foo />\n",
+    )
+    .expect("write fixture");
+
+    let stdout = run_ok(
+        legion_cmd(data_dir.path())
+            .env("XDG_STATE_HOME", state_dir.path())
+            .args([
+                "sym",
+                "etc",
+                "extract",
+                repo_dir.path().join("doc.mdx").to_str().unwrap(),
+                "--field",
+                "title",
+            ]),
+    );
+    assert_eq!(stdout.trim(), "Hello");
+}
+
+#[test]
+fn extract_cli_missing_field_fails_loudly_and_lands_in_telemetry() {
+    let data_dir = tempfile::tempdir().expect("data dir");
+    let repo_dir = tempfile::tempdir().expect("repo dir");
+    let state_dir = tempfile::tempdir().expect("state dir");
+    std::fs::write(
+        repo_dir.path().join("package.json"),
+        r#"{"scripts": {"build": "tsc"}}"#,
+    )
+    .expect("write fixture");
+
+    let (_stdout, stderr) = run_fail(
+        legion_cmd(data_dir.path())
+            .env("XDG_STATE_HOME", state_dir.path())
+            .args([
+                "sym",
+                "etc",
+                "extract",
+                repo_dir.path().join("package.json").to_str().unwrap(),
+                "--field",
+                "scripts.test",
+            ]),
+    );
+    assert!(
+        stderr.contains("'test'") && stderr.contains("'scripts'"),
+        "expected the deepest-resolved-segment error, got:\n{stderr}"
+    );
+
+    let usage = std::fs::read_to_string(state_dir.path().join("legion/etc-usage.jsonl"))
+        .expect("errored invocation still writes a usage row");
+    let row: serde_json::Value =
+        serde_json::from_str(usage.lines().next().expect("one row")).expect("row is JSON");
+    assert_eq!(row["hit_count"], 0);
+    assert_eq!(row["format"], "json");
+    assert!(row["error"].as_str().is_some_and(|e| e.contains("scripts")));
+}
+
+#[test]
+fn extract_cli_unsupported_extension_fails_loudly() {
+    let data_dir = tempfile::tempdir().expect("data dir");
+    let repo_dir = tempfile::tempdir().expect("repo dir");
+    let state_dir = tempfile::tempdir().expect("state dir");
+    std::fs::write(repo_dir.path().join("notes.txt"), "plain text\n").expect("write fixture");
+
+    let (_stdout, stderr) = run_fail(
+        legion_cmd(data_dir.path())
+            .env("XDG_STATE_HOME", state_dir.path())
+            .args([
+                "sym",
+                "etc",
+                "extract",
+                repo_dir.path().join("notes.txt").to_str().unwrap(),
+                "--field",
+                "anything",
+            ]),
+    );
+    assert!(
+        stderr.contains("unsupported format"),
+        "expected the unsupported-format error, got:\n{stderr}"
+    );
+
+    // Format could not be detected, so the telemetry row's format is null,
+    // not a guess.
+    let usage = std::fs::read_to_string(state_dir.path().join("legion/etc-usage.jsonl"))
+        .expect("errored invocation still writes a usage row");
+    let row: serde_json::Value =
+        serde_json::from_str(usage.lines().next().expect("one row")).expect("row is JSON");
+    assert!(row["format"].is_null());
 }


### PR DESCRIPTION
## Summary

Adds `legion sym etc extract <path> --field <dotted.path> [--json]`: pull one field out of a
JSON/TOML/YAML config file or the YAML frontmatter of a `.md`/`.mdx`/`.astro` doc, without
reading the whole file. All four source shapes convert into one `serde_json::Value` tree
(`parse_source`, src/etc.rs:330) so a single dotted-path walker (`walk_field`, src/etc.rs:409)
serves every format. Telemetry lands in the existing `etc-usage.jsonl` via a new `format`
field on `EtcUsageRecord` (src/telemetry.rs), reusing #707's shared-schema design rather than
adding a parallel record type.

## Acceptance criteria mapping

### 1. `legion sym etc extract package.json --field scripts.build` returns just that value

`run_etc_extract` (src/cli/index_cmd.rs:316) wires the CLI subcommand to `etc::extract_field`
and prints the bare scalar by default (`print_extract_value`, src/cli/index_cmd.rs:352).
Evidence: `extract_json_nested_string_field` (src/etc.rs) asserts
`extract_field(package.json, "scripts.build") == json!("tsc -p .")` at the library level;
`extract_cli_default_output_and_telemetry` (tests/integration/etc.rs) drives the actual
binary end-to-end and asserts `stdout.trim() == "tsc -p ."` (unquoted, not the JSON form).

### 2. Numeric segments index arrays; frontmatter fields extract from `.mdx` / `.astro`

`walk_field` (src/etc.rs:409) tries `segment.parse::<usize>()` first and array-indexes on
success, falling back to object-key lookup otherwise. Evidence: `extract_numeric_segment_indexes_array`
and `extract_nested_numeric_segment_indexes_array` (src/etc.rs) cover a top-level and a nested
array index (`keywords.1`, `workspaces.packages.1`). Frontmatter extraction goes through
`extract_frontmatter` (src/etc.rs:375), which isolates the leading `---`/`---` (or `...`)
block before handing it to the same YAML parser. Evidence: `extract_mdx_frontmatter_field` and
`extract_astro_frontmatter_field` (src/etc.rs) plus the CLI-level
`extract_cli_mdx_frontmatter_field` (tests/integration/etc.rs) all resolve a field from a real
`.mdx`/`.astro` fixture through the actual frontmatter fence.

### 3. Missing field errors clearly, naming the deepest segment that resolved

`walk_field` accumulates the segments that DID resolve in `resolved: Vec<&str>` and, on a
miss, names both the failing segment and the deepest resolved prefix (`<root>` if none
resolved) in the `LegionError::Etc` message (src/etc.rs:409-435). Evidence:
`extract_missing_field_names_deepest_resolved_segment` asserts the message contains both
`'test'` (the failing segment) and `'scripts'` (the deepest resolved one);
`extract_missing_top_level_field_names_root` asserts `<root>` appears when nothing resolved.
The CLI-level `extract_cli_missing_field_fails_loudly_and_lands_in_telemetry`
(tests/integration/etc.rs) confirms the same message shape reaches stderr through the real
binary and that the errored invocation still writes a usage row (`hit_count: 0`).

### 4. YAML handled by a maintained (non-serde_yaml) parser

Cargo.toml adds `serde_yaml_ng = "0.10"` with an inline comment naming the reason: `serde_yaml`
is archived with an open advisory (RUSTSEC-2024-0320); `serde_yaml_ng` is the maintained,
API-compatible fork. `parse_yaml` (src/etc.rs:360) is the only place `serde_yaml_ng` is
invoked. Evidence: `grep serde_yaml Cargo.toml` shows only the `_ng` crate; `extract_yaml_field`
and `extract_yml_extension_also_parses_as_yaml` (src/etc.rs) exercise both accepted
extensions end to end.

### 5. All tests pass; simplify + review done; PR created and linked

`cargo fmt -- --check` and `cargo clippy --all-targets -- -D warnings` both exit clean on
HEAD. `cargo test` passes 1227 lib tests + 221 + 219 integration tests (0 failed, 2 ignored --
the 2 ignored are pre-existing, unrelated to this change). Simplify gate recorded clean
(`legion quality-gate check --skill legion-simplify --result clean --findings-count 0`, gate
id 019f2fb2-7a7b-7232-8d1f-e7687ea8508c). This PR references and closes #708.

## Deliberately not done

- **Dotted-key escaping / JSON Pointer syntax** -- out of scope per the issue; a key
  containing a literal `.` (e.g. `"a.b": 1`) is unreachable via `--field`, and the error
  message says so explicitly (src/etc.rs:409, doc comment).
- **Literal numeric object keys** (`{"0": "x"}`) are unreachable by that key -- a numeric
  segment always tries array-indexing first. Documented in `walk_field`'s doc comment
  (src/etc.rs) as a v1 scope limitation, same class as the dotted-key issue above.
- **`.astro` fences that are actually JS/TS component script, not YAML** -- extract only
  covers `.astro` files whose fence happens to be YAML-shaped (plain frontmatter metadata
  above the component script). This is documented in `SourceFormat`'s doc comment
  (src/etc.rs) rather than attempting a JS-aware frontmatter parse.
- **Coverage gaps flagged by the pre-push review (non-blocking, left for the review stage):**
  the `other`-scalar and whole-object arms of `print_extract_value`'s non-`--json` output
  path have no dedicated test, and the TOML/YAML parse-error and value-conversion-failure
  branches in `parse_source` are untested beyond the JSON parse-error case
  (`extract_invalid_json_is_a_loud_error`). Flagging here rather than quietly leaving it for
  review to rediscover.