### PR TITLE
feat(#710): module-graph engine via oxc_parser + oxc_resolver

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,6 +121,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrayvec"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
+
+[[package]]
 name = "async-stream"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -471,6 +477,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "cow-utils"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "417bef24afe1460300965a25ff4a24b8b45ad011948302ec221e8a0a81eb2c79"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -586,6 +598,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06d2e3287df1c007e74221c49ca10a95d557349e54b3a75dc2fb14712c751f04"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "dashmap"
+version = "6.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -708,6 +734,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
+name = "dragonbox_ecma"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd8e701084c37e7ef62d3f9e453b618130cbc0ef3573847785952a3ac3f746bf"
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -775,6 +807,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
+name = "fast-glob"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b9e81515b0279bf618200fd15d132e7195d2048fb46eed6f0f3c10cbc068266"
+dependencies = [
+ "arrayvec",
+]
+
+[[package]]
 name = "fastdivide"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -814,6 +855,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "float-cmp"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -824,6 +874,12 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "foreign-types"
@@ -1078,6 +1134,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "halfbrown"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c7ed2f2edad8a14c8186b847909a41fbb9c3eafa44f88bd891114ed5019da09"
+dependencies = [
+ "hashbrown 0.16.1",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+
+[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1085,7 +1156,7 @@ checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash",
+ "foldhash 0.1.5",
 ]
 
 [[package]]
@@ -1093,6 +1164,20 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "allocator-api2",
+]
 
 [[package]]
 name = "hashlink"
@@ -1546,6 +1631,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "json-strip-comments"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9301b34ecbe81051a62001a2dfa56d906628efdfbc68153e0a4d5eba58181ece"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1575,6 +1669,10 @@ dependencies = [
  "libc",
  "mime_guess",
  "model2vec-rs",
+ "oxc_allocator",
+ "oxc_parser",
+ "oxc_resolver",
+ "oxc_span",
  "portable-pty",
  "protobuf",
  "rand 0.9.2",
@@ -1888,6 +1986,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "nodejs-built-in-modules"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5eb86a92577833b75522336f210c49d9ebd7dd55a44d80a92e68c668a75f27c"
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1898,12 +2002,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "nonmax"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "610a5acd306ec67f907abe5567859a3c693fb9886eb1f012ab8f2a47bef3db51"
+
+[[package]]
 name = "ntapi"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
+dependencies = [
+ "num-integer",
+ "num-traits",
 ]
 
 [[package]]
@@ -2003,9 +2123,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "once_cell_polyfill"
@@ -2101,6 +2221,244 @@ dependencies = [
 ]
 
 [[package]]
+name = "owo-colors"
+version = "4.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
+
+[[package]]
+name = "oxc-miette"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b776084bf11ad750806cb63f9ed2606a12ab374cf458f36a7731eba1f5d753fc"
+dependencies = [
+ "cfg-if",
+ "owo-colors",
+ "oxc-miette-derive",
+ "textwrap",
+ "thiserror 2.0.18",
+ "unicode-segmentation",
+ "unicode-width",
+]
+
+[[package]]
+name = "oxc-miette-derive"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66e0bafc397eee2f94c5bf89bb5a82ba6d522d1b79e2924c8169f053febb433f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "oxc_allocator"
+version = "0.138.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8c54f9bbf7e174b39691080396390a9c6bea6d0dce206660567c1b88951f7b6"
+dependencies = [
+ "allocator-api2",
+ "hashbrown 0.17.1",
+ "oxc_data_structures",
+ "rustc-hash 2.1.2",
+]
+
+[[package]]
+name = "oxc_ast"
+version = "0.138.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22bf885a47f8e0562ae73e0487ec8f83358bbbca8aad99a8293a9919d6d9e7fe"
+dependencies = [
+ "bitflags 2.11.0",
+ "oxc_allocator",
+ "oxc_ast_macros",
+ "oxc_data_structures",
+ "oxc_diagnostics",
+ "oxc_estree",
+ "oxc_regular_expression",
+ "oxc_span",
+ "oxc_str",
+ "oxc_syntax",
+]
+
+[[package]]
+name = "oxc_ast_macros"
+version = "0.138.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81dcc7cd7607a42e3fed0d789535789ac6c16284f941a8aeed251265f29d1e52"
+dependencies = [
+ "phf",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "oxc_data_structures"
+version = "0.138.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30c920b812d5c7cd2c6b914dbeda4a7e6720e1de7869119b6de833ae39bedac9"
+
+[[package]]
+name = "oxc_diagnostics"
+version = "0.138.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b2d82feef8bf6118f57dffdc2cd9c22426b438b3f3298bc398bdf596297aeaa"
+dependencies = [
+ "cow-utils",
+ "oxc-miette",
+ "percent-encoding",
+]
+
+[[package]]
+name = "oxc_ecmascript"
+version = "0.138.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a5382979eb00843975f7dc33b567d9821f818b26f78d3e31ccf94af3cf78a8c"
+dependencies = [
+ "cow-utils",
+ "num-bigint",
+ "num-traits",
+ "oxc_allocator",
+ "oxc_ast",
+ "oxc_regular_expression",
+ "oxc_span",
+ "oxc_syntax",
+]
+
+[[package]]
+name = "oxc_estree"
+version = "0.138.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9891b86dad0ad62c3ff1585aa0601af7b49bb3d19c7115e3115e2fba3d13d6d2"
+
+[[package]]
+name = "oxc_index"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "191884bee6c3744909a51acc7d78d4ae370d817b25875b10642f632327b6296e"
+dependencies = [
+ "nonmax",
+ "serde",
+]
+
+[[package]]
+name = "oxc_parser"
+version = "0.138.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd79d7f27f20413eaeecada4d850aeb0220e70c821d4863d9fb0df115eae62a9"
+dependencies = [
+ "bitflags 2.11.0",
+ "cow-utils",
+ "memchr",
+ "num-bigint",
+ "num-traits",
+ "oxc_allocator",
+ "oxc_ast",
+ "oxc_data_structures",
+ "oxc_diagnostics",
+ "oxc_ecmascript",
+ "oxc_regular_expression",
+ "oxc_span",
+ "oxc_str",
+ "oxc_syntax",
+ "rustc-hash 2.1.2",
+ "seq-macro",
+]
+
+[[package]]
+name = "oxc_regular_expression"
+version = "0.138.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95bee883f864fb7c75d92ccae3b7db98afc4dce5d0b8b5165e681d93cb010399"
+dependencies = [
+ "bitflags 2.11.0",
+ "oxc_allocator",
+ "oxc_ast_macros",
+ "oxc_diagnostics",
+ "oxc_span",
+ "oxc_str",
+ "phf",
+ "rustc-hash 2.1.2",
+ "unicode-id-start",
+]
+
+[[package]]
+name = "oxc_resolver"
+version = "11.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "136a61141e3b45c8e5388464cbd85dc0e0437b79d6e496803f47210386cf18ea"
+dependencies = [
+ "cfg-if",
+ "compact_str",
+ "dashmap",
+ "fast-glob",
+ "indexmap",
+ "json-strip-comments",
+ "memchr",
+ "nodejs-built-in-modules",
+ "once_cell",
+ "percent-encoding",
+ "rustc-hash 2.1.2",
+ "rustix 1.1.4",
+ "self_cell",
+ "serde",
+ "serde_json",
+ "simd-json",
+ "simdutf8",
+ "thiserror 2.0.18",
+ "tracing",
+ "windows 0.62.2",
+]
+
+[[package]]
+name = "oxc_span"
+version = "0.138.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8faf48e243cdacc96018515701bea560664a4cdef545c1fc50be139c0637db13"
+dependencies = [
+ "compact_str",
+ "oxc-miette",
+ "oxc_allocator",
+ "oxc_ast_macros",
+ "oxc_estree",
+ "oxc_str",
+]
+
+[[package]]
+name = "oxc_str"
+version = "0.138.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7beac249fbb9815b974f1b1c2d22cb59be0c2a4a2ad42f1ee948e2600f4ff04c"
+dependencies = [
+ "compact_str",
+ "hashbrown 0.17.1",
+ "oxc_allocator",
+ "oxc_estree",
+]
+
+[[package]]
+name = "oxc_syntax"
+version = "0.138.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbe873bf4a3e494a56ec34f2710cb44309a071fd2c8360b893a12347d584c34"
+dependencies = [
+ "bitflags 2.11.0",
+ "cow-utils",
+ "dragonbox_ecma",
+ "nonmax",
+ "oxc_allocator",
+ "oxc_ast_macros",
+ "oxc_estree",
+ "oxc_index",
+ "oxc_span",
+ "oxc_str",
+ "phf",
+ "unicode-id-start",
+]
+
+[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2134,6 +2492,49 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "phf"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "010378780309880b08997fae13be7834dba947d36393bd372f2b1556deb2a2f6"
+dependencies = [
+ "phf_macros",
+ "phf_shared",
+ "serde",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aeb62e0959d5a1bebc965f4d15d9e2b7cea002b6b0f5ba8cde6cc26738467100"
+dependencies = [
+ "fastrand",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fa8d0ca26d424d27630da600c6624696e7dec8bf7b3b492b383c5dc49e5e085"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6fd9027e2d9319be6349febd1db4e8d02aa544921200c9b777720ac34a3aa89"
+dependencies = [
+ "siphasher",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -2477,6 +2878,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2798,10 +3219,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "self_cell"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b12e76d157a900eb52e81bc6e9f3069344290341720e9178cde2407113ac8d89"
+
+[[package]]
 name = "semver"
 version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+
+[[package]]
+name = "seq-macro"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc711410fbe7399f390ca1c3b60ad0f53f80e95c5eb935e52268a0e2cd49acc"
 
 [[package]]
 name = "serde"
@@ -2839,6 +3272,7 @@ version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
+ "indexmap",
  "itoa",
  "memchr",
  "serde",
@@ -2952,6 +3386,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
 
 [[package]]
+name = "simd-json"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4255126f310d2ba20048db6321c81ab376f6a6735608bf11f0785c41f01f64e3"
+dependencies = [
+ "halfbrown",
+ "ref-cast",
+ "simdutf8",
+ "value-trait",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
+name = "siphasher"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
+
+[[package]]
 name = "sketches-ddsketch"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2971,6 +3429,12 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "smawk"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8e2fb0f499abb4d162f2bedad68f5ef91a1682b5a03596ddb67efd37768d100"
 
 [[package]]
 name = "smugglr-core"
@@ -3116,7 +3580,7 @@ dependencies = [
  "memchr",
  "ntapi",
  "objc2-core-foundation",
- "windows",
+ "windows 0.57.0",
 ]
 
 [[package]]
@@ -3292,6 +3756,17 @@ dependencies = [
  "once_cell",
  "rustix 1.1.4",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c13547615a44dc9c452a8a534638acdf07120d4b6847c8178705da06306a3057"
+dependencies = [
+ "smawk",
+ "unicode-linebreak",
+ "unicode-width",
 ]
 
 [[package]]
@@ -3635,10 +4110,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
+name = "unicode-id-start"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81b79ad29b5e19de4260020f8919b443b2ef0277d242ce532ec7b7a2cc8b6007"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-linebreak"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
 
 [[package]]
 name = "unicode-normalization-alignments"
@@ -3754,6 +4241,18 @@ dependencies = [
  "js-sys",
  "serde_core",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "value-trait"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e80f0c733af0720a501b3905d22e2f97662d8eacfe082a75ed7ffb5ab08cb59"
+dependencies = [
+ "float-cmp",
+ "halfbrown",
+ "itoa",
+ "ryu",
 ]
 
 [[package]]
@@ -4006,6 +4505,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections",
+ "windows-core 0.62.2",
+ "windows-future",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
+dependencies = [
+ "windows-core 0.62.2",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4028,6 +4548,17 @@ dependencies = [
  "windows-link",
  "windows-result 0.4.1",
  "windows-strings",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core 0.62.2",
+ "windows-link",
+ "windows-threading",
 ]
 
 [[package]]
@@ -4079,6 +4610,16 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-numerics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
+dependencies = [
+ "windows-core 0.62.2",
+ "windows-link",
+]
 
 [[package]]
 name = "windows-registry"
@@ -4209,6 +4750,15 @@ dependencies = [
  "windows_x86_64_gnu 0.53.1",
  "windows_x86_64_gnullvm 0.53.1",
  "windows_x86_64_msvc 0.53.1",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,19 @@ ignore = "0.4"
 # (one dotted-path walker shared across json/toml/yaml/frontmatter).
 serde_yaml_ng = "0.10"
 
+# Module-graph engine (#710): parse js/ts/jsx/tsx imports and resolve each
+# specifier against the referrer. oxc_parser's ModuleRecord already collects
+# every static import/export/re-export specifier (deduped, source-order) as
+# part of parsing -- no hand-rolled AST visitor needed. oxc_resolver mirrors
+# Node + bundler resolution (tsconfig `paths`, node_modules, package.json
+# `exports`/`imports`) and is the same resolution engine Rolldown/Rspack
+# embed. Headless: legion INDEXES, it does not bundle or emit code, so the
+# runtime dependency is these crates, not the Rolldown binary.
+oxc_parser = "0.138.0"
+oxc_resolver = "11.23.0"
+oxc_allocator = "0.138.0"
+oxc_span = "0.138.0"
+
 # libc pulls in only on unix for killpg in call_plugin_inner's timeout arm.
 # Must stay AFTER all platform-independent deps -- TOML tables consume
 # every key until the next header, so listing it mid-file would leak the

--- a/src/cli/index_cmd.rs
+++ b/src/cli/index_cmd.rs
@@ -2042,12 +2042,16 @@ pub(crate) fn handle_index(
         .filter(|e| e.lang.as_deref() == Some("typescript"))
         .map(|e| PathBuf::from(&e.path))
         .collect();
+    // Computed once and reused for both the upsert below (which files must
+    // have their stale rows cleared before the fresh edges are inserted)
+    // and the prune below (which files are still live at all).
+    let live_from: Vec<&str> = ts_files.iter().filter_map(|p| p.to_str()).collect();
     let mut edge_count: usize = 0;
     if !ts_files.is_empty() {
         match graph::build_module_graph(&repo, &repo_path, &ts_files) {
             Ok(edges) => {
                 edge_count = edges.len();
-                database.upsert_module_edges(&edges)?;
+                database.upsert_module_edges(&repo, &live_from, &edges)?;
             }
             Err(e) => {
                 eprintln!("[legion] module graph build failed for {repo}: {e}");
@@ -2065,7 +2069,6 @@ pub(crate) fn handle_index(
     // against that incomplete set would evict edges for files the walk
     // simply failed to see this run.
     if outcome.walk_errors == 0 {
-        let live_from: Vec<&str> = ts_files.iter().filter_map(|p| p.to_str()).collect();
         let pruned_edges = database.prune_module_edges(&repo, &live_from)?;
         eprintln!(
             "[legion] module graph: {edge_count} edges for {repo} ({pruned_edges} stale edges pruned)"

--- a/src/cli/index_cmd.rs
+++ b/src/cli/index_cmd.rs
@@ -7,7 +7,7 @@ use clap::Subcommand;
 
 use crate::cli::datadir::data_dir;
 use crate::cli::util::{open_db, open_db_and_index};
-use crate::{db, error, etc, inventory, scip, sym, telemetry, watch};
+use crate::{db, error, etc, graph, inventory, scip, sym, telemetry, watch};
 
 #[derive(Subcommand)]
 pub(crate) enum SymAction {
@@ -1730,6 +1730,52 @@ pub(crate) fn handle_index(
         "[legion] inventoried {} files for {repo} ({pruned} stale rows pruned)",
         outcome.entries.len()
     );
+
+    // Module graph (#710): parse js/ts/jsx/tsx imports and resolve each
+    // specifier against its referrer. Runs over the inventory's
+    // typescript-lang subset (extension-based, from the walk above) --
+    // independent of the SCIP `langs` marker-file detection below, since
+    // oxc_parser/oxc_resolver need only the files themselves, not a
+    // scip-typescript binary on PATH.
+    let ts_files: Vec<PathBuf> = outcome
+        .entries
+        .iter()
+        .filter(|e| e.lang.as_deref() == Some("typescript"))
+        .map(|e| PathBuf::from(&e.path))
+        .collect();
+    let mut edge_count: usize = 0;
+    if !ts_files.is_empty() {
+        match graph::build_module_graph(&repo, &repo_path, &ts_files) {
+            Ok(edges) => {
+                edge_count = edges.len();
+                database.upsert_module_edges(&edges)?;
+            }
+            Err(e) => {
+                eprintln!("[legion] module graph build failed for {repo}: {e}");
+            }
+        }
+    }
+    // Prune unconditionally on a clean walk -- mirroring the file-inventory
+    // prune above, including its zero-entries case: a repo that has gone to
+    // zero JS/TS files (last one deleted, or the repo migrated off JS) must
+    // still wipe its now-stale module_edges rows, exactly as
+    // `prune_file_inventory` wipes the whole repo when `live_paths` is empty.
+    // Gating this behind `!ts_files.is_empty()` would leave those rows
+    // orphaned forever. Same partial-walk guard as the file-inventory prune:
+    // a walk with errors may be missing files that still exist, and pruning
+    // against that incomplete set would evict edges for files the walk
+    // simply failed to see this run.
+    if outcome.walk_errors == 0 {
+        let live_from: Vec<&str> = ts_files.iter().filter_map(|p| p.to_str()).collect();
+        let pruned_edges = database.prune_module_edges(&repo, &live_from)?;
+        eprintln!(
+            "[legion] module graph: {edge_count} edges for {repo} ({pruned_edges} stale edges pruned)"
+        );
+    } else {
+        eprintln!(
+            "[legion] module graph: {edge_count} edges for {repo} (stale-edge prune skipped: partial walk)"
+        );
+    }
 
     // SCIP indexing runs only when language markers are present. A docs-only
     // repo (no Cargo.toml, package.json, etc.) skips this block entirely --

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -14,6 +14,7 @@ mod health;
 mod heartbeat;
 pub mod inventory;
 mod kanban;
+pub mod module_edges;
 pub(crate) mod quality_gates;
 mod reflections;
 mod schedules;
@@ -119,6 +120,7 @@ impl Database {
         autonomy::create_tables(conn)?;
         heartbeat::create_tables(conn)?;
         inventory::create_tables(conn)?;
+        module_edges::create_tables(conn)?;
         tx.commit()?;
 
         reflections::migrate(conn)?;

--- a/src/db/module_edges.rs
+++ b/src/db/module_edges.rs
@@ -1,0 +1,268 @@
+//! Module graph edges: one row per resolved (or unresolved) import (#710).
+//!
+//! `module_edges` stores the output of `graph::build_module_graph`: for every
+//! static import/export-from/re-export and every literal dynamic `import()`
+//! found in a js/ts/jsx/tsx file, one row records the specifier text and
+//! where (if anywhere) it resolved to. This is the substrate `sym` uses to
+//! answer "which files import X" / "what does X import" -- questions SCIP
+//! symbol references cannot answer, because they are about the module graph,
+//! not a symbol.
+
+use rusqlite::Connection;
+
+use super::Database;
+use crate::error::Result;
+use crate::graph::ImportEdge;
+
+/// Create the `module_edges` table and its lookup indexes.
+///
+/// Called from `init_schema` inside the schema-creation transaction.
+/// Idempotent via `IF NOT EXISTS`.
+///
+/// No single-column primary key fits: a file can import the same specifier
+/// only once in practice (`requested_modules` is keyed by specifier text
+/// already), but a repo can re-index and re-resolve the same edge, so the
+/// natural key is `(repo, from_path, specifier)` -- re-running the graph
+/// build for a file updates its edges in place rather than duplicating them.
+pub(super) fn create_tables(conn: &Connection) -> Result<()> {
+    conn.execute_batch(
+        "CREATE TABLE IF NOT EXISTS module_edges (
+            repo      TEXT NOT NULL,
+            from_path TEXT NOT NULL,
+            specifier TEXT NOT NULL,
+            to_path   TEXT,
+            PRIMARY KEY (repo, from_path, specifier)
+        );
+        CREATE INDEX IF NOT EXISTS idx_module_edges_repo_to
+            ON module_edges(repo, to_path);",
+    )?;
+    Ok(())
+}
+
+impl Database {
+    /// Upsert a batch of module edges, keyed on `(repo, from_path, specifier)`.
+    ///
+    /// Idempotent: re-running the graph build for a file updates its edges'
+    /// resolution in place rather than duplicating them. All rows are
+    /// written inside a single transaction, through one prepared statement,
+    /// for throughput.
+    pub fn upsert_module_edges(&self, edges: &[ImportEdge]) -> Result<()> {
+        let tx = self.conn.unchecked_transaction()?;
+        {
+            let mut stmt = tx.prepare(
+                "INSERT INTO module_edges (repo, from_path, specifier, to_path)
+                 VALUES (?1, ?2, ?3, ?4)
+                 ON CONFLICT(repo, from_path, specifier) DO UPDATE SET
+                     to_path = excluded.to_path",
+            )?;
+            for edge in edges {
+                stmt.execute(rusqlite::params![
+                    &edge.repo,
+                    &edge.from,
+                    &edge.specifier,
+                    &edge.to,
+                ])?;
+            }
+        }
+        tx.commit()?;
+        Ok(())
+    }
+
+    /// Return every edge whose importer is `from_path` -- "what does this
+    /// file import" -- ordered by specifier for stable output.
+    pub fn list_module_edges_from(&self, repo: &str, from_path: &str) -> Result<Vec<ImportEdge>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT repo, from_path, specifier, to_path
+             FROM module_edges
+             WHERE repo = ?1 AND from_path = ?2
+             ORDER BY specifier",
+        )?;
+        let rows = stmt
+            .query_map(rusqlite::params![repo, from_path], row_to_edge)?
+            .collect::<std::result::Result<Vec<_>, _>>()?;
+        Ok(rows)
+    }
+
+    /// Return every edge that resolved to `to_path` -- "what imports this
+    /// file" -- ordered by importer path for stable output. Edges with
+    /// `to_path IS NULL` (unresolved/external) never match; there is
+    /// nothing to look up an importee for.
+    pub fn list_module_edges_to(&self, repo: &str, to_path: &str) -> Result<Vec<ImportEdge>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT repo, from_path, specifier, to_path
+             FROM module_edges
+             WHERE repo = ?1 AND to_path = ?2
+             ORDER BY from_path",
+        )?;
+        let rows = stmt
+            .query_map(rusqlite::params![repo, to_path], row_to_edge)?
+            .collect::<std::result::Result<Vec<_>, _>>()?;
+        Ok(rows)
+    }
+
+    /// Delete edges for `repo` whose importer is not in `live_from_paths`.
+    ///
+    /// Mirrors `prune_file_inventory`: call after `upsert_module_edges` on a
+    /// full repo re-walk so edges from deleted/renamed files do not linger.
+    /// When `live_from_paths` is empty every edge for the repo is removed.
+    pub fn prune_module_edges(&self, repo: &str, live_from_paths: &[&str]) -> Result<usize> {
+        if live_from_paths.is_empty() {
+            let n = self.conn.execute(
+                "DELETE FROM module_edges WHERE repo = ?1",
+                rusqlite::params![repo],
+            )?;
+            return Ok(n);
+        }
+
+        self.conn.execute_batch(
+            "CREATE TEMP TABLE IF NOT EXISTS _module_edges_live_from (path TEXT PRIMARY KEY)",
+        )?;
+        self.conn
+            .execute_batch("DELETE FROM _module_edges_live_from")?;
+
+        {
+            let tx = self.conn.unchecked_transaction()?;
+            {
+                let mut insert =
+                    tx.prepare("INSERT OR IGNORE INTO _module_edges_live_from (path) VALUES (?1)")?;
+                for p in live_from_paths {
+                    insert.execute(rusqlite::params![p])?;
+                }
+            }
+            tx.commit()?;
+        }
+
+        let n = self.conn.execute(
+            "DELETE FROM module_edges
+             WHERE repo = ?1
+               AND from_path NOT IN (SELECT path FROM _module_edges_live_from)",
+            rusqlite::params![repo],
+        )?;
+        Ok(n)
+    }
+}
+
+fn row_to_edge(row: &rusqlite::Row<'_>) -> rusqlite::Result<ImportEdge> {
+    Ok(ImportEdge {
+        repo: row.get(0)?,
+        from: row.get(1)?,
+        specifier: row.get(2)?,
+        to: row.get(3)?,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::testutil::test_db;
+
+    fn edge(repo: &str, from: &str, specifier: &str, to: Option<&str>) -> ImportEdge {
+        ImportEdge {
+            repo: repo.to_string(),
+            from: from.to_string(),
+            specifier: specifier.to_string(),
+            to: to.map(|s| s.to_string()),
+        }
+    }
+
+    #[test]
+    fn upsert_and_list_from_round_trip() {
+        let db = test_db();
+        let edges = vec![
+            edge("r", "src/a.ts", "./b", Some("src/b.ts")),
+            edge("r", "src/a.ts", "lodash", None),
+        ];
+        db.upsert_module_edges(&edges).unwrap();
+
+        let got = db.list_module_edges_from("r", "src/a.ts").unwrap();
+        assert_eq!(got.len(), 2);
+        // Ordered by specifier: "./b" before "lodash".
+        assert_eq!(got[0].specifier, "./b");
+        assert_eq!(got[0].to.as_deref(), Some("src/b.ts"));
+        assert_eq!(got[1].specifier, "lodash");
+        assert_eq!(
+            got[1].to, None,
+            "unresolved/external must be None, not dropped"
+        );
+    }
+
+    #[test]
+    fn list_to_answers_importee_query() {
+        let db = test_db();
+        db.upsert_module_edges(&[
+            edge("r", "src/a.ts", "./b", Some("src/b.ts")),
+            edge("r", "src/c.ts", "./b", Some("src/b.ts")),
+            edge("r", "src/d.ts", "./e", Some("src/e.ts")),
+        ])
+        .unwrap();
+
+        let got = db.list_module_edges_to("r", "src/b.ts").unwrap();
+        assert_eq!(got.len(), 2);
+        let importers: Vec<&str> = got.iter().map(|e| e.from.as_str()).collect();
+        assert!(importers.contains(&"src/a.ts"));
+        assert!(importers.contains(&"src/c.ts"));
+    }
+
+    #[test]
+    fn upsert_is_idempotent_and_updates_resolution() {
+        let db = test_db();
+        db.upsert_module_edges(&[edge("r", "src/a.ts", "./b", None)])
+            .unwrap();
+        // Re-run after the file appears: resolution flips from None to Some.
+        db.upsert_module_edges(&[edge("r", "src/a.ts", "./b", Some("src/b.ts"))])
+            .unwrap();
+
+        let got = db.list_module_edges_from("r", "src/a.ts").unwrap();
+        assert_eq!(got.len(), 1, "re-run must not duplicate the edge");
+        assert_eq!(got[0].to.as_deref(), Some("src/b.ts"));
+    }
+
+    #[test]
+    fn prune_removes_edges_for_deleted_importers() {
+        let db = test_db();
+        db.upsert_module_edges(&[
+            edge("r", "src/a.ts", "./b", Some("src/b.ts")),
+            edge("r", "src/gone.ts", "./b", Some("src/b.ts")),
+        ])
+        .unwrap();
+
+        let pruned = db.prune_module_edges("r", &["src/a.ts"]).unwrap();
+        assert_eq!(pruned, 1);
+
+        assert!(
+            db.list_module_edges_from("r", "src/gone.ts")
+                .unwrap()
+                .is_empty()
+        );
+        assert_eq!(db.list_module_edges_from("r", "src/a.ts").unwrap().len(), 1);
+    }
+
+    #[test]
+    fn prune_empty_live_paths_wipes_repo() {
+        let db = test_db();
+        db.upsert_module_edges(&[edge("r", "src/a.ts", "./b", Some("src/b.ts"))])
+            .unwrap();
+
+        let pruned = db.prune_module_edges("r", &[]).unwrap();
+        assert_eq!(pruned, 1);
+        assert!(
+            db.list_module_edges_from("r", "src/a.ts")
+                .unwrap()
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn scoped_to_repo() {
+        let db = test_db();
+        db.upsert_module_edges(&[
+            edge("alpha", "src/a.ts", "./b", Some("src/b.ts")),
+            edge("beta", "src/a.ts", "./b", Some("src/b.ts")),
+        ])
+        .unwrap();
+
+        let got = db.list_module_edges_from("alpha", "src/a.ts").unwrap();
+        assert_eq!(got.len(), 1);
+        assert_eq!(got[0].repo, "alpha");
+    }
+}

--- a/src/db/module_edges.rs
+++ b/src/db/module_edges.rs
@@ -70,6 +70,14 @@ impl Database {
 
     /// Return every edge whose importer is `from_path` -- "what does this
     /// file import" -- ordered by specifier for stable output.
+    ///
+    /// Not yet wired to a CLI surface -- #710 only populates the table via
+    /// `legion index` (see `handle_index` in `src/cli/index_cmd.rs`). No
+    /// issue is filed yet for the query commands (`sym imports` /
+    /// `sym importers`, or similar) that would call this; this is the query
+    /// API they will use once one is. Exercised directly by this module's
+    /// tests in the meantime.
+    #[allow(dead_code)]
     pub fn list_module_edges_from(&self, repo: &str, from_path: &str) -> Result<Vec<ImportEdge>> {
         let mut stmt = self.conn.prepare(
             "SELECT repo, from_path, specifier, to_path
@@ -87,6 +95,9 @@ impl Database {
     /// file" -- ordered by importer path for stable output. Edges with
     /// `to_path IS NULL` (unresolved/external) never match; there is
     /// nothing to look up an importee for.
+    ///
+    /// Not yet wired to a CLI surface; see `list_module_edges_from`.
+    #[allow(dead_code)]
     pub fn list_module_edges_to(&self, repo: &str, to_path: &str) -> Result<Vec<ImportEdge>> {
         let mut stmt = self.conn.prepare(
             "SELECT repo, from_path, specifier, to_path

--- a/src/db/module_edges.rs
+++ b/src/db/module_edges.rs
@@ -40,23 +40,47 @@ pub(super) fn create_tables(conn: &Connection) -> Result<()> {
 }
 
 impl Database {
-    /// Upsert a batch of module edges, keyed on `(repo, from_path, specifier)`.
+    /// Replace module edges for a batch of just-(re)parsed files, keyed on
+    /// `(repo, from_path, specifier)`.
     ///
-    /// Idempotent: re-running the graph build for a file updates its edges'
-    /// resolution in place rather than duplicating them. All rows are
-    /// written inside a single transaction, through one prepared statement,
-    /// for throughput.
-    pub fn upsert_module_edges(&self, edges: &[ImportEdge]) -> Result<()> {
+    /// `parsed_from_paths` must list every file whose edges were (re)computed
+    /// this call -- including one that now produces zero edges (its last
+    /// import was just deleted, or it never had any). Every existing row for
+    /// each of those files is deleted before `edges` is inserted, in the same
+    /// transaction. The delete set has to come from `parsed_from_paths`, not
+    /// from `edges` itself: a file that shrinks to zero imports contributes
+    /// no rows to `edges` at all, so nothing in the edges list would point
+    /// back at it to clear its now-stale rows, and `prune_module_edges` does
+    /// not catch this either -- it only removes edges for files that are no
+    /// longer live, not files whose import set changed while staying live.
+    ///
+    /// The `ON CONFLICT` clause is a defensive no-op once the delete above
+    /// has run for every path in `parsed_from_paths`; it only matters if a
+    /// caller passes an edge whose `from` is outside `parsed_from_paths`,
+    /// which should not happen but would otherwise duplicate a row instead
+    /// of erroring.
+    pub fn upsert_module_edges(
+        &self,
+        repo: &str,
+        parsed_from_paths: &[&str],
+        edges: &[ImportEdge],
+    ) -> Result<()> {
         let tx = self.conn.unchecked_transaction()?;
         {
-            let mut stmt = tx.prepare(
+            let mut delete_stmt =
+                tx.prepare("DELETE FROM module_edges WHERE repo = ?1 AND from_path = ?2")?;
+            for from_path in parsed_from_paths {
+                delete_stmt.execute(rusqlite::params![repo, from_path])?;
+            }
+
+            let mut insert_stmt = tx.prepare(
                 "INSERT INTO module_edges (repo, from_path, specifier, to_path)
                  VALUES (?1, ?2, ?3, ?4)
                  ON CONFLICT(repo, from_path, specifier) DO UPDATE SET
                      to_path = excluded.to_path",
             )?;
             for edge in edges {
-                stmt.execute(rusqlite::params![
+                insert_stmt.execute(rusqlite::params![
                     &edge.repo,
                     &edge.from,
                     &edge.specifier,
@@ -183,7 +207,7 @@ mod tests {
             edge("r", "src/a.ts", "./b", Some("src/b.ts")),
             edge("r", "src/a.ts", "lodash", None),
         ];
-        db.upsert_module_edges(&edges).unwrap();
+        db.upsert_module_edges("r", &["src/a.ts"], &edges).unwrap();
 
         let got = db.list_module_edges_from("r", "src/a.ts").unwrap();
         assert_eq!(got.len(), 2);
@@ -200,11 +224,15 @@ mod tests {
     #[test]
     fn list_to_answers_importee_query() {
         let db = test_db();
-        db.upsert_module_edges(&[
-            edge("r", "src/a.ts", "./b", Some("src/b.ts")),
-            edge("r", "src/c.ts", "./b", Some("src/b.ts")),
-            edge("r", "src/d.ts", "./e", Some("src/e.ts")),
-        ])
+        db.upsert_module_edges(
+            "r",
+            &["src/a.ts", "src/c.ts", "src/d.ts"],
+            &[
+                edge("r", "src/a.ts", "./b", Some("src/b.ts")),
+                edge("r", "src/c.ts", "./b", Some("src/b.ts")),
+                edge("r", "src/d.ts", "./e", Some("src/e.ts")),
+            ],
+        )
         .unwrap();
 
         let got = db.list_module_edges_to("r", "src/b.ts").unwrap();
@@ -217,11 +245,15 @@ mod tests {
     #[test]
     fn upsert_is_idempotent_and_updates_resolution() {
         let db = test_db();
-        db.upsert_module_edges(&[edge("r", "src/a.ts", "./b", None)])
+        db.upsert_module_edges("r", &["src/a.ts"], &[edge("r", "src/a.ts", "./b", None)])
             .unwrap();
         // Re-run after the file appears: resolution flips from None to Some.
-        db.upsert_module_edges(&[edge("r", "src/a.ts", "./b", Some("src/b.ts"))])
-            .unwrap();
+        db.upsert_module_edges(
+            "r",
+            &["src/a.ts"],
+            &[edge("r", "src/a.ts", "./b", Some("src/b.ts"))],
+        )
+        .unwrap();
 
         let got = db.list_module_edges_from("r", "src/a.ts").unwrap();
         assert_eq!(got.len(), 1, "re-run must not duplicate the edge");
@@ -229,12 +261,74 @@ mod tests {
     }
 
     #[test]
+    fn reindex_drops_a_removed_specifier_from_a_still_live_file() {
+        let db = test_db();
+        db.upsert_module_edges(
+            "r",
+            &["src/a.ts"],
+            &[
+                edge("r", "src/a.ts", "./b", Some("src/b.ts")),
+                edge("r", "src/a.ts", "./c", Some("src/c.ts")),
+            ],
+        )
+        .unwrap();
+
+        // Re-index after the file drops its `./c` import. The file is still
+        // live (still passed in `parsed_from_paths`), so `prune_module_edges`
+        // never sees it -- the stale `./c` edge must be dropped by the
+        // upsert itself, not left to linger forever.
+        db.upsert_module_edges(
+            "r",
+            &["src/a.ts"],
+            &[edge("r", "src/a.ts", "./b", Some("src/b.ts"))],
+        )
+        .unwrap();
+
+        let got = db.list_module_edges_from("r", "src/a.ts").unwrap();
+        assert_eq!(
+            got.len(),
+            1,
+            "the removed ./c specifier must not survive re-indexing, got {got:?}"
+        );
+        assert_eq!(got[0].specifier, "./b");
+    }
+
+    #[test]
+    fn reindex_clears_all_edges_when_a_live_file_drops_every_import() {
+        let db = test_db();
+        db.upsert_module_edges(
+            "r",
+            &["src/a.ts"],
+            &[edge("r", "src/a.ts", "./b", Some("src/b.ts"))],
+        )
+        .unwrap();
+
+        // The file still exists (still passed as a parsed path) but now has
+        // no imports at all -- build_module_graph produces zero edges for
+        // it, not an edge with `to: None`. Nothing in `edges` references
+        // "src/a.ts" to trigger a delete unless the delete is keyed on
+        // `parsed_from_paths` rather than on the edges list.
+        db.upsert_module_edges("r", &["src/a.ts"], &[]).unwrap();
+
+        assert!(
+            db.list_module_edges_from("r", "src/a.ts")
+                .unwrap()
+                .is_empty(),
+            "a live file with zero current imports must have zero edges after re-index"
+        );
+    }
+
+    #[test]
     fn prune_removes_edges_for_deleted_importers() {
         let db = test_db();
-        db.upsert_module_edges(&[
-            edge("r", "src/a.ts", "./b", Some("src/b.ts")),
-            edge("r", "src/gone.ts", "./b", Some("src/b.ts")),
-        ])
+        db.upsert_module_edges(
+            "r",
+            &["src/a.ts", "src/gone.ts"],
+            &[
+                edge("r", "src/a.ts", "./b", Some("src/b.ts")),
+                edge("r", "src/gone.ts", "./b", Some("src/b.ts")),
+            ],
+        )
         .unwrap();
 
         let pruned = db.prune_module_edges("r", &["src/a.ts"]).unwrap();
@@ -251,8 +345,12 @@ mod tests {
     #[test]
     fn prune_empty_live_paths_wipes_repo() {
         let db = test_db();
-        db.upsert_module_edges(&[edge("r", "src/a.ts", "./b", Some("src/b.ts"))])
-            .unwrap();
+        db.upsert_module_edges(
+            "r",
+            &["src/a.ts"],
+            &[edge("r", "src/a.ts", "./b", Some("src/b.ts"))],
+        )
+        .unwrap();
 
         let pruned = db.prune_module_edges("r", &[]).unwrap();
         assert_eq!(pruned, 1);
@@ -266,10 +364,17 @@ mod tests {
     #[test]
     fn scoped_to_repo() {
         let db = test_db();
-        db.upsert_module_edges(&[
-            edge("alpha", "src/a.ts", "./b", Some("src/b.ts")),
-            edge("beta", "src/a.ts", "./b", Some("src/b.ts")),
-        ])
+        db.upsert_module_edges(
+            "alpha",
+            &["src/a.ts"],
+            &[edge("alpha", "src/a.ts", "./b", Some("src/b.ts"))],
+        )
+        .unwrap();
+        db.upsert_module_edges(
+            "beta",
+            &["src/a.ts"],
+            &[edge("beta", "src/a.ts", "./b", Some("src/b.ts"))],
+        )
         .unwrap();
 
         let got = db.list_module_edges_from("alpha", "src/a.ts").unwrap();

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -1,0 +1,555 @@
+//! Module graph engine (#710): parse js/ts/jsx/tsx imports and resolve each
+//! specifier against its referrer.
+//!
+//! `oxc_parser` builds a `ModuleRecord` as part of parsing every file --
+//! `requested_modules` already holds every static import / export-from /
+//! re-export specifier, deduplicated and in source order, so no hand-rolled
+//! AST visitor is needed for the static half. Dynamic `import()` calls are
+//! not part of `requested_modules` (their argument is an arbitrary
+//! expression, not necessarily a literal); `dynamic_imports` gives the span
+//! of that argument expression, and this module treats it as a specifier
+//! only when the source text at that span is a plain string literal with no
+//! interpolation -- a computed dynamic import (`import(base + name)`) is not
+//! a graph edge legion can resolve statically, and is silently skipped
+//! rather than guessed at.
+//!
+//! `oxc_resolver` then resolves each specifier the same way Node / bundlers
+//! do: tsconfig `paths` (auto-discovered per file, so a monorepo with nested
+//! tsconfig.json files resolves each importer against the config that
+//! actually owns it), `node_modules`, extension resolution, and
+//! package.json `exports`/`imports`. A specifier that does not resolve
+//! (external package, missing file, Node builtin) is recorded with
+//! `to: None` rather than dropped -- the module graph must show *that* a
+//! file references something external, even when it cannot say where.
+//!
+//! This module is headless: it produces the graph, it does not bundle or
+//! emit code. Rolldown is the reference architecture (it composes the same
+//! oxc crates to parse + resolve + graph before bundling); legion embeds
+//! the crates directly to stop one step earlier, at the graph.
+
+use std::path::{Path, PathBuf};
+
+use oxc_allocator::Allocator;
+use oxc_parser::Parser;
+use oxc_resolver::{ResolveOptions, Resolver, TsconfigDiscovery};
+use oxc_span::SourceType;
+
+use crate::error::Result;
+
+/// One import/export/re-export edge from a file to the module it references.
+///
+/// `to` is `None` when the specifier did not resolve to a file on disk
+/// (an external package, a Node builtin, or a genuinely broken import) --
+/// the edge is still recorded, never dropped, so the graph can show that a
+/// file references something even when it cannot say where.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ImportEdge {
+    pub repo: String,
+    /// Repo-relative path of the importing file (forward-slash separated).
+    pub from: String,
+    /// The specifier text exactly as written in the source (e.g. `./foo`,
+    /// `lodash`, `@/components/Button`).
+    pub specifier: String,
+    /// Repo-relative path of the resolved file, or an absolute path when
+    /// resolution lands outside `repo_root` (a hoisted/symlinked
+    /// `node_modules` in a monorepo). `None` when unresolved/external.
+    pub to: Option<String>,
+}
+
+/// Build the module graph for `files` (repo-relative paths, forward-slash
+/// separated -- the same convention `file_inventory` uses) rooted at
+/// `repo_root`.
+///
+/// Only files `oxc_span::SourceType::from_path` recognizes as js/ts/jsx/tsx
+/// are parsed; every other file in `files` is skipped silently (the caller
+/// is expected to pass the inventory's `typescript`-lang subset, but passing
+/// the full corpus is harmless). A file that cannot be read, or that the
+/// parser panics on, is logged to stderr and skipped -- one bad file must
+/// not abort the graph for the rest of the repo.
+///
+/// `repo` stamps every edge's `repo` field; `build_module_graph` itself
+/// never inspects `repo_root`'s directory name for it (worktree checkouts
+/// routinely live under a path that does not match the repo's logical
+/// name).
+pub fn build_module_graph(
+    repo: &str,
+    repo_root: &Path,
+    files: &[PathBuf],
+) -> Result<Vec<ImportEdge>> {
+    // Canonicalize once: on macOS `/tmp` and `/var` are symlinks (to
+    // `/private/tmp` / `/private/var`), and the resolver's internal path
+    // cache canonicalizes every path it touches. Comparing an
+    // uncanonicalized `repo_root` against the resolver's canonicalized
+    // output would make `strip_prefix` fail for every resolution even
+    // though the file genuinely lives under `repo_root`. Falls back to the
+    // given root if it does not exist (a caller passing a path that is
+    // about to be created, or a broken watch entry) -- resolution will
+    // simply fail per-file in that case, which is already handled.
+    let repo_root = std::fs::canonicalize(repo_root).unwrap_or_else(|_| repo_root.to_path_buf());
+    let repo_root = repo_root.as_path();
+
+    let resolver = Resolver::new(ResolveOptions {
+        tsconfig: Some(TsconfigDiscovery::Auto),
+        extensions: vec![
+            ".ts".into(),
+            ".tsx".into(),
+            ".d.ts".into(),
+            ".js".into(),
+            ".jsx".into(),
+            ".mjs".into(),
+            ".cjs".into(),
+            ".mts".into(),
+            ".cts".into(),
+            ".json".into(),
+        ],
+        condition_names: vec![
+            "node".into(),
+            "import".into(),
+            "require".into(),
+            "default".into(),
+        ],
+        builtin_modules: true,
+        ..ResolveOptions::default()
+    });
+
+    let mut edges: Vec<ImportEdge> = Vec::new();
+
+    for rel_path in files {
+        let abs_path = repo_root.join(rel_path);
+
+        let source_type = match SourceType::from_path(&abs_path) {
+            Ok(t) => t,
+            // Not a js/ts/jsx/tsx file (or an oxc_parser-recognized
+            // extension) -- not an error, just out of scope for the graph.
+            Err(_) => continue,
+        };
+
+        let source_text = match std::fs::read_to_string(&abs_path) {
+            Ok(s) => s,
+            Err(e) => {
+                eprintln!(
+                    "[legion] graph: skipped {} (read error: {e})",
+                    abs_path.display()
+                );
+                continue;
+            }
+        };
+
+        let allocator = Allocator::default();
+        let ret = Parser::new(&allocator, &source_text, source_type).parse();
+
+        if ret.panicked {
+            eprintln!(
+                "[legion] graph: skipped {} (parser panicked: {} diagnostic(s))",
+                abs_path.display(),
+                ret.diagnostics.len()
+            );
+            continue;
+        }
+
+        let from = to_repo_relative(rel_path);
+
+        let mut specifiers: Vec<String> = ret
+            .module_record
+            .requested_modules
+            .keys()
+            .map(|s| s.as_str().to_string())
+            .collect();
+
+        for dynamic_import in &ret.module_record.dynamic_imports {
+            let raw = dynamic_import.module_request.source_text(&source_text);
+            if let Some(spec) = literal_specifier(raw)
+                && !specifiers.contains(&spec)
+            {
+                specifiers.push(spec);
+            }
+        }
+        specifiers.sort_unstable();
+
+        for specifier in specifiers {
+            let to = match resolver.resolve_file(&abs_path, &specifier) {
+                Ok(resolution) => Some(resolve_to_repo_relative(repo_root, resolution.path())),
+                Err(_) => None,
+            };
+            edges.push(ImportEdge {
+                repo: repo.to_string(),
+                from: from.clone(),
+                specifier,
+                to,
+            });
+        }
+    }
+
+    edges.sort_unstable_by(|a, b| (&a.from, &a.specifier).cmp(&(&b.from, &b.specifier)));
+    Ok(edges)
+}
+
+/// Normalize a path to forward-slash separators without requiring it be
+/// repo-relative already -- callers may pass either.
+fn to_repo_relative(path: &Path) -> String {
+    path.to_string_lossy().replace('\\', "/")
+}
+
+/// Render a resolved absolute path as repo-relative when it lives under
+/// `repo_root`, or as a forward-slash-normalized absolute path otherwise (a
+/// hoisted/symlinked `node_modules` can resolve outside the repo root in a
+/// monorepo layout).
+fn resolve_to_repo_relative(repo_root: &Path, resolved: &Path) -> String {
+    match resolved.strip_prefix(repo_root) {
+        Ok(rel) => to_repo_relative(rel),
+        Err(_) => to_repo_relative(resolved),
+    }
+}
+
+/// Extract the literal string value from the raw source text of a dynamic
+/// `import()` argument, or `None` when it is not a plain string literal
+/// (a computed specifier, e.g. `import(base + "/foo")`, cannot be resolved
+/// statically).
+///
+/// A template literal (backtick) with no `${` interpolation is treated as
+/// a plain literal, since its value is fixed regardless of context.
+fn literal_specifier(raw: &str) -> Option<String> {
+    let raw = raw.trim();
+    let bytes = raw.as_bytes();
+    if bytes.len() < 2 {
+        return None;
+    }
+    let quote = bytes[0];
+    if quote != b'\'' && quote != b'"' && quote != b'`' {
+        return None;
+    }
+    if bytes[bytes.len() - 1] != quote {
+        return None;
+    }
+    let inner = &raw[1..raw.len() - 1];
+    if quote == b'`' && inner.contains("${") {
+        return None;
+    }
+    Some(unescape_quotes(inner))
+}
+
+/// Unescape the small set of backslash escapes that matter for a module
+/// specifier: the quote character itself and a literal backslash. This is
+/// deliberately not a full JS string-escape decoder -- specifiers containing
+/// `\n`/`\t`/unicode escapes are not valid file paths or package names, so
+/// there is nothing meaningful to decode for the graph's purposes.
+fn unescape_quotes(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut chars = s.chars();
+    while let Some(c) = chars.next() {
+        if c == '\\' {
+            if let Some(next) = chars.next() {
+                out.push(next);
+            }
+        } else {
+            out.push(c);
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    fn write(dir: &Path, rel: &str, content: &str) {
+        let path = dir.join(rel);
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).unwrap();
+        }
+        fs::write(path, content).unwrap();
+    }
+
+    // --- literal_specifier: the dynamic import() text -> specifier helper ---
+
+    #[test]
+    fn literal_specifier_double_quoted() {
+        assert_eq!(literal_specifier("\"./foo\""), Some("./foo".to_string()));
+    }
+
+    #[test]
+    fn literal_specifier_single_quoted() {
+        assert_eq!(literal_specifier("'./foo'"), Some("./foo".to_string()));
+    }
+
+    #[test]
+    fn literal_specifier_plain_template() {
+        assert_eq!(literal_specifier("`./foo`"), Some("./foo".to_string()));
+    }
+
+    #[test]
+    fn literal_specifier_rejects_interpolated_template() {
+        assert_eq!(literal_specifier("`./${name}`"), None);
+    }
+
+    #[test]
+    fn literal_specifier_rejects_computed_expression() {
+        assert_eq!(literal_specifier("base + \"/foo\""), None);
+        assert_eq!(literal_specifier("name"), None);
+    }
+
+    #[test]
+    fn literal_specifier_unescapes_quote() {
+        assert_eq!(
+            literal_specifier("\"./foo\\\"bar\""),
+            Some("./foo\"bar".to_string())
+        );
+    }
+
+    // --- build_module_graph: static imports resolve relative specifiers ---
+
+    #[test]
+    fn resolves_a_relative_static_import() {
+        let dir = tempfile::tempdir().unwrap();
+        write(
+            dir.path(),
+            "src/a.ts",
+            "import { b } from './b';\nexport { b };\n",
+        );
+        write(dir.path(), "src/b.ts", "export const b = 1;\n");
+
+        let files = vec![PathBuf::from("src/a.ts"), PathBuf::from("src/b.ts")];
+        let edges = build_module_graph("r", dir.path(), &files).unwrap();
+
+        let a_edges: Vec<&ImportEdge> = edges.iter().filter(|e| e.from == "src/a.ts").collect();
+        assert_eq!(a_edges.len(), 1);
+        assert_eq!(a_edges[0].specifier, "./b");
+        assert_eq!(a_edges[0].to.as_deref(), Some("src/b.ts"));
+        assert_eq!(a_edges[0].repo, "r");
+    }
+
+    // --- unresolved/external specifiers: to = None, not dropped ---
+
+    #[test]
+    fn unresolved_specifier_recorded_as_none_not_dropped() {
+        let dir = tempfile::tempdir().unwrap();
+        write(
+            dir.path(),
+            "src/a.ts",
+            "import { z } from 'some-external-package-that-does-not-exist';\n",
+        );
+
+        let files = vec![PathBuf::from("src/a.ts")];
+        let edges = build_module_graph("r", dir.path(), &files).unwrap();
+
+        assert_eq!(edges.len(), 1, "the edge must be recorded, not dropped");
+        assert_eq!(
+            edges[0].specifier,
+            "some-external-package-that-does-not-exist"
+        );
+        assert_eq!(edges[0].to, None);
+    }
+
+    #[test]
+    fn missing_relative_import_is_none_not_dropped() {
+        let dir = tempfile::tempdir().unwrap();
+        write(
+            dir.path(),
+            "src/a.ts",
+            "import { b } from './does-not-exist';\n",
+        );
+
+        let files = vec![PathBuf::from("src/a.ts")];
+        let edges = build_module_graph("r", dir.path(), &files).unwrap();
+
+        assert_eq!(edges.len(), 1);
+        assert_eq!(edges[0].to, None);
+    }
+
+    // --- tsconfig `paths` resolution ---
+
+    #[test]
+    fn resolves_through_tsconfig_paths() {
+        let dir = tempfile::tempdir().unwrap();
+        write(
+            dir.path(),
+            "tsconfig.json",
+            r#"{
+                "compilerOptions": {
+                    "baseUrl": ".",
+                    "paths": { "@/*": ["src/*"] }
+                }
+            }"#,
+        );
+        write(
+            dir.path(),
+            "src/index.ts",
+            "import { widget } from '@/widget';\nexport { widget };\n",
+        );
+        write(dir.path(), "src/widget.ts", "export const widget = 1;\n");
+
+        let files = vec![
+            PathBuf::from("src/index.ts"),
+            PathBuf::from("src/widget.ts"),
+        ];
+        let edges = build_module_graph("r", dir.path(), &files).unwrap();
+
+        let edge = edges
+            .iter()
+            .find(|e| e.from == "src/index.ts" && e.specifier == "@/widget")
+            .expect("the @/widget edge must be present");
+        assert_eq!(edge.to.as_deref(), Some("src/widget.ts"));
+    }
+
+    // --- dynamic import() ---
+
+    #[test]
+    fn resolves_a_literal_dynamic_import() {
+        let dir = tempfile::tempdir().unwrap();
+        write(
+            dir.path(),
+            "src/a.ts",
+            "export async function load() { return import('./b'); }\n",
+        );
+        write(dir.path(), "src/b.ts", "export const b = 1;\n");
+
+        let files = vec![PathBuf::from("src/a.ts"), PathBuf::from("src/b.ts")];
+        let edges = build_module_graph("r", dir.path(), &files).unwrap();
+
+        let a_edges: Vec<&ImportEdge> = edges.iter().filter(|e| e.from == "src/a.ts").collect();
+        assert_eq!(a_edges.len(), 1);
+        assert_eq!(a_edges[0].specifier, "./b");
+        assert_eq!(a_edges[0].to.as_deref(), Some("src/b.ts"));
+    }
+
+    #[test]
+    fn computed_dynamic_import_is_skipped_not_guessed() {
+        let dir = tempfile::tempdir().unwrap();
+        write(
+            dir.path(),
+            "src/a.ts",
+            "export async function load(name: string) { return import('./' + name); }\n",
+        );
+
+        let files = vec![PathBuf::from("src/a.ts")];
+        let edges = build_module_graph("r", dir.path(), &files).unwrap();
+        assert!(
+            edges.is_empty(),
+            "a computed dynamic import must not produce a guessed edge"
+        );
+    }
+
+    // --- re-exports (export ... from) ---
+
+    #[test]
+    fn export_from_produces_an_edge() {
+        let dir = tempfile::tempdir().unwrap();
+        write(dir.path(), "src/a.ts", "export { b } from './b';\n");
+        write(dir.path(), "src/b.ts", "export const b = 1;\n");
+
+        let files = vec![PathBuf::from("src/a.ts"), PathBuf::from("src/b.ts")];
+        let edges = build_module_graph("r", dir.path(), &files).unwrap();
+
+        let a_edges: Vec<&ImportEdge> = edges.iter().filter(|e| e.from == "src/a.ts").collect();
+        assert_eq!(a_edges.len(), 1);
+        assert_eq!(a_edges[0].specifier, "./b");
+        assert_eq!(a_edges[0].to.as_deref(), Some("src/b.ts"));
+    }
+
+    #[test]
+    fn export_star_produces_an_edge() {
+        let dir = tempfile::tempdir().unwrap();
+        write(dir.path(), "src/a.ts", "export * from './b';\n");
+        write(dir.path(), "src/b.ts", "export const b = 1;\n");
+
+        let files = vec![PathBuf::from("src/a.ts"), PathBuf::from("src/b.ts")];
+        let edges = build_module_graph("r", dir.path(), &files).unwrap();
+
+        let a_edges: Vec<&ImportEdge> = edges.iter().filter(|e| e.from == "src/a.ts").collect();
+        assert_eq!(a_edges.len(), 1);
+        assert_eq!(a_edges[0].to.as_deref(), Some("src/b.ts"));
+    }
+
+    // --- non-js/ts files are silently skipped, not an error ---
+
+    #[test]
+    fn non_js_files_are_skipped_without_error() {
+        let dir = tempfile::tempdir().unwrap();
+        write(dir.path(), "README.md", "# hello\n");
+
+        let files = vec![PathBuf::from("README.md")];
+        let edges = build_module_graph("r", dir.path(), &files).unwrap();
+        assert!(edges.is_empty());
+    }
+
+    // --- a file that fails to read is skipped, not fatal to the batch ---
+
+    #[test]
+    fn unreadable_file_does_not_abort_the_batch() {
+        let dir = tempfile::tempdir().unwrap();
+        write(
+            dir.path(),
+            "src/ok.ts",
+            "import { x } from './missing-but-fine';\n",
+        );
+
+        let files = vec![
+            PathBuf::from("src/does-not-exist.ts"),
+            PathBuf::from("src/ok.ts"),
+        ];
+        let edges = build_module_graph("r", dir.path(), &files).unwrap();
+
+        assert_eq!(
+            edges.len(),
+            1,
+            "the missing file must be skipped, not fatal"
+        );
+        assert_eq!(edges[0].from, "src/ok.ts");
+    }
+
+    // --- jsx/tsx source types parse correctly ---
+
+    #[test]
+    fn tsx_file_parses_and_resolves() {
+        let dir = tempfile::tempdir().unwrap();
+        write(
+            dir.path(),
+            "src/App.tsx",
+            "import { Button } from './Button';\nexport const App = () => <Button />;\n",
+        );
+        write(
+            dir.path(),
+            "src/Button.tsx",
+            "export const Button = () => <div />;\n",
+        );
+
+        let files = vec![
+            PathBuf::from("src/App.tsx"),
+            PathBuf::from("src/Button.tsx"),
+        ];
+        let edges = build_module_graph("r", dir.path(), &files).unwrap();
+
+        let app_edges: Vec<&ImportEdge> =
+            edges.iter().filter(|e| e.from == "src/App.tsx").collect();
+        assert_eq!(app_edges.len(), 1);
+        assert_eq!(app_edges[0].to.as_deref(), Some("src/Button.tsx"));
+    }
+
+    // --- multiple distinct specifiers from the same file each get a row ---
+
+    #[test]
+    fn multiple_specifiers_each_produce_their_own_edge() {
+        let dir = tempfile::tempdir().unwrap();
+        write(
+            dir.path(),
+            "src/a.ts",
+            "import { b } from './b';\nimport { c } from './c';\n",
+        );
+        write(dir.path(), "src/b.ts", "export const b = 1;\n");
+        write(dir.path(), "src/c.ts", "export const c = 1;\n");
+
+        let files = vec![
+            PathBuf::from("src/a.ts"),
+            PathBuf::from("src/b.ts"),
+            PathBuf::from("src/c.ts"),
+        ];
+        let edges = build_module_graph("r", dir.path(), &files).unwrap();
+
+        let a_edges: Vec<&ImportEdge> = edges.iter().filter(|e| e.from == "src/a.ts").collect();
+        assert_eq!(a_edges.len(), 2);
+        let specifiers: Vec<&str> = a_edges.iter().map(|e| e.specifier.as_str()).collect();
+        assert!(specifiers.contains(&"./b"));
+        assert!(specifiers.contains(&"./c"));
+    }
+}

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -85,7 +85,19 @@ pub fn build_module_graph(
     // given root if it does not exist (a caller passing a path that is
     // about to be created, or a broken watch entry) -- resolution will
     // simply fail per-file in that case, which is already handled.
+    //
+    // On Windows, `std::fs::canonicalize` returns the verbatim form
+    // (`\\?\C:\...`). `oxc_resolver` canonicalizes its own resolved output
+    // too (`ResolveOptions::symlinks` defaults to `true`), but its
+    // `Cache::canonicalize` strips that same verbatim prefix before handing
+    // the path back (see `oxc_resolver`'s `cache/cache_impl.rs`, which calls
+    // `strip_windows_prefix` under `cfg(target_os = "windows")`). Left
+    // unstripped here, `repo_root` stays verbatim while every resolved
+    // import comes back plain, so `strip_prefix` below disagrees on every
+    // single edge -- on Windows only, since canonicalize does not add a
+    // prefix on macOS/Linux.
     let repo_root = std::fs::canonicalize(repo_root).unwrap_or_else(|_| repo_root.to_path_buf());
+    let repo_root = strip_verbatim_prefix(&repo_root);
     let repo_root = repo_root.as_path();
 
     let resolver = Resolver::new(ResolveOptions {
@@ -190,6 +202,26 @@ fn to_repo_relative(path: &Path) -> String {
     path.to_string_lossy().replace('\\', "/")
 }
 
+/// Strip Windows' `\\?\` verbatim-path prefix (and the `\\?\UNC\` variant)
+/// from an already-canonicalized path.
+///
+/// `std::fs::canonicalize` hands back the verbatim form on Windows, but
+/// `oxc_resolver`'s resolved paths come back in plain form (it strips the
+/// same prefix internally -- see the call site of `strip_verbatim_prefix`
+/// above for why the two must agree before `strip_prefix` compares them). A
+/// no-op when the prefix is absent, so safe to call unconditionally on every
+/// platform and every path, not just ones that came from Windows.
+fn strip_verbatim_prefix(path: &Path) -> PathBuf {
+    let raw = path.to_string_lossy();
+    if let Some(rest) = raw.strip_prefix(r"\\?\UNC\") {
+        PathBuf::from(format!(r"\\{rest}"))
+    } else if let Some(rest) = raw.strip_prefix(r"\\?\") {
+        PathBuf::from(rest)
+    } else {
+        path.to_path_buf()
+    }
+}
+
 /// Render a resolved absolute path as repo-relative when it lives under
 /// `repo_root`, or as a forward-slash-normalized absolute path otherwise (a
 /// hoisted/symlinked `node_modules` can resolve outside the repo root in a
@@ -259,6 +291,40 @@ mod tests {
             fs::create_dir_all(parent).unwrap();
         }
         fs::write(path, content).unwrap();
+    }
+
+    // --- strip_verbatim_prefix: Windows verbatim-path normalization ---
+    //
+    // Pure string transforms, so these run (and matter) on every OS, not
+    // just Windows -- the bug they guard is a mismatch between two forms
+    // that only diverge on Windows, but the function itself is portable.
+
+    #[test]
+    fn strip_verbatim_prefix_strips_dos_disk_prefix() {
+        assert_eq!(
+            strip_verbatim_prefix(Path::new(r"\\?\C:\Users\user\repo")),
+            PathBuf::from(r"C:\Users\user\repo")
+        );
+    }
+
+    #[test]
+    fn strip_verbatim_prefix_strips_unc_prefix() {
+        assert_eq!(
+            strip_verbatim_prefix(Path::new(r"\\?\UNC\server\share\repo")),
+            PathBuf::from(r"\\server\share\repo")
+        );
+    }
+
+    #[test]
+    fn strip_verbatim_prefix_is_noop_without_the_prefix() {
+        assert_eq!(
+            strip_verbatim_prefix(Path::new(r"C:\Users\user\repo")),
+            PathBuf::from(r"C:\Users\user\repo")
+        );
+        assert_eq!(
+            strip_verbatim_prefix(Path::new("/home/user/repo")),
+            PathBuf::from("/home/user/repo")
+        );
     }
 
     // --- literal_specifier: the dynamic import() text -> specifier helper ---

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,7 @@ mod embed;
 mod error;
 mod etc;
 mod gate_trust;
+mod graph;
 mod health;
 mod init;
 mod inventory;

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -17,6 +17,7 @@ mod kanban;
 mod mcp;
 mod memory;
 mod mesh;
+mod module_graph;
 mod serve;
 mod spec_gen;
 mod sym_tree;

--- a/tests/integration/module_graph.rs
+++ b/tests/integration/module_graph.rs
@@ -1,0 +1,121 @@
+//! CLI end-to-end tests for the module-graph wiring in `legion index` (#710).
+//!
+//! `src/graph.rs` and `src/db/module_edges.rs` carry their own unit tests for
+//! the parse/resolve logic and the persistence API in isolation; these tests
+//! exercise the actual binary surface -- a real `legion index <repo>` run
+//! over a small TS fixture must populate `module_edges`, honoring tsconfig
+//! `paths` and recording unresolved specifiers as `to_path = NULL` rather
+//! than dropping them. No CLI query surface exists yet (see
+//! `Database::list_module_edges_from`'s doc comment), so assertions read the
+//! `module_edges` table directly out of the data dir's `legion.db`.
+
+use rusqlite::Connection;
+
+use crate::common::{legion_cmd, run_ok};
+
+/// Seed a watch.toml in the data dir pointing at `repos` (name, workdir).
+/// Mirrors `sym_tree::seed_watch_toml` -- forward-slash normalized so a
+/// Windows path interpolated into this basic TOML string does not have its
+/// backslashes read back as escape sequences.
+fn seed_watch_toml(data_dir: &std::path::Path, repos: &[(&str, &std::path::Path)]) {
+    let mut toml = String::new();
+    for (name, workdir) in repos {
+        toml.push_str(&format!(
+            "[[repos]]\nname = \"{}\"\nworkdir = \"{}\"\n\n",
+            name,
+            workdir.display().to_string().replace('\\', "/")
+        ));
+    }
+    std::fs::write(data_dir.join("watch.toml"), toml).expect("seed watch.toml");
+}
+
+/// One `(from_path, specifier, to_path)` row read back from `module_edges`.
+fn edges_for_repo(data_dir: &std::path::Path, repo: &str) -> Vec<(String, String, Option<String>)> {
+    let conn = Connection::open(data_dir.join("legion.db")).expect("open legion.db");
+    let mut stmt = conn
+        .prepare("SELECT from_path, specifier, to_path FROM module_edges WHERE repo = ?1 ORDER BY from_path, specifier")
+        .expect("prepare query");
+    stmt.query_map([repo], |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)))
+        .expect("query_map")
+        .collect::<Result<Vec<_>, _>>()
+        .expect("collect rows")
+}
+
+#[test]
+fn index_populates_module_edges_through_tsconfig_paths_and_records_unresolved() {
+    let data_dir = tempfile::tempdir().expect("data dir");
+    let repo_dir = tempfile::tempdir().expect("repo dir");
+
+    std::fs::write(
+        repo_dir.path().join("tsconfig.json"),
+        r#"{
+            "compilerOptions": {
+                "baseUrl": ".",
+                "paths": { "@/*": ["src/*"] }
+            }
+        }"#,
+    )
+    .expect("write tsconfig.json");
+    std::fs::create_dir_all(repo_dir.path().join("src")).expect("mkdir src");
+    std::fs::write(
+        repo_dir.path().join("src/index.ts"),
+        "import { widget } from '@/widget';\n\
+         import unresolved from 'some-external-package-that-does-not-exist';\n\
+         export { widget, unresolved };\n",
+    )
+    .expect("write index.ts");
+    std::fs::write(
+        repo_dir.path().join("src/widget.ts"),
+        "export const widget = 1;\n",
+    )
+    .expect("write widget.ts");
+
+    seed_watch_toml(data_dir.path(), &[("graphrepo", repo_dir.path())]);
+
+    // A real `legion index` run: file inventory walk, then the module-graph
+    // pass wired in src/cli/index_cmd.rs::handle_index. No package.json is
+    // present, so no SCIP `typescript` indexer even attempts to run -- the
+    // graph pass must be independent of that marker-file detection.
+    run_ok(legion_cmd(data_dir.path()).args(["index", "graphrepo"]));
+
+    let edges = edges_for_repo(data_dir.path(), "graphrepo");
+
+    let resolved = edges
+        .iter()
+        .find(|(from, spec, _)| from == "src/index.ts" && spec == "@/widget")
+        .unwrap_or_else(|| panic!("expected an @/widget edge from src/index.ts, got {edges:?}"));
+    assert_eq!(
+        resolved.2.as_deref(),
+        Some("src/widget.ts"),
+        "tsconfig `paths` must resolve @/widget to src/widget.ts, got {edges:?}"
+    );
+
+    let unresolved = edges
+        .iter()
+        .find(|(from, spec, _)| {
+            from == "src/index.ts" && spec == "some-external-package-that-does-not-exist"
+        })
+        .unwrap_or_else(|| {
+            panic!("expected the external-package edge to be recorded, not dropped, got {edges:?}")
+        });
+    assert_eq!(
+        unresolved.2, None,
+        "an unresolved/external specifier must be recorded with to_path = NULL, not dropped"
+    );
+}
+
+#[test]
+fn index_with_no_ts_files_leaves_module_edges_empty() {
+    // A repo with no js/ts/jsx/tsx files at all must not error, and must
+    // simply produce no module_edges rows -- the graph pass is skipped
+    // entirely rather than running over an empty file list.
+    let data_dir = tempfile::tempdir().expect("data dir");
+    let repo_dir = tempfile::tempdir().expect("repo dir");
+    std::fs::write(repo_dir.path().join("README.md"), "# hi\n").expect("write fixture");
+    seed_watch_toml(data_dir.path(), &[("docsonly", repo_dir.path())]);
+
+    run_ok(legion_cmd(data_dir.path()).args(["index", "docsonly"]));
+
+    let edges = edges_for_repo(data_dir.path(), "docsonly");
+    assert!(edges.is_empty(), "expected no module edges, got {edges:?}");
+}

--- a/tests/integration/module_graph.rs
+++ b/tests/integration/module_graph.rs
@@ -105,6 +105,57 @@ fn index_populates_module_edges_through_tsconfig_paths_and_records_unresolved() 
 }
 
 #[test]
+fn reindex_drops_edges_for_imports_removed_from_a_still_live_file() {
+    // Regression test for the module_edges upsert bug where a file that
+    // stays live but sheds an import (or all of them) left the stale edge
+    // rows behind forever: the upsert only ever inserts/updates, and
+    // `prune_module_edges` only removes edges for files that are no longer
+    // walked at all, so neither path used to clear a specifier that
+    // disappeared from a file's *current* content.
+    let data_dir = tempfile::tempdir().expect("data dir");
+    let repo_dir = tempfile::tempdir().expect("repo dir");
+
+    std::fs::create_dir_all(repo_dir.path().join("src")).expect("mkdir src");
+    std::fs::write(
+        repo_dir.path().join("src/index.ts"),
+        "import { b } from './b';\nimport { c } from './c';\nexport { b, c };\n",
+    )
+    .expect("write index.ts");
+    std::fs::write(repo_dir.path().join("src/b.ts"), "export const b = 1;\n").expect("write b.ts");
+    std::fs::write(repo_dir.path().join("src/c.ts"), "export const c = 1;\n").expect("write c.ts");
+
+    seed_watch_toml(data_dir.path(), &[("reindexrepo", repo_dir.path())]);
+    run_ok(legion_cmd(data_dir.path()).args(["index", "reindexrepo"]));
+
+    let first_pass = edges_for_repo(data_dir.path(), "reindexrepo");
+    assert_eq!(
+        first_pass.len(),
+        2,
+        "expected both ./b and ./c edges on the first index, got {first_pass:?}"
+    );
+
+    // src/index.ts stays live but drops its `./c` import entirely.
+    std::fs::write(
+        repo_dir.path().join("src/index.ts"),
+        "import { b } from './b';\nexport { b };\n",
+    )
+    .expect("rewrite index.ts");
+
+    run_ok(legion_cmd(data_dir.path()).args(["index", "reindexrepo"]));
+
+    let second_pass = edges_for_repo(data_dir.path(), "reindexrepo");
+    assert_eq!(
+        second_pass,
+        vec![(
+            "src/index.ts".to_string(),
+            "./b".to_string(),
+            Some("src/b.ts".to_string())
+        )],
+        "the dropped ./c import must not survive re-indexing, got {second_pass:?}"
+    );
+}
+
+#[test]
 fn index_with_no_ts_files_leaves_module_edges_empty() {
     // A repo with no js/ts/jsx/tsx files at all must not error, and must
     // simply produce no module_edges rows -- the graph pass is skipped


### PR DESCRIPTION
## Summary

Adds a module-graph engine (#710): `src/graph.rs` parses every js/ts/jsx/tsx file's static
imports/exports/re-exports and literal dynamic `import()`s via `oxc_parser`'s `ModuleRecord`,
then resolves each specifier against its referrer via `oxc_resolver` (tsconfig `paths` auto-
discovered per file, `node_modules`, extension resolution, package.json `exports`/`imports`).
Edges persist in a new `module_edges` table (`src/db/module_edges.rs`) keyed on
`(repo, from_path, specifier)`.

`legion index` now runs this pass over the file inventory's typescript-lang subset on every
invocation (`handle_index` in `src/cli/index_cmd.rs`), independent of whether a `scip-typescript`
binary is installed or a `package.json` marker is present -- oxc needs only the files on disk.
The prune step mirrors `prune_file_inventory`'s own semantics, including wiping a repo's edges
entirely when it has zero JS/TS files left.

No CLI query surface (`sym imports` / `sym importers`) exists yet -- `list_module_edges_from` /
`list_module_edges_to` are the query API a follow-on issue will wire up; see "Deliberately not
done" below.

## Acceptance criteria mapping

### 1. On a TS repo, a known import edge resolves through tsconfig paths

`build_module_graph` configures `oxc_resolver::Resolver` with `TsconfigDiscovery::Auto`
(src/graph.rs:95), so each importer resolves against the tsconfig that actually owns it. Unit
test `resolves_through_tsconfig_paths` (src/graph.rs, tests module) seeds a `tsconfig.json` with
`"paths": { "@/*": ["src/*"] }` and asserts `@/widget` resolves to `src/widget.ts`. This is also
exercised at the CLI boundary, not just the library function: integration test
`index_populates_module_edges_through_tsconfig_paths_and_records_unresolved`
(tests/integration/module_graph.rs) runs a real `legion index <repo>` over the same fixture
shape and reads the `module_edges` row back out of `legion.db` directly, asserting
`to_path = 'src/widget.ts'` for the `@/widget` specifier from `src/index.ts`.

Evidence: `cargo test graph::tests::resolves_through_tsconfig_paths` and
`cargo test --test integration module_graph::index_populates_module_edges_through_tsconfig_paths_and_records_unresolved`,
both pass.

### 2. Unresolved/external specifiers recorded with `to = None`, not dropped

`build_module_graph` records every specifier as an edge regardless of whether `resolver.resolve_file`
succeeds (src/graph.rs:163-171) -- a resolution failure maps to `to: None`, the edge is still
pushed. Two unit tests pin this: `unresolved_specifier_recorded_as_none_not_dropped` (an external
package name that resolves nowhere) and `missing_relative_import_is_none_not_dropped` (a relative
specifier pointing at a file that does not exist). The same integration test named above also
asserts this at the CLI boundary: `some-external-package-that-does-not-exist` imported from
`src/index.ts` lands in `module_edges` with `to_path IS NULL`, in the same `legion index` run
that resolved `@/widget` successfully -- proving both outcomes coexist correctly in one pass.
`Database::prune_module_edges` and `upsert_module_edges` also treat `to: None` as a normal,
persisted value (`rusqlite::params![... &edge.to]` with `to_path` nullable), never filtering it
out before the DB layer.

Evidence: `cargo test graph::tests::unresolved_specifier_recorded_as_none_not_dropped`,
`cargo test graph::tests::missing_relative_import_is_none_not_dropped`, and the same
`index_populates_module_edges_through_tsconfig_paths_and_records_unresolved` integration test
above (asserts `unresolved.2 == None`), all pass.

### 3. Tests pass; simplify + review done; PR linked

Full workspace test suite: `cargo test` -- 1268 passed / 0 failed / 2 ignored (unit +
`src/`-embedded tests), 226 passed / 0 failed / 2 ignored (integration crate), including the
12 new `src/graph.rs` unit tests, 6 new `src/db/module_edges.rs` unit tests, and 2 new
`tests/integration/module_graph.rs` end-to-end tests. `cargo clippy --all-targets -- -D
warnings` clean. `cargo fmt -- --check` clean. Simplify gate recorded clean
(`legion quality-gate check --skill legion-simplify`, gate id `019f3045-6e0b-72b3-aec9-f773519dda4d`,
9 file entries). This PR is opened against #710 and will link on creation.

## Deliberately not done

- **No CLI query surface for the module graph.** `Database::list_module_edges_from` /
  `list_module_edges_to` exist and are unit-tested, but nothing calls them outside tests yet --
  marked `#[allow(dead_code)]` with a doc comment explaining why (no issue filed yet for
  `sym imports` / `sym importers` or similar). The issue's own Interface section only specifies
  `ImportEdge` + `build_module_graph`; the query commands are explicitly a follow-on, matching
  the "sym can answer importer/importee queries" framing as a future capability, not a
  requirement of this issue.
- **CSS symbols (#711) and Astro handling (#712)** -- explicitly out of scope per the issue.
- **A bundler or any code emission** -- this is index-only, resolution + graph, never bundling,
  matching the issue's stated scope and the Rolldown-as-reference-architecture-only framing in
  `src/graph.rs`'s module doc.
- **Non-literal dynamic `import()` resolution** (e.g. `import(base + name)`) -- deliberately
  skipped rather than guessed at; see `computed_dynamic_import_is_skipped_not_guessed`. This is
  a correctness choice, not a gap: guessing at a computed specifier would silently fabricate a
  graph edge that may not exist at runtime.
- **Full JS string-escape decoding for dynamic-import literals** -- `unescape_quotes` only
  handles the quote character and a literal backslash, not `\n`/`\t`/unicode escapes, since none
  of those produce valid file paths or package names anyway (documented in the function's doc
  comment).