### PR TITLE
feat(#709): sym etc find-file -- locate files by name/role across repos

### DIFF
--- a/src/cli/index_cmd.rs
+++ b/src/cli/index_cmd.rs
@@ -868,9 +868,14 @@ struct FindFileScan {
 
 /// Resolve and filter `sym etc find-file` scope: validate an explicit
 /// `--repo` against watch.toml (the fix-hint error path), query the
-/// inventory table (server-side `--repo` filter only -- name and role have
-/// no dedicated column), then narrow by name/role in-process, the same
-/// split `scan_tree` uses for `--under`/`--depth`.
+/// inventory table once (server-side `--repo` filter only -- name and role
+/// have no dedicated column), then narrow by name/role in-process, the
+/// same split `scan_tree` uses for `--under`/`--depth`. Unlike `scan_tree`
+/// (whose main query is already `--ext`-filtered, so its uncovered-message
+/// baseline is a genuinely different, unfiltered query), find-file's main
+/// query has no server-side name/role filter to begin with -- so `raw`
+/// emptiness *is* the "never indexed" baseline, and no second query is
+/// needed to compute it.
 fn scan_find_file(
     database: &db::Database,
     repo: Option<&str>,
@@ -887,6 +892,7 @@ fn scan_find_file(
         lang: None,
     };
     let raw = database.list_file_inventory(&filter)?;
+    let never_indexed = raw.is_empty();
     let mut entries: Vec<db::inventory::FileInventoryEntry> = raw
         .into_iter()
         .filter(|e| db::inventory::matches_name(e, query))
@@ -894,31 +900,27 @@ fn scan_find_file(
         .collect();
     entries.sort_by(|a, b| a.repo.cmp(&b.repo).then(a.path.cmp(&b.path)));
 
-    let message = compute_find_file_uncovered_message(database, repo, query, role, &entries)?;
+    let message = compute_find_file_uncovered_message(repo, query, role, never_indexed, &entries);
     Ok(FindFileScan { entries, message })
 }
 
 /// Empty-result message, distinguishing "this repo has never been indexed"
 /// (or no repo has, cross-repo) from "the name/role filter matched
 /// nothing" -- the criterion requires an explicit hint, not a bare empty
-/// list. Runs a second, unfiltered query only on the empty path, so the
-/// common non-empty case pays no extra cost.
+/// list. `never_indexed` is the emptiness of the *unfiltered* inventory
+/// read `scan_find_file` already performed -- a pure function of that
+/// result, not a second database round-trip.
 fn compute_find_file_uncovered_message(
-    database: &db::Database,
     repo: Option<&str>,
     query: &str,
     role: Option<db::inventory::FileRole>,
+    never_indexed: bool,
     entries: &[db::inventory::FileInventoryEntry],
-) -> error::Result<Option<String>> {
+) -> Option<String> {
     if !entries.is_empty() {
-        return Ok(None);
+        return None;
     }
-    let baseline = database.list_file_inventory(&db::inventory::InventoryFilter {
-        repo,
-        ext: None,
-        lang: None,
-    })?;
-    Ok(Some(if baseline.is_empty() {
+    Some(if never_indexed {
         match repo {
             Some(name) => format!("no inventory for '{name}'; run `legion index {name}` first"),
             None => {
@@ -930,7 +932,7 @@ fn compute_find_file_uncovered_message(
             Some(r) => format!("no file named '{query}' with role '{r}' found"),
             None => format!("no file named '{query}' found"),
         }
-    }))
+    })
 }
 
 /// Compact telemetry description of the query/role used, e.g.
@@ -1009,18 +1011,20 @@ mod find_file_tests {
 
     #[test]
     fn message_none_when_entries_present_find_file() {
-        let db = crate::db::testutil::test_db();
         let entries = vec![entry("r", "components.json", Some("json"), None)];
-        let msg =
-            compute_find_file_uncovered_message(&db, Some("r"), "components.json", None, &entries)
-                .unwrap();
+        let msg = compute_find_file_uncovered_message(
+            Some("r"),
+            "components.json",
+            None,
+            false,
+            &entries,
+        );
         assert!(msg.is_none());
     }
 
     #[test]
     fn message_no_inventory_hint_when_repo_never_indexed() {
-        let db = crate::db::testutil::test_db();
-        let msg = compute_find_file_uncovered_message(&db, Some("ghost"), "x", None, &[]).unwrap();
+        let msg = compute_find_file_uncovered_message(Some("ghost"), "x", None, true, &[]);
         assert!(msg.as_deref().is_some_and(
             |m| m.contains("no inventory for 'ghost'") && m.contains("legion index ghost")
         ));
@@ -1028,8 +1032,7 @@ mod find_file_tests {
 
     #[test]
     fn message_cross_repo_wording_when_repo_none_find_file() {
-        let db = crate::db::testutil::test_db();
-        let msg = compute_find_file_uncovered_message(&db, None, "x", None, &[]).unwrap();
+        let msg = compute_find_file_uncovered_message(None, "x", None, true, &[]);
         assert!(
             msg.as_deref()
                 .is_some_and(|m| m.contains("no inventory across any watched repo"))
@@ -1038,17 +1041,13 @@ mod find_file_tests {
 
     #[test]
     fn message_no_match_names_query_and_role() {
-        let db = crate::db::testutil::test_db();
-        db.upsert_file_inventory(&[entry("r", "a.rs", Some("rs"), Some("rust"))])
-            .unwrap();
         let msg = compute_find_file_uncovered_message(
-            &db,
             Some("r"),
             "nope.json",
             Some(db::inventory::FileRole::Config),
+            false,
             &[],
-        )
-        .unwrap();
+        );
         assert!(msg.as_deref().is_some_and(|m| {
             m.contains("no file named 'nope.json'") && m.contains("role 'config'")
         }));

--- a/src/cli/index_cmd.rs
+++ b/src/cli/index_cmd.rs
@@ -182,6 +182,30 @@ pub(crate) enum EtcShape {
         #[arg(long)]
         json: bool,
     },
+
+    /// Locate a file by basename/glob or by role heuristic across watched
+    /// repos (#709) -- the "which repo owns X" / "locate the Y checkout"
+    /// shape. Queries the file inventory built by `legion index`
+    /// (`Database::list_file_inventory`); never walks the filesystem at
+    /// query time.
+    FindFile {
+        /// Basename or glob to match (e.g. "components.json",
+        /// "*.test.ts"). Matched against the file's basename; a query
+        /// containing `/` matches the full repo-relative path instead
+        /// (e.g. "src/db/*.rs"). `*`/`?` are glob wildcards; case-sensitive.
+        query: String,
+        /// Restrict to a single repo (default: cross-repo over every repo
+        /// with inventory rows, each entry tagged with its own `repo` field)
+        #[arg(long)]
+        repo: Option<String>,
+        /// Restrict to files matching a coarse role heuristic inferred
+        /// from path/extension only -- no content read.
+        #[arg(long)]
+        role: Option<db::inventory::FileRole>,
+        /// Emit results as a JSON array of FileInventoryEntry objects
+        #[arg(long)]
+        json: bool,
+    },
 }
 
 /// Dispatch `legion sym <action>` against the local index store.
@@ -237,13 +261,15 @@ fn run_sym_action(database: &db::Database, action: SymAction) -> error::Result<(
             depth,
             json,
         } => run_sym_tree(database, repo, ext, under, depth, json),
-        SymAction::Etc { shape } => run_sym_etc(shape),
+        SymAction::Etc { shape } => run_sym_etc(database, shape),
     }
 }
 
-/// Dispatch `legion sym etc <shape>`. Unlike the symbol queries these do not
-/// read the SCIP store -- find-content scans watched workdirs directly.
-fn run_sym_etc(shape: EtcShape) -> error::Result<()> {
+/// Dispatch `legion sym etc <shape>`. `find-content`/`extract` do not read
+/// the SCIP store -- find-content scans watched workdirs directly and
+/// extract reads one file directly. `find-file` queries the file inventory
+/// table, hence the `database` handle every arm now threads through.
+fn run_sym_etc(database: &db::Database, shape: EtcShape) -> error::Result<()> {
     match shape {
         EtcShape::FindContent {
             pattern,
@@ -254,6 +280,12 @@ fn run_sym_etc(shape: EtcShape) -> error::Result<()> {
             json,
         } => run_etc_find_content(&pattern, repo, ext, fixed_strings, hidden, json),
         EtcShape::Extract { path, field, json } => run_etc_extract(&path, &field, json),
+        EtcShape::FindFile {
+            query,
+            repo,
+            role,
+            json,
+        } => run_etc_find_file(database, &query, repo, role, json),
     }
 }
 
@@ -769,6 +801,274 @@ fn describe_tree_scope(ext: Option<&str>, under: Option<&str>, depth: Option<u32
         parts.push(format!("depth={d}"));
     }
     parts.join(",")
+}
+
+/// `sym etc find-file` (#709): locate a file by basename/glob or role
+/// heuristic across the file inventory (`Database::list_file_inventory`) --
+/// no filesystem walk at query time. Telemetry records one row per
+/// invocation, mirroring `find-content`/`tree` (#704's zero-result metric).
+fn run_etc_find_file(
+    database: &db::Database,
+    query: &str,
+    repo: Option<String>,
+    role: Option<db::inventory::FileRole>,
+    json: bool,
+) -> error::Result<()> {
+    use std::io::Write;
+
+    let scan = scan_find_file(database, repo.as_deref(), query, role);
+
+    let usage = telemetry::EtcUsageRecord {
+        ts: chrono::Utc::now(),
+        command: "find-file".to_string(),
+        repo: repo.clone(),
+        pattern: describe_find_file_scope(query, role),
+        fixed_strings: false,
+        hit_count: scan.as_ref().map_or(0, |r| r.entries.len() as u64),
+        skipped_files: 0,
+        error: scan.as_ref().err().map(|e| e.to_string()),
+        failed_repos: 0,
+        format: None,
+    };
+    if let Err(e) = telemetry::append_etc_usage(&usage) {
+        eprintln!("[legion] etc usage telemetry write failed: {e}");
+    }
+
+    let result = scan?;
+    if let Some(msg) = &result.message {
+        eprintln!("[legion] {msg}");
+    }
+
+    let stdout = std::io::stdout();
+    let mut out = stdout.lock();
+    if json {
+        serde_json::to_writer(&mut out, &result.entries)?;
+        writeln!(out)?;
+    } else {
+        let cross_repo = repo.is_none();
+        for e in &result.entries {
+            if cross_repo {
+                writeln!(out, "{}/{}", e.repo, e.path)?;
+            } else {
+                writeln!(out, "{}", e.path)?;
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Result of a `sym etc find-file` scan: the filtered, sorted entries plus
+/// an optional human-facing note for the empty case (either "never
+/// indexed" or "name/role matched nothing").
+#[derive(Debug)]
+struct FindFileScan {
+    entries: Vec<db::inventory::FileInventoryEntry>,
+    message: Option<String>,
+}
+
+/// Resolve and filter `sym etc find-file` scope: validate an explicit
+/// `--repo` against watch.toml (the fix-hint error path), query the
+/// inventory table (server-side `--repo` filter only -- name and role have
+/// no dedicated column), then narrow by name/role in-process, the same
+/// split `scan_tree` uses for `--under`/`--depth`.
+fn scan_find_file(
+    database: &db::Database,
+    repo: Option<&str>,
+    query: &str,
+    role: Option<db::inventory::FileRole>,
+) -> error::Result<FindFileScan> {
+    if let Some(name) = repo {
+        validate_repo_known(name)?;
+    }
+
+    let filter = db::inventory::InventoryFilter {
+        repo,
+        ext: None,
+        lang: None,
+    };
+    let raw = database.list_file_inventory(&filter)?;
+    let mut entries: Vec<db::inventory::FileInventoryEntry> = raw
+        .into_iter()
+        .filter(|e| db::inventory::matches_name(e, query))
+        .filter(|e| role.is_none_or(|r| r.matches(e)))
+        .collect();
+    entries.sort_by(|a, b| a.repo.cmp(&b.repo).then(a.path.cmp(&b.path)));
+
+    let message = compute_find_file_uncovered_message(database, repo, query, role, &entries)?;
+    Ok(FindFileScan { entries, message })
+}
+
+/// Empty-result message, distinguishing "this repo has never been indexed"
+/// (or no repo has, cross-repo) from "the name/role filter matched
+/// nothing" -- the criterion requires an explicit hint, not a bare empty
+/// list. Runs a second, unfiltered query only on the empty path, so the
+/// common non-empty case pays no extra cost.
+fn compute_find_file_uncovered_message(
+    database: &db::Database,
+    repo: Option<&str>,
+    query: &str,
+    role: Option<db::inventory::FileRole>,
+    entries: &[db::inventory::FileInventoryEntry],
+) -> error::Result<Option<String>> {
+    if !entries.is_empty() {
+        return Ok(None);
+    }
+    let baseline = database.list_file_inventory(&db::inventory::InventoryFilter {
+        repo,
+        ext: None,
+        lang: None,
+    })?;
+    Ok(Some(if baseline.is_empty() {
+        match repo {
+            Some(name) => format!("no inventory for '{name}'; run `legion index {name}` first"),
+            None => {
+                "no inventory across any watched repo; run `legion index <repo>` first".to_string()
+            }
+        }
+    } else {
+        match role {
+            Some(r) => format!("no file named '{query}' with role '{r}' found"),
+            None => format!("no file named '{query}' found"),
+        }
+    }))
+}
+
+/// Compact telemetry description of the query/role used, e.g.
+/// "query=components.json,role=config".
+fn describe_find_file_scope(query: &str, role: Option<db::inventory::FileRole>) -> String {
+    match role {
+        Some(r) => format!("query={query},role={r}"),
+        None => format!("query={query}"),
+    }
+}
+
+#[cfg(test)]
+mod find_file_tests {
+    use super::*;
+
+    fn entry(
+        repo: &str,
+        path: &str,
+        ext: Option<&str>,
+        lang: Option<&str>,
+    ) -> db::inventory::FileInventoryEntry {
+        db::inventory::FileInventoryEntry {
+            repo: repo.to_string(),
+            path: path.to_string(),
+            ext: ext.map(|s| s.to_string()),
+            lang: lang.map(|s| s.to_string()),
+            size: 10,
+            mtime: "2026-07-01T00:00:00+00:00".to_string(),
+            symbol_count: 0,
+        }
+    }
+
+    #[test]
+    fn scan_find_file_matches_by_basename_across_repos() {
+        let db = crate::db::testutil::test_db();
+        db.upsert_file_inventory(&[
+            entry("alpha", "web/components.json", Some("json"), None),
+            entry("beta", "components.json", Some("json"), None),
+            entry("alpha", "src/main.rs", Some("rs"), Some("rust")),
+        ])
+        .unwrap();
+
+        let scan = scan_find_file(&db, None, "components.json", None).unwrap();
+        assert_eq!(scan.entries.len(), 2);
+        assert!(scan.entries.iter().any(|e| e.repo == "alpha"));
+        assert!(scan.entries.iter().any(|e| e.repo == "beta"));
+        assert!(scan.message.is_none());
+    }
+
+    // NOTE: repo-scoping (`--repo alpha`) is not unit-tested here because
+    // `scan_find_file` validates `--repo` against a real watch.toml via
+    // `validate_repo_known`, which needs `LEGION_DATA_DIR` wired up --
+    // covered by the CLI end-to-end tests in tests/integration/find_file.rs
+    // instead (same split `sym_tree_tests` uses for `scan_tree`).
+
+    #[test]
+    fn scan_find_file_filters_by_role() {
+        let db = crate::db::testutil::test_db();
+        db.upsert_file_inventory(&[
+            entry("r", "app.config.json", Some("json"), None),
+            entry("r", "app.rs", Some("rs"), Some("rust")),
+        ])
+        .unwrap();
+
+        let scan = scan_find_file(&db, None, "*", Some(db::inventory::FileRole::Config)).unwrap();
+        assert_eq!(scan.entries.len(), 1);
+        assert_eq!(scan.entries[0].path, "app.config.json");
+    }
+
+    #[test]
+    fn scan_find_file_unknown_repo_errors() {
+        let db = crate::db::testutil::test_db();
+        let err = scan_find_file(&db, Some("ghost-repo"), "x", None).unwrap_err();
+        assert!(err.to_string().contains("ghost-repo"));
+    }
+
+    #[test]
+    fn message_none_when_entries_present_find_file() {
+        let db = crate::db::testutil::test_db();
+        let entries = vec![entry("r", "components.json", Some("json"), None)];
+        let msg =
+            compute_find_file_uncovered_message(&db, Some("r"), "components.json", None, &entries)
+                .unwrap();
+        assert!(msg.is_none());
+    }
+
+    #[test]
+    fn message_no_inventory_hint_when_repo_never_indexed() {
+        let db = crate::db::testutil::test_db();
+        let msg = compute_find_file_uncovered_message(&db, Some("ghost"), "x", None, &[]).unwrap();
+        assert!(msg.as_deref().is_some_and(
+            |m| m.contains("no inventory for 'ghost'") && m.contains("legion index ghost")
+        ));
+    }
+
+    #[test]
+    fn message_cross_repo_wording_when_repo_none_find_file() {
+        let db = crate::db::testutil::test_db();
+        let msg = compute_find_file_uncovered_message(&db, None, "x", None, &[]).unwrap();
+        assert!(
+            msg.as_deref()
+                .is_some_and(|m| m.contains("no inventory across any watched repo"))
+        );
+    }
+
+    #[test]
+    fn message_no_match_names_query_and_role() {
+        let db = crate::db::testutil::test_db();
+        db.upsert_file_inventory(&[entry("r", "a.rs", Some("rs"), Some("rust"))])
+            .unwrap();
+        let msg = compute_find_file_uncovered_message(
+            &db,
+            Some("r"),
+            "nope.json",
+            Some(db::inventory::FileRole::Config),
+            &[],
+        )
+        .unwrap();
+        assert!(msg.as_deref().is_some_and(|m| {
+            m.contains("no file named 'nope.json'") && m.contains("role 'config'")
+        }));
+    }
+
+    #[test]
+    fn describe_find_file_scope_query_only() {
+        assert_eq!(
+            describe_find_file_scope("components.json", None),
+            "query=components.json"
+        );
+    }
+
+    #[test]
+    fn describe_find_file_scope_with_role() {
+        assert_eq!(
+            describe_find_file_scope("*", Some(db::inventory::FileRole::Config)),
+            "query=*,role=config"
+        );
+    }
 }
 
 #[cfg(test)]

--- a/src/db/inventory.rs
+++ b/src/db/inventory.rs
@@ -185,18 +185,41 @@ fn is_entry(entry: &FileInventoryEntry) -> bool {
 /// single character); every other character must match literally. Matching
 /// is anchored to the whole string -- a query of `config` does not also
 /// match `myconfig.toml` -- and case-sensitive, since basenames are
-/// case-sensitive on the platforms legion indexes. Recurses over `char`
-/// slices (not bytes) so multi-byte UTF-8 basenames compare correctly.
+/// case-sensitive on the platforms legion indexes. Compares by `char`
+/// (not byte) so multi-byte UTF-8 basenames compare correctly.
+///
+/// Iterative two-pointer scan (the classic wildcard-matching algorithm),
+/// not recursive backtracking: `query` is free-form input run against
+/// every inventory row, and a naive `glob_match(pat) = glob_match(pat[1..])
+/// || glob_match(pat, name[1..])` recursion on `*` is exponential on an
+/// adversarial pattern like `"*a*a*a*a*a*a*a*a*a*a"` against a long
+/// near-miss name. This version tracks at most one "last `*`" backtrack
+/// point (`star_idx`/`match_idx`) and never re-explores a branch, so it's
+/// linear in `pattern.len() + name.len()` for any input.
 fn glob_match(pattern: &[char], name: &[char]) -> bool {
-    match (pattern.first(), name.first()) {
-        (None, None) => true,
-        (Some('*'), _) => {
-            glob_match(&pattern[1..], name) || (!name.is_empty() && glob_match(pattern, &name[1..]))
+    let (mut pi, mut ni) = (0usize, 0usize);
+    let mut star_idx: Option<usize> = None;
+    let mut match_idx = 0usize;
+    while ni < name.len() {
+        if pi < pattern.len() && (pattern[pi] == '?' || pattern[pi] == name[ni]) {
+            pi += 1;
+            ni += 1;
+        } else if pi < pattern.len() && pattern[pi] == '*' {
+            star_idx = Some(pi);
+            match_idx = ni;
+            pi += 1;
+        } else if let Some(si) = star_idx {
+            pi = si + 1;
+            match_idx += 1;
+            ni = match_idx;
+        } else {
+            return false;
         }
-        (Some('?'), Some(_)) => glob_match(&pattern[1..], &name[1..]),
-        (Some(p), Some(n)) if p == n => glob_match(&pattern[1..], &name[1..]),
-        _ => false,
     }
+    while pi < pattern.len() && pattern[pi] == '*' {
+        pi += 1;
+    }
+    pi == pattern.len()
 }
 
 /// True when `entry` matches `query` for `sym etc find-file` (#709). A
@@ -724,6 +747,31 @@ mod tests {
         let e = entry("r", "src/db/inventory.rs", Some("rs"), Some("rust"));
         assert!(matches_name(&e, "src/db/*.rs"));
         assert!(!matches_name(&e, "src/cli/*.rs"));
+    }
+
+    /// Regression guard: a naive recursive `glob_match` that backtracks by
+    /// re-exploring both branches of `*` is exponential on a many-star
+    /// pattern against a long near-miss name. This asserts the match
+    /// completes (and answers correctly) well within a runtime that would
+    /// be unreachable if the exponential behavior had regressed.
+    #[test]
+    fn matches_name_many_star_pattern_is_not_exponential() {
+        let long_name = "a".repeat(40) + "!"; // never satisfies a trailing literal "a"
+        let e = entry("r", &long_name, None, None);
+        let pattern = "*a*a*a*a*a*a*a*a*a*a*a*a*a*a*a*a*a*a*a*a";
+
+        let start = std::time::Instant::now();
+        let result = matches_name(&e, pattern);
+        let elapsed = start.elapsed();
+
+        assert!(
+            !result,
+            "pattern requires a literal trailing 'a', name ends in '!'"
+        );
+        assert!(
+            elapsed < std::time::Duration::from_secs(1),
+            "glob_match took {elapsed:?} -- backtracking blowup regressed"
+        );
     }
 
     // --- FileRole heuristics ---

--- a/src/db/inventory.rs
+++ b/src/db/inventory.rs
@@ -52,6 +52,170 @@ pub struct InventoryFilter<'a> {
     pub lang: Option<&'a str>,
 }
 
+/// Coarse role bucket for `sym etc find-file --role` (#709), inferred
+/// purely from path and extension -- no file content is read. Each
+/// heuristic trades completeness for being answerable straight from the
+/// inventory row; a project with unconventional naming will have real
+/// files a role misses. `sym etc find-content`/`extract` are the routes
+/// for anything that needs to look inside a file.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
+pub enum FileRole {
+    /// Settings/config files: a known config extension, or a well-known
+    /// config basename that carries no extension of its own.
+    Config,
+    /// Test files: under a tests/test/__tests__ directory, or named with a
+    /// test/spec convention (`foo.test.ts`, `test_foo.py`, `foo_test.go`).
+    Test,
+    /// Documentation: prose extensions, files under a docs/ directory, or
+    /// well-known doc basenames (README, CHANGELOG, LICENSE).
+    Doc,
+    /// Entrypoints: the file a language's toolchain treats as a program's
+    /// starting point (`main.rs`, `index.ts`, `__init__.py`, ...).
+    Entry,
+}
+
+impl std::fmt::Display for FileRole {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let s = match self {
+            Self::Config => "config",
+            Self::Test => "test",
+            Self::Doc => "doc",
+            Self::Entry => "entry",
+        };
+        write!(f, "{s}")
+    }
+}
+
+const CONFIG_EXTS: &[&str] = &["toml", "yaml", "yml", "json", "ini", "cfg", "conf", "env"];
+const CONFIG_BASENAMES: &[&str] = &[
+    "Dockerfile",
+    "Makefile",
+    ".env",
+    ".gitignore",
+    ".editorconfig",
+    ".npmrc",
+    ".nvmrc",
+];
+const DOC_EXTS: &[&str] = &["md", "mdx", "txt", "rst", "adoc"];
+const DOC_BASENAMES: &[&str] = &[
+    "README",
+    "README.md",
+    "CHANGELOG.md",
+    "LICENSE",
+    "CONTRIBUTING.md",
+];
+const ENTRY_BASENAMES: &[&str] = &[
+    "main.rs",
+    "lib.rs",
+    "mod.rs",
+    "main.py",
+    "__init__.py",
+    "app.py",
+    "index.ts",
+    "index.js",
+    "index.tsx",
+    "index.jsx",
+    "main.go",
+    "main.java",
+];
+const TEST_DIR_SEGMENTS: &[&str] = &["tests", "test", "__tests__", "spec"];
+
+/// Final path segment (the filename), or the whole path when it has no `/`.
+fn basename(path: &str) -> &str {
+    path.rsplit('/').next().unwrap_or(path)
+}
+
+impl FileRole {
+    /// True when `entry`'s path/extension matches this role's heuristic.
+    pub fn matches(self, entry: &FileInventoryEntry) -> bool {
+        match self {
+            Self::Config => is_config(entry),
+            Self::Test => is_test(entry),
+            Self::Doc => is_doc(entry),
+            Self::Entry => is_entry(entry),
+        }
+    }
+}
+
+fn is_config(entry: &FileInventoryEntry) -> bool {
+    if let Some(ext) = &entry.ext
+        && CONFIG_EXTS.contains(&ext.as_str())
+    {
+        return true;
+    }
+    CONFIG_BASENAMES.contains(&basename(&entry.path))
+}
+
+fn is_test(entry: &FileInventoryEntry) -> bool {
+    let path = entry.path.as_str();
+    if path.split('/').any(|seg| TEST_DIR_SEGMENTS.contains(&seg)) {
+        return true;
+    }
+    let base = basename(path);
+    let stem = entry
+        .ext
+        .as_deref()
+        .and_then(|e| base.strip_suffix(&format!(".{e}")))
+        .unwrap_or(base);
+    stem.starts_with("test_")
+        || stem.ends_with("_test")
+        || stem.ends_with(".test")
+        || stem.ends_with(".spec")
+}
+
+fn is_doc(entry: &FileInventoryEntry) -> bool {
+    if let Some(ext) = &entry.ext
+        && DOC_EXTS.contains(&ext.as_str())
+    {
+        return true;
+    }
+    let path = entry.path.as_str();
+    if path == "docs" || path.starts_with("docs/") || path.contains("/docs/") {
+        return true;
+    }
+    DOC_BASENAMES.contains(&basename(path))
+}
+
+fn is_entry(entry: &FileInventoryEntry) -> bool {
+    ENTRY_BASENAMES.contains(&basename(&entry.path))
+}
+
+/// True when `name` matches `pattern`, where `pattern` may use glob
+/// wildcards `*` (any run of characters, including none) and `?` (any
+/// single character); every other character must match literally. Matching
+/// is anchored to the whole string -- a query of `config` does not also
+/// match `myconfig.toml` -- and case-sensitive, since basenames are
+/// case-sensitive on the platforms legion indexes. Recurses over `char`
+/// slices (not bytes) so multi-byte UTF-8 basenames compare correctly.
+fn glob_match(pattern: &[char], name: &[char]) -> bool {
+    match (pattern.first(), name.first()) {
+        (None, None) => true,
+        (Some('*'), _) => {
+            glob_match(&pattern[1..], name) || (!name.is_empty() && glob_match(pattern, &name[1..]))
+        }
+        (Some('?'), Some(_)) => glob_match(&pattern[1..], &name[1..]),
+        (Some(p), Some(n)) if p == n => glob_match(&pattern[1..], &name[1..]),
+        _ => false,
+    }
+}
+
+/// True when `entry` matches `query` for `sym etc find-file` (#709). A
+/// query containing `/` matches against the full repo-relative path (so a
+/// subtree-scoped glob like `src/db/*.rs` works); otherwise it matches
+/// against just the basename, so `components.json` finds the file
+/// regardless of which directory holds it. See [`glob_match`] for wildcard
+/// semantics.
+pub fn matches_name(entry: &FileInventoryEntry, query: &str) -> bool {
+    let pattern: Vec<char> = query.chars().collect();
+    if query.contains('/') {
+        let path: Vec<char> = entry.path.chars().collect();
+        glob_match(&pattern, &path)
+    } else {
+        let base: Vec<char> = basename(&entry.path).chars().collect();
+        glob_match(&pattern, &base)
+    }
+}
+
 /// Create the `file_inventory` table and its `(repo, ext)` covering index.
 ///
 /// Repo-scoped lookups need no dedicated index: the `(repo, path)` primary
@@ -517,5 +681,102 @@ mod tests {
             .unwrap();
         assert_eq!(got.len(), 1);
         assert_eq!(got[0].repo, "alpha");
+    }
+
+    // --- matches_name / glob_match ---
+
+    #[test]
+    fn matches_name_exact_basename() {
+        let e = entry("r", "src/components.json", Some("json"), None);
+        assert!(matches_name(&e, "components.json"));
+        assert!(!matches_name(&e, "component.json"));
+    }
+
+    #[test]
+    fn matches_name_ignores_directory_when_query_has_no_slash() {
+        let e = entry("r", "deep/nested/dir/config.toml", Some("toml"), None);
+        assert!(matches_name(&e, "config.toml"));
+    }
+
+    #[test]
+    fn matches_name_star_glob_matches_basename() {
+        let e = entry("r", "src/foo.test.ts", Some("ts"), Some("typescript"));
+        assert!(matches_name(&e, "*.test.ts"));
+        assert!(!matches_name(&e, "*.spec.ts"));
+    }
+
+    #[test]
+    fn matches_name_question_mark_matches_single_char() {
+        let e = entry("r", "a.rs", Some("rs"), Some("rust"));
+        assert!(matches_name(&e, "?.rs"));
+        assert!(!matches_name(&e, "??.rs"));
+    }
+
+    #[test]
+    fn matches_name_is_anchored_not_substring() {
+        let e = entry("r", "myconfig.toml", Some("toml"), None);
+        assert!(!matches_name(&e, "config"));
+        assert!(matches_name(&e, "myconfig.toml"));
+    }
+
+    #[test]
+    fn matches_name_slash_in_query_matches_full_path() {
+        let e = entry("r", "src/db/inventory.rs", Some("rs"), Some("rust"));
+        assert!(matches_name(&e, "src/db/*.rs"));
+        assert!(!matches_name(&e, "src/cli/*.rs"));
+    }
+
+    // --- FileRole heuristics ---
+
+    #[test]
+    fn role_config_matches_known_ext_and_basename() {
+        assert!(FileRole::Config.matches(&entry("r", "watch.toml", Some("toml"), None)));
+        assert!(FileRole::Config.matches(&entry("r", "Dockerfile", None, None)));
+        assert!(!FileRole::Config.matches(&entry("r", "src/main.rs", Some("rs"), Some("rust"))));
+    }
+
+    #[test]
+    fn role_test_matches_test_dir_and_naming_conventions() {
+        assert!(FileRole::Test.matches(&entry(
+            "r",
+            "tests/integration/foo.rs",
+            Some("rs"),
+            Some("rust")
+        )));
+        assert!(FileRole::Test.matches(&entry(
+            "r",
+            "src/foo.test.ts",
+            Some("ts"),
+            Some("typescript")
+        )));
+        assert!(FileRole::Test.matches(&entry("r", "test_foo.py", Some("py"), Some("python"))));
+        assert!(!FileRole::Test.matches(&entry("r", "src/main.rs", Some("rs"), Some("rust"))));
+    }
+
+    #[test]
+    fn role_doc_matches_prose_ext_and_docs_dir() {
+        assert!(FileRole::Doc.matches(&entry("r", "docs/site/architecture.md", Some("md"), None)));
+        assert!(FileRole::Doc.matches(&entry("r", "README.md", Some("md"), None)));
+        assert!(!FileRole::Doc.matches(&entry("r", "src/main.rs", Some("rs"), Some("rust"))));
+    }
+
+    #[test]
+    fn role_entry_matches_known_entrypoint_basenames() {
+        assert!(FileRole::Entry.matches(&entry("r", "src/main.rs", Some("rs"), Some("rust"))));
+        assert!(FileRole::Entry.matches(&entry("r", "index.ts", Some("ts"), Some("typescript"))));
+        assert!(!FileRole::Entry.matches(&entry(
+            "r",
+            "src/db/inventory.rs",
+            Some("rs"),
+            Some("rust")
+        )));
+    }
+
+    #[test]
+    fn role_display_matches_cli_value_names() {
+        assert_eq!(FileRole::Config.to_string(), "config");
+        assert_eq!(FileRole::Test.to_string(), "test");
+        assert_eq!(FileRole::Doc.to_string(), "doc");
+        assert_eq!(FileRole::Entry.to_string(), "entry");
     }
 }

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -82,13 +82,13 @@ pub fn append_bypass(record: &BypassRecord) -> Result<()> {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct EtcUsageRecord {
     pub ts: DateTime<Utc>,
-    /// Query shape, e.g. "find-content", "tree", "extract".
+    /// Query shape, e.g. "find-content", "tree", "extract", "find-file".
     pub command: String,
     /// Repo filter; `None` means cross-repo. Always `None` for `extract`,
     /// which takes a direct path rather than a watch.toml repo.
     pub repo: Option<String>,
-    /// The search pattern (`find-content`) or dotted `--field` path
-    /// (`extract`).
+    /// The search pattern (`find-content`), dotted `--field` path
+    /// (`extract`), or `query=...[,role=...]` description (`find-file`).
     pub pattern: String,
     /// `find-content` only; always `false` for other shapes.
     pub fixed_strings: bool,

--- a/tests/integration/find_file.rs
+++ b/tests/integration/find_file.rs
@@ -1,0 +1,212 @@
+//! CLI end-to-end tests for `legion sym etc find-file` (#709).
+//!
+//! The pure matching/heuristic logic (`matches_name`, `FileRole::matches`)
+//! is unit-tested in src/db/inventory.rs, and the scan/message plumbing
+//! (`scan_find_file`, `compute_find_file_uncovered_message`,
+//! `describe_find_file_scope`) in src/cli/index_cmd.rs; these tests
+//! exercise the actual binary surface: flag parsing, the
+//! `Database::list_file_inventory` read path seeded by a real `legion
+//! index` run, cross-repo tagging, `--repo` scoping (which needs a real
+//! watch.toml to validate against), and the telemetry side effect landing
+//! in etc-usage.jsonl.
+
+use crate::common::{legion_cmd, run_fail, run_ok, run_ok_stderr};
+
+/// Seed a watch.toml in the data dir pointing at `repos` (name, workdir).
+/// Backslashes are TOML escape syntax, so Windows paths interpolated raw
+/// into a basic string make the whole file unparseable -- normalize to
+/// forward slashes, which Windows path APIs accept.
+fn seed_watch_toml(data_dir: &std::path::Path, repos: &[(&str, &std::path::Path)]) {
+    let mut toml = String::new();
+    for (name, workdir) in repos {
+        toml.push_str(&format!(
+            "[[repos]]\nname = \"{}\"\nworkdir = \"{}\"\n\n",
+            name,
+            workdir.display().to_string().replace('\\', "/")
+        ));
+    }
+    std::fs::write(data_dir.join("watch.toml"), toml).expect("seed watch.toml");
+}
+
+#[test]
+fn find_file_matches_by_basename_across_repos() {
+    let data_dir = tempfile::tempdir().expect("data dir");
+    let alpha_dir = tempfile::tempdir().expect("alpha dir");
+    let beta_dir = tempfile::tempdir().expect("beta dir");
+    let state_dir = tempfile::tempdir().expect("state dir");
+
+    std::fs::create_dir_all(alpha_dir.path().join("web")).expect("mkdir");
+    std::fs::write(alpha_dir.path().join("web/components.json"), "{}").expect("write fixture");
+    std::fs::write(beta_dir.path().join("components.json"), "{}").expect("write fixture");
+    seed_watch_toml(
+        data_dir.path(),
+        &[("alpha", alpha_dir.path()), ("beta", beta_dir.path())],
+    );
+    run_ok(legion_cmd(data_dir.path()).args(["index", "alpha"]));
+    run_ok(legion_cmd(data_dir.path()).args(["index", "beta"]));
+
+    let json_out = run_ok(
+        legion_cmd(data_dir.path())
+            .env("XDG_STATE_HOME", state_dir.path())
+            .args(["sym", "etc", "find-file", "components.json", "--json"]),
+    );
+    let entries: Vec<serde_json::Value> =
+        serde_json::from_str(json_out.trim()).expect("stdout is a JSON array");
+    assert_eq!(
+        entries.len(),
+        2,
+        "must find the file in both repos: {entries:?}"
+    );
+    let repos: std::collections::HashSet<&str> = entries
+        .iter()
+        .map(|e| e["repo"].as_str().unwrap())
+        .collect();
+    assert!(repos.contains("alpha") && repos.contains("beta"));
+
+    // Human output tags each hit with its repo since the query is cross-repo.
+    let human_out = run_ok(
+        legion_cmd(data_dir.path())
+            .env("XDG_STATE_HOME", state_dir.path())
+            .args(["sym", "etc", "find-file", "components.json"]),
+    );
+    assert!(
+        human_out.contains("alpha/web/components.json"),
+        "got:\n{human_out}"
+    );
+    assert!(
+        human_out.contains("beta/components.json"),
+        "got:\n{human_out}"
+    );
+}
+
+#[test]
+fn find_file_repo_flag_scopes_to_one_repo() {
+    let data_dir = tempfile::tempdir().expect("data dir");
+    let alpha_dir = tempfile::tempdir().expect("alpha dir");
+    let beta_dir = tempfile::tempdir().expect("beta dir");
+    let state_dir = tempfile::tempdir().expect("state dir");
+
+    std::fs::write(alpha_dir.path().join("components.json"), "{}").expect("write fixture");
+    std::fs::write(beta_dir.path().join("components.json"), "{}").expect("write fixture");
+    seed_watch_toml(
+        data_dir.path(),
+        &[("alpha", alpha_dir.path()), ("beta", beta_dir.path())],
+    );
+    run_ok(legion_cmd(data_dir.path()).args(["index", "alpha"]));
+    run_ok(legion_cmd(data_dir.path()).args(["index", "beta"]));
+
+    let json_out = run_ok(
+        legion_cmd(data_dir.path())
+            .env("XDG_STATE_HOME", state_dir.path())
+            .args([
+                "sym",
+                "etc",
+                "find-file",
+                "components.json",
+                "--repo",
+                "alpha",
+                "--json",
+            ]),
+    );
+    let entries: Vec<serde_json::Value> =
+        serde_json::from_str(json_out.trim()).expect("stdout is a JSON array");
+    assert_eq!(entries.len(), 1, "must scope to alpha only: {entries:?}");
+    assert_eq!(entries[0]["repo"], "alpha");
+}
+
+#[test]
+fn find_file_role_filters_to_config_files() {
+    let data_dir = tempfile::tempdir().expect("data dir");
+    let repo_dir = tempfile::tempdir().expect("repo dir");
+    let state_dir = tempfile::tempdir().expect("state dir");
+
+    std::fs::write(repo_dir.path().join("watch.toml"), "").expect("write fixture");
+    std::fs::write(repo_dir.path().join("main.rs"), "").expect("write fixture");
+    seed_watch_toml(data_dir.path(), &[("rolerepo", repo_dir.path())]);
+    run_ok(legion_cmd(data_dir.path()).args(["index", "rolerepo"]));
+
+    let json_out = run_ok(
+        legion_cmd(data_dir.path())
+            .env("XDG_STATE_HOME", state_dir.path())
+            .args(["sym", "etc", "find-file", "*", "--role", "config", "--json"]),
+    );
+    let entries: Vec<serde_json::Value> =
+        serde_json::from_str(json_out.trim()).expect("stdout is a JSON array");
+    assert_eq!(
+        entries.len(),
+        1,
+        "only the .toml file is role=config: {entries:?}"
+    );
+    assert_eq!(entries[0]["path"], "watch.toml");
+}
+
+#[test]
+fn find_file_unknown_repo_fails_loudly() {
+    let data_dir = tempfile::tempdir().expect("data dir");
+    let repo_dir = tempfile::tempdir().expect("repo dir");
+    let state_dir = tempfile::tempdir().expect("state dir");
+    seed_watch_toml(data_dir.path(), &[("realrepo", repo_dir.path())]);
+
+    let (_stdout, stderr) = run_fail(
+        legion_cmd(data_dir.path())
+            .env("XDG_STATE_HOME", state_dir.path())
+            .args(["sym", "etc", "find-file", "x", "--repo", "nonesuch"]),
+    );
+    assert!(
+        stderr.contains("not in watch.toml"),
+        "expected the fix-hint error, got:\n{stderr}"
+    );
+
+    // The failed invocation itself lands in telemetry with the error text.
+    let usage = std::fs::read_to_string(state_dir.path().join("legion/etc-usage.jsonl"))
+        .expect("errored invocation still writes a usage row");
+    let row: serde_json::Value =
+        serde_json::from_str(usage.lines().next().expect("one row")).expect("row is JSON");
+    assert_eq!(row["command"], "find-file");
+    assert_eq!(row["hit_count"], 0);
+    assert!(
+        row["error"]
+            .as_str()
+            .is_some_and(|e| e.contains("nonesuch")),
+        "error field should carry the failure, got: {row}"
+    );
+}
+
+#[test]
+fn find_file_no_match_prints_explicit_message_not_silence() {
+    let data_dir = tempfile::tempdir().expect("data dir");
+    let repo_dir = tempfile::tempdir().expect("repo dir");
+    let state_dir = tempfile::tempdir().expect("state dir");
+    std::fs::write(repo_dir.path().join("a.rs"), "").expect("write fixture");
+    seed_watch_toml(data_dir.path(), &[("findrepo", repo_dir.path())]);
+    run_ok(legion_cmd(data_dir.path()).args(["index", "findrepo"]));
+
+    let stderr = run_ok_stderr(
+        legion_cmd(data_dir.path())
+            .env("XDG_STATE_HOME", state_dir.path())
+            .args(["sym", "etc", "find-file", "nope.json", "--repo", "findrepo"]),
+    );
+    assert!(
+        stderr.contains("no file named 'nope.json'"),
+        "expected the explicit no-match hint, got:\n{stderr}"
+    );
+}
+
+#[test]
+fn find_file_uncovered_repo_prints_explicit_message_not_silence() {
+    let data_dir = tempfile::tempdir().expect("data dir");
+    let repo_dir = tempfile::tempdir().expect("repo dir");
+    let state_dir = tempfile::tempdir().expect("state dir");
+    // In watch.toml but never indexed -- zero inventory rows.
+    seed_watch_toml(data_dir.path(), &[("findrepo", repo_dir.path())]);
+
+    let stderr = run_ok_stderr(
+        legion_cmd(data_dir.path())
+            .env("XDG_STATE_HOME", state_dir.path())
+            .args(["sym", "etc", "find-file", "x", "--repo", "findrepo"]),
+    );
+    assert!(
+        stderr.contains("no inventory for 'findrepo'") && stderr.contains("legion index findrepo"),
+        "expected the explicit no-inventory hint, got:\n{stderr}"
+    );
+}

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -11,6 +11,7 @@ mod bullpen;
 mod daemon_watch;
 mod documents;
 mod etc;
+mod find_file;
 mod governance;
 mod index_telemetry;
 mod kanban;


### PR DESCRIPTION
## Summary

Adds `legion sym etc find-file` -- locate a file by basename/glob or by a coarse role
heuristic (config/test/doc/entry) across every watched repo's file inventory, without
touching the filesystem or SCIP at query time. This is the "which repo owns X" / "locate the
huttspawn checkout" shape from #704's bypass survey. Queries `Database::list_file_inventory`
(built by `legion index`, from #705), matches basenames/paths against a hand-rolled glob
(`*`/`?`), optionally narrows by `--role`, and tags every cross-repo hit with its owning repo
so the answer is unambiguous.

A first push of this branch tripped the pre-push automated review, which flagged two real
issues (an exponential-worst-case recursive glob matcher, and a redundant duplicate inventory
query on the empty-result path); both are fixed in a follow-up commit before this PR, and are
called out below where relevant.

## Acceptance criteria mapping

### 1. `legion sym etc find-file components.json` finds it across repos, tagged by repo

Cross-repo is the default (`--repo` unset): `run_etc_find_file` in `src/cli/index_cmd.rs`
queries `list_file_inventory` with no repo filter, matches basenames via `matches_name`
(`src/db/inventory.rs`), and prints `{repo}/{path}` per line in human mode (or the full
`FileInventoryEntry`, including its `repo` field, per hit in `--json` mode) whenever the query
is cross-repo. `matches_name` splits on whether the query contains `/`: a bare basename
(`components.json`) matches any file with that basename regardless of directory; a query
containing `/` (e.g. `src/db/*.rs`) matches the full repo-relative path instead.

Evidence: `tests/integration/find_file.rs::find_file_matches_by_basename_across_repos` seeds
two repos (`alpha`, `beta`) each with a `components.json` at a different depth, indexes both,
and asserts the JSON output contains both repos' entries and the human output contains both
`alpha/web/components.json` and `beta/components.json` lines. Unit-level:
`src/db/inventory.rs::matches_name_exact_basename` and
`matches_name_ignores_directory_when_query_has_no_slash` cover the basename-matching rule in
isolation; `matches_name_slash_in_query_matches_full_path` covers the full-path branch.

### 2. `--role config` surfaces config files; `--repo` scopes

`--role` takes a `clap::ValueEnum` (`FileRole::{Config,Test,Doc,Entry}`, `src/db/inventory.rs`)
and filters in-process after the inventory read, via `FileRole::matches`, which dispatches to
one of four table-driven heuristics (`is_config`/`is_test`/`is_doc`/`is_entry`) checking
extension, well-known basenames, and (for test/doc) path segments -- no file content is read.
`--repo` is validated against `watch.toml` (`validate_repo_known`) and passed through as a
server-side filter on `list_file_inventory` (`InventoryFilter.repo`), so an unknown repo fails
loudly with a fix-hint rather than silently returning nothing.

Evidence: `tests/integration/find_file.rs::find_file_role_filters_to_config_files` indexes a
repo containing both a `.toml` file and a `.rs` file and asserts `--role config --json`
returns exactly the `.toml` one. `find_file_repo_flag_scopes_to_one_repo` indexes two repos
with an identically-named file in each and asserts `--repo alpha` returns only alpha's entry.
`find_file_unknown_repo_fails_loudly` asserts an unknown `--repo` exits non-zero with
`"not in watch.toml"` in stderr, and that the errored invocation still lands a telemetry row
(`hit_count: 0`, `error` containing the bad repo name) in `etc-usage.jsonl` -- matching the
errored-invocation telemetry convention `4774b96` established for `find-content`/`tree`. Unit
tests `role_config_matches_known_ext_and_basename`, `role_test_matches_test_dir_and_naming_conventions`,
`role_doc_matches_prose_ext_and_docs_dir`, `role_entry_matches_known_entrypoint_basenames`, and
`role_display_matches_cli_value_names` (pinning that the `Display` impl's wording matches
clap's derived `--role` value names) cover each heuristic and the enum/CLI wiring directly.

### 3. Tests pass; simplify + review done; PR linked

`cargo test` passes clean: 1265 passed / 2 ignored (unit/lib suite), 230 passed / 2 ignored
(integration suite), 0 failures -- including the new `find_file_tests` module in
`src/cli/index_cmd.rs`, the `matches_name`/`FileRole` unit tests in `src/db/inventory.rs`
(including `matches_name_many_star_pattern_is_not_exponential`, a regression guard for the
glob-matcher fix below), and the seven end-to-end CLI tests in
`tests/integration/find_file.rs`. `cargo clippy --all-targets -- -D warnings` and
`cargo fmt -- --check` both pass clean. `/legion-simplify` ran on the branch and recorded a
clean gate (0 findings) after two real issues surfaced by the pre-push automated review were
fixed: `glob_match`'s original recursive-backtracking implementation was exponential-worst-case
on an adversarial many-`*` pattern (replaced with the standard linear iterative two-pointer
algorithm); and `scan_find_file`'s empty-result path re-queried the inventory table with an
identical filter to compute a baseline it already had from the main query (fixed to reuse the
already-fetched emptiness instead of a second round-trip). This PR references and closes #709.

## Deliberately not done

- **Content search.** Explicitly out of scope per the issue -- `sym etc find-content` (E3,
  already shipped) is the route for looking inside files; `find-file` never reads file
  contents, only path/extension metadata already in the inventory table.
- **Custom role categories or a `--role` value beyond the four specified
  (config/test/doc/entry).** The heuristics are intentionally coarse and documented as such
  (`FileRole`'s doc comment: "a project with unconventional naming will have real files a role
  misses") -- extending coverage is a follow-up, not part of this shape.
- **Fuzzy/typo-tolerant matching.** Only literal glob (`*`/`?`) matching is supported, matching
  the issue's stated interface (`<name-or-glob>`); no edit-distance or substring fallback.
- **Case-insensitive matching.** Matching is case-sensitive throughout, since basenames are
  case-sensitive on every platform legion indexes (documented on `glob_match`).
- **A `--role` value that also requires a `--repo`, or vice versa.** The two filters are
  fully independent and composable (`scan_find_file` applies both), not entangled.