### PR TITLE
feat(#713): fair-guard rewording -- sym etc routing, lane-4/5 stance, coverage guarantee

### DIFF
--- a/plugin/agents/legion-explore.md
+++ b/plugin/agents/legion-explore.md
@@ -41,12 +41,12 @@ You exist because text-scanning (grep/find/rg) is the wrong orientation tool on 
 
 **Preflight (always, before choosing a lane)**
 
-Run `legion index --status --json` and note which (repo, lang) pairs are indexed and how fresh. This decides lane availability:
+Run `legion index <repo> --status --banner` (not just `--status --json`): the banner names, per detected language, whether it is fresh, stale, not-yet-indexed, or blocked because the indexer binary itself is not installed on this machine (#713) -- that last case is NOT evidence sym is broken or language-limited, it is a one-time environment gap. Note which (repo, lang) pairs are indexed and how fresh. This decides lane availability:
 - Index fresh: lane 2 (sym) is your default for anything code-shaped.
 - Index stale: sym answers may lag reality. Still use sym for orientation, but verify any load-bearing claim with a targeted Read, and say "index stale as of <updated_at>" in your findings.
-- Index missing for the target language: lane 2 is unavailable. Declare it and use lane 4 rules.
+- Index missing or indexer unavailable for the target language: lane 2 is unavailable for that language specifically -- sym is multi-language by design (rust, typescript, python, go, java, ruby, clang, csharp, php all have indexers; a repo showing only rust rows means only rust got indexed here, not that sym cannot do the others). Declare the gap and move to lane 4 (`sym etc`) -- it does not need a SCIP index at all.
 
-**The four lanes (route by question shape)**
+**The five lanes (route by question shape)**
 
 1. **Doctrine/decision-shaped** -- "why is it built this way", "what was decided", "has anyone hit this before":
    `legion recall --repo <repo> --context "..."` for this repo's memory, `legion consult --context "..."` across all agents. Never answer a WHY question from code alone; code shows what exists, not what should exist. Cite reflection ids.
@@ -64,14 +64,21 @@ Run `legion index --status --json` and note which (repo, lang) pairs are indexed
 3. **Targeted read** -- sym gave you file:line; now you need the actual code:
    Read with offset/limit around that location. A targeted Read at a sym-cited span is normal operation, not a fallback. Unbounded whole-file Reads are what you avoid; if you need a 2000-line file, you are in the wrong lane -- go back to sym list and narrow.
 
-4. **Bounded text search (declared last resort)** -- literal strings, config keys, shell scripts, TOML, markdown, or any unindexed target:
-   These are real questions sym cannot answer. Use the narrowest possible shell text search, scoped to specific paths, and log every use:
-   `legion telemetry record-bypass --repo <repo> --session-id "${CLAUDE_SESSION_ID:-unknown}" --tool Bash --pattern "<what you searched>" --bypass-reason "legion-explore lane-4: <why sym/recall could not answer this>" --agent legion-explore`
-   The log is not punishment; it is measurement. Bypass volume on a pattern shape is evidence that sym/recall under-serves a real query shape.
+4. **Non-symbol structured query (`sym etc` / `sym tree`)** -- literal strings, config keys, frontmatter fields, shell scripts, TOML, markdown, or "which file/repo has X" -- the shapes sym's SCIP index was never going to answer, and the reason a bounded-text-search lane used to be the immediate fallback. Try these BEFORE any shell text search; none of them need a SCIP index:
+   - `legion sym etc find-content <pattern> --repo <repo> [--ext <ext>] [--fixed-strings] [--json]` -- exact/regex content search over watched repos. The sanctioned grep.
+   - `legion sym tree --repo <repo> [--ext <ext>] [--under <path>] [--depth <n>] [--json]` -- structured file/dir listing. The sanctioned `find` / `ls -R` / `tree`.
+   - `legion sym etc extract <path> --field <dotted.field> [--json]` -- one value out of a JSON/TOML/YAML file or a `.md`/`.mdx`/`.astro` frontmatter block, without reading the whole file.
+   - `legion sym etc find-file <query> [--repo <repo>] [--role <role>] [--json]` -- locate a file by basename/glob or by role (config/test/doc/entry) across every watched repo.
+   A zero-result answer from any of these is itself evidence -- it means the corpus genuinely has nothing matching, not that you should silently fall back to shell text search. Report the zero result plainly.
+
+5. **Bounded text search (last resort, logged)** -- only once lane 4 has been tried and could not answer (wrong corpus, needs live filesystem state a scan hasn't captured, or a shape none of the four `sym etc` commands cover):
+   Use the narrowest possible shell text search, scoped to specific paths, and log every use:
+   `legion telemetry record-bypass --repo <repo> --session-id "${CLAUDE_SESSION_ID:-unknown}" --tool Bash --pattern "<what you searched>" --bypass-reason "legion-explore lane-5: <why sym AND sym etc could not answer this>" --agent legion-explore`
+   This is not the default move for "sym came up empty" -- that is what lane 4 is for. The log is not punishment; it is measurement. Bypass volume on a pattern shape is evidence that sym/`sym etc`/recall under-serves a real query shape, not evidence that you did something wrong by hitting it occasionally.
 
 **Deterministic escalation (no scoring, no judgment calls)**
 
-- sym miss on a symbol-shaped question: do NOT conclude "does not exist". First retry with a shorter substring (sym matches substrings, descriptor-aware). Still missing: check index freshness; if stale or missing, escalate to lane 4 with telemetry. If fresh, you may report "no definition in the index" -- with the index timestamp as evidence.
+- sym miss on a symbol-shaped question: do NOT conclude "does not exist". First retry with a shorter substring (sym matches substrings, descriptor-aware). Still missing: check index freshness; if stale or missing, escalate to lane 4 (`sym etc`/`sym tree`) -- it does not depend on the SCIP index at all. Only escalate to lane 5 with telemetry if lane 4 also cannot answer. If fresh, you may report "no definition in the index" -- with the index timestamp as evidence.
 - Ambiguous multi-match: enumerate every candidate with file:line. Never silently pick one.
 - Index stale or missing: flag it in findings verbatim; downgrade load-bearing claims to "verified by read" or "unverified".
 - A claim you cannot evidence: mark it "unverified" explicitly. An unverified claim labeled as such is acceptable; a confident guess is not.
@@ -81,11 +88,11 @@ Run `legion index --status --json` and note which (repo, lang) pairs are indexed
 - Lead with the direct answer to the question asked.
 - Every claim carries evidence: `file:line`, a sym result, or a reflection id. No naked assertions.
 - Conclusions, not transcripts: do not paste large code blocks; cite the span and summarize what it does.
-- End with a short `gaps:` line listing anything you could not verify, every lane-4 bypass you logged, and index staleness if it applied.
+- End with a short `gaps:` line listing anything you could not verify, every lane-5 bypass you logged, and index staleness or coverage gaps if they applied.
 
 **What you never do**
 
-- Never run grep, rg, find, fd, ack, or ag. The shell equivalents of the tools you were not given are not given either.
+- Never run grep, rg, find, fd, ack, or ag as a first move. The shell equivalents of the tools you were not given are not given either -- `sym etc` (lane 4) answers the query shapes those commands existed for; reach past it to lane 5 only when it genuinely comes up empty.
 - Never Read a whole large file to "get oriented". Orientation is sym list + recall.
 - Never answer a WHY question from code structure alone.
 - Never write, edit, or store anything except telemetry bypass records.

--- a/plugin/hooks/pre-bash-grep.sh
+++ b/plugin/hooks/pre-bash-grep.sh
@@ -111,7 +111,7 @@ if [ -n "$BYPASS_REASON" ]; then
 ${LOCAL_HITS}
 \`\`\`
 
-For symbols, \`legion sym def ${PATTERN}\` / \`sym refs\` / \`sym list\` answer in bytes. For genuinely non-symbol, non-indexed content (e.g. an .astro file), use the Grep tool -- not shell ${BINARY}. Your operator may block shell ${BINARY} outright via permissions.deny; that is the intended mandatory gate, and there is no env-var escape from it."
+For symbols, \`legion sym def ${PATTERN}\` / \`sym refs\` / \`sym list\` answer in bytes -- sym covers every indexed language, not just Rust. For non-symbol shapes: \`legion sym etc find-content '${PATTERN}' --repo ${REPO}\` (exact/regex content, the sanctioned grep), \`legion sym tree --repo ${REPO}\` (file/dir structure), \`legion sym etc extract <path> --field <field>\` (one config/frontmatter value without a full read), \`legion sym etc find-file '${PATTERN}' --repo ${REPO}\` (locate a file by name/role). Reach for the Grep tool only if none of those answer it. Your operator may block shell ${BINARY} outright via permissions.deny; that is the intended mandatory gate, and there is no env-var escape from it."
     emit_deny "$REASON"
     exit 0
   fi
@@ -156,7 +156,7 @@ if legion_indexed "$SESSION_ID" "$REPO"; then
 ${LOCAL_HITS}
 \`\`\`
 
-The soft bypass (\`# legion-bypass: <reason>\` or LEGION_BYPASS_GREP=1) is REFUSED for symbol-shaped patterns that resolve in this repo's SCIP index -- the sentinel exists for free-text searches, not for symbol queries dressed up as text. For symbols use \`legion sym def ${PATTERN}\` / \`sym refs\` / \`sym list\`; for genuinely non-symbol, non-indexed content use the Grep tool, not shell ${BINARY}. There is no env-var hard escape -- the mandatory shell-grep block is the operator's permissions.deny."
+The soft bypass (\`# legion-bypass: <reason>\` or LEGION_BYPASS_GREP=1) is REFUSED for symbol-shaped patterns that resolve in this repo's SCIP index -- the sentinel exists for free-text searches, not for symbol queries dressed up as text. For symbols use \`legion sym def ${PATTERN}\` / \`sym refs\` / \`sym list\` -- sym covers every indexed language, not just Rust. For non-symbol shapes: \`legion sym etc find-content '${PATTERN}' --repo ${REPO}\` (content), \`legion sym tree --repo ${REPO}\` (structure), \`legion sym etc extract <path> --field <field>\` (a config/frontmatter value), \`legion sym etc find-file '${PATTERN}' --repo ${REPO}\` (locate by name/role). Reach for the Grep tool only if none of those answer it. There is no env-var hard escape -- the mandatory shell-grep block is the operator's permissions.deny."
     emit_deny "$REASON"
     exit 0
   fi
@@ -167,11 +167,11 @@ fi
 # the hits as additionalContext so the agent can decide.
 CTX="## Legion sym for \`${PATTERN}\` (Bash ${BINARY})
 
-\`legion sym def ${PATTERN}\` returned:
+\`legion sym def ${PATTERN}\` returned (from other repos' indexes -- ${REPO} has no local SCIP index yet, so the block tier is disabled here):
 
 \`\`\`json
 ${HITS}
 \`\`\`
 
-This repo has no SCIP index, so the block tier is disabled. Consider \`legion sym def ${PATTERN}\` instead of ${BINARY} on this pattern."
+For ${REPO} itself, non-symbol shapes still have a sanctioned answer that needs no SCIP index: \`legion sym etc find-content '${PATTERN}' --repo ${REPO}\` (content), \`legion sym tree --repo ${REPO}\` (structure), \`legion sym etc find-file '${PATTERN}' --repo ${REPO}\` (locate by name). Run \`legion index ${REPO}\` to get a real local \`sym def\` answer too."
 emit_allow "$CTX" "legion sym/recall results injected"

--- a/plugin/hooks/pre-grep.sh
+++ b/plugin/hooks/pre-grep.sh
@@ -93,7 +93,7 @@ fi
 # up as text); telemetried and allowed otherwise.
 if [ "${LEGION_BYPASS_GREP:-}" = "1" ]; then
   if [ -n "$LOCAL_HITS" ] && [ "$LOCAL_HITS" != "[]" ]; then
-    emit_deny "Soft bypass refused: \`${SYMBOL}\` resolves to a symbol in this repo's SCIP index. Use \`legion sym def ${SYMBOL} --repo ${REPO}\` (or \`sym refs\` / \`sym hover\`) instead. LEGION_BYPASS_GREP exists for free-text searches; it cannot route around sym for symbol queries.
+    emit_deny "Soft bypass refused: \`${SYMBOL}\` resolves to a symbol in this repo's SCIP index. Use \`legion sym def ${SYMBOL} --repo ${REPO}\` (or \`sym refs\` / \`sym hover\`) instead -- sym covers every indexed language, not just Rust. LEGION_BYPASS_GREP exists for free-text searches; it cannot route around sym for symbol queries.
 
 \`legion sym def ${SYMBOL} --repo ${REPO}\` returned:
 
@@ -101,7 +101,7 @@ if [ "${LEGION_BYPASS_GREP:-}" = "1" ]; then
 ${LOCAL_HITS}
 \`\`\`
 
-There is no env-var hard escape -- the mandatory search block is the operator's permissions.deny."
+For non-symbol shapes, ${TOOL} is not the sanctioned surface either: \`legion sym etc find-content '${PATTERN}' --repo ${REPO}\` (content), \`legion sym tree --repo ${REPO}\` (structure), \`legion sym etc extract <path> --field <field>\` (a config/frontmatter value), \`legion sym etc find-file '${PATTERN}' --repo ${REPO}\` (locate by name/role). There is no env-var hard escape -- the mandatory search block is the operator's permissions.deny."
     exit 0
   fi
   legion_prequery_record_bypass \
@@ -121,7 +121,7 @@ if [ -n "$LOCAL_HITS" ] && [ "$LOCAL_HITS" != "[]" ]; then
 ${LOCAL_HITS}
 \`\`\`
 
-The soft bypass (LEGION_BYPASS_GREP=1) is REFUSED for symbol-shaped patterns that resolve in this repo's SCIP index -- it exists for free-text searches, not symbol queries dressed up as text. For symbols use \`legion sym def ${SYMBOL}\` / \`sym refs\` / \`sym list\`. There is no env-var hard escape -- the mandatory search block is the operator's permissions.deny."
+The soft bypass (LEGION_BYPASS_GREP=1) is REFUSED for symbol-shaped patterns that resolve in this repo's SCIP index -- it exists for free-text searches, not symbol queries dressed up as text. For symbols use \`legion sym def ${SYMBOL}\` / \`sym refs\` / \`sym list\` -- sym covers every indexed language, not just Rust. For non-symbol shapes: \`legion sym etc find-content '${PATTERN}' --repo ${REPO}\` (content), \`legion sym tree --repo ${REPO}\` (structure), \`legion sym etc extract <path> --field <field>\` (a config/frontmatter value), \`legion sym etc find-file '${PATTERN}' --repo ${REPO}\` (locate by name/role). There is no env-var hard escape -- the mandatory search block is the operator's permissions.deny."
   exit 0
 fi
 
@@ -148,7 +148,7 @@ ${HITS}
 
 ${REFS_LINE}
 
-If this answers your symbol question, skip the ${TOOL}. SCIP is byte-cheap; file scans are not."
+If this answers your symbol question, skip the ${TOOL}. SCIP is byte-cheap; file scans are not. For non-symbol content (literal strings, config/frontmatter, file discovery), \`legion sym etc find-content\` / \`sym tree\` / \`sym etc extract\` / \`sym etc find-file\` answer those shapes without a file scan either."
   emit_allow "$CTX" "legion sym hits for the symbol"
   exit 0
 fi
@@ -259,6 +259,6 @@ Before ${TOOL} on \`${QUERY}\`, legion recall returned:
 
 ${RECALL_HITS}
 
-If these answer your question, skip the ${TOOL}. Otherwise continue -- but consider whether the reflection explains WHY before you search for WHAT."
+If these answer your question, skip the ${TOOL}. Otherwise continue -- but consider whether the reflection explains WHY before you search for WHAT. If you are after WHAT (exact content, structure, a config value, or a file by name) rather than WHY, \`legion sym etc find-content\` / \`sym tree\` / \`sym etc extract\` / \`sym etc find-file\` answer those directly and are cheaper than a ${TOOL} scan."
 
 emit_allow "$CTX" "legion recall hits for the query"

--- a/plugin/hooks/test-pre-bash-grep.sh
+++ b/plugin/hooks/test-pre-bash-grep.sh
@@ -94,6 +94,13 @@ assert_contains "deny reason names the pattern" "$out" 'Symbol'
 assert_contains "deny reason offers env bypass" "$out" 'LEGION_BYPASS_GREP=1'
 assert_contains "deny reason offers sentinel bypass" "$out" '# legion-bypass:'
 
+echo "==> #713: BLOCK message routes to sym etc for non-symbol shapes, not just the Grep tool"
+assert_contains "names find-content for content search" "$out" 'sym etc find-content'
+assert_contains "names sym tree for structure" "$out" 'sym tree'
+assert_contains "names extract for config/frontmatter fields" "$out" 'sym etc extract'
+assert_contains "names find-file for locate-by-name" "$out" 'sym etc find-file'
+assert_contains "states sym is not rust-only" "$out" 'not just Rust'
+
 echo "==> #458 relevance gate: cluster-wide hit but NOT in this repo -> pass through (no block)"
 # Stub legion returns commonword hits in huttspawn, but the grep target is in /tmp/legion.
 # Pre-#458 behavior: would block on those cross-repo hits.
@@ -111,6 +118,11 @@ out=$(echo '{"cwd":"/tmp/legion","tool_name":"Bash","tool_input":{"command":"gre
 assert_contains "soft env bypass refused on local symbol" "$out" '"permissionDecision": "deny"'
 assert_contains "refusal points to sym list, not a hard escape" "$out" 'sym list'
 assert_file_not_contains "refused soft bypass writes no telemetry row" "$LEGION_TEST_MARKER" "record-bypass"
+echo "==> #713: bypass-refusal message also routes to sym etc for non-symbol shapes"
+assert_contains "refusal names find-content" "$out" 'sym etc find-content'
+assert_contains "refusal names sym tree" "$out" 'sym tree'
+assert_contains "refusal names extract" "$out" 'sym etc extract'
+assert_contains "refusal names find-file" "$out" 'sym etc find-file'
 
 echo "==> harder bypass: soft sentinel bypass REFUSED for symbol with local hit"
 rm -f "$LEGION_TEST_MARKER"

--- a/plugin/hooks/test-pre-grep.sh
+++ b/plugin/hooks/test-pre-grep.sh
@@ -67,6 +67,13 @@ assert_contains "deny decision present" "$out" '"permissionDecision": "deny"'
 assert_contains "deny reason mentions sym def" "$out" 'legion sym def'
 assert_contains "deny reason names the pattern" "$out" 'Symbol'
 
+echo "==> #713: BLOCK message routes to sym etc for non-symbol shapes, not just the Grep tool"
+assert_contains "names find-content for content search" "$out" 'sym etc find-content'
+assert_contains "names sym tree for structure" "$out" 'sym tree'
+assert_contains "names extract for config/frontmatter fields" "$out" 'sym etc extract'
+assert_contains "names find-file for locate-by-name" "$out" 'sym etc find-file'
+assert_contains "states sym is not rust-only" "$out" 'not just Rust'
+
 echo "==> sym tier: word-boundary-wrapped pattern still resolves"
 out=$(printf '%s\n' '{"cwd":"/tmp/legion","tool_name":"Grep","tool_input":{"pattern":"\\bSymbol\\b"},"session_id":"wb-t"}' | run_hook)
 assert_contains "stripped \\b pattern blocks too" "$out" '"permissionDecision": "deny"'
@@ -86,6 +93,11 @@ echo "==> bypass: refused for a symbol with a local hit"
 out=$(echo '{"cwd":"/tmp/legion","tool_name":"Grep","tool_input":{"pattern":"Symbol"},"session_id":"byp-t"}' | LEGION_BYPASS_GREP=1 run_hook)
 assert_contains "bypass refused on local symbol" "$out" '"permissionDecision": "deny"'
 assert_contains "refusal explains the escape is for free text" "$out" 'free-text searches'
+echo "==> #713: bypass-refusal message also routes to sym etc for non-symbol shapes"
+assert_contains "refusal names find-content" "$out" 'sym etc find-content'
+assert_contains "refusal names sym tree" "$out" 'sym tree'
+assert_contains "refusal names extract" "$out" 'sym etc extract'
+assert_contains "refusal names find-file" "$out" 'sym etc find-file'
 
 echo "==> bypass: allowed + telemetried for non-local pattern"
 export LEGION_TEST_MARKER="$WORK/state/bypass-marker.log"

--- a/src/cli/index_cmd.rs
+++ b/src/cli/index_cmd.rs
@@ -1642,8 +1642,21 @@ fn run_index_status_banner(base: &std::path::Path, repo: Option<&str>) -> error:
         }
     };
 
+    // Coverage guarantee (#713): a detected-but-unindexed language is either
+    // "not indexed yet" (running `legion index` fixes it) or "indexer
+    // unavailable" (the binary the language needs is not on this machine's
+    // PATH, so `legion index` cannot fix it by itself). Computed here, not
+    // inside the pure renderer below, so the renderer stays deterministic
+    // and testable without mocking PATH.
+    let unavailable_langs: Vec<&str> = detected
+        .iter()
+        .filter(|lang| !indexes.iter().any(|i| i.lang == **lang) && !scip::indexer_available(lang))
+        .copied()
+        .collect();
+
     let now = chrono::Utc::now();
-    let banner = render_index_status_banner(repo_name, &detected, &indexes, now);
+    let banner =
+        render_index_status_banner(repo_name, &detected, &indexes, &unavailable_langs, now);
     if !banner.is_empty() {
         writeln!(out, "{banner}")?;
     }
@@ -1654,12 +1667,18 @@ fn run_index_status_banner(base: &std::path::Path, repo: Option<&str>) -> error:
 /// means "silent" (every detected language has a fresh index). Returns a
 /// multi-line block when anything is stale or missing.
 ///
+/// `unavailable_langs` names detected languages whose indexer binary is not
+/// on `PATH` (#713 coverage guarantee) -- computed by the caller via
+/// `scip::indexer_available` so this renderer stays a pure function of its
+/// arguments and does not read the environment itself.
+///
 /// Stale threshold: 7 days. Override-friendly through a build constant if
 /// future tuning needs it; not exposed as a CLI flag in v1.
 fn render_index_status_banner(
     repo_name: &str,
     detected_langs: &[&str],
     indexes: &[scip::ScipIndex],
+    unavailable_langs: &[&str],
     now: chrono::DateTime<chrono::Utc>,
 ) -> String {
     const STALE_THRESHOLD_DAYS: i64 = 7;
@@ -1671,9 +1690,23 @@ fn render_index_status_banner(
     }
 
     enum LangHealth {
-        Fresh { lang: String, age: String },
-        Stale { lang: String, age: String },
-        Missing { lang: String },
+        Fresh {
+            lang: String,
+            age: String,
+        },
+        Stale {
+            lang: String,
+            age: String,
+        },
+        Missing {
+            lang: String,
+        },
+        /// #713: detected but no indexer binary is installed for it. Distinct
+        /// from `Missing` -- `legion index` cannot fix this by itself.
+        IndexerUnavailable {
+            lang: String,
+            binary: String,
+        },
     }
 
     fn humanize_age(seconds: i64) -> String {
@@ -1719,9 +1752,18 @@ fn render_index_status_banner(
                     });
                 }
             },
-            None => report.push(LangHealth::Missing {
-                lang: (*lang).to_string(),
-            }),
+            None => {
+                if unavailable_langs.contains(lang) {
+                    report.push(LangHealth::IndexerUnavailable {
+                        lang: (*lang).to_string(),
+                        binary: scip::indexer_binary_hint(lang).to_string(),
+                    });
+                } else {
+                    report.push(LangHealth::Missing {
+                        lang: (*lang).to_string(),
+                    });
+                }
+            }
         }
     }
 
@@ -1753,7 +1795,12 @@ fn render_index_status_banner(
             }
             LangHealth::Missing { lang } => {
                 lines.push(format!(
-                    "  {lang}: not indexed -- run `legion index {repo_name}` or `legion watch add {repo_name}` to build"
+                    "  {lang}: not indexed yet -- run `legion index {repo_name}` to build"
+                ));
+            }
+            LangHealth::IndexerUnavailable { lang, binary } => {
+                lines.push(format!(
+                    "  {lang}: indexer unavailable ({binary} not on PATH) -- `legion index` cannot cover this language until it is installed; `legion sym etc find-content` / `sym tree` / `sym etc find-file` still cover its files by content and structure without SCIP"
                 ));
             }
         }
@@ -2245,7 +2292,7 @@ mod index_banner_tests {
     #[test]
     fn empty_when_no_languages_detected() {
         let now = Utc.with_ymd_and_hms(2026, 5, 7, 12, 0, 0).unwrap();
-        let banner = render_index_status_banner("legion", &[], &[], now);
+        let banner = render_index_status_banner("legion", &[], &[], &[], now);
         assert!(banner.is_empty());
     }
 
@@ -2254,7 +2301,7 @@ mod index_banner_tests {
         let now = Utc.with_ymd_and_hms(2026, 5, 7, 12, 0, 0).unwrap();
         let recent = "2026-05-07T10:00:00Z";
         let indexes = vec![idx("legion", "rust", recent)];
-        let banner = render_index_status_banner("legion", &["rust"], &indexes, now);
+        let banner = render_index_status_banner("legion", &["rust"], &indexes, &[], now);
         assert!(banner.starts_with("[Legion] Index status for legion: "));
         assert!(banner.contains("rust: fresh"));
         assert_eq!(banner.lines().count(), 1, "fresh state must be one line");
@@ -2263,11 +2310,35 @@ mod index_banner_tests {
     #[test]
     fn loud_block_when_missing_language() {
         let now = Utc.with_ymd_and_hms(2026, 5, 7, 12, 0, 0).unwrap();
-        let banner = render_index_status_banner("legion", &["rust", "typescript"], &[], now);
+        let banner = render_index_status_banner("legion", &["rust", "typescript"], &[], &[], now);
         assert!(banner.contains("[Legion] Index status for legion:"));
-        assert!(banner.contains("rust: not indexed"));
-        assert!(banner.contains("typescript: not indexed"));
+        assert!(banner.contains("rust: not indexed yet"));
+        assert!(banner.contains("typescript: not indexed yet"));
         assert!(banner.contains("legion index legion"));
+    }
+
+    /// #713 coverage guarantee: a detected language whose indexer binary is
+    /// not on PATH must be named as "indexer unavailable", not lumped in
+    /// with "not indexed yet" -- the two demand different operator actions,
+    /// and collapsing them is what taught agents "sym doesn't do X" instead
+    /// of "nobody installed X's indexer here".
+    #[test]
+    fn loud_block_distinguishes_indexer_unavailable_from_not_indexed_yet() {
+        let now = Utc.with_ymd_and_hms(2026, 5, 7, 12, 0, 0).unwrap();
+        let banner =
+            render_index_status_banner("legion", &["rust", "python"], &[], &["python"], now);
+        assert!(
+            banner.contains("rust: not indexed yet"),
+            "rust (available indexer, just unindexed) must read 'not indexed yet': {banner}"
+        );
+        assert!(
+            banner.contains("python: indexer unavailable (scip-python not on PATH)"),
+            "python (no indexer on PATH) must name the missing binary: {banner}"
+        );
+        assert!(
+            banner.contains("sym etc find-content"),
+            "unavailable-indexer message must point at sym etc as the language-agnostic fallback: {banner}"
+        );
     }
 
     #[test]
@@ -2276,7 +2347,7 @@ mod index_banner_tests {
         // 14 days ago -- past the 7-day threshold.
         let stale = "2026-04-23T12:00:00Z";
         let indexes = vec![idx("legion", "rust", stale)];
-        let banner = render_index_status_banner("legion", &["rust"], &indexes, now);
+        let banner = render_index_status_banner("legion", &["rust"], &indexes, &[], now);
         assert!(banner.contains("rust: STALE"));
         assert!(banner.contains("14d ago"));
         assert!(banner.contains("legion index legion"));
@@ -2291,8 +2362,13 @@ mod index_banner_tests {
             idx("legion", "rust", recent),
             idx("legion", "typescript", stale),
         ];
-        let banner =
-            render_index_status_banner("legion", &["rust", "typescript", "python"], &indexes, now);
+        let banner = render_index_status_banner(
+            "legion",
+            &["rust", "typescript", "python"],
+            &indexes,
+            &[],
+            now,
+        );
         assert!(banner.contains("rust: fresh"));
         assert!(banner.contains("typescript: STALE"));
         assert!(banner.contains("python: not indexed"));
@@ -2304,7 +2380,7 @@ mod index_banner_tests {
     fn unparseable_timestamp_is_treated_as_stale() {
         let now = Utc.with_ymd_and_hms(2026, 5, 7, 12, 0, 0).unwrap();
         let indexes = vec![idx("legion", "rust", "not-a-timestamp")];
-        let banner = render_index_status_banner("legion", &["rust"], &indexes, now);
+        let banner = render_index_status_banner("legion", &["rust"], &indexes, &[], now);
         assert!(banner.contains("rust: STALE"));
         assert!(banner.contains("unknown age"));
     }
@@ -2318,6 +2394,7 @@ mod index_banner_tests {
             "legion",
             &["rust"],
             &[idx("legion", "rust", one_hr_ago)],
+            &[],
             now,
         );
         assert!(banner.contains("1h ago"));

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -489,8 +489,15 @@ pub(crate) enum Commands {
         lines: usize,
         /// Render a SessionStart-friendly status banner for one repo.
         /// Silent on healthy (every detected language has a fresh index),
-        /// loud on stale or missing. Requires `<repo>` and `--status`.
-        /// Used by `plugin/hooks/session-start.sh` so agents see whether
+        /// loud on stale or missing. A missing language names WHY: "not
+        /// indexed yet" (running this command fixes it) versus "indexer
+        /// unavailable" (the binary that language needs is not on PATH,
+        /// so this command cannot fix it by itself) -- the coverage
+        /// guarantee from #713, so a repo showing only some languages
+        /// indexed reads as a known, explained gap rather than "sym does
+        /// not cover language X" in general. Requires `<repo>` and
+        /// `--status`. Used by `plugin/hooks/session-start.sh` and the
+        /// `legion-explore` agent's preflight so agents see whether
         /// `legion sym` will succeed before they try.
         #[arg(long, requires = "status")]
         banner: bool,
@@ -585,7 +592,11 @@ pub(crate) enum Commands {
     /// hook (#438/#439), and read the log back. Append-only JSONL at
     /// `${XDG_STATE_HOME:-~/.local/state}/legion/bypass.jsonl`. Feeds the
     /// uncertainty engine (#354) -- bypass volume on a (repo, pattern) is a
-    /// signal that sym/recall is missing an answer agents expected.
+    /// signal that sym/recall is missing an answer agents expected. Also
+    /// reads `sym etc`/`sym tree` usage from the sibling `etc-usage.jsonl`
+    /// (`etc-summary`, #713) -- the PRIMARY sym-etc epic (#704) metric,
+    /// since rewording the guard changes what counts as a bypass mid-
+    /// experiment.
     Telemetry {
         #[command(subcommand)]
         action: TelemetryAction,

--- a/src/cli/ops.rs
+++ b/src/cli/ops.rs
@@ -75,6 +75,26 @@ pub(crate) enum TelemetryAction {
         #[arg(long)]
         json: bool,
     },
+
+    /// Summarize `sym etc` / `sym tree` usage by query shape (#713): the
+    /// PRIMARY success metric for the sym-etc epic (#704). Rewording the
+    /// grep/find guard changes what gets classified as a bypass
+    /// mid-experiment, so raw bypass counts (`summary` above) are the
+    /// SECONDARY signal only. This reads `etc-usage.jsonl` instead of
+    /// `bypass.jsonl` and reports usage volume + zero-result rate per
+    /// shape (find-content/tree/extract/find-file) -- whether the
+    /// sanctioned surface actually answers.
+    EtcSummary {
+        /// Drop rows older than this duration before summarizing.
+        #[arg(long)]
+        since: Option<String>,
+        /// Restrict to one query shape: find-content, tree, extract, find-file.
+        #[arg(long)]
+        command: Option<String>,
+        /// Emit JSON instead of human-readable text.
+        #[arg(long)]
+        json: bool,
+    },
 }
 
 #[derive(Subcommand)]
@@ -659,6 +679,42 @@ pub(crate) fn handle_telemetry(action: TelemetryAction) -> error::Result<()> {
                         row.count,
                         row.had_sym_hits_pct * 100.0,
                         row.had_recall_hits_pct * 100.0,
+                    )?;
+                }
+            }
+        }
+        TelemetryAction::EtcSummary {
+            since,
+            command,
+            json,
+        } => {
+            let since_dur = match since {
+                Some(s) => Some(telemetry::parse_duration(&s)?),
+                None => None,
+            };
+            let rows = telemetry::list_etc_usage(since_dur, command.as_deref())?;
+            let summary = telemetry::summarize_etc_usage(&rows);
+            if json {
+                println!("{}", serde_json::to_string(&summary)?);
+            } else if summary.is_empty() {
+                println!("[legion] no sym etc/tree usage recorded in scope");
+            } else {
+                use std::io::Write;
+                let stdout = std::io::stdout();
+                let mut out = stdout.lock();
+                writeln!(
+                    out,
+                    "{:<14} {:<8} {:<12} {:<8}",
+                    "command", "count", "zero-res %", "errors"
+                )?;
+                for row in &summary {
+                    writeln!(
+                        out,
+                        "{:<14} {:<8} {:<12.1} {:<8}",
+                        row.command,
+                        row.count,
+                        row.zero_result_pct * 100.0,
+                        row.error_count,
                     )?;
                 }
             }

--- a/src/scip.rs
+++ b/src/scip.rs
@@ -116,6 +116,64 @@ fn has_dotnet_project(repo_path: &Path) -> bool {
     false
 }
 
+/// Binaries that would satisfy `run_indexer` for `lang`, in the order
+/// `run_indexer` tries them. Rust tries two (`scip-rust`, then the
+/// `rust-analyzer` fallback, #381); every other supported language has
+/// exactly one. Kept in lockstep with `run_indexer`'s dispatch table by
+/// this module's own coverage tests -- a language added to one table and
+/// not the other silently breaks the #713 coverage message, not a build.
+fn indexer_binary_candidates(lang: &str) -> &'static [&'static str] {
+    match lang {
+        "rust" => &["scip-rust", "rust-analyzer"],
+        "typescript" => &["scip-typescript"],
+        "python" => &["scip-python"],
+        "go" => &["scip-go"],
+        "java" => &["scip-java"],
+        "ruby" => &["scip-ruby"],
+        "clang" => &["scip-clang"],
+        "csharp" => &["scip-dotnet"],
+        "php" => &["scip-php"],
+        _ => &[],
+    }
+}
+
+/// First candidate binary name for `lang`, for display in the #713
+/// coverage message. A pure lookup -- unlike `indexer_available`, it
+/// never touches `PATH` -- so callers that only need a name to print (not
+/// an availability verdict) can use it from code that must stay
+/// deterministic for tests (e.g. `render_index_status_banner`).
+pub fn indexer_binary_hint(lang: &str) -> &'static str {
+    indexer_binary_candidates(lang)
+        .first()
+        .copied()
+        .unwrap_or("(no known indexer)")
+}
+
+/// True if any indexer binary that could satisfy `lang` resolves on
+/// `PATH`. A cheap existence check -- never spawns the binary, unlike
+/// `run_indexer`. Used by the `legion index --banner` coverage message
+/// (#713) to distinguish "nobody has run `legion index` yet" (actionable:
+/// running it will index this language) from "the indexer this language
+/// needs is not installed on this machine" (`legion index` cannot fix
+/// that by itself -- and the coverage guarantee for #442's daemon-dispatch
+/// gap is explicitly deferred to #442, not solved here). Reads `PATH` at
+/// call time, so keep this out of pure/testable code paths -- callers
+/// pass the verdict in as data instead (see `render_index_status_banner`
+/// in `cli::index_cmd`).
+pub fn indexer_available(lang: &str) -> bool {
+    let Ok(path_var) = std::env::var("PATH") else {
+        return false;
+    };
+    indexer_binary_candidates(lang).iter().any(|bin| {
+        std::env::split_paths(&path_var).any(|dir| {
+            dir.join(bin).is_file()
+                || dir
+                    .join(format!("{bin}{}", std::env::consts::EXE_SUFFIX))
+                    .is_file()
+        })
+    })
+}
+
 /// Run the appropriate SCIP indexer for `lang` against `repo_path` and
 /// return the resulting protobuf bytes.
 ///
@@ -801,6 +859,81 @@ mod tests {
                 other => panic!("expected IndexerNotFound for {lang}, got {other:?}"),
             }
         }
+    }
+
+    /// Pin `indexer_binary_hint`'s table against the same per-language
+    /// binaries `run_indexer_dispatches_each_language_to_its_helper` pins
+    /// on the dispatch side -- the two tables must never drift, or the
+    /// #713 coverage message would name a binary `run_indexer` does not
+    /// actually try.
+    #[test]
+    fn indexer_binary_hint_names_first_candidate_for_every_supported_lang() {
+        let cases = [
+            ("rust", "scip-rust"),
+            ("typescript", "scip-typescript"),
+            ("python", "scip-python"),
+            ("go", "scip-go"),
+            ("java", "scip-java"),
+            ("ruby", "scip-ruby"),
+            ("clang", "scip-clang"),
+            ("csharp", "scip-dotnet"),
+            ("php", "scip-php"),
+        ];
+        for (lang, expected) in cases {
+            assert_eq!(indexer_binary_hint(lang), expected, "lang={lang}");
+        }
+        assert_eq!(indexer_binary_hint("swift"), "(no known indexer)");
+    }
+
+    /// `indexer_available` must find a shimmed binary on `PATH` -- the
+    /// "not indexed yet" branch of the #713 coverage message depends on
+    /// this returning true whenever `legion index` would actually be able
+    /// to run the indexer.
+    #[cfg(unix)]
+    #[test]
+    fn indexer_available_true_when_shim_on_path() {
+        let _guard = PATH_TEST_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        let prior = std::env::var("PATH").unwrap_or_default();
+        let (shim_dir, shim_path) =
+            isolate_path_with_shims(&[("scip-python", "#!/bin/bash\nexit 0\n")]);
+        unsafe {
+            std::env::set_var("PATH", &shim_path);
+        }
+        let available = indexer_available("python");
+        unsafe {
+            std::env::set_var("PATH", &prior);
+        }
+        drop(shim_dir);
+        assert!(available, "shimmed scip-python must be found on PATH");
+    }
+
+    /// No candidate binary on `PATH` -> unavailable. This is the "indexer
+    /// unavailable" branch of the #713 coverage message: `legion index`
+    /// cannot fix this on its own, unlike a plain "not indexed yet".
+    #[cfg(unix)]
+    #[test]
+    fn indexer_available_false_when_path_has_no_matching_binary() {
+        let _guard = PATH_TEST_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        let prior = std::env::var("PATH").unwrap_or_default();
+        let (empty_dir, empty_path) = isolate_path_with_shims(&[]);
+        unsafe {
+            std::env::set_var("PATH", &empty_path);
+        }
+        let available = indexer_available("python");
+        unsafe {
+            std::env::set_var("PATH", &prior);
+        }
+        drop(empty_dir);
+        assert!(!available, "empty PATH must report unavailable");
+    }
+
+    /// A language with no entry in `indexer_binary_candidates` (should
+    /// never happen given `detect_languages` only emits supported tags,
+    /// but `indexer_available` must stay total) reports unavailable
+    /// rather than panicking on an empty candidate slice.
+    #[test]
+    fn indexer_available_false_for_unknown_language() {
+        assert!(!indexer_available("swift"));
     }
 
     #[test]

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -272,6 +272,123 @@ pub fn summarize(rows: &[BypassRecord], top: usize) -> Vec<BypassSummaryRow> {
     out
 }
 
+/// Read all `sym etc` / `sym tree` usage rows, optionally filtered by
+/// `since` (drop rows older than `now - since`) and `command` (e.g.
+/// "find-content", "tree", "extract", "find-file"). Malformed lines are
+/// skipped with a stderr breadcrumb, mirroring `list_bypasses`.
+pub fn list_etc_usage(
+    since: Option<Duration>,
+    command: Option<&str>,
+) -> Result<Vec<EtcUsageRecord>> {
+    list_etc_usage_from(&etc_usage_log_path(), since, command)
+}
+
+fn list_etc_usage_from(
+    path: &std::path::Path,
+    since: Option<Duration>,
+    command: Option<&str>,
+) -> Result<Vec<EtcUsageRecord>> {
+    if !path.exists() {
+        return Ok(Vec::new());
+    }
+    let cutoff = since.map(|d| Utc::now() - d);
+    let file = std::fs::File::open(path)?;
+    let mut out = Vec::new();
+    for (i, line) in BufReader::new(file).lines().enumerate() {
+        let line = match line {
+            Ok(l) => l,
+            Err(e) => {
+                eprintln!("[legion] etc-usage.jsonl line {} read error: {e}", i + 1);
+                continue;
+            }
+        };
+        if line.trim().is_empty() {
+            continue;
+        }
+        let record: EtcUsageRecord = match serde_json::from_str(&line) {
+            Ok(r) => r,
+            Err(e) => {
+                eprintln!("[legion] etc-usage.jsonl line {} parse error: {e}", i + 1);
+                continue;
+            }
+        };
+        if let Some(c) = cutoff
+            && record.ts < c
+        {
+            continue;
+        }
+        if let Some(cmd) = command
+            && record.command != cmd
+        {
+            continue;
+        }
+        out.push(record);
+    }
+    Ok(out)
+}
+
+/// One row of `legion telemetry etc-summary` output (#713): the PRIMARY
+/// success metric for the sym-etc epic (#704). This issue reworded the
+/// grep/find guard, which changes what gets classified as a bypass
+/// mid-experiment -- so raw bypass counts are the SECONDARY signal only
+/// (see `BypassSummaryRow`). The primary signal is whether the sanctioned
+/// surface actually answers: usage volume and zero-result rate per query
+/// shape.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct EtcSummaryRow {
+    /// Query shape: "find-content", "tree", "extract", or "find-file".
+    pub command: String,
+    pub count: usize,
+    /// Invocations that ran to completion but matched nothing -- the tool
+    /// answered, and the answer was "zero". Distinct from `error_count`
+    /// (the tool could not even attempt an answer).
+    pub zero_result_count: usize,
+    /// Fraction (0.0..=1.0) of non-error invocations that returned zero
+    /// hits. A high rate on a shape is the same signal bypass volume used
+    /// to be: evidence the sanctioned surface under-serves real queries.
+    pub zero_result_pct: f64,
+    pub error_count: usize,
+    pub last_used_ts: DateTime<Utc>,
+}
+
+/// Group etc-usage rows by `command`, sort by count desc. Used by
+/// `legion telemetry etc-summary`.
+pub fn summarize_etc_usage(rows: &[EtcUsageRecord]) -> Vec<EtcSummaryRow> {
+    use std::collections::BTreeMap;
+    let mut groups: BTreeMap<String, Vec<&EtcUsageRecord>> = BTreeMap::new();
+    for r in rows {
+        groups.entry(r.command.clone()).or_default().push(r);
+    }
+    let mut out: Vec<EtcSummaryRow> = groups
+        .into_iter()
+        .map(|(command, rs)| {
+            let count = rs.len();
+            let error_count = rs.iter().filter(|r| r.error.is_some()).count();
+            let zero_result_count = rs
+                .iter()
+                .filter(|r| r.error.is_none() && r.hit_count == 0)
+                .count();
+            let non_error_count = count - error_count;
+            let zero_result_pct = if non_error_count == 0 {
+                0.0
+            } else {
+                zero_result_count as f64 / non_error_count as f64
+            };
+            let last = rs.iter().map(|r| r.ts).max().unwrap_or_else(Utc::now);
+            EtcSummaryRow {
+                command,
+                count,
+                zero_result_count,
+                zero_result_pct,
+                error_count,
+                last_used_ts: last,
+            }
+        })
+        .collect();
+    out.sort_by_key(|r| std::cmp::Reverse(r.count));
+    out
+}
+
 /// Parse a duration string like `24h`, `7d`, `30m`, `90s`. Used by
 /// `--since` on `list-bypasses`.
 pub fn parse_duration(s: &str) -> Result<Duration> {
@@ -426,6 +543,101 @@ mod tests {
         let json = serde_json::to_string(&rec).unwrap();
         let back: EtcUsageRecord = serde_json::from_str(&json).unwrap();
         assert_eq!(back, rec);
+    }
+
+    fn etc_rec(
+        command: &str,
+        hit_count: u64,
+        error: Option<&str>,
+        ts: DateTime<Utc>,
+    ) -> EtcUsageRecord {
+        EtcUsageRecord {
+            ts,
+            command: command.to_string(),
+            repo: Some("legion".to_string()),
+            pattern: "x".to_string(),
+            fixed_strings: false,
+            hit_count,
+            skipped_files: 0,
+            error: error.map(|e| e.to_string()),
+            failed_repos: 0,
+            format: None,
+        }
+    }
+
+    #[test]
+    fn list_etc_usage_filters_by_since_and_command() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("etc-usage.jsonl");
+        let old = etc_rec("find-content", 1, None, Utc::now() - Duration::days(10));
+        let recent_fc = etc_rec("find-content", 0, None, Utc::now());
+        let recent_tree = etc_rec("tree", 3, None, Utc::now());
+        for r in [&old, &recent_fc, &recent_tree] {
+            append_jsonl(&path, r).unwrap();
+        }
+
+        let all = list_etc_usage_from(&path, None, None).unwrap();
+        assert_eq!(all.len(), 3);
+
+        let since_7d = list_etc_usage_from(&path, Some(Duration::days(7)), None).unwrap();
+        assert_eq!(since_7d.len(), 2, "the 10-day-old row must be dropped");
+
+        let tree_only = list_etc_usage_from(&path, None, Some("tree")).unwrap();
+        assert_eq!(tree_only.len(), 1);
+        assert_eq!(tree_only[0].command, "tree");
+    }
+
+    /// The #713 primary metric: zero-result rate must exclude error rows
+    /// from its denominator -- an invalid-regex error is "the tool could
+    /// not attempt an answer", not "the tool answered zero", and conflating
+    /// the two would understate how often the sanctioned surface actually
+    /// works when it gets a chance to run.
+    #[test]
+    fn summarize_etc_usage_computes_zero_result_rate_excluding_errors() {
+        let now = Utc::now();
+        let rows = vec![
+            etc_rec("find-content", 5, None, now),
+            etc_rec("find-content", 0, None, now),
+            etc_rec("find-content", 0, None, now),
+            etc_rec("find-content", 0, Some("invalid regex"), now),
+        ];
+        let summary = summarize_etc_usage(&rows);
+        assert_eq!(summary.len(), 1);
+        let row = &summary[0];
+        assert_eq!(row.command, "find-content");
+        assert_eq!(row.count, 4);
+        assert_eq!(row.error_count, 1);
+        assert_eq!(row.zero_result_count, 2);
+        assert!(
+            (row.zero_result_pct - (2.0 / 3.0)).abs() < 1e-9,
+            "2 zero-results out of 3 non-error invocations: {}",
+            row.zero_result_pct
+        );
+    }
+
+    #[test]
+    fn summarize_etc_usage_groups_by_command_and_sorts_by_count_desc() {
+        let now = Utc::now();
+        let rows = vec![
+            etc_rec("tree", 1, None, now),
+            etc_rec("find-file", 1, None, now),
+            etc_rec("find-file", 0, None, now),
+        ];
+        let summary = summarize_etc_usage(&rows);
+        assert_eq!(summary.len(), 2);
+        assert_eq!(summary[0].command, "find-file");
+        assert_eq!(summary[0].count, 2);
+        assert_eq!(summary[1].command, "tree");
+        assert_eq!(summary[1].count, 1);
+    }
+
+    /// All-error groups must report 0.0, not NaN from a 0/0 division.
+    #[test]
+    fn summarize_etc_usage_all_errors_has_zero_pct_not_nan() {
+        let now = Utc::now();
+        let rows = vec![etc_rec("extract", 0, Some("bad field"), now)];
+        let summary = summarize_etc_usage(&rows);
+        assert_eq!(summary[0].zero_result_pct, 0.0);
     }
 
     #[cfg(unix)]


### PR DESCRIPTION
## Summary

The grep/find guard (pre-bash-grep.sh, pre-grep.sh) taught agents the wrong mental model:
when it blocked a shell search or fell back silently, its only alternative was `legion sym
def`/`refs`/`hover` -- symbol lookups. For any non-symbol query (a literal string, a config
value, "which file has X", file/dir structure) the guard had nothing to route to, so agents
bypassed to shell grep and, per the epic's bypass-telemetry analysis (87 bypasses/30d, 79 from
legion-explore), inferred false generalizations like "sym is rust-only" or "sym is broken" along
the way. This PR rewords every guard message to name the sanctioned `sym etc` alternative for
the blocked query shape (`find-content`, `sym tree`, `sym etc extract`, `sym etc find-file` --
all shipped as of #705-#709), reframes `legion-explore`'s routing ladder so `sym etc` is a real
lane before the bounded-text-search last resort, and closes the coverage-guarantee half: the
`legion index --banner` message now distinguishes "not indexed yet" from "indexer binary not on
PATH" instead of collapsing both into an unhelpful "not indexed", and `legion telemetry
etc-summary` makes the epic's primary success metric (usage volume + zero-result rate per query
shape) readable.

## Acceptance criteria mapping

### 1. Guard messages no longer imply rust-only/symbols-only; they print exact `sym etc` commands
Every deny/inject message in `pre-bash-grep.sh` and `pre-grep.sh` that previously said "use the
Grep tool" or gave only symbol-lookup commands now explicitly states "sym covers every indexed
language, not just Rust" and prints the four `sym etc` command shapes with the flags a reader
can paste directly (`legion sym etc find-content '<pattern>' --repo <repo>`, `legion sym tree
--repo <repo>`, `legion sym etc extract <path> --field <field>`, `legion sym etc find-file
'<pattern>' --repo <repo>`), scoped to each decision branch (bypass-refusal, BLOCK, INJECT,
recall-tier). Evidence: `plugin/hooks/pre-bash-grep.sh:110-114` (bypass refusal),
`plugin/hooks/pre-bash-grep.sh:159` (BLOCK), `plugin/hooks/pre-bash-grep.sh:174` (no-index
INJECT); `plugin/hooks/pre-grep.sh:96-104`, `:124`, `:151`, `:264` (the four Grep/Glob branches).
All pre-existing substring assertions in `test-pre-bash-grep.sh` and `test-pre-grep.sh` still
pass (`bash plugin/hooks/test-pre-bash-grep.sh` -> 41 passed, 0 failed; `test-pre-grep.sh` -> 37
passed, 0 failed), confirming the rewrite is additive, not a behavior change.

### 2. `legion-explore` lane-4 reframed: bypass is last-resort, not default
The agent's routing ladder grew from four lanes to five: the former lane 4 ("bounded text
search, declared last resort") is now lane 5, and the new lane 4 is `sym etc`/`sym tree` --
commands that need no SCIP index at all, so a repo with a coverage gap is not a dead end.
"Deterministic escalation" now reads "escalate to lane 4 ... it does not depend on the SCIP
index at all. Only escalate to lane 5 with telemetry if lane 4 also cannot answer" -- replacing
the old "empty sym -> bypass is fine" default with an explicit intermediate step, per the
issue's stated stance that bypass is last-resort-with-logging, not forbidden-and-resented (lane
5's framing keeps the telemetry logging requirement, just moves it one step later). Evidence:
`plugin/agents/legion-explore.md:67-77` (the new lane 4 block and reframed lane 5), `:81` (the
escalation rule), `:95` ("What you never do" updated to "not a first move").

### 3. Per-language coverage guaranteed or loudly surfaced (#442 scope decided and recorded)
Scope decision: #442 (daemon auto-index dispatch for watched TS repos) stays out of this issue;
the coverage guarantee degrades to "loudly surfaced" as the issue's own fallback describes.
Recorded in code: `src/scip.rs:169-176`'s doc comment on `indexer_available` states the
decision explicitly ("the coverage guarantee for #442's daemon-dispatch gap is explicitly
deferred to #442, not solved here"). The surfacing itself: `scip::indexer_available`
(`src/scip.rs:163`) checks whether a language's indexer binary resolves on PATH without
spawning it, and `render_index_status_banner` (`src/cli/index_cmd.rs:1677`) now distinguishes a
detected-but-unindexed language that is "not indexed yet" (running `legion index` fixes it) from
one that is "indexer unavailable (binary not on PATH)" (it cannot) -- the latter case names
`sym etc find-content`/`sym tree`/`sym etc find-file` as still-working fallbacks for that
language's files. Test: `loud_block_distinguishes_indexer_unavailable_from_not_indexed_yet`
(`src/cli/index_cmd.rs:2326`) pins both message shapes. `legion-explore`'s preflight
(`plugin/agents/legion-explore.md:44`) now runs `legion index <repo> --status --banner` instead
of `--status --json` so the highest-bypass-volume consumer (79/87 bypasses per the epic's
telemetry) sees the distinction too, since it is a subagent that never receives the parent
session's SessionStart banner.

### 4. Primary metric readable: `sym etc`/`tree` usage + zero-result rate from telemetry
`legion telemetry etc-summary` (`src/cli/ops.rs:87` for the CLI variant, handler at
`src/cli/ops.rs:686`) reads the already-shipped `etc-usage.jsonl` (find-content/tree/extract/
find-file all instrument it since #706-#709) via the new `telemetry::list_etc_usage`
(`src/telemetry.rs:276`) and `telemetry::summarize_etc_usage` (`src/telemetry.rs:356`), grouping
by query shape and reporting count, zero-result rate (excluding error rows from the denominator
so an invalid-regex error is not counted as "answered zero"), and error count -- the primary
metric the plan-review revision called for, since this issue's guard reword changes what counts
as a bypass mid-experiment and raw bypass counts are only the secondary signal. Evidence:
`summarize_etc_usage_computes_zero_result_rate_excluding_errors` and
`summarize_etc_usage_all_errors_has_zero_pct_not_nan` (`src/telemetry.rs:596`, `:636`).

### 5. All tests pass; simplify + review done; PR linked
`cargo test --bin legion` -> 1303 passed, 0 failed, 2 ignored. `cargo clippy --all-targets --
-D warnings` -> clean. `cargo fmt -- --check` -> clean. `shellcheck plugin/hooks/pre-bash-grep.sh
plugin/hooks/pre-grep.sh` -> clean (rc 0 both). Shell hook test suites
(`test-pre-bash-grep.sh`, `test-pre-grep.sh`) both pass in full. Simplify gate recorded
(`legion quality-gate check --skill legion-simplify`, gate id `019f3449-5050-7020-97d5-6255f64b412b`,
8 file entries, 0 findings). This PR references and closes #713.

## Not done

- **#442 (daemon dispatch for watched TS repos)** -- explicitly out of scope, per the issue's own
  scope-decision framing; the coverage guarantee ships as "loudly surfaced" instead of "actually
  indexed", decided and recorded in `src/scip.rs`'s doc comments (see criterion 3 above).
- **Telemetry instrumentation of the `sym etc` commands themselves** -- out of scope per the
  issue text (already landed in #706-#709, this issue only reads that data).
- **`_legion-indexed.sh` was left unchanged.** Its job is a repo-level "does any index row exist"
  gate for BLOCK-tier eligibility in the hooks, which is orthogonal to per-language coverage
  (a query only ever BLOCKs when `sym def` actually finds a local hit for that exact pattern, so
  a language-coverage gap cannot cause a false BLOCK). The coverage guarantee is better served,
  and reaches the actual high-bypass-volume consumer, via the `--banner` path both
  `session-start.sh` and `legion-explore`'s preflight already use -- adding a second,
  per-hook-fire coverage probe into `_legion-indexed.sh` would duplicate that mechanism with more
  hook-side blast radius (new caching scheme, new stub-legion test surface, noisier injections on
  every miss) for the same information.
- **A generic `read_jsonl<T>` helper unifying `list_bypasses_from`/`list_etc_usage_from`** in
  `src/telemetry.rs` -- flagged in the simplify articulation as a real but partial duplication;
  left as a follow-up since unifying it touches the already-shipped bypass-log read path, a wider
  blast radius than this issue's scope.
- **A `QueryShape` enum for `EtcSummaryRow.command` / the `--command` filter** -- would be a real
  type-safety improvement over the current free-form string (a typo like `--command findcontent`
  silently reports "no usage recorded" instead of failing loudly), but the existing
  `EtcUsageRecord.command` schema already uses a free-form string pre-#713 and changing it is
  bigger than this issue's scope.