### PR TITLE
feat(#711): CSS symbols via lightningcss (class + custom-property defs)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -145,7 +145,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -156,7 +156,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -407,7 +407,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -448,6 +448,35 @@ dependencies = [
  "once_cell",
  "unicode-width",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "const-str"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21077772762a1002bb421c3af42ac1725fa56066bfc53d9a55bb79905df2aaf3"
+dependencies = [
+ "const-str-proc-macro",
+]
+
+[[package]]
+name = "const-str-proc-macro"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e1e0fdd2e5d3041e530e1b21158aeeef8b5d0e306bc5c1e3d6cf0930d10e25a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "convert_case"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
+dependencies = [
+ "unicode-segmentation",
 ]
 
 [[package]]
@@ -557,6 +586,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "cssparser"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9be934d936a0fbed5bcdc01042b770de1398bf79d0e192f49fa7faea0e99281e"
+dependencies = [
+ "cssparser-macros",
+ "dtoa-short",
+ "itoa",
+ "phf 0.11.3",
+ "smallvec",
+]
+
+[[package]]
+name = "cssparser-color"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "556c099a61d85989d7af52b692e35a8d68a57e7df8c6d07563dc0778b3960c9f"
+dependencies = [
+ "cssparser",
+]
+
+[[package]]
+name = "cssparser-macros"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13b588ba4ac1a99f7f2964d24b3d896ddc6bf847ee3855dbd4366f058cfcd331"
+dependencies = [
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "darling"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -577,7 +638,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -588,7 +649,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -613,6 +674,12 @@ dependencies = [
  "once_cell",
  "parking_lot_core",
 ]
+
+[[package]]
+name = "data-encoding"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "deranged"
@@ -642,7 +709,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -652,7 +719,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
 dependencies = [
  "derive_builder_core",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -724,7 +791,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -738,6 +805,21 @@ name = "dragonbox_ecma"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd8e701084c37e7ef62d3f9e453b618130cbc0ef3573847785952a3ac3f746bf"
+
+[[package]]
+name = "dtoa"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c3cf4824e2d5f025c7b531afcb2325364084a16806f6d47fbc1f5fbd9960590"
+
+[[package]]
+name = "dtoa-short"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd1511a7b6a56299bd043a9c167a6d2bfb37bf84a6dfceaba651168adfb43c87"
+dependencies = [
+ "dtoa",
+]
 
 [[package]]
 name = "either"
@@ -971,7 +1053,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1588,6 +1670,15 @@ checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
@@ -1667,6 +1758,7 @@ dependencies = [
  "hostname",
  "ignore",
  "libc",
+ "lightningcss",
  "mime_guess",
  "model2vec-rs",
  "oxc_allocator",
@@ -1733,6 +1825,41 @@ dependencies = [
  "cc",
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "lightningcss"
+version = "1.0.0-alpha.71"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb6314c2f0590ac93c86099b98bb7ba8abcf759bfd89604ffca906472bb54937"
+dependencies = [
+ "ahash",
+ "bitflags 2.11.0",
+ "const-str",
+ "cssparser",
+ "cssparser-color",
+ "data-encoding",
+ "getrandom 0.3.4",
+ "indexmap",
+ "itertools 0.10.5",
+ "lazy_static",
+ "lightningcss-derive",
+ "parcel_selectors",
+ "pastey",
+ "pathdiff",
+ "smallvec",
+]
+
+[[package]]
+name = "lightningcss-derive"
+version = "1.0.0-alpha.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84c12744d1279367caed41739ef094c325d53fb0ffcd4f9b84a368796f870252"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1934,7 +2061,7 @@ checksum = "e4db6d5580af57bf992f59068d4ea26fd518574ff48d7639b255a36f9de6e7e9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2184,7 +2311,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2249,7 +2376,7 @@ checksum = "66e0bafc397eee2f94c5bf89bb5a82ba6d522d1b79e2924c8169f053febb433f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2288,10 +2415,10 @@ version = "0.138.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81dcc7cd7607a42e3fed0d789535789ac6c16284f941a8aeed251265f29d1e52"
 dependencies = [
- "phf",
+ "phf 0.14.0",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2379,7 +2506,7 @@ dependencies = [
  "oxc_diagnostics",
  "oxc_span",
  "oxc_str",
- "phf",
+ "phf 0.14.0",
  "rustc-hash 2.1.2",
  "unicode-id-start",
 ]
@@ -2454,8 +2581,24 @@ dependencies = [
  "oxc_index",
  "oxc_span",
  "oxc_str",
- "phf",
+ "phf 0.14.0",
  "unicode-id-start",
+]
+
+[[package]]
+name = "parcel_selectors"
+version = "0.28.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54fd03f1ad26cb6b3ec1b7414fa78a3bd639e7dbb421b1a60513c96ce886a196"
+dependencies = [
+ "bitflags 2.11.0",
+ "cssparser",
+ "log",
+ "phf 0.11.3",
+ "phf_codegen",
+ "precomputed-hash",
+ "rustc-hash 2.1.2",
+ "smallvec",
 ]
 
 [[package]]
@@ -2488,6 +2631,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "pastey"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec"
+
+[[package]]
+name = "pathdiff"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2495,13 +2650,43 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "phf"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
+dependencies = [
+ "phf_macros 0.11.3",
+ "phf_shared 0.11.3",
+]
+
+[[package]]
+name = "phf"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "010378780309880b08997fae13be7834dba947d36393bd372f2b1556deb2a2f6"
 dependencies = [
- "phf_macros",
- "phf_shared",
+ "phf_macros 0.14.0",
+ "phf_shared 0.14.0",
  "serde",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
+dependencies = [
+ "phf_generator 0.11.3",
+ "phf_shared 0.11.3",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
+dependencies = [
+ "phf_shared 0.11.3",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -2511,7 +2696,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aeb62e0959d5a1bebc965f4d15d9e2b7cea002b6b0f5ba8cde6cc26738467100"
 dependencies = [
  "fastrand",
- "phf_shared",
+ "phf_shared 0.14.0",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
+dependencies = [
+ "phf_generator 0.11.3",
+ "phf_shared 0.11.3",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2520,11 +2718,20 @@ version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5fa8d0ca26d424d27630da600c6624696e7dec8bf7b3b492b383c5dc49e5e085"
 dependencies = [
- "phf_generator",
- "phf_shared",
+ "phf_generator 0.14.0",
+ "phf_shared 0.14.0",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher",
 ]
 
 [[package]]
@@ -2616,13 +2823,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "precomputed-hash"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
+
+[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2894,7 +3107,7 @@ checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3030,7 +3243,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rust-embed-utils",
- "syn",
+ "syn 2.0.117",
  "walkdir",
 ]
 
@@ -3263,7 +3476,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3541,6 +3754,17 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
@@ -3567,7 +3791,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3795,7 +4019,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3806,7 +4030,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3925,7 +4149,7 @@ checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4079,7 +4303,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4365,7 +4589,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
@@ -4569,7 +4793,7 @@ checksum = "9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4580,7 +4804,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4591,7 +4815,7 @@ checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4602,7 +4826,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4947,7 +5171,7 @@ dependencies = [
  "heck",
  "indexmap",
  "prettyplease",
- "syn",
+ "syn 2.0.117",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -4963,7 +5187,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -5030,7 +5254,7 @@ checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -5051,7 +5275,7 @@ checksum = "f65c489a7071a749c849713807783f70672b28094011623e200cb86dcb835953"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5071,7 +5295,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -5111,7 +5335,7 @@ checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,14 +78,10 @@ oxc_allocator = "0.138.0"
 oxc_span = "0.138.0"
 
 # CSS symbol extraction (#711): parse compiled stylesheets into class-selector
-# and custom-property definitions. lightningcss, not oxc-css-parser --
-# oxc-css-parser 0.0.3 is spec-strict and REJECTS real Tailwind v4 output
-# (`--spacing-0.5`, a dotted custom-property name that is grammar-illegal but
-# browser-accepted and pervasive in compiled Tailwind sheets); lightningcss
-# parses it with zero errors and benchmarked speed-neutral (reflections
-# 019f1eee/019f1eef). Default features pull in nodejs/bundler/sourcemap
-# extras (serde-content, dashmap, rayon, parcel_sourcemap) this binary never
-# uses -- disabled for a lean dependency footprint.
+# and custom-property definitions. lightningcss, not oxc-css-parser -- see
+# src/css.rs module docs for why. Default features pull in nodejs/bundler/
+# sourcemap extras (serde-content, dashmap, rayon, parcel_sourcemap) this
+# binary never uses -- disabled for a lean dependency footprint.
 lightningcss = { version = "1.0.0-alpha.71", default-features = false }
 
 # libc pulls in only on unix for killpg in call_plugin_inner's timeout arm.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,6 +77,17 @@ oxc_resolver = "11.23.0"
 oxc_allocator = "0.138.0"
 oxc_span = "0.138.0"
 
+# CSS symbol extraction (#711): parse compiled stylesheets into class-selector
+# and custom-property definitions. lightningcss, not oxc-css-parser --
+# oxc-css-parser 0.0.3 is spec-strict and REJECTS real Tailwind v4 output
+# (`--spacing-0.5`, a dotted custom-property name that is grammar-illegal but
+# browser-accepted and pervasive in compiled Tailwind sheets); lightningcss
+# parses it with zero errors and benchmarked speed-neutral (reflections
+# 019f1eee/019f1eef). Default features pull in nodejs/bundler/sourcemap
+# extras (serde-content, dashmap, rayon, parcel_sourcemap) this binary never
+# uses -- disabled for a lean dependency footprint.
+lightningcss = { version = "1.0.0-alpha.71", default-features = false }
+
 # libc pulls in only on unix for killpg in call_plugin_inner's timeout arm.
 # Must stay AFTER all platform-independent deps -- TOML tables consume
 # every key until the next header, so listing it mid-file would leak the

--- a/src/cli/index_cmd.rs
+++ b/src/cli/index_cmd.rs
@@ -7,7 +7,7 @@ use clap::Subcommand;
 
 use crate::cli::datadir::data_dir;
 use crate::cli::util::{open_db, open_db_and_index};
-use crate::{db, error, etc, graph, inventory, scip, sym, telemetry, watch};
+use crate::{css, db, error, etc, graph, inventory, scip, sym, telemetry, watch};
 
 #[derive(Subcommand)]
 pub(crate) enum SymAction {
@@ -2079,6 +2079,50 @@ pub(crate) fn handle_index(
         );
     }
 
+    // CSS symbols (#711): parse compiled stylesheets' class-selector and
+    // custom-property definitions via lightningcss, so `sym` can answer
+    // "where is `.foo` / `--token` defined" for the design system. Runs over
+    // the inventory's `.css`-extension subset -- css is not a SCIP language
+    // (`inventory::lang_for_ext` maps it to `None`), so this is independent
+    // of the `langs` marker-file detection below.
+    //
+    // `counts_available`/`symbol_counts` are shared with the SCIP loop below
+    // and enriched by BOTH sources before the single `update_file_symbol_counts`
+    // call at the end of this function: that call resets the whole repo's
+    // counts to 0 before applying the map, so calling it twice (once per
+    // source) would let the second call zero out the first source's counts.
+    let mut counts_available = false;
+    let mut symbol_counts: std::collections::HashMap<String, u32> =
+        std::collections::HashMap::new();
+
+    let css_files: Vec<PathBuf> = outcome
+        .entries
+        .iter()
+        .filter(|e| e.ext.as_deref() == Some("css"))
+        .map(|e| PathBuf::from(&e.path))
+        .collect();
+    let live_css: Vec<&str> = css_files.iter().filter_map(|p| p.to_str()).collect();
+    let css_symbols = css::extract_css_symbols_for_files(&repo_path, &css_files);
+    if !css_files.is_empty() {
+        counts_available = true;
+        for s in &css_symbols {
+            *symbol_counts.entry(s.path.clone()).or_insert(0) += 1;
+        }
+    }
+    database.upsert_css_symbols(&repo, &live_css, &css_symbols)?;
+    if outcome.walk_errors == 0 {
+        let pruned_css = database.prune_css_symbols(&repo, &live_css)?;
+        eprintln!(
+            "[legion] css symbols: {} for {repo} ({pruned_css} stale rows pruned)",
+            css_symbols.len()
+        );
+    } else {
+        eprintln!(
+            "[legion] css symbols: {} for {repo} (stale-row prune skipped: partial walk)",
+            css_symbols.len()
+        );
+    }
+
     // SCIP indexing runs only when language markers are present. A docs-only
     // repo (no Cargo.toml, package.json, etc.) skips this block entirely --
     // the file inventory above already covered it (#705).
@@ -2090,9 +2134,6 @@ pub(crate) fn handle_index(
         );
     } else {
         let mut indexed: u32 = 0;
-        let mut counts_available = false;
-        let mut symbol_counts: std::collections::HashMap<String, u32> =
-            std::collections::HashMap::new();
         for lang in &langs {
             let blob = match scip::run_indexer(lang, &repo_path) {
                 Ok(b) => b,
@@ -2139,15 +2180,18 @@ pub(crate) fn handle_index(
                 langs.join(", ")
             )));
         }
-        // Gate on parse success, not on non-empty counts: a blob that parsed
-        // but yielded zero definitions (the repo's last definition was
-        // deleted) must still run the enrich pass so its reset clears the
-        // now-stale counts. A parse FAILURE skips the pass entirely,
-        // preserving prior enrichment.
-        if counts_available {
-            let updated = database.update_file_symbol_counts(&repo, &symbol_counts)?;
-            eprintln!("[legion] symbol counts applied to {updated} inventoried files for {repo}");
-        }
+    }
+
+    // Gate on a source having run at all, not on non-empty counts: a blob
+    // (or css batch) that parsed but yielded zero definitions (the repo's
+    // last definition was deleted) must still run the enrich pass so its
+    // reset clears the now-stale counts. A source that never ran (no
+    // languages detected, no css files) leaves prior enrichment untouched --
+    // this call is shared by SCIP and CSS (see the comment above the css
+    // block) so a docs-only-turned-css-only repo still gets counts applied.
+    if counts_available {
+        let updated = database.update_file_symbol_counts(&repo, &symbol_counts)?;
+        eprintln!("[legion] symbol counts applied to {updated} inventoried files for {repo}");
     }
 
     Ok(())

--- a/src/cli/index_cmd.rs
+++ b/src/cli/index_cmd.rs
@@ -2102,14 +2102,20 @@ pub(crate) fn handle_index(
         .map(|e| PathBuf::from(&e.path))
         .collect();
     let live_css: Vec<&str> = css_files.iter().filter_map(|p| p.to_str()).collect();
-    let css_symbols = css::extract_css_symbols_for_files(&repo_path, &css_files);
+    let mut css_symbols: Vec<css::CssSymbol> = Vec::new();
     if !css_files.is_empty() {
+        css_symbols = css::extract_css_symbols_for_files(&repo_path, &css_files);
         counts_available = true;
         for s in &css_symbols {
             *symbol_counts.entry(s.path.clone()).or_insert(0) += 1;
         }
+        database.upsert_css_symbols(&repo, &live_css, &css_symbols)?;
     }
-    database.upsert_css_symbols(&repo, &live_css, &css_symbols)?;
+    // Prune unconditionally on a clean walk -- mirroring the module-graph
+    // prune above (and `prune_file_inventory`), including its zero-entries
+    // case: a repo that has gone to zero css files (last one deleted) must
+    // still wipe its now-stale css_symbols rows. Gating this behind
+    // `!css_files.is_empty()` would leave those rows orphaned forever.
     if outcome.walk_errors == 0 {
         let pruned_css = database.prune_css_symbols(&repo, &live_css)?;
         eprintln!(

--- a/src/css.rs
+++ b/src/css.rs
@@ -1,0 +1,501 @@
+//! CSS symbol extraction via lightningcss (#711): parse stylesheets into
+//! class-selector and custom-property definitions so `sym` can answer
+//! "where is `.foo` / `--token` defined" for the design system.
+//!
+//! lightningcss is chosen over `oxc-css-parser` deliberately: `oxc-css-parser`
+//! 0.0.3 is spec-strict and rejects real Tailwind v4 output, which is
+//! pervasive with dotted custom-property names (`--spacing-0.5`). A bare
+//! unescaped `.` is not a valid ident code point -- the CSS tokenizer would
+//! split it into an `Ident("--spacing-0")` and a `Number(0.5)` -- so
+//! Tailwind's compiled output escapes the dot (`--spacing-0\.5`), which the
+//! tokenizer resolves into a single ident whose decoded text is the literal
+//! `--spacing-0.5`. lightningcss parses that real input with zero errors,
+//! and the two are speed-neutral on inputs both can parse (see reflections
+//! 019f1eee / 019f1eef). An indexer must tolerate the CSS that actually
+//! exists on disk, not conformance-check it.
+//!
+//! Tailwind v4's `@theme { ... }` block is unknown to lightningcss (it has no
+//! built-in knowledge of Tailwind at-rules), so it parses as
+//! `CssRule::Unknown` with the block preserved as a raw token list rather
+//! than a declaration block. `--custom-property` definitions inside `@theme`
+//! are recovered by scanning that token list directly: lightningcss's value
+//! tokenizer already rewrites any `--foo`-shaped identifier into a
+//! `TokenOrValue::DashedIdent`, and a `var(--foo)` *reference* is wrapped in
+//! `TokenOrValue::Var` instead -- so a bare `DashedIdent` immediately
+//! followed by a colon (skipping whitespace/comments) is unambiguously a
+//! *definition*, never a reference.
+
+use std::path::{Path, PathBuf};
+
+use lightningcss::declaration::DeclarationBlock;
+use lightningcss::properties::Property;
+use lightningcss::properties::custom::{CustomPropertyName, Token, TokenOrValue};
+use lightningcss::rules::CssRule;
+use lightningcss::selector::{Component, Selector, SelectorList};
+use lightningcss::stylesheet::{ParserOptions, StyleSheet};
+
+use crate::error::{LegionError, Result};
+
+/// What kind of CSS definition a [`CssSymbol`] represents.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CssSymbolKind {
+    /// A class selector definition (`.foo { ... }`).
+    Class,
+    /// A `--custom-property` definition, whether written as a normal
+    /// declaration (`:root { --foo: ...; }`), inside an `@property` rule, or
+    /// inside a Tailwind `@theme` block.
+    CustomProperty,
+}
+
+/// One CSS symbol definition site.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CssSymbol {
+    pub kind: CssSymbolKind,
+    /// The selector/property name exactly as written, including its sigil
+    /// (`.foo` for a class, `--foo` for a custom property).
+    pub name: String,
+    /// Forward-slash-separated path, as given to [`extract_css_symbols`].
+    pub path: String,
+    /// 1-based line number of the enclosing rule. For symbols recovered from
+    /// a raw token list (`@theme` and other at-rules lightningcss does not
+    /// parse structurally), this is the line of the *enclosing rule*, not
+    /// the exact declaration -- individual raw tokens carry no location of
+    /// their own.
+    pub line: u32,
+}
+
+/// Parse `content` (the text of the file at `path`) and return every class
+/// selector and `--custom-property` definition it contains.
+///
+/// A genuine parse failure (not a tolerated construct -- see the module
+/// docs) is returned as `Err`, never panics or silently drops the file;
+/// callers walking a repo are expected to log and skip per file, mirroring
+/// `graph::build_module_graph`'s per-file error handling.
+pub fn extract_css_symbols(path: &Path, content: &str) -> Result<Vec<CssSymbol>> {
+    let path_str = to_forward_slash(path);
+    let options = ParserOptions {
+        filename: path_str.clone(),
+        ..ParserOptions::default()
+    };
+    let stylesheet = StyleSheet::parse(content, options)
+        .map_err(|e| LegionError::Css(format!("parse error in {path_str}: {e}")))?;
+
+    let mut symbols = Vec::new();
+    walk_rules(&stylesheet.rules.0, &path_str, &mut symbols);
+    symbols.sort_by(|a, b| a.line.cmp(&b.line).then_with(|| a.name.cmp(&b.name)));
+    Ok(symbols)
+}
+
+/// Extract CSS symbols for a batch of files rooted at `repo_root`, mirroring
+/// `graph::build_module_graph`'s shape (read + parse + skip-and-log per
+/// file) so `legion index`'s wiring stays a short call site instead of
+/// owning the read/error-handling loop itself. Not part of the issue's
+/// literal single-file interface, added the same way #710 added a `repo`
+/// parameter beyond its given signature: the given signature has no room for
+/// batching, and the established convention in this codebase (`graph.rs`) is
+/// for the domain module to own its own file reads.
+pub fn extract_css_symbols_for_files(repo_root: &Path, files: &[PathBuf]) -> Vec<CssSymbol> {
+    let mut symbols = Vec::new();
+    for rel_path in files {
+        let abs_path = repo_root.join(rel_path);
+        let content = match std::fs::read_to_string(&abs_path) {
+            Ok(c) => c,
+            Err(e) => {
+                eprintln!(
+                    "[legion] css: skipped {} (read error: {e})",
+                    abs_path.display()
+                );
+                continue;
+            }
+        };
+        match extract_css_symbols(rel_path, &content) {
+            Ok(mut file_symbols) => symbols.append(&mut file_symbols),
+            Err(e) => {
+                eprintln!("[legion] css: skipped {} ({e})", abs_path.display());
+            }
+        }
+    }
+    symbols
+}
+
+/// Normalize a path to forward-slash separators, matching the convention
+/// `file_inventory` and `graph::ImportEdge` use.
+fn to_forward_slash(path: &Path) -> String {
+    path.to_string_lossy().replace('\\', "/")
+}
+
+/// Walk a rule list, recursing into every container-style rule
+/// (`@media`, `@supports`, native CSS nesting, etc.) that lightningcss
+/// models structurally, plus the raw token list of at-rules it does not
+/// recognize (Tailwind's `@theme` and friends).
+fn walk_rules<'i, R>(rules: &[CssRule<'i, R>], path: &str, out: &mut Vec<CssSymbol>) {
+    for rule in rules {
+        match rule {
+            CssRule::Style(style_rule) => {
+                collect_selector_list(&style_rule.selectors, path, style_rule.loc.line, out);
+                collect_declarations(&style_rule.declarations, path, style_rule.loc.line, out);
+                walk_rules(&style_rule.rules.0, path, out);
+            }
+            CssRule::Nesting(nesting_rule) => {
+                let style_rule = &nesting_rule.style;
+                collect_selector_list(&style_rule.selectors, path, style_rule.loc.line, out);
+                collect_declarations(&style_rule.declarations, path, style_rule.loc.line, out);
+                walk_rules(&style_rule.rules.0, path, out);
+            }
+            CssRule::NestedDeclarations(nested) => {
+                collect_declarations(&nested.declarations, path, nested.loc.line, out);
+            }
+            CssRule::Media(r) => walk_rules(&r.rules.0, path, out),
+            CssRule::Supports(r) => walk_rules(&r.rules.0, path, out),
+            CssRule::Container(r) => walk_rules(&r.rules.0, path, out),
+            CssRule::Scope(r) => walk_rules(&r.rules.0, path, out),
+            CssRule::StartingStyle(r) => walk_rules(&r.rules.0, path, out),
+            CssRule::LayerBlock(r) => walk_rules(&r.rules.0, path, out),
+            CssRule::MozDocument(r) => walk_rules(&r.rules.0, path, out),
+            CssRule::Property(property_rule) => {
+                out.push(CssSymbol {
+                    kind: CssSymbolKind::CustomProperty,
+                    name: property_rule.name.0.as_ref().to_string(),
+                    path: path.to_string(),
+                    line: property_rule.loc.line + 1,
+                });
+            }
+            CssRule::Unknown(unknown_rule) => {
+                if let Some(block) = &unknown_rule.block {
+                    collect_custom_props_from_tokens(&block.0, path, unknown_rule.loc.line, out);
+                }
+            }
+            // Import, Keyframes, FontFace, Page, Viewport, CustomMedia,
+            // LayerStatement, Namespace, ViewTransition, CounterStyle,
+            // FontPaletteValues, FontFeatureValues, Ignored, Custom: none of
+            // these define a class selector or a custom property.
+            _ => {}
+        }
+    }
+}
+
+fn collect_selector_list(
+    selectors: &SelectorList<'_>,
+    path: &str,
+    loc_line: u32,
+    out: &mut Vec<CssSymbol>,
+) {
+    for selector in selectors.0.iter() {
+        collect_classes_from_selector(selector, path, loc_line, out);
+    }
+}
+
+fn collect_classes_from_selector(
+    selector: &Selector<'_>,
+    path: &str,
+    loc_line: u32,
+    out: &mut Vec<CssSymbol>,
+) {
+    for component in selector.iter_raw_match_order() {
+        collect_classes_from_component(component, path, loc_line, out);
+    }
+}
+
+/// Extract `Component::Class` from a selector component, recursing into the
+/// nested selector lists of functional pseudo-classes (`:is()`, `:where()`,
+/// `:not()`, `:has()`, `::slotted()`, `:host()`) so a class named only
+/// inside one of those still surfaces.
+fn collect_classes_from_component(
+    component: &Component<'_>,
+    path: &str,
+    loc_line: u32,
+    out: &mut Vec<CssSymbol>,
+) {
+    match component {
+        Component::Class(ident) => {
+            out.push(CssSymbol {
+                kind: CssSymbolKind::Class,
+                name: format!(".{}", ident.0.as_ref()),
+                path: path.to_string(),
+                line: loc_line + 1,
+            });
+        }
+        Component::Negation(list)
+        | Component::Where(list)
+        | Component::Is(list)
+        | Component::Has(list) => {
+            for nested in list.iter() {
+                collect_classes_from_selector(nested, path, loc_line, out);
+            }
+        }
+        Component::Any(_, list) => {
+            for nested in list.iter() {
+                collect_classes_from_selector(nested, path, loc_line, out);
+            }
+        }
+        Component::Slotted(nested) => {
+            collect_classes_from_selector(nested, path, loc_line, out);
+        }
+        Component::Host(Some(nested)) => {
+            collect_classes_from_selector(nested, path, loc_line, out);
+        }
+        _ => {}
+    }
+}
+
+/// Extract `--custom-property` definitions from a normal declaration block
+/// (a `StyleRule` or `NestedDeclarationsRule`'s declarations).
+fn collect_declarations(
+    block: &DeclarationBlock<'_>,
+    path: &str,
+    loc_line: u32,
+    out: &mut Vec<CssSymbol>,
+) {
+    for property in block
+        .declarations
+        .iter()
+        .chain(block.important_declarations.iter())
+    {
+        if let Property::Custom(custom) = property
+            && let CustomPropertyName::Custom(name) = &custom.name
+        {
+            out.push(CssSymbol {
+                kind: CssSymbolKind::CustomProperty,
+                name: name.0.as_ref().to_string(),
+                path: path.to_string(),
+                line: loc_line + 1,
+            });
+        }
+    }
+}
+
+/// Extract `--custom-property` definitions from the raw token list of an
+/// at-rule block lightningcss does not know how to parse structurally (e.g.
+/// Tailwind's `@theme`). See the module docs for why a bare `DashedIdent`
+/// immediately followed by a colon is unambiguously a definition, not a
+/// `var()` reference.
+fn collect_custom_props_from_tokens(
+    tokens: &[TokenOrValue<'_>],
+    path: &str,
+    loc_line: u32,
+    out: &mut Vec<CssSymbol>,
+) {
+    for (i, token) in tokens.iter().enumerate() {
+        let TokenOrValue::DashedIdent(ident) = token else {
+            continue;
+        };
+        let is_definition = tokens[i + 1..]
+            .iter()
+            .find(|t| !is_skippable(t))
+            .is_some_and(|t| matches!(t, TokenOrValue::Token(Token::Colon)));
+        if is_definition {
+            out.push(CssSymbol {
+                kind: CssSymbolKind::CustomProperty,
+                name: ident.0.as_ref().to_string(),
+                path: path.to_string(),
+                line: loc_line + 1,
+            });
+        }
+    }
+}
+
+fn is_skippable(token: &TokenOrValue<'_>) -> bool {
+    token.is_whitespace() || matches!(token, TokenOrValue::Token(Token::Comment(_)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // --- class selectors ---
+
+    #[test]
+    fn extracts_a_simple_class_selector() {
+        let symbols = extract_css_symbols(Path::new("a.css"), ".foo { color: red; }").unwrap();
+        assert_eq!(symbols.len(), 1);
+        assert_eq!(symbols[0].kind, CssSymbolKind::Class);
+        assert_eq!(symbols[0].name, ".foo");
+        assert_eq!(symbols[0].path, "a.css");
+        assert_eq!(symbols[0].line, 1);
+    }
+
+    #[test]
+    fn multiple_comma_separated_selectors_each_produce_a_symbol() {
+        let symbols =
+            extract_css_symbols(Path::new("a.css"), ".foo, .bar {\n  color: red;\n}").unwrap();
+        let names: Vec<&str> = symbols.iter().map(|s| s.name.as_str()).collect();
+        assert!(names.contains(&".foo"));
+        assert!(names.contains(&".bar"));
+        assert_eq!(symbols.len(), 2);
+    }
+
+    #[test]
+    fn nested_class_under_native_css_nesting_is_found() {
+        // Tailwind v4 output uses native nesting for state variants.
+        let symbols = extract_css_symbols(
+            Path::new("a.css"),
+            ".foo {\n  color: red;\n\n  &:hover {\n    color: blue;\n  }\n\n  .bar {\n    color: green;\n  }\n}",
+        )
+        .unwrap();
+        let names: Vec<&str> = symbols.iter().map(|s| s.name.as_str()).collect();
+        assert!(names.contains(&".foo"), "got: {names:?}");
+        assert!(
+            names.contains(&".bar"),
+            "a class nested inside another rule must be found, got: {names:?}"
+        );
+    }
+
+    #[test]
+    fn class_inside_is_pseudo_class_is_found() {
+        let symbols =
+            extract_css_symbols(Path::new("a.css"), ":is(.foo, .bar) { color: red; }").unwrap();
+        let names: Vec<&str> = symbols.iter().map(|s| s.name.as_str()).collect();
+        assert!(names.contains(&".foo"), "got: {names:?}");
+        assert!(names.contains(&".bar"), "got: {names:?}");
+    }
+
+    // --- custom properties: plain declarations ---
+
+    #[test]
+    fn extracts_a_custom_property_declaration() {
+        let symbols =
+            extract_css_symbols(Path::new("a.css"), ":root { --brand-color: #ff0000; }").unwrap();
+        assert_eq!(symbols.len(), 1);
+        assert_eq!(symbols[0].kind, CssSymbolKind::CustomProperty);
+        assert_eq!(symbols[0].name, "--brand-color");
+    }
+
+    #[test]
+    fn extracts_a_dotted_custom_property_name() {
+        // A bare unescaped `.` inside a CSS ident is grammar-illegal -- the
+        // tokenizer splits `--spacing-0.5` into an Ident("--spacing-0") and
+        // a Number(0.5), which is why `oxc-css-parser` rejects it outright.
+        // Tailwind v4's actual compiled output escapes the dot
+        // (`--spacing-0\.5`), which the CSS tokenizer resolves into a
+        // SINGLE ident whose decoded text is the literal `--spacing-0.5` --
+        // this is the real on-disk shape lightningcss must (and does)
+        // tolerate.
+        let symbols =
+            extract_css_symbols(Path::new("a.css"), ":root { --spacing-0\\.5: 0.125rem; }")
+                .unwrap();
+        assert_eq!(symbols.len(), 1);
+        assert_eq!(symbols[0].name, "--spacing-0.5");
+    }
+
+    // --- custom properties: @property ---
+
+    #[test]
+    fn extracts_an_at_property_rule_name() {
+        let symbols = extract_css_symbols(
+            Path::new("a.css"),
+            "@property --my-color {\n  syntax: '<color>';\n  inherits: false;\n  initial-value: #c0ffee;\n}",
+        )
+        .unwrap();
+        assert_eq!(symbols.len(), 1);
+        assert_eq!(symbols[0].kind, CssSymbolKind::CustomProperty);
+        assert_eq!(symbols[0].name, "--my-color");
+    }
+
+    // --- custom properties: @theme (Tailwind v4, raw-token recovery) ---
+
+    #[test]
+    fn extracts_custom_properties_from_a_theme_block() {
+        let symbols = extract_css_symbols(
+            Path::new("a.css"),
+            "@theme {\n  --spacing-0\\.5: 0.125rem;\n  --color-red-500: oklch(0.63 0.24 25);\n}",
+        )
+        .unwrap();
+        let names: Vec<&str> = symbols.iter().map(|s| s.name.as_str()).collect();
+        assert!(names.contains(&"--spacing-0.5"), "got: {names:?}");
+        assert!(names.contains(&"--color-red-500"), "got: {names:?}");
+        assert_eq!(symbols.len(), 2);
+    }
+
+    #[test]
+    fn theme_block_var_reference_is_not_mistaken_for_a_definition() {
+        // `--color-red-500` inside `var(...)` is a REFERENCE, not a
+        // definition -- only `--other` (the declaration name) must surface.
+        let symbols = extract_css_symbols(
+            Path::new("a.css"),
+            "@theme {\n  --other: var(--color-red-500);\n}",
+        )
+        .unwrap();
+        let names: Vec<&str> = symbols.iter().map(|s| s.name.as_str()).collect();
+        assert_eq!(
+            names,
+            vec!["--other"],
+            "the var() target must not be reported as a definition"
+        );
+    }
+
+    // --- tolerance: the full documented Tailwind v4 hazard set at once ---
+
+    #[test]
+    fn tolerates_a_representative_tailwind_v4_sheet_with_zero_errors() {
+        let content = "@import \"tailwindcss\";\n\n@theme {\n  --spacing-0\\.5: 0.125rem;\n  --color-red-500: oklch(0.637 0.237 25.331);\n  --font-sans: ui-sans-serif, system-ui;\n}\n\n:root {\n  --brand: var(--color-red-500);\n}\n\n.text-red-500 {\n  color: var(--color-red-500);\n}\n";
+        let symbols = extract_css_symbols(Path::new("rafters.css"), content).unwrap();
+        let names: Vec<&str> = symbols.iter().map(|s| s.name.as_str()).collect();
+        assert!(names.contains(&"--spacing-0.5"));
+        assert!(names.contains(&"--color-red-500"));
+        assert!(names.contains(&"--font-sans"));
+        assert!(names.contains(&"--brand"));
+        assert!(names.contains(&".text-red-500"));
+    }
+
+    // --- error path: a genuine parse failure is Err, not a panic ---
+
+    #[test]
+    fn excessive_nesting_depth_is_a_parse_error_not_a_panic() {
+        // TokenList::parse enforces a max nesting depth of 500 inside a raw
+        // at-rule block; past that it is a real ParseError, not a tolerated
+        // construct -- the one reliable way to force a hard failure out of
+        // an otherwise very lenient parser. Reaching the depth check itself
+        // takes ~500 recursive-descent stack frames, so this runs on a
+        // thread with a generous stack rather than risking an overflow on
+        // whatever stack size the test harness's own thread happens to have.
+        let handle = std::thread::Builder::new()
+            .stack_size(64 * 1024 * 1024)
+            .spawn(|| {
+                let opens = "(".repeat(600);
+                let closes = ")".repeat(600);
+                let content = format!("@theme {{ --x: {opens}{closes}; }}");
+                extract_css_symbols(Path::new("a.css"), &content).is_err()
+            })
+            .expect("spawn thread");
+        assert!(
+            handle.join().expect("thread panicked"),
+            "excessive nesting must surface as Err"
+        );
+    }
+
+    // --- path normalization ---
+
+    #[test]
+    fn path_is_forward_slash_normalized() {
+        let symbols = extract_css_symbols(Path::new("src\\styles\\a.css"), ".foo {}").unwrap();
+        assert_eq!(symbols[0].path, "src/styles/a.css");
+    }
+
+    // --- batch extraction over files ---
+
+    #[test]
+    fn extract_for_files_reads_and_parses_each_file() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("a.css"), ".foo {}").unwrap();
+        std::fs::write(dir.path().join("b.css"), ":root { --x: 1; }").unwrap();
+
+        let files = vec![PathBuf::from("a.css"), PathBuf::from("b.css")];
+        let symbols = extract_css_symbols_for_files(dir.path(), &files);
+        assert_eq!(symbols.len(), 2);
+    }
+
+    #[test]
+    fn extract_for_files_skips_unreadable_file_without_aborting_the_batch() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("ok.css"), ".foo {}").unwrap();
+
+        let files = vec![PathBuf::from("does-not-exist.css"), PathBuf::from("ok.css")];
+        let symbols = extract_css_symbols_for_files(dir.path(), &files);
+        assert_eq!(
+            symbols.len(),
+            1,
+            "the missing file must be skipped, not fatal"
+        );
+        assert_eq!(symbols[0].path, "ok.css");
+    }
+}

--- a/src/db/css_symbols.rs
+++ b/src/db/css_symbols.rs
@@ -1,0 +1,343 @@
+//! CSS symbols: one row per class-selector or `--custom-property` definition
+//! found by `css::extract_css_symbols` (#711).
+//!
+//! `css_symbols` is the substrate `sym` uses to answer "where is `.foo` /
+//! `--token` defined" for the design system -- the question the rafters
+//! agent's dynamically-composed-class bugs and token work routes through.
+//! Mirrors `module_edges`'s persistence shape (#710): a full re-walk deletes
+//! and re-inserts a file's rows in one transaction, so a file that loses a
+//! definition does not leave a stale row behind.
+
+use rusqlite::Connection;
+
+use super::Database;
+use crate::css::{CssSymbol, CssSymbolKind};
+use crate::error::Result;
+
+/// Create the `css_symbols` table and its lookup index.
+///
+/// Called from `init_schema` inside the schema-creation transaction.
+/// Idempotent via `IF NOT EXISTS`.
+///
+/// No single-column primary key fits: the same class or custom property can
+/// legitimately be (re)defined at more than one line in the same file (a
+/// second `.foo { }` block, or `@theme` blocks split across `@layer`
+/// sections), so the natural key is `(repo, path, kind, name, line)`.
+pub(super) fn create_tables(conn: &Connection) -> Result<()> {
+    conn.execute_batch(
+        "CREATE TABLE IF NOT EXISTS css_symbols (
+            repo TEXT NOT NULL,
+            path TEXT NOT NULL,
+            kind TEXT NOT NULL,
+            name TEXT NOT NULL,
+            line INTEGER NOT NULL,
+            PRIMARY KEY (repo, path, kind, name, line)
+        );
+        CREATE INDEX IF NOT EXISTS idx_css_symbols_repo_kind_name
+            ON css_symbols(repo, kind, name);",
+    )?;
+    Ok(())
+}
+
+fn kind_to_str(kind: CssSymbolKind) -> &'static str {
+    match kind {
+        CssSymbolKind::Class => "class",
+        CssSymbolKind::CustomProperty => "custom-property",
+    }
+}
+
+fn kind_from_str(s: &str) -> rusqlite::Result<CssSymbolKind> {
+    match s {
+        "class" => Ok(CssSymbolKind::Class),
+        "custom-property" => Ok(CssSymbolKind::CustomProperty),
+        other => Err(rusqlite::Error::InvalidColumnType(
+            2,
+            format!("css_symbols.kind: unknown value '{other}'"),
+            rusqlite::types::Type::Text,
+        )),
+    }
+}
+
+fn row_to_symbol(row: &rusqlite::Row<'_>) -> rusqlite::Result<CssSymbol> {
+    let kind_str: String = row.get(2)?;
+    Ok(CssSymbol {
+        kind: kind_from_str(&kind_str)?,
+        path: row.get(1)?,
+        name: row.get(3)?,
+        line: row.get::<_, i64>(4)? as u32,
+    })
+}
+
+impl Database {
+    /// Replace CSS symbols for a batch of just-(re)parsed files, keyed on
+    /// `(repo, path)`.
+    ///
+    /// `parsed_paths` must list every file whose symbols were (re)computed
+    /// this call -- including one that now yields zero symbols (its last
+    /// rule was just deleted). Every existing row for each of those files is
+    /// deleted before `symbols` is inserted, in the same transaction --
+    /// mirrors `upsert_module_edges`'s reasoning: a file that shrinks to
+    /// zero symbols contributes no rows to `symbols` at all, so nothing in
+    /// the symbol list would point back at it to clear its now-stale rows.
+    pub fn upsert_css_symbols(
+        &self,
+        repo: &str,
+        parsed_paths: &[&str],
+        symbols: &[CssSymbol],
+    ) -> Result<()> {
+        let tx = self.conn.unchecked_transaction()?;
+        {
+            let mut delete_stmt =
+                tx.prepare("DELETE FROM css_symbols WHERE repo = ?1 AND path = ?2")?;
+            for path in parsed_paths {
+                delete_stmt.execute(rusqlite::params![repo, path])?;
+            }
+
+            let mut insert_stmt = tx.prepare(
+                "INSERT INTO css_symbols (repo, path, kind, name, line)
+                 VALUES (?1, ?2, ?3, ?4, ?5)
+                 ON CONFLICT(repo, path, kind, name, line) DO NOTHING",
+            )?;
+            for symbol in symbols {
+                insert_stmt.execute(rusqlite::params![
+                    repo,
+                    &symbol.path,
+                    kind_to_str(symbol.kind),
+                    &symbol.name,
+                    symbol.line as i64,
+                ])?;
+            }
+        }
+        tx.commit()?;
+        Ok(())
+    }
+
+    /// Return every symbol definition named `name` -- "where is `.foo` /
+    /// `--token` defined" -- optionally scoped to a single repo, ordered by
+    /// `(repo, path, line)` for stable output.
+    ///
+    /// Not yet wired to a CLI surface -- #711 only populates the table via
+    /// `legion index` (see `handle_index` in `src/cli/index_cmd.rs`), same
+    /// as `module_edges` (#710). Exercised directly by this module's tests
+    /// in the meantime.
+    #[allow(dead_code)]
+    pub fn find_css_symbol(&self, repo: Option<&str>, name: &str) -> Result<Vec<CssSymbol>> {
+        if let Some(repo) = repo {
+            let mut stmt = self.conn.prepare(
+                "SELECT repo, path, kind, name, line
+                 FROM css_symbols
+                 WHERE repo = ?1 AND name = ?2
+                 ORDER BY repo, path, line",
+            )?;
+            let rows = stmt
+                .query_map(rusqlite::params![repo, name], row_to_symbol)?
+                .collect::<std::result::Result<Vec<_>, _>>()?;
+            Ok(rows)
+        } else {
+            let mut stmt = self.conn.prepare(
+                "SELECT repo, path, kind, name, line
+                 FROM css_symbols
+                 WHERE name = ?1
+                 ORDER BY repo, path, line",
+            )?;
+            let rows = stmt
+                .query_map(rusqlite::params![name], row_to_symbol)?
+                .collect::<std::result::Result<Vec<_>, _>>()?;
+            Ok(rows)
+        }
+    }
+
+    /// Delete CSS symbols for `repo` whose file is not in `live_paths`.
+    ///
+    /// Mirrors `prune_module_edges`: call after `upsert_css_symbols` on a
+    /// full repo re-walk so symbols from deleted/renamed files do not
+    /// linger. When `live_paths` is empty every row for the repo is removed.
+    pub fn prune_css_symbols(&self, repo: &str, live_paths: &[&str]) -> Result<usize> {
+        if live_paths.is_empty() {
+            let n = self.conn.execute(
+                "DELETE FROM css_symbols WHERE repo = ?1",
+                rusqlite::params![repo],
+            )?;
+            return Ok(n);
+        }
+
+        self.conn.execute_batch(
+            "CREATE TEMP TABLE IF NOT EXISTS _css_symbols_live_paths (path TEXT PRIMARY KEY)",
+        )?;
+        self.conn
+            .execute_batch("DELETE FROM _css_symbols_live_paths")?;
+
+        {
+            let tx = self.conn.unchecked_transaction()?;
+            {
+                let mut insert =
+                    tx.prepare("INSERT OR IGNORE INTO _css_symbols_live_paths (path) VALUES (?1)")?;
+                for p in live_paths {
+                    insert.execute(rusqlite::params![p])?;
+                }
+            }
+            tx.commit()?;
+        }
+
+        let n = self.conn.execute(
+            "DELETE FROM css_symbols
+             WHERE repo = ?1
+               AND path NOT IN (SELECT path FROM _css_symbols_live_paths)",
+            rusqlite::params![repo],
+        )?;
+        Ok(n)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::testutil::test_db;
+
+    fn symbol(kind: CssSymbolKind, name: &str, path: &str, line: u32) -> CssSymbol {
+        CssSymbol {
+            kind,
+            name: name.to_string(),
+            path: path.to_string(),
+            line,
+        }
+    }
+
+    #[test]
+    fn upsert_and_find_round_trip() {
+        let db = test_db();
+        let symbols = vec![
+            symbol(CssSymbolKind::Class, ".foo", "a.css", 1),
+            symbol(CssSymbolKind::CustomProperty, "--brand", "a.css", 5),
+        ];
+        db.upsert_css_symbols("r", &["a.css"], &symbols).unwrap();
+
+        let got = db.find_css_symbol(Some("r"), ".foo").unwrap();
+        assert_eq!(got.len(), 1);
+        assert_eq!(got[0].kind, CssSymbolKind::Class);
+        assert_eq!(got[0].path, "a.css");
+        assert_eq!(got[0].line, 1);
+    }
+
+    #[test]
+    fn find_without_repo_searches_across_repos() {
+        let db = test_db();
+        db.upsert_css_symbols(
+            "alpha",
+            &["a.css"],
+            &[symbol(CssSymbolKind::Class, ".shared", "a.css", 1)],
+        )
+        .unwrap();
+        db.upsert_css_symbols(
+            "beta",
+            &["b.css"],
+            &[symbol(CssSymbolKind::Class, ".shared", "b.css", 2)],
+        )
+        .unwrap();
+
+        let got = db.find_css_symbol(None, ".shared").unwrap();
+        assert_eq!(got.len(), 2, "cross-repo search must find both");
+    }
+
+    #[test]
+    fn reindex_drops_a_removed_symbol_from_a_still_live_file() {
+        let db = test_db();
+        db.upsert_css_symbols(
+            "r",
+            &["a.css"],
+            &[
+                symbol(CssSymbolKind::Class, ".foo", "a.css", 1),
+                symbol(CssSymbolKind::Class, ".bar", "a.css", 2),
+            ],
+        )
+        .unwrap();
+
+        // Re-index after the file drops `.bar`. The file is still live
+        // (still passed in `parsed_paths`), so `prune_css_symbols` never
+        // sees it -- the stale `.bar` row must be dropped by the upsert
+        // itself.
+        db.upsert_css_symbols(
+            "r",
+            &["a.css"],
+            &[symbol(CssSymbolKind::Class, ".foo", "a.css", 1)],
+        )
+        .unwrap();
+
+        let got = db.find_css_symbol(Some("r"), ".bar").unwrap();
+        assert!(
+            got.is_empty(),
+            "the removed class must not survive re-indexing"
+        );
+        assert_eq!(db.find_css_symbol(Some("r"), ".foo").unwrap().len(), 1);
+    }
+
+    #[test]
+    fn reindex_clears_all_symbols_when_a_live_file_drops_every_rule() {
+        let db = test_db();
+        db.upsert_css_symbols(
+            "r",
+            &["a.css"],
+            &[symbol(CssSymbolKind::Class, ".foo", "a.css", 1)],
+        )
+        .unwrap();
+
+        // The file still exists (still passed as a parsed path) but now
+        // yields zero symbols.
+        db.upsert_css_symbols("r", &["a.css"], &[]).unwrap();
+
+        assert!(db.find_css_symbol(Some("r"), ".foo").unwrap().is_empty());
+    }
+
+    #[test]
+    fn prune_removes_symbols_for_deleted_files() {
+        let db = test_db();
+        db.upsert_css_symbols(
+            "r",
+            &["a.css", "gone.css"],
+            &[
+                symbol(CssSymbolKind::Class, ".foo", "a.css", 1),
+                symbol(CssSymbolKind::Class, ".gone", "gone.css", 1),
+            ],
+        )
+        .unwrap();
+
+        let pruned = db.prune_css_symbols("r", &["a.css"]).unwrap();
+        assert_eq!(pruned, 1);
+        assert!(db.find_css_symbol(Some("r"), ".gone").unwrap().is_empty());
+        assert_eq!(db.find_css_symbol(Some("r"), ".foo").unwrap().len(), 1);
+    }
+
+    #[test]
+    fn prune_empty_live_paths_wipes_repo() {
+        let db = test_db();
+        db.upsert_css_symbols(
+            "r",
+            &["a.css"],
+            &[symbol(CssSymbolKind::Class, ".foo", "a.css", 1)],
+        )
+        .unwrap();
+
+        let pruned = db.prune_css_symbols("r", &[]).unwrap();
+        assert_eq!(pruned, 1);
+        assert!(db.find_css_symbol(Some("r"), ".foo").unwrap().is_empty());
+    }
+
+    #[test]
+    fn same_name_at_different_lines_in_the_same_file_are_both_kept() {
+        // A class can legitimately be (re)defined more than once in the
+        // same compiled sheet.
+        let db = test_db();
+        db.upsert_css_symbols(
+            "r",
+            &["a.css"],
+            &[
+                symbol(CssSymbolKind::Class, ".foo", "a.css", 1),
+                symbol(CssSymbolKind::Class, ".foo", "a.css", 20),
+            ],
+        )
+        .unwrap();
+
+        let got = db.find_css_symbol(Some("r"), ".foo").unwrap();
+        assert_eq!(got.len(), 2, "both definition sites must be kept");
+    }
+}

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -9,6 +9,7 @@
 mod audit;
 mod autonomy;
 mod board;
+pub mod css_symbols;
 mod documents;
 mod health;
 mod heartbeat;
@@ -121,6 +122,7 @@ impl Database {
         heartbeat::create_tables(conn)?;
         inventory::create_tables(conn)?;
         module_edges::create_tables(conn)?;
+        css_symbols::create_tables(conn)?;
         tx.commit()?;
 
         reflections::migrate(conn)?;

--- a/src/error.rs
+++ b/src/error.rs
@@ -126,6 +126,9 @@ pub enum LegionError {
     #[error("mesh error: {0}")]
     Mesh(String),
 
+    #[error("css error: {0}")]
+    Css(String),
+
     #[error(
         "indexer not found: '{binary}' is not on PATH (required for {lang} indexing). For Rust, install rust-analyzer (`rustup component add rust-analyzer`) which provides `rust-analyzer scip`; the legacy scip-rust repo is archived."
     )]

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ mod board;
 mod card_parse;
 mod channel;
 mod cluster;
+mod css;
 mod daemon;
 mod db;
 mod documents;

--- a/tests/integration/css_symbols.rs
+++ b/tests/integration/css_symbols.rs
@@ -1,0 +1,173 @@
+//! CLI end-to-end tests for the CSS symbol wiring in `legion index` (#711).
+//!
+//! `src/css.rs` and `src/db/css_symbols.rs` carry their own unit tests for
+//! the parse/extract logic and the persistence API in isolation; these tests
+//! exercise the actual binary surface -- a real `legion index <repo>` run
+//! over a small CSS fixture (including a Tailwind-v4-shaped `@theme` block)
+//! must populate `css_symbols` and bump `file_inventory.symbol_count` for
+//! the css file. No CLI query surface exists yet (see
+//! `Database::find_css_symbol`'s doc comment), so assertions read the
+//! `css_symbols` and `file_inventory` tables directly out of the data dir's
+//! `legion.db`. Mirrors `module_graph.rs`'s shape (#710).
+
+use rusqlite::Connection;
+
+use crate::common::{legion_cmd, run_ok};
+
+/// Seed a watch.toml in the data dir pointing at `repos` (name, workdir).
+/// Mirrors `module_graph::seed_watch_toml` -- forward-slash normalized so a
+/// Windows path interpolated into this basic TOML string does not have its
+/// backslashes read back as escape sequences.
+fn seed_watch_toml(data_dir: &std::path::Path, repos: &[(&str, &std::path::Path)]) {
+    let mut toml = String::new();
+    for (name, workdir) in repos {
+        toml.push_str(&format!(
+            "[[repos]]\nname = \"{}\"\nworkdir = \"{}\"\n\n",
+            name,
+            workdir.display().to_string().replace('\\', "/")
+        ));
+    }
+    std::fs::write(data_dir.join("watch.toml"), toml).expect("seed watch.toml");
+}
+
+/// One `(path, kind, name, line)` row read back from `css_symbols`.
+fn css_symbols_for_repo(
+    data_dir: &std::path::Path,
+    repo: &str,
+) -> Vec<(String, String, String, i64)> {
+    let conn = Connection::open(data_dir.join("legion.db")).expect("open legion.db");
+    let mut stmt = conn
+        .prepare(
+            "SELECT path, kind, name, line FROM css_symbols WHERE repo = ?1 ORDER BY path, name",
+        )
+        .expect("prepare query");
+    stmt.query_map([repo], |row| {
+        Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?))
+    })
+    .expect("query_map")
+    .collect::<Result<Vec<_>, _>>()
+    .expect("collect rows")
+}
+
+fn symbol_count_for_file(data_dir: &std::path::Path, repo: &str, path: &str) -> i64 {
+    let conn = Connection::open(data_dir.join("legion.db")).expect("open legion.db");
+    conn.query_row(
+        "SELECT symbol_count FROM file_inventory WHERE repo = ?1 AND path = ?2",
+        [repo, path],
+        |row| row.get(0),
+    )
+    .expect("query symbol_count")
+}
+
+#[test]
+fn index_populates_css_symbols_and_tolerates_a_theme_block() {
+    let data_dir = tempfile::tempdir().expect("data dir");
+    let repo_dir = tempfile::tempdir().expect("repo dir");
+
+    // Escaped dot: Tailwind v4's actual compiled output escapes a literal
+    // `.` inside a custom-property name (a bare unescaped dot is not a
+    // valid ident code point and would tokenize as two separate tokens).
+    std::fs::write(
+        repo_dir.path().join("rafters.css"),
+        "@import \"tailwindcss\";\n\n\
+         @theme {\n  --spacing-0\\.5: 0.125rem;\n  --color-red-500: oklch(0.637 0.237 25.331);\n}\n\n\
+         .text-red-500 {\n  color: var(--color-red-500);\n}\n",
+    )
+    .expect("write rafters.css");
+
+    seed_watch_toml(data_dir.path(), &[("cssrepo", repo_dir.path())]);
+
+    // A real `legion index` run: file inventory walk, then the css-symbol
+    // pass wired in src/cli/index_cmd.rs::handle_index. No package.json is
+    // present, so no SCIP language even attempts to run -- the css pass
+    // must be independent of that marker-file detection.
+    run_ok(legion_cmd(data_dir.path()).args(["index", "cssrepo"]));
+
+    let symbols = css_symbols_for_repo(data_dir.path(), "cssrepo");
+
+    assert!(
+        symbols
+            .iter()
+            .any(|(path, kind, name, _)| path == "rafters.css"
+                && kind == "custom-property"
+                && name == "--spacing-0.5"),
+        "expected --spacing-0.5 recovered from the @theme block, got {symbols:?}"
+    );
+    assert!(
+        symbols
+            .iter()
+            .any(|(path, kind, name, _)| path == "rafters.css"
+                && kind == "custom-property"
+                && name == "--color-red-500"),
+        "expected --color-red-500 recovered from the @theme block, got {symbols:?}"
+    );
+    assert!(
+        symbols
+            .iter()
+            .any(|(path, kind, name, _)| path == "rafters.css"
+                && kind == "class"
+                && name == ".text-red-500"),
+        "expected .text-red-500 class selector, got {symbols:?}"
+    );
+
+    let count = symbol_count_for_file(data_dir.path(), "cssrepo", "rafters.css");
+    assert_eq!(
+        count,
+        symbols.len() as i64,
+        "file_inventory.symbol_count must be bumped to the css symbol count"
+    );
+}
+
+#[test]
+fn reindex_drops_css_symbols_removed_from_a_still_live_file() {
+    let data_dir = tempfile::tempdir().expect("data dir");
+    let repo_dir = tempfile::tempdir().expect("repo dir");
+
+    std::fs::write(
+        repo_dir.path().join("a.css"),
+        ".foo { color: red; }\n.bar { color: blue; }\n",
+    )
+    .expect("write a.css");
+
+    seed_watch_toml(data_dir.path(), &[("reindexcss", repo_dir.path())]);
+    run_ok(legion_cmd(data_dir.path()).args(["index", "reindexcss"]));
+
+    let first_pass = css_symbols_for_repo(data_dir.path(), "reindexcss");
+    assert_eq!(
+        first_pass.len(),
+        2,
+        "expected both .foo and .bar on the first index, got {first_pass:?}"
+    );
+
+    // a.css stays live but drops `.bar` entirely.
+    std::fs::write(repo_dir.path().join("a.css"), ".foo { color: red; }\n").expect("rewrite a.css");
+
+    run_ok(legion_cmd(data_dir.path()).args(["index", "reindexcss"]));
+
+    let second_pass = css_symbols_for_repo(data_dir.path(), "reindexcss");
+    assert_eq!(
+        second_pass.len(),
+        1,
+        "the dropped .bar class must not survive re-indexing, got {second_pass:?}"
+    );
+    assert_eq!(second_pass[0].2, ".foo");
+}
+
+#[test]
+fn index_with_no_css_files_leaves_css_symbols_empty() {
+    // A repo with no .css files at all must not error, and must simply
+    // produce no css_symbols rows -- the css pass is skipped entirely
+    // rather than running over an empty file list.
+    let data_dir = tempfile::tempdir().expect("data dir");
+    let repo_dir = tempfile::tempdir().expect("repo dir");
+    std::fs::write(repo_dir.path().join("README.md"), "# hi\n").expect("write fixture");
+    seed_watch_toml(data_dir.path(), &[("docsonlycss", repo_dir.path())]);
+
+    run_ok(legion_cmd(data_dir.path()).args(["index", "docsonlycss"]));
+
+    let symbols = css_symbols_for_repo(data_dir.path(), "docsonlycss");
+    assert!(
+        symbols.is_empty(),
+        "expected no css symbols, got {symbols:?}"
+    );
+}

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -8,6 +8,7 @@
 mod common;
 
 mod bullpen;
+mod css_symbols;
 mod daemon_watch;
 mod documents;
 mod etc;


### PR DESCRIPTION
## Summary

- `src/css.rs` (new): `extract_css_symbols(path, content)` parses a CSS file
  with `lightningcss` and returns every class-selector and
  `--custom-property` definition, each stamped with a 1-based `path:line`.
  Walks the full `CssRule` tree (style rules, native nesting, `@media` /
  `@supports` / `@container` / `@scope` / `@starting-style` / `@layer` /
  `@-moz-document`, `@property`), recursing into `:is()`/`:where()`/
  `:not()`/`:has()`/`::slotted()`/`:host()` for classes named only inside a
  functional pseudo-class. `@theme` (Tailwind v4's token block) is unknown
  to lightningcss and parses as a raw token list rather than a declaration
  block; custom-property definitions inside it are recovered by scanning
  that token list directly, distinguishing a definition (`DashedIdent`
  immediately followed by a colon) from a `var()` reference.
- `src/db/css_symbols.rs` (new): `css_symbols` table + upsert/find/prune,
  mirroring the `module_edges` persistence shape from #710.
- `src/cli/index_cmd.rs`: wired the extraction into `legion index`'s walk,
  alongside the existing module-graph pass, and bumped
  `file_inventory.symbol_count` for css files through the same enrich pass
  the SCIP loop uses.
- `Cargo.toml`: added `lightningcss = "1.0.0-alpha.71"` with default
  features disabled (default pulls in nodejs/bundler/sourcemap extras this
  binary never touches).
- `src/error.rs`: added `LegionError::Css(String)`.
- Integration tests at `tests/integration/css_symbols.rs`, mirroring
  `tests/integration/module_graph.rs`'s shape.

## Acceptance criteria mapping

### 1. Parse real `.rafters/output/rafters.css` (Tailwind v4) with zero errors

The actual external rafters build artifact is not part of this repo's test
tree, so this is verified against a synthetic fixture that reproduces every
documented hazard from the benchmark reflections (019f1eee/019f1eef) that
originally justified choosing lightningcss over `oxc-css-parser`: `@import
"tailwindcss"`, an `@theme` block, `oklch()` colors, and a dotted
custom-property name.

Evidence: `src/css.rs::tests::tolerates_a_representative_tailwind_v4_sheet_with_zero_errors`
(also exercised end-to-end through the real CLI binary in
`tests/integration/css_symbols.rs::index_populates_css_symbols_and_tolerates_a_theme_block`,
which runs an actual `legion index <repo>` over a css fixture file on disk).

One correction to the original benchmark framing, made explicit in the
module docs at `src/css.rs:5-15`: a bare *unescaped* dot inside a
custom-property name is not tolerated by lightningcss either -- it is not
a valid CSS ident code point in any spec-conformant tokenizer, and
splits into two tokens (`Ident("--spacing-0")` + `Number(0.5)`). This was
confirmed empirically: a first draft of the dotted-name test used an
unescaped `--spacing-0.5` and got a real `LegionError::Css` parse error
back from `DeclarationBlock::parse`. Tailwind v4's actual compiled output
escapes the dot (`--spacing-0\.5`), which the tokenizer resolves into a
single ident whose decoded text is the literal `--spacing-0.5` -- that is
the real on-disk shape the fixtures now use
(`src/css.rs::tests::extracts_a_dotted_custom_property_name`).

### 2. Enumerate class + `--custom-property` symbols with correct `path:line`

Evidence: `src/css.rs::tests::extracts_a_simple_class_selector` asserts
`name == ".foo"`, `path == "a.css"`, `line == 1`.
`src/css.rs::tests::multiple_comma_separated_selectors_each_produce_a_symbol`
and `::nested_class_under_native_css_nesting_is_found` cover
comma-separated selector lists and native-CSS-nesting recursion.
`::extracts_a_custom_property_declaration`, `::extracts_an_at_property_rule_name`,
and `::extracts_custom_properties_from_a_theme_block` cover the three
places a `--custom-property` can be defined (a plain declaration, an
`@property` rule, and a Tailwind `@theme` block). Line numbers are 1-based
(lightningcss's `Location.line` is 0-based; `+ 1` applied at every push
site, e.g. `src/css.rs:159, 213, 250, 296`).

The `sym`-facing store: `src/db/css_symbols.rs` persists every symbol keyed
on `(repo, path, kind, name, line)` and bumps `file_inventory.symbol_count`
for css files through `update_file_symbol_counts` (wired in
`src/cli/index_cmd.rs`, shared with the SCIP loop so the same
reset-then-apply call is not run twice). End-to-end evidence:
`tests/integration/css_symbols.rs::index_populates_css_symbols_and_tolerates_a_theme_block`
asserts `file_inventory.symbol_count` equals the number of `css_symbols`
rows for the file after a real `legion index` run, and
`::reindex_drops_css_symbols_removed_from_a_still_live_file` asserts a
class dropped from a still-live file does not survive re-indexing.

### 3. Tests pass; simplify + review done; PR linked

- `cargo test --bin legion`: 1315 passed, 0 failed (14 new unit tests in
  `src/css.rs`, 7 in `src/db/css_symbols.rs`).
- `cargo test --test integration`: 236 passed, 0 failed (3 new tests in
  `tests/integration/css_symbols.rs`).
- `cargo clippy --all-targets -- -D warnings`: clean.
- `cargo fmt -- --check`: clean.
- Simplify gate: `legion quality-gate check --skill legion-simplify
  --result clean --findings-count 0` recorded, gate id
  `019f3450-8d35-7b53-8053-df31a87ed38e`.
- This PR, linked to #711.

## Not done (deliberately)

- No CLI query surface for `css_symbols` yet (no `sym find-css` or
  similar). Mirrors the #710 precedent exactly:
  `Database::find_css_symbol` is written, tested directly, and documented
  as "not yet wired to a CLI surface" in its own doc comment, the same way
  `Database::list_module_edges_from`/`_to` were left for #710.
- No SCSS/Less dialect support and no Astro/Vue `<style>` block extraction
  -- both explicitly out of scope per the issue.
- No full selector-specificity analysis -- also explicitly out of scope.
- The actual external `.rafters/output/rafters.css` file was not available
  to test against directly (it lives in a different repo); a synthetic
  fixture reproducing every documented parsing hazard is used instead (see
  criterion 1 above).