### PR TITLE
feat(#745): add --no-ignore to sym etc find-content

### DIFF
--- a/src/cli/index_cmd.rs
+++ b/src/cli/index_cmd.rs
@@ -160,6 +160,17 @@ pub(crate) enum EtcShape {
         /// matching lines printed.
         #[arg(long)]
         hidden: bool,
+        /// Disable .gitignore/.ignore/parent-dir-ignore/.git/info/exclude/global
+        /// gitignore checks (ripgrep's -u/--no-ignore semantics). Combine with
+        /// --hidden to reach a gitignored DOT-directory (e.g. a generated
+        /// `.rafters/` workspace) -- --no-ignore alone does not admit dotfiles.
+        /// `.git/` stays excluded regardless of this flag.
+        ///
+        /// SECURITY: gitignored files commonly hold secrets (.env is typically
+        /// gitignored BECAUSE it holds secrets) -- this flag widens the scan to
+        /// include them, and any matching line is printed to stdout/JSON.
+        #[arg(long)]
+        no_ignore: bool,
         /// Emit results as a JSON array of ContentHit objects
         #[arg(long)]
         json: bool,
@@ -277,8 +288,9 @@ fn run_sym_etc(database: &db::Database, shape: EtcShape) -> error::Result<()> {
             ext,
             fixed_strings,
             hidden,
+            no_ignore,
             json,
-        } => run_etc_find_content(&pattern, repo, ext, fixed_strings, hidden, json),
+        } => run_etc_find_content(&pattern, repo, ext, fixed_strings, hidden, no_ignore, json),
         EtcShape::Extract { path, field, json } => run_etc_extract(&path, &field, json),
         EtcShape::FindFile {
             query,
@@ -303,6 +315,7 @@ fn run_etc_find_content(
     ext: Option<String>,
     fixed_strings: bool,
     hidden: bool,
+    no_ignore: bool,
     json: bool,
 ) -> error::Result<()> {
     let scan = scan_etc_content(
@@ -311,6 +324,7 @@ fn run_etc_find_content(
         ext.as_deref(),
         fixed_strings,
         hidden,
+        no_ignore,
     );
 
     let usage = telemetry::EtcUsageRecord {
@@ -435,6 +449,7 @@ fn scan_etc_content(
     ext: Option<&str>,
     fixed_strings: bool,
     hidden: bool,
+    no_ignore: bool,
 ) -> error::Result<(etc::FindContentResult, usize)> {
     let base = data_dir()?;
     let watch_path = base.join("watch.toml");
@@ -467,6 +482,7 @@ fn scan_etc_content(
         ext,
         fixed_strings,
         include_hidden: hidden,
+        no_ignore,
         max_file_size: etc::MAX_FILE_SIZE,
         max_hits: etc::MAX_HITS,
     };

--- a/src/etc.rs
+++ b/src/etc.rs
@@ -120,6 +120,13 @@ pub struct ContentScope<'a> {
     /// configs). Off by default to match ripgrep; `.git/` stays excluded
     /// even when enabled.
     pub include_hidden: bool,
+    /// Disable all ignore-file sources (.gitignore, .ignore, parent-directory
+    /// ignore files, .git/info/exclude, global gitignore) -- mirrors
+    /// ripgrep's `-u`/`--no-ignore`. INDEPENDENT of `include_hidden`: this
+    /// does NOT admit dotfiles/dot-directories on its own (a gitignored
+    /// dot-directory like `.rafters/` needs BOTH flags together). `.git/`
+    /// itself stays excluded regardless, via the existing filter_entry guard.
+    pub no_ignore: bool,
     pub max_file_size: u64,
     pub max_hits: usize,
 }
@@ -130,11 +137,15 @@ pub struct ContentScope<'a> {
 /// not readdir-order roulette.
 ///
 /// The walk respects `.gitignore` (even outside a git checkout -- watched
-/// workdirs are the corpus, not arbitrary directories), skips hidden files
-/// unless `include_hidden` is set (ripgrep's `--hidden` semantics; the
-/// `ignore` crate does NOT skip `.git/` on its own once hidden files are
-/// admitted -- verified empirically in #705's twin walk -- so `.git` is
-/// excluded explicitly), and quits on binary content (a NUL byte), counting
+/// workdirs are the corpus, not arbitrary directories) unless `no_ignore` is
+/// set (ripgrep's `-u`/`--no-ignore` semantics), skips hidden files unless
+/// `include_hidden` is set (ripgrep's `--hidden` semantics; the `ignore`
+/// crate does NOT skip `.git/` on its own once hidden files are admitted --
+/// verified empirically in #705's twin walk -- so `.git` is excluded
+/// explicitly). `no_ignore` and `include_hidden` are independent toggles:
+/// a gitignored dot-directory (e.g. `.rafters/`) needs both together, since
+/// the hidden-file filter prunes it regardless of ignore-file state. Quits
+/// on binary content (a NUL byte), counting
 /// the file in `binary_skipped` -- the quit itself returns Ok, so without
 /// that counter a text file with an embedded NUL would vanish silently.
 /// Non-UTF-8 text files are searched lossily (invalid bytes become U+FFFD)
@@ -170,6 +181,11 @@ pub fn find_content(pattern: &str, scope: &ContentScope<'_>) -> Result<FindConte
         let walker = WalkBuilder::new(workdir)
             .require_git(false)
             .hidden(!scope.include_hidden)
+            .parents(!scope.no_ignore)
+            .ignore(!scope.no_ignore)
+            .git_ignore(!scope.no_ignore)
+            .git_exclude(!scope.no_ignore)
+            .git_global(!scope.no_ignore)
             .filter_entry(|entry| entry.file_name() != ".git")
             .sort_by_file_name(std::ffi::OsStr::cmp)
             .build();
@@ -454,6 +470,7 @@ mod tests {
             ext: None,
             fixed_strings: false,
             include_hidden: false,
+            no_ignore: false,
             max_file_size: MAX_FILE_SIZE,
             max_hits: MAX_HITS,
         }
@@ -660,6 +677,74 @@ mod tests {
         let result = find_content("needle", &sc).expect("search");
         let paths: Vec<&str> = result.hits.iter().map(|h| h.path.as_str()).collect();
         assert_eq!(paths, vec![".github/workflows/ci.yml", "seen.txt"]);
+    }
+
+    #[test]
+    fn no_ignore_includes_gitignored_non_hidden_files() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write(dir.path(), ".gitignore", "ignored.txt\n");
+        write(dir.path(), "ignored.txt", "needle\n");
+        write(dir.path(), "kept.txt", "needle\n");
+        let repos = one_repo(dir.path());
+        let mut sc = scope(&repos);
+        sc.no_ignore = true;
+        let result = find_content("needle", &sc).expect("search");
+        let paths: Vec<&str> = result.hits.iter().map(|h| h.path.as_str()).collect();
+        assert_eq!(paths, vec!["ignored.txt", "kept.txt"]);
+    }
+
+    /// Load-bearing (#745): `--no-ignore` alone does NOT reach a gitignored
+    /// DOT-directory. `.rafters/` is pruned by the hidden-directory filter
+    /// independent of gitignore state, so bypassing ignore files alone
+    /// cannot surface it -- pinning the exact failure mode from the field
+    /// report (bullpen 019f355c) where the missing flag was misdiagnosed.
+    #[test]
+    fn no_ignore_alone_does_not_reach_gitignored_dot_dir() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write(dir.path(), ".gitignore", ".rafters/\n");
+        write(dir.path(), ".rafters/output/rafters.css", "needle\n");
+        let repos = one_repo(dir.path());
+        let mut sc = scope(&repos);
+        sc.no_ignore = true;
+        let result = find_content("needle", &sc).expect("search");
+        assert!(
+            result.hits.is_empty(),
+            "no_ignore alone must not reach a gitignored dot-dir, got: {:?}",
+            result.hits
+        );
+    }
+
+    /// Direct regression test for the reported rafters bug: reaching a
+    /// gitignored generated workspace requires --no-ignore AND --hidden
+    /// together, not --no-ignore alone.
+    #[test]
+    fn no_ignore_plus_hidden_reaches_gitignored_dot_dir() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write(dir.path(), ".gitignore", ".rafters/\n");
+        write(dir.path(), ".rafters/output/rafters.css", "needle\n");
+        let repos = one_repo(dir.path());
+        let mut sc = scope(&repos);
+        sc.no_ignore = true;
+        sc.include_hidden = true;
+        let result = find_content("needle", &sc).expect("search");
+        assert_eq!(result.hits.len(), 1);
+        assert_eq!(result.hits[0].path, ".rafters/output/rafters.css");
+    }
+
+    #[test]
+    fn no_ignore_still_excludes_git_dir() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write(dir.path(), ".git/config", "needle\n");
+        let repos = one_repo(dir.path());
+        let mut sc = scope(&repos);
+        sc.no_ignore = true;
+        sc.include_hidden = true;
+        let result = find_content("needle", &sc).expect("search");
+        assert!(
+            result.hits.is_empty(),
+            ".git/ must stay excluded even with no_ignore + include_hidden, got: {:?}",
+            result.hits
+        );
     }
 
     #[test]

--- a/tests/integration/etc.rs
+++ b/tests/integration/etc.rs
@@ -290,6 +290,96 @@ fn find_content_hit_cap_warns_on_stderr() {
     );
 }
 
+/// The --no-ignore flag parses independently of --hidden (#745): a bare
+/// `--no-ignore` invocation with no `--hidden` present must be accepted by
+/// clap and reach the scan, not be rejected as a missing-flag combination.
+/// The library-level semantics (no_ignore alone vs. no_ignore+hidden) are
+/// pinned in src/etc.rs; this pins the clap wiring the review found
+/// uncovered for --hidden (per reflection 019f2068).
+#[test]
+fn find_content_no_ignore_flag_parses_independently_of_hidden() {
+    let data_dir = tempfile::tempdir().expect("data dir");
+    let repo_dir = tempfile::tempdir().expect("repo dir");
+    let state_dir = tempfile::tempdir().expect("state dir");
+    std::fs::write(repo_dir.path().join(".gitignore"), "ignored.txt\n").expect("write fixture");
+    std::fs::write(repo_dir.path().join("ignored.txt"), "needle\n").expect("write fixture");
+    seed_watch_toml(data_dir.path(), &[("etcrepo", repo_dir.path())]);
+
+    // --no-ignore alone (no --hidden) must be accepted and reach ignored.txt,
+    // an ordinary (non-dot) gitignored file.
+    let out = run_ok(
+        legion_cmd(data_dir.path())
+            .env("XDG_STATE_HOME", state_dir.path())
+            .args([
+                "sym",
+                "etc",
+                "find-content",
+                "needle",
+                "--repo",
+                "etcrepo",
+                "--no-ignore",
+            ]),
+    );
+    assert!(
+        out.contains("ignored.txt:1: needle"),
+        "--no-ignore alone must be accepted by clap and reach a gitignored file, got:\n{out}"
+    );
+}
+
+/// End-to-end pin of the load-bearing behavior (#745): --no-ignore alone
+/// does not reach a gitignored DOT-directory; --no-ignore + --hidden
+/// together do. This is the exact rafters field report (bullpen 019f355c).
+#[test]
+fn find_content_no_ignore_and_hidden_together_reach_gitignored_dot_dir() {
+    let data_dir = tempfile::tempdir().expect("data dir");
+    let repo_dir = tempfile::tempdir().expect("repo dir");
+    let state_dir = tempfile::tempdir().expect("state dir");
+    std::fs::write(repo_dir.path().join(".gitignore"), ".rafters/\n").expect("write fixture");
+    let rafters_dir = repo_dir.path().join(".rafters/output");
+    std::fs::create_dir_all(&rafters_dir).expect("mkdir .rafters/output");
+    std::fs::write(rafters_dir.join("rafters.css"), "needle\n").expect("write fixture");
+    seed_watch_toml(data_dir.path(), &[("etcrepo", repo_dir.path())]);
+
+    // --no-ignore alone: the dot-dir is still pruned by the hidden filter.
+    let no_ignore_only = run_ok(
+        legion_cmd(data_dir.path())
+            .env("XDG_STATE_HOME", state_dir.path())
+            .args([
+                "sym",
+                "etc",
+                "find-content",
+                "needle",
+                "--repo",
+                "etcrepo",
+                "--no-ignore",
+            ]),
+    );
+    assert!(
+        !no_ignore_only.contains(".rafters"),
+        "--no-ignore alone must not reach a gitignored dot-dir, got:\n{no_ignore_only}"
+    );
+
+    // --no-ignore + --hidden together: the dot-dir is reached.
+    let both = run_ok(
+        legion_cmd(data_dir.path())
+            .env("XDG_STATE_HOME", state_dir.path())
+            .args([
+                "sym",
+                "etc",
+                "find-content",
+                "needle",
+                "--repo",
+                "etcrepo",
+                "--no-ignore",
+                "--hidden",
+            ]),
+    );
+    assert!(
+        both.contains(".rafters/output/rafters.css:1: needle"),
+        "--no-ignore + --hidden together must reach the gitignored dot-dir, got:\n{both}"
+    );
+}
+
 // -- extract (#708) --
 
 #[test]


### PR DESCRIPTION
## Summary

Adds `--no-ignore` to `legion sym etc find-content`, mirroring ripgrep's `-u`/`--no-ignore`,
so a gitignored-but-load-bearing directory (e.g. rafters' generated `.rafters/` workspace)
can be reached through the sanctioned grep replacement instead of forcing a shell-cat/grep
bypass of the fair-guard (#704). The flag is independent of the existing `--hidden`: a
gitignored dot-directory needs both together, since the hidden-file filter prunes dot-paths
regardless of ignore-file state. `.git/` stays excluded under every combination.

## Acceptance criteria mapping

### 1. All tests pass, including the four new `find_content` tests and a CLI-level test confirming `--no-ignore` parses independently of `--hidden`

All four named unit tests exist and pass in `src/etc.rs`:
`no_ignore_includes_gitignored_non_hidden_files`, `no_ignore_alone_does_not_reach_gitignored_dot_dir`,
`no_ignore_plus_hidden_reaches_gitignored_dot_dir`, `no_ignore_still_excludes_git_dir`.

Evidence: `cargo test --quiet` -- lib: 1335 passed, 0 failed, 2 ignored; integration: 238
passed, 0 failed, 2 ignored. `cargo fmt --check` and `cargo clippy --all-targets
--all-features -- -D warnings` both clean.

The CLI-level parsing test is `find_content_no_ignore_flag_parses_independently_of_hidden`
in `tests/integration/etc.rs:293-322` -- it invokes the built binary with `--no-ignore` and
no `--hidden` present, and asserts stdout contains the gitignored file's hit line, closing
the exact clap-wiring gap the acceptance criterion names.

A second integration test, `find_content_no_ignore_and_hidden_together_reach_gitignored_dot_dir`
(`tests/integration/etc.rs:328-380`), replays the rafters field report end-to-end at the
binary level: `--no-ignore` alone does not surface `.rafters/`, `--no-ignore --hidden`
together does, asserting on the exact `.rafters/output/rafters.css:1: needle` line.

### 2. Simplify pass completed

Gate recorded: `legion quality-gate check --skill legion-simplify --result clean
--findings-count 0` -- gate id `019f36a7-0252-7c31-ba51-fc5b43cb429e`, articulation covering
all three changed files (`src/cli/index_cmd.rs`, `src/etc.rs`, `tests/integration/etc.rs`).
No structural issues found: the new flag reuses the exact plumbing pattern the pre-existing
`hidden` flag already established (same three call sites, same parameter-passthrough shape),
and the five new `WalkBuilder` toggles (`parents`, `ignore`, `git_ignore`, `git_exclude`,
`git_global`) are individually necessary because the `ignore` crate exposes no single
"disable everything" switch.

### 3. Review pass completed and issues fixed

The pre-push hook ran a PR review on the pushed commit and returned PASS with no CRITICAL or
HIGH issues; it verified the flag wiring is correct end to end, the default-false path is
byte-identical to prior behavior (all five toggles pass `true` when `no_ignore` is false,
matching the `ignore` crate's own defaults), `.git/` exclusion is independent of both flags
via the pre-existing `filter_entry` guard, and test coverage hits all four load-bearing
combinations. One informational (non-blocking) note was raised: `EtcUsageRecord` does not
capture `no_ignore` in telemetry -- consistent with the existing omission of `hidden` from
the same struct, so no change was made (see Deliberately not done).

Evidence: `git push origin feat/745-find-content-no-ignore` pre-push hook output --
"PASS: No CRITICAL or HIGH issues found."

### 4. PR created and linked to this issue

This PR is opened via `legion pr create --repo legion --title 'feat(#745): ...' --body
<this file>` against `head=feat/745-find-content-no-ignore`. The `#745` in the title and
this body's own references to issue #745 throughout are what GitHub's linking picks up to
associate the PR with the issue (closing keywords are not used since this PR alone does not
close the parent epic #704).

Evidence: PR title carries the literal substring `#745`, and the branch name
`feat/745-find-content-no-ignore` itself encodes the issue number, matching this repo's
established branch-naming convention for issue-linked work (see recent merged PRs #737-#739,
each titled `feat(#<issue>): ...`).

## Deliberately not done

- **`EtcUsageRecord` telemetry for `no_ignore`** -- not requested by the issue, and the
  existing `hidden` flag already lacks a telemetry field, so adding one for `no_ignore` alone
  would be an inconsistent half-step. Flagged as a follow-up if flag-usage metrics matter for
  epic #704.
- **Extending `sym tree` / `sym etc find-file` to see gitignored generated directories** --
  those two shapes read the pre-built `file_inventory` table populated once at `legion index`
  time; a query-time CLI flag on `find-content` cannot reach rows an inventory walk never
  wrote. That needs a build-time include mechanism (e.g. a `watch.toml` per-repo key), which
  is a distinct schema and walk-behavior change tracked in the parallel inventory-staleness
  issue, not this one.
- **Expanding the hardcoded always-excluded set beyond `.git/`** -- e.g. permanently denying
  `node_modules/`/`target/` independent of gitignore. Out of scope per the issue; `.git/`
  remains the sole hardcoded exclusion, everything else is gitignore's call, now escapable
  via `--no-ignore`.
- **`sym etc extract`, `sym tree`, `sym etc find-file` themselves** -- unaffected; this change
  touches only `find_content`'s live directory walk.
- **CSS-symbol read surface (bullpen 019f355c, item 1)** -- unrelated code path, no shared
  logic with this change.