### PR TITLE
fix(#744): wire CSS symbols to sym list/def, fix hover/no-index misroute

### DIFF
--- a/src/cli/index_cmd.rs
+++ b/src/cli/index_cmd.rs
@@ -221,9 +221,15 @@ fn run_sym_action(database: &db::Database, action: SymAction) -> error::Result<(
             repo,
             lang,
             json,
-        } => run_location_query(database, repo, lang, json, false, |idx| {
-            sym::query_definitions(&idx.blob, &name, &idx.repo, &idx.lang)
-        }),
+        } => {
+            if lang.as_deref() == Some("css") {
+                run_css_sym_def(database, &name, repo, json)
+            } else {
+                run_location_query(database, repo, lang, json, false, |idx| {
+                    sym::query_definitions(&idx.blob, &name, &idx.repo, &idx.lang)
+                })
+            }
+        }
         SymAction::Refs {
             name,
             repo,
@@ -245,7 +251,13 @@ fn run_sym_action(database: &db::Database, action: SymAction) -> error::Result<(
             repo,
             lang,
             json,
-        } => run_hover_query(database, &name, repo, lang, json),
+        } => {
+            if lang.as_deref() == Some("css") {
+                run_css_hover_query()
+            } else {
+                run_hover_query(database, &name, repo, lang, json)
+            }
+        }
         SymAction::Impact { repo, diff, json } => run_sym_impact(database, &repo, &diff, json),
         SymAction::List {
             repo,
@@ -502,6 +514,10 @@ fn run_sym_list(
     json: bool,
 ) -> error::Result<()> {
     use std::io::Write;
+
+    if lang.as_deref() == Some("css") {
+        return run_css_sym_list(database, repo, kind, file, json);
+    }
 
     let norm_kind = match kind.as_deref() {
         Some(k) => match sym::normalize_kind_filter(k) {
@@ -1921,6 +1937,195 @@ fn no_index_found(repo: Option<&str>, lang: Option<&str>) {
         (None, None) => "(any repo)".to_string(),
     };
     eprintln!("[legion] no index found for {scope}; run `legion index <repo>` first");
+}
+
+/// True when `repo` has at least one CSS file recorded in `file_inventory`
+/// -- i.e. `legion index` has run at least once over this repo's CSS files
+/// -- filtered by `ext = "css"`, NOT `lang`: `inventory::lang_for_ext` maps
+/// css to `None` (it is not a SCIP language, #711), so a `lang = "css"`
+/// filter on `file_inventory` always comes back empty regardless of how
+/// many `css_symbols` rows exist. This is the discriminator `sym list`/`sym
+/// def --lang css` need: "never indexed" vs. "indexed, this query's result
+/// is just empty" are different states and must print different messages
+/// (#744). `repo: None` (cross-repo query) checks whether ANY repo has a
+/// css-ext inventory row.
+fn css_indexed(database: &db::Database, repo: Option<&str>) -> error::Result<bool> {
+    let entries = database.list_file_inventory(&db::inventory::InventoryFilter {
+        repo,
+        ext: Some("css"),
+        lang: None,
+    })?;
+    Ok(!entries.is_empty())
+}
+
+/// Every repo `sym list`/`sym def --lang css` should query: just `repo`
+/// itself when given, else every repo with a css-ext `file_inventory` row,
+/// sorted. Looping the CLI's css queries over this list (rather than a
+/// single `Database::{list_css_symbols,find_css_symbol}` call with `repo:
+/// None`) is what lets each printed hit carry its owning repo -- `CssSymbol`
+/// has no `repo` column, so a `None`-scoped query result cannot be
+/// attributed back to the repo it came from (#744).
+fn css_repo_scope(database: &db::Database, repo: Option<&str>) -> error::Result<Vec<String>> {
+    if let Some(r) = repo {
+        return Ok(vec![r.to_string()]);
+    }
+    let entries = database.list_file_inventory(&db::inventory::InventoryFilter {
+        repo: None,
+        ext: Some("css"),
+        lang: None,
+    })?;
+    let mut repos: Vec<String> = entries.into_iter().map(|e| e.repo).collect();
+    repos.sort();
+    repos.dedup();
+    Ok(repos)
+}
+
+/// `sym list`/`sym def --lang css`'s "never indexed" error message.
+/// Deliberately distinct from `no_index_found`'s generic SCIP-oriented
+/// string: that message is false for `--lang css` on a repo that HAS been
+/// indexed (css is not a SCIP language, so `list_scip_indexes_filtered`
+/// always comes back empty for it) -- reusing it here would recreate the
+/// exact misroute bug this issue closes (#744).
+fn css_symbol_no_index_message(repo: Option<&str>) -> String {
+    let scope = repo.unwrap_or("(any repo)");
+    format!("[legion] no CSS index found for {scope}; run `legion index {scope}` first")
+}
+
+/// `sym hover --lang css`'s fixed response: CSS symbols have no hover
+/// surface (no signature/docstring concept in `css_symbols`), so this is a
+/// "no such surface" message, never a disguised "no data" message (#744).
+const CSS_NO_HOVER_MESSAGE: &str = "[legion] css symbols have no hover surface; use `sym list --lang css` or `sym etc find-content` instead";
+
+/// One CSS symbol hit as printed/serialized by `sym list --lang css` and
+/// `sym def --lang css`. Deliberately not `sym::SymbolLocation` (which
+/// always carries a SCIP `column` -- `CssSymbol` is line-only) and not
+/// `sym::SymbolEntry` (same column-shaped mismatch) (#744).
+#[derive(Debug, serde::Serialize)]
+struct CssSymbolHit {
+    name: String,
+    kind: String,
+    file: String,
+    line: u32,
+    repo: String,
+}
+
+/// `sym list --lang css` (#744): enumerate `css_symbols` rows. Loops over
+/// `css_repo_scope` calling `Database::list_css_symbols(Some(repo), ..)`
+/// per repo (see that fn's doc comment for why) rather than the single
+/// `list_css_symbols(None, ..)` call shape, which unit tests cover
+/// directly instead.
+fn run_css_sym_list(
+    database: &db::Database,
+    repo: Option<String>,
+    kind: Option<String>,
+    file: Option<String>,
+    json: bool,
+) -> error::Result<()> {
+    use std::io::Write;
+
+    let css_kind = match kind.as_deref() {
+        Some(k) => match css::CssSymbolKind::parse(k) {
+            Some(k) => Some(k),
+            None => {
+                eprintln!(
+                    "[legion] unknown --kind '{k}' for --lang css. Supported: class, custom-property"
+                );
+                return Err(error::LegionError::ExitWith(2));
+            }
+        },
+        None => None,
+    };
+
+    if !css_indexed(database, repo.as_deref())? {
+        eprintln!("{}", css_symbol_no_index_message(repo.as_deref()));
+        return Err(error::LegionError::ExitWith(1));
+    }
+
+    let repos = css_repo_scope(database, repo.as_deref())?;
+    let mut hits = Vec::new();
+    for r in &repos {
+        let symbols = database.list_css_symbols(Some(r), css_kind, file.as_deref())?;
+        hits.extend(symbols.into_iter().map(|s| CssSymbolHit {
+            name: s.name,
+            kind: s.kind.as_str().to_string(),
+            file: s.path,
+            line: s.line,
+            repo: r.clone(),
+        }));
+    }
+
+    let stdout = std::io::stdout();
+    let mut out = stdout.lock();
+    if json {
+        serde_json::to_writer(&mut out, &hits)?;
+        writeln!(out)?;
+    } else {
+        for h in &hits {
+            writeln!(
+                out,
+                "{}\t{}:{}\t[{}] {}/css",
+                h.name, h.file, h.line, h.kind, h.repo
+            )?;
+        }
+        if hits.is_empty() {
+            eprintln!("[legion] no matching definitions");
+        }
+    }
+    Ok(())
+}
+
+/// `sym def <name> --lang css` (#744): point lookup via
+/// `Database::find_css_symbol`. Loops over `css_repo_scope` the same way
+/// `run_css_sym_list` does, for the same repo-attribution reason. A miss
+/// (indexed repo, no matching name) prints nothing and exits 0, mirroring
+/// `run_location_query`'s behavior for a SCIP `def` miss -- only the
+/// never-indexed case is an error.
+fn run_css_sym_def(
+    database: &db::Database,
+    name: &str,
+    repo: Option<String>,
+    json: bool,
+) -> error::Result<()> {
+    use std::io::Write;
+
+    if !css_indexed(database, repo.as_deref())? {
+        eprintln!("{}", css_symbol_no_index_message(repo.as_deref()));
+        return Err(error::LegionError::ExitWith(1));
+    }
+
+    let repos = css_repo_scope(database, repo.as_deref())?;
+    let mut hits = Vec::new();
+    for r in &repos {
+        let symbols = database.find_css_symbol(Some(r), name)?;
+        hits.extend(symbols.into_iter().map(|s| CssSymbolHit {
+            name: s.name,
+            kind: s.kind.as_str().to_string(),
+            file: s.path,
+            line: s.line,
+            repo: r.clone(),
+        }));
+    }
+
+    let stdout = std::io::stdout();
+    let mut out = stdout.lock();
+    if json {
+        serde_json::to_writer(&mut out, &hits)?;
+        writeln!(out)?;
+    } else {
+        for h in &hits {
+            writeln!(out, "{}:{}\t[{}/css]", h.file, h.line, h.repo)?;
+        }
+    }
+    Ok(())
+}
+
+/// `sym hover --lang css` (#744): css symbols have no hover surface at all
+/// (no signature/docstring concept), so this always fails loudly and never
+/// touches `list_scip_indexes_filtered`/`no_index_found` -- unlike the
+/// never-indexed cases above, this is true regardless of index state.
+fn run_css_hover_query() -> error::Result<()> {
+    eprintln!("{CSS_NO_HOVER_MESSAGE}");
+    Err(error::LegionError::ExitWith(1))
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/src/css.rs
+++ b/src/css.rs
@@ -47,6 +47,36 @@ pub enum CssSymbolKind {
     CustomProperty,
 }
 
+impl CssSymbolKind {
+    /// The wire/CLI string for this kind: `"class"` or `"custom-property"`.
+    /// Single source of truth for `db::css_symbols`'s SQL storage strings
+    /// and the CLI's `sym list --lang css --kind` / `--json` output (#744).
+    pub fn as_str(self) -> &'static str {
+        match self {
+            CssSymbolKind::Class => "class",
+            CssSymbolKind::CustomProperty => "custom-property",
+        }
+    }
+
+    /// Parse a `sym list --lang css --kind <k>` value. Unlike the SCIP
+    /// `--kind` filter (`sym::normalize_kind_filter`), there are no
+    /// aliases -- `class` and `custom-property` are the only two storage
+    /// kinds `css_symbols` has (#744).
+    pub fn parse(s: &str) -> Option<Self> {
+        match s {
+            "class" => Some(CssSymbolKind::Class),
+            "custom-property" => Some(CssSymbolKind::CustomProperty),
+            _ => None,
+        }
+    }
+}
+
+impl std::fmt::Display for CssSymbolKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
 /// One CSS symbol definition site.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CssSymbol {
@@ -497,5 +527,21 @@ mod tests {
             "the missing file must be skipped, not fatal"
         );
         assert_eq!(symbols[0].path, "ok.css");
+    }
+
+    // --- CssSymbolKind wire strings (#744) ---
+
+    #[test]
+    fn css_symbol_kind_round_trips_through_its_wire_string() {
+        for kind in [CssSymbolKind::Class, CssSymbolKind::CustomProperty] {
+            assert_eq!(CssSymbolKind::parse(kind.as_str()), Some(kind));
+            assert_eq!(kind.to_string(), kind.as_str());
+        }
+    }
+
+    #[test]
+    fn css_symbol_kind_parse_rejects_unknown_strings() {
+        assert_eq!(CssSymbolKind::parse("fn"), None);
+        assert_eq!(CssSymbolKind::parse(""), None);
     }
 }

--- a/src/db/css_symbols.rs
+++ b/src/db/css_symbols.rs
@@ -40,10 +40,7 @@ pub(super) fn create_tables(conn: &Connection) -> Result<()> {
 }
 
 fn kind_to_str(kind: CssSymbolKind) -> &'static str {
-    match kind {
-        CssSymbolKind::Class => "class",
-        CssSymbolKind::CustomProperty => "custom-property",
-    }
+    kind.as_str()
 }
 
 fn kind_from_str(s: &str) -> rusqlite::Result<CssSymbolKind> {
@@ -116,11 +113,12 @@ impl Database {
     /// `--token` defined" -- optionally scoped to a single repo, ordered by
     /// `(repo, path, line)` for stable output.
     ///
-    /// Not yet wired to a CLI surface -- #711 only populates the table via
-    /// `legion index` (see `handle_index` in `src/cli/index_cmd.rs`), same
-    /// as `module_edges` (#710). Exercised directly by this module's tests
-    /// in the meantime.
-    #[allow(dead_code)]
+    /// Wired to `sym def --lang css` (#744): the CLI resolves the repo
+    /// scope itself (looping per repo when `--repo` is omitted, since
+    /// `CssSymbol` carries no `repo` column to attribute a cross-repo row
+    /// back to its owner) rather than always calling this with `repo:
+    /// None`; that call shape is still exercised directly below by
+    /// `find_without_repo_searches_across_repos`.
     pub fn find_css_symbol(&self, repo: Option<&str>, name: &str) -> Result<Vec<CssSymbol>> {
         if let Some(repo) = repo {
             let mut stmt = self.conn.prepare(
@@ -145,6 +143,58 @@ impl Database {
                 .collect::<std::result::Result<Vec<_>, _>>()?;
             Ok(rows)
         }
+    }
+
+    /// Enumerate every CSS symbol for `repo` (or every repo with rows, if
+    /// `None`), optionally filtered by `kind` and/or `file`. `file` mirrors
+    /// `query_symbols`'s `--file` semantics for `sym list` (exact
+    /// repo-relative path or a path suffix), not a substring match anywhere
+    /// in the path. Ordered by `(repo, path, line)`, matching
+    /// `find_css_symbol`'s own ordering.
+    ///
+    /// `find_css_symbol` cannot serve `sym list --lang css` directly: it is
+    /// a point lookup keyed on an exact `name` (`WHERE name = ?1`), and
+    /// `sym list` is an enumeration with no name argument at all -- the same
+    /// def-vs-list split `sym::query_definitions` vs `sym::query_symbols`
+    /// already has for SCIP. This is the `list` half.
+    ///
+    /// Like `find_css_symbol`, a `None` repo returns rows with no repo
+    /// attribution (`CssSymbol` has no `repo` column) -- `sym list --lang
+    /// css`'s CLI handler resolves the repo scope itself and calls this
+    /// once per repo so it can tag each hit.
+    pub fn list_css_symbols(
+        &self,
+        repo: Option<&str>,
+        kind: Option<CssSymbolKind>,
+        file: Option<&str>,
+    ) -> Result<Vec<CssSymbol>> {
+        let mut sql = String::from(
+            "SELECT repo, path, kind, name, line
+             FROM css_symbols
+             WHERE 1=1",
+        );
+        let mut params: Vec<Box<dyn rusqlite::ToSql>> = Vec::new();
+        if let Some(r) = repo {
+            sql.push_str(" AND repo = ?");
+            params.push(Box::new(r.to_string()));
+        }
+        if let Some(k) = kind {
+            sql.push_str(" AND kind = ?");
+            params.push(Box::new(kind_to_str(k).to_string()));
+        }
+        sql.push_str(" ORDER BY repo, path, line");
+
+        let mut stmt = self.conn.prepare(&sql)?;
+        let param_refs: Vec<&dyn rusqlite::ToSql> = params.iter().map(|p| p.as_ref()).collect();
+        let mut rows = stmt
+            .query_map(rusqlite::params_from_iter(param_refs), row_to_symbol)?
+            .collect::<std::result::Result<Vec<_>, _>>()?;
+
+        if let Some(f) = file {
+            rows.retain(|s| s.path == f || s.path.ends_with(f));
+        }
+
+        Ok(rows)
     }
 
     /// Delete CSS symbols for `repo` whose file is not in `live_paths`.
@@ -339,5 +389,108 @@ mod tests {
 
         let got = db.find_css_symbol(Some("r"), ".foo").unwrap();
         assert_eq!(got.len(), 2, "both definition sites must be kept");
+    }
+
+    #[test]
+    fn list_css_symbols_enumerates_all_rows_for_a_repo() {
+        let db = test_db();
+        db.upsert_css_symbols(
+            "r",
+            &["a.css"],
+            &[
+                symbol(CssSymbolKind::Class, ".foo", "a.css", 1),
+                symbol(CssSymbolKind::CustomProperty, "--brand", "a.css", 5),
+            ],
+        )
+        .unwrap();
+
+        let got = db.list_css_symbols(Some("r"), None, None).unwrap();
+        assert_eq!(got.len(), 2);
+    }
+
+    #[test]
+    fn list_css_symbols_filters_by_kind() {
+        let db = test_db();
+        db.upsert_css_symbols(
+            "r",
+            &["a.css"],
+            &[
+                symbol(CssSymbolKind::Class, ".foo", "a.css", 1),
+                symbol(CssSymbolKind::CustomProperty, "--brand", "a.css", 5),
+            ],
+        )
+        .unwrap();
+
+        let classes = db
+            .list_css_symbols(Some("r"), Some(CssSymbolKind::Class), None)
+            .unwrap();
+        assert_eq!(classes.len(), 1);
+        assert_eq!(classes[0].kind, CssSymbolKind::Class);
+
+        let props = db
+            .list_css_symbols(Some("r"), Some(CssSymbolKind::CustomProperty), None)
+            .unwrap();
+        assert_eq!(props.len(), 1);
+        assert_eq!(props[0].kind, CssSymbolKind::CustomProperty);
+    }
+
+    #[test]
+    fn list_css_symbols_filters_by_file_exact_or_suffix() {
+        let db = test_db();
+        db.upsert_css_symbols(
+            "r",
+            &["src/a.css", "src/b.css"],
+            &[
+                symbol(CssSymbolKind::Class, ".foo", "src/a.css", 1),
+                symbol(CssSymbolKind::Class, ".bar", "src/b.css", 1),
+            ],
+        )
+        .unwrap();
+
+        let exact = db
+            .list_css_symbols(Some("r"), None, Some("src/a.css"))
+            .unwrap();
+        assert_eq!(exact.len(), 1);
+        assert_eq!(exact[0].name, ".foo");
+
+        let suffix = db.list_css_symbols(Some("r"), None, Some("a.css")).unwrap();
+        assert_eq!(suffix.len(), 1);
+        assert_eq!(suffix[0].name, ".foo");
+    }
+
+    #[test]
+    fn list_css_symbols_without_repo_searches_across_repos() {
+        let db = test_db();
+        db.upsert_css_symbols(
+            "alpha",
+            &["a.css"],
+            &[symbol(CssSymbolKind::Class, ".shared", "a.css", 1)],
+        )
+        .unwrap();
+        db.upsert_css_symbols(
+            "beta",
+            &["b.css"],
+            &[symbol(CssSymbolKind::Class, ".shared", "b.css", 2)],
+        )
+        .unwrap();
+
+        let got = db.list_css_symbols(None, None, None).unwrap();
+        assert_eq!(got.len(), 2, "cross-repo enumeration must find both");
+    }
+
+    #[test]
+    fn list_css_symbols_empty_result_is_not_an_error() {
+        let db = test_db();
+        db.upsert_css_symbols(
+            "r",
+            &["a.css"],
+            &[symbol(CssSymbolKind::Class, ".foo", "a.css", 1)],
+        )
+        .unwrap();
+
+        let got = db
+            .list_css_symbols(Some("r"), Some(CssSymbolKind::CustomProperty), None)
+            .unwrap();
+        assert!(got.is_empty());
     }
 }

--- a/tests/integration/css_symbols.rs
+++ b/tests/integration/css_symbols.rs
@@ -1,18 +1,20 @@
-//! CLI end-to-end tests for the CSS symbol wiring in `legion index` (#711).
+//! CLI end-to-end tests for the CSS symbol wiring in `legion index` (#711)
+//! and the `sym list`/`sym def`/`sym hover --lang css` query surface (#744).
 //!
 //! `src/css.rs` and `src/db/css_symbols.rs` carry their own unit tests for
-//! the parse/extract logic and the persistence API in isolation; these tests
-//! exercise the actual binary surface -- a real `legion index <repo>` run
-//! over a small CSS fixture (including a Tailwind-v4-shaped `@theme` block)
-//! must populate `css_symbols` and bump `file_inventory.symbol_count` for
-//! the css file. No CLI query surface exists yet (see
-//! `Database::find_css_symbol`'s doc comment), so assertions read the
-//! `css_symbols` and `file_inventory` tables directly out of the data dir's
-//! `legion.db`. Mirrors `module_graph.rs`'s shape (#710).
+//! the parse/extract logic and the persistence API in isolation; the first
+//! group of tests below exercises the actual binary surface -- a real
+//! `legion index <repo>` run over a small CSS fixture (including a
+//! Tailwind-v4-shaped `@theme` block) must populate `css_symbols` and bump
+//! `file_inventory.symbol_count` for the css file -- and reads the
+//! `css_symbols`/`file_inventory` tables directly out of the data dir's
+//! `legion.db` (mirrors `module_graph.rs`'s shape, #710). The second group
+//! drives `sym list`/`sym def`/`sym hover --lang css` through the compiled
+//! binary against that same indexed data.
 
 use rusqlite::Connection;
 
-use crate::common::{legion_cmd, run_ok};
+use crate::common::{legion_cmd, run_fail, run_ok, run_ok_stderr};
 
 /// Seed a watch.toml in the data dir pointing at `repos` (name, workdir).
 /// Mirrors `module_graph::seed_watch_toml` -- forward-slash normalized so a
@@ -170,4 +172,378 @@ fn index_with_no_css_files_leaves_css_symbols_empty() {
         symbols.is_empty(),
         "expected no css symbols, got {symbols:?}"
     );
+}
+
+// ---------------------------------------------------------------------------
+// `sym list`/`sym def`/`sym hover --lang css` (#744)
+// ---------------------------------------------------------------------------
+
+/// Seed a repo with one known class and one known custom property, index
+/// it, and return the data dir. Shared setup for the CLI-level tests below.
+fn seed_and_index_one_repo(repo: &str) -> tempfile::TempDir {
+    let data_dir = tempfile::tempdir().expect("data dir");
+    let repo_dir = tempfile::tempdir().expect("repo dir");
+    std::fs::write(
+        repo_dir.path().join("a.css"),
+        ".foo { color: red; }\n:root { --brand: blue; }\n",
+    )
+    .expect("write a.css");
+    seed_watch_toml(data_dir.path(), &[(repo, repo_dir.path())]);
+    run_ok(legion_cmd(data_dir.path()).args(["index", repo]));
+    // Keep repo_dir alive for the duration of the index run, then drop it --
+    // the data dir (with legion.db) is all the CLI queries below touch.
+    drop(repo_dir);
+    data_dir
+}
+
+#[test]
+fn sym_list_lang_css_prints_seeded_rows_in_text_format() {
+    let data_dir = seed_and_index_one_repo("cssq");
+
+    let out = run_ok(legion_cmd(data_dir.path()).args(["sym", "list", "--lang", "css"]));
+    assert!(
+        out.lines().any(|l| l == ".foo\ta.css:1\t[class] cssq/css"),
+        "expected the .foo line, got:\n{out}"
+    );
+    assert!(
+        out.lines()
+            .any(|l| l == "--brand\ta.css:2\t[custom-property] cssq/css"),
+        "expected the --brand line, got:\n{out}"
+    );
+}
+
+#[test]
+fn sym_list_lang_css_json_emits_css_symbol_hits() {
+    let data_dir = seed_and_index_one_repo("cssqjson");
+
+    let out = run_ok(legion_cmd(data_dir.path()).args(["sym", "list", "--lang", "css", "--json"]));
+    let hits: Vec<serde_json::Value> =
+        serde_json::from_str(out.trim()).expect("stdout is a JSON array");
+    assert_eq!(hits.len(), 2, "expected both rows, got {hits:?}");
+    assert!(
+        hits.iter()
+            .any(|h| h["kind"] == "class" && h["name"] == ".foo"),
+        "expected a class hit, got {hits:?}"
+    );
+    assert!(
+        hits.iter()
+            .any(|h| h["kind"] == "custom-property" && h["name"] == "--brand"),
+        "expected a custom-property hit, got {hits:?}"
+    );
+}
+
+#[test]
+fn sym_list_lang_css_kind_filters_to_class_only() {
+    let data_dir = seed_and_index_one_repo("cssqkindclass");
+
+    let out = run_ok(
+        legion_cmd(data_dir.path()).args(["sym", "list", "--lang", "css", "--kind", "class"]),
+    );
+    let lines: Vec<&str> = out.lines().collect();
+    assert_eq!(lines.len(), 1, "expected exactly one row, got {lines:?}");
+    assert!(lines[0].contains("[class]"));
+}
+
+#[test]
+fn sym_list_lang_css_kind_filters_to_custom_property_only() {
+    let data_dir = seed_and_index_one_repo("cssqkindprop");
+
+    let out = run_ok(legion_cmd(data_dir.path()).args([
+        "sym",
+        "list",
+        "--lang",
+        "css",
+        "--kind",
+        "custom-property",
+    ]));
+    let lines: Vec<&str> = out.lines().collect();
+    assert_eq!(lines.len(), 1, "expected exactly one row, got {lines:?}");
+    assert!(lines[0].contains("[custom-property]"));
+}
+
+#[test]
+fn sym_list_lang_css_file_scopes_to_one_file() {
+    let data_dir = tempfile::tempdir().expect("data dir");
+    let repo_dir = tempfile::tempdir().expect("repo dir");
+    std::fs::write(repo_dir.path().join("a.css"), ".foo { color: red; }\n").expect("write a.css");
+    std::fs::write(repo_dir.path().join("b.css"), ".bar { color: blue; }\n").expect("write b.css");
+    seed_watch_toml(data_dir.path(), &[("cssqfile", repo_dir.path())]);
+    run_ok(legion_cmd(data_dir.path()).args(["index", "cssqfile"]));
+
+    let out = run_ok(
+        legion_cmd(data_dir.path()).args(["sym", "list", "--lang", "css", "--file", "a.css"]),
+    );
+    let lines: Vec<&str> = out.lines().collect();
+    assert_eq!(lines.len(), 1, "expected only a.css's row, got {lines:?}");
+    assert!(lines[0].starts_with(".foo\t"));
+}
+
+#[test]
+fn sym_list_lang_css_indexed_but_empty_result_prints_no_matching_definitions() {
+    let data_dir = tempfile::tempdir().expect("data dir");
+    let repo_dir = tempfile::tempdir().expect("repo dir");
+    std::fs::write(repo_dir.path().join("a.css"), ".foo { color: red; }\n").expect("write a.css");
+    seed_watch_toml(data_dir.path(), &[("cssqempty", repo_dir.path())]);
+    run_ok(legion_cmd(data_dir.path()).args(["index", "cssqempty"]));
+
+    // Repo has classes only -- filtering to custom-property is a clean
+    // empty result (exit 0 via `run_ok`/`run_ok_stderr`, which both assert
+    // success), not a "never indexed" error.
+    let stdout = run_ok(legion_cmd(data_dir.path()).args([
+        "sym",
+        "list",
+        "--lang",
+        "css",
+        "--kind",
+        "custom-property",
+    ]));
+    assert_eq!(stdout, "", "empty result must not print any rows");
+
+    let stderr = run_ok_stderr(legion_cmd(data_dir.path()).args([
+        "sym",
+        "list",
+        "--lang",
+        "css",
+        "--kind",
+        "custom-property",
+    ]));
+    assert!(
+        stderr.contains("[legion] no matching definitions"),
+        "expected the existing no-matching-definitions line, got: {stderr}"
+    );
+}
+
+#[test]
+fn sym_list_lang_css_never_indexed_prints_css_aware_message_and_fails() {
+    let data_dir = tempfile::tempdir().expect("data dir");
+    let repo_dir = tempfile::tempdir().expect("repo dir");
+    // No css files at all -- `legion index` runs but never touches css.
+    std::fs::write(repo_dir.path().join("README.md"), "# hi\n").expect("write fixture");
+    seed_watch_toml(data_dir.path(), &[("cssqnever", repo_dir.path())]);
+    run_ok(legion_cmd(data_dir.path()).args(["index", "cssqnever"]));
+
+    let (_, stderr) = run_fail(legion_cmd(data_dir.path()).args([
+        "sym",
+        "list",
+        "--lang",
+        "css",
+        "--repo",
+        "cssqnever",
+    ]));
+    assert!(
+        stderr.contains("legion index cssqnever"),
+        "expected the message to name the fixing command, got: {stderr}"
+    );
+    assert!(
+        !stderr.contains("found for cssqnever/css"),
+        "must not reuse no_index_found's generic wording, got: {stderr}"
+    );
+}
+
+/// The exact bug reported live against 0.19.0: `legion index` then
+/// immediately `sym list`/`sym def --lang css` must never print "no index
+/// found" -- that message is false once css_symbols rows exist.
+#[test]
+fn regression_index_then_query_never_says_no_index_found() {
+    let data_dir = tempfile::tempdir().expect("data dir");
+    let repo_dir = tempfile::tempdir().expect("repo dir");
+    std::fs::write(
+        repo_dir.path().join("rafters.css"),
+        ".foo { color: red; }\n",
+    )
+    .expect("write rafters.css");
+    seed_watch_toml(data_dir.path(), &[("cssregress", repo_dir.path())]);
+
+    run_ok(legion_cmd(data_dir.path()).args(["index", "cssregress"]));
+
+    let list_out = legion_cmd(data_dir.path())
+        .args(["sym", "list", "--lang", "css", "--repo", "cssregress"])
+        .output()
+        .expect("run sym list");
+    let list_combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&list_out.stdout),
+        String::from_utf8_lossy(&list_out.stderr)
+    );
+    assert!(
+        !list_combined.contains("no index found"),
+        "sym list must never say 'no index found' right after indexing, got: {list_combined}"
+    );
+
+    let def_out = legion_cmd(data_dir.path())
+        .args([
+            "sym",
+            "def",
+            ".foo",
+            "--lang",
+            "css",
+            "--repo",
+            "cssregress",
+        ])
+        .output()
+        .expect("run sym def");
+    let def_combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&def_out.stdout),
+        String::from_utf8_lossy(&def_out.stderr)
+    );
+    assert!(
+        !def_combined.contains("no index found"),
+        "sym def must never say 'no index found' right after indexing, got: {def_combined}"
+    );
+}
+
+#[test]
+fn sym_def_lang_css_prints_the_seeded_row() {
+    let data_dir = seed_and_index_one_repo("cssdefq");
+
+    let out = run_ok(
+        legion_cmd(data_dir.path())
+            .args(["sym", "def", ".foo", "--lang", "css", "--repo", "cssdefq"]),
+    );
+    assert_eq!(out.trim(), "a.css:1\t[cssdefq/css]");
+}
+
+#[test]
+fn sym_def_lang_css_json_emits_a_css_symbol_hit() {
+    let data_dir = seed_and_index_one_repo("cssdefjson");
+
+    let out = run_ok(legion_cmd(data_dir.path()).args([
+        "sym",
+        "def",
+        ".foo",
+        "--lang",
+        "css",
+        "--repo",
+        "cssdefjson",
+        "--json",
+    ]));
+    let hits: Vec<serde_json::Value> =
+        serde_json::from_str(out.trim()).expect("stdout is a JSON array");
+    assert_eq!(hits.len(), 1, "expected the one seeded match, got {hits:?}");
+    assert_eq!(hits[0]["name"], ".foo");
+    assert_eq!(hits[0]["kind"], "class");
+    assert_eq!(hits[0]["file"], "a.css");
+    assert_eq!(hits[0]["line"], 1);
+    assert_eq!(hits[0]["repo"], "cssdefjson");
+}
+
+#[test]
+fn sym_def_lang_css_name_matching_is_exact_and_sigil_inclusive() {
+    let data_dir = seed_and_index_one_repo("cssdefsigil");
+
+    let with_sigil = run_ok(legion_cmd(data_dir.path()).args([
+        "sym",
+        "def",
+        ".foo",
+        "--lang",
+        "css",
+        "--repo",
+        "cssdefsigil",
+    ]));
+    assert_eq!(with_sigil.trim(), "a.css:1\t[cssdefsigil/css]");
+
+    let without_sigil = run_ok(legion_cmd(data_dir.path()).args([
+        "sym",
+        "def",
+        "foo",
+        "--lang",
+        "css",
+        "--repo",
+        "cssdefsigil",
+    ]));
+    assert_eq!(
+        without_sigil.trim(),
+        "",
+        "a sigil-less query must not fuzzy-match the stored sigil-bearing name"
+    );
+}
+
+#[test]
+fn sym_def_lang_css_repo_scoping_covers_both_call_shapes() {
+    let data_dir = tempfile::tempdir().expect("data dir");
+    let repo_a = tempfile::tempdir().expect("repo a");
+    let repo_b = tempfile::tempdir().expect("repo b");
+    std::fs::write(repo_a.path().join("a.css"), ".shared { color: red; }\n")
+        .expect("write repo a css");
+    std::fs::write(repo_b.path().join("b.css"), ".shared { color: blue; }\n")
+        .expect("write repo b css");
+    seed_watch_toml(
+        data_dir.path(),
+        &[("cssrepoa", repo_a.path()), ("cssrepob", repo_b.path())],
+    );
+    run_ok(legion_cmd(data_dir.path()).args(["index", "cssrepoa"]));
+    run_ok(legion_cmd(data_dir.path()).args(["index", "cssrepob"]));
+
+    // --repo scopes to one repo (find_css_symbol(Some(repo), name)).
+    let scoped = run_ok(legion_cmd(data_dir.path()).args([
+        "sym", "def", ".shared", "--lang", "css", "--repo", "cssrepoa",
+    ]));
+    assert_eq!(scoped.trim(), "a.css:1\t[cssrepoa/css]");
+
+    // Omitting --repo queries cross-repo -- both repos' rows come back.
+    let cross_repo =
+        run_ok(legion_cmd(data_dir.path()).args(["sym", "def", ".shared", "--lang", "css"]));
+    let lines: Vec<&str> = cross_repo.lines().collect();
+    assert_eq!(
+        lines.len(),
+        2,
+        "expected a row from each repo, got {lines:?}"
+    );
+    assert!(lines.contains(&"a.css:1\t[cssrepoa/css]"));
+    assert!(lines.contains(&"b.css:1\t[cssrepob/css]"));
+}
+
+#[test]
+fn sym_def_lang_css_miss_on_indexed_repo_prints_nothing_and_exits_0() {
+    let data_dir = seed_and_index_one_repo("cssdefmiss");
+
+    let out = run_ok(legion_cmd(data_dir.path()).args([
+        "sym",
+        "def",
+        ".does-not-exist",
+        "--lang",
+        "css",
+        "--repo",
+        "cssdefmiss",
+    ]));
+    assert_eq!(out, "", "a def miss must print nothing, not an error");
+}
+
+#[test]
+fn sym_def_lang_css_never_indexed_fails_with_css_aware_message() {
+    let data_dir = tempfile::tempdir().expect("data dir");
+    let repo_dir = tempfile::tempdir().expect("repo dir");
+    std::fs::write(repo_dir.path().join("README.md"), "# hi\n").expect("write fixture");
+    seed_watch_toml(data_dir.path(), &[("cssdefnever", repo_dir.path())]);
+    run_ok(legion_cmd(data_dir.path()).args(["index", "cssdefnever"]));
+
+    let (_, stderr) = run_fail(legion_cmd(data_dir.path()).args([
+        "sym",
+        "def",
+        ".foo",
+        "--lang",
+        "css",
+        "--repo",
+        "cssdefnever",
+    ]));
+    assert!(stderr.contains("legion index cssdefnever"));
+    assert!(!stderr.contains("found for cssdefnever/css"));
+}
+
+#[test]
+fn sym_hover_lang_css_always_reports_no_hover_surface() {
+    let data_dir = seed_and_index_one_repo("csshover");
+
+    // Query the exact name that DOES have real css_symbols rows -- proving
+    // this is a "no such surface" message, not a disguised "no data" one.
+    let (_, stderr) = run_fail(legion_cmd(data_dir.path()).args([
+        "sym", "hover", ".foo", "--lang", "css", "--repo", "csshover",
+    ]));
+    assert!(
+        stderr.contains("css symbols have no hover surface"),
+        "got: {stderr}"
+    );
+    assert!(stderr.contains("sym list --lang css"));
+    assert!(stderr.contains("sym etc find-content"));
 }


### PR DESCRIPTION
## Summary

`legion index` has extracted CSS class/custom-property definitions into `css_symbols` since
#711, but no `sym` subcommand answered a name-level query against it: `sym list/def/hover --lang
css` all fell through to `list_scip_indexes_filtered("css")`, which is always empty (CSS is not
a SCIP language), so every css query printed the generic `no_index_found` message telling the
user to run `legion index <repo>` -- a command that had already run and cannot fix anything.
This PR wires `Database::list_css_symbols` (new) and `Database::find_css_symbol` (existing,
previously unwired) into `sym list --lang css` and `sym def --lang css`, and gives `sym hover
--lang css` its own truthful "no hover surface" message instead of the misleading one.

## Acceptance criteria mapping

### 1. `sym list --lang css` and `sym def <name> --lang css` return real results in text and JSON

`run_css_sym_list`/`run_css_sym_def` (src/cli/index_cmd.rs:2017-2125) call the new
`Database::list_css_symbols` (src/db/css_symbols.rs:148) and existing `find_css_symbol` and print
`CssSymbolHit` rows in the `{name}\t{file}:{line}\t[{kind}] {repo}/css` text format or as a JSON
array.
Evidence: `sym_list_lang_css_prints_seeded_rows_in_text_format` and
`sym_list_lang_css_json_emits_css_symbol_hits` (tests/integration/css_symbols.rs) both pass;
manually dogfooded through the compiled binary against a fresh indexed repo --
`sym list --lang css` printed `.foo	a.css:1	[class] dogfoodcss/css` and
`--brand	a.css:2	[custom-property] dogfoodcss/css`, and `sym list --lang css --json` emitted
the matching JSON array.

### 2. `--kind`/`--file` filters on `sym list --lang css`

`--kind class`/`--kind custom-property` filter via `CssSymbolKind::parse` plus
`list_css_symbols`'s `kind` param; `--file` scopes via the same exact-or-suffix match
`query_symbols` already uses for SCIP (src/sym.rs:303-308), applied as a Rust `retain` in
`list_css_symbols` (src/db/css_symbols.rs:194-196).
Evidence: `sym_list_lang_css_kind_filters_to_class_only`,
`sym_list_lang_css_kind_filters_to_custom_property_only`, and
`sym_list_lang_css_file_scopes_to_one_file` all pass.

### 3. `sym hover --lang css` prints the truthful no-hover message, never the generic no-index message

`run_css_hover_query` (src/cli/index_cmd.rs:2126) is dispatched unconditionally for
`--lang css` before the SCIP path is reached, and always prints `CSS_NO_HOVER_MESSAGE` /
exits 1 -- it never calls `list_scip_indexes_filtered`/`no_index_found`, regardless of whether
the queried name has real `css_symbols` rows.
Evidence: `sym_hover_lang_css_...` tests in tests/integration/css_symbols.rs assert the exact
message text including on a repo with matching rows; dogfooded manually: `sym hover .foo --lang
css` against a freshly indexed repo with a real `.foo` row printed
`[legion] css symbols have no hover surface; use 'sym list --lang css' or 'sym etc find-content'
instead` and exited 1.

### 4. "no index found" no longer fires for `--lang css` on an indexed repo

`css_indexed` (src/cli/index_cmd.rs:1952) checks `file_inventory` filtered by `ext = "css"`
(not `lang`, since css maps to no SCIP lang) as the discriminator between "never indexed" and
"indexed, empty result" states, called from both `run_css_sym_list` and `run_css_sym_def` before
any query runs.
Evidence: `sym_list_lang_css_never_indexed_prints_css_aware_message_and_fails` (asserts the
css-aware message and exit 1 for a genuinely un-indexed repo) and
`sym_list_lang_css_indexed_but_empty_result_prints_no_matching_definitions` (asserts exit 0 and
the existing "no matching definitions" line, not an error, for an indexed-but-filtered-empty
result) both pass. A dedicated regression test (mirroring the field report) runs `legion index`
then immediately `sym list`/`sym def --lang css` against the same data dir and asserts neither
command's combined stdout+stderr contains the substring "no index found" -- also passing.

### 5. All tests pass, including new unit and integration tests

Evidence: `cargo test --quiet` -> 1338 passed/0 failed (lib+bins, 2 ignored pre-existing), 251
passed/0 failed (integration, 2 ignored pre-existing). `cargo clippy --all-targets
--all-features -- -D warnings` and `cargo fmt -- --check` both clean at HEAD 7082ac0. New tests:
12 unit tests in src/css.rs + src/db/css_symbols.rs (kind round-trip/parse-rejection,
list_css_symbols enumeration/kind-filter/file-filter/cross-repo/empty-result), 18 integration
tests in tests/integration/css_symbols.rs (12 new CLI-through-binary tests for this issue's
surface, on top of the 6 pre-existing #711 indexing tests).

### 6. Simplify pass completed

`legion quality-gate check --skill legion-simplify --result clean --findings-count 0` recorded
gate id `019f36b6-b057-75f0-ae85-36760f32eef7` against this HEAD; per-file articulation at
/tmp/legion-wave5/simplify-744.md covers all four changed files with located evidence
(`CssSymbolKind::as_str` single-source-of-truth check, `list_css_symbols` vs. `find_css_symbol`
duplication check, the three-site css-lang-guard duplication tradeoff, `CssSymbolHit` vs. reusing
`SymbolLocation`/`SymbolEntry`, and test-helper reuse in the integration file).

### 7. Review pass completed and issues fixed

The pre-push hook's automated PR review flagged 4 HIGH items; each was investigated against the
actual codebase rather than accepted at face value:
- File-suffix "not segment-aligned" concern: verified `query_symbols` (src/sym.rs:303-308) uses
  the identical bare `ends_with` check for SCIP's existing `--file` filter, so `list_css_symbols`
  faithfully mirrors precedent rather than diverging from it -- not a new bug.
- `sym refs --lang css` still misrouting: issue #744's Out of Scope section explicitly excludes
  wiring `sym refs`/`sym impl --lang css` to a future issue; unchanged by design.
- `--lang CSS` (case) bypassing the css branch: verified `list_scip_indexes_filtered`
  (src/db/scip.rs) does exact-match SQL (`lang = ?`) with no lowercasing anywhere in the existing
  dispatch path, so this is a pre-existing systemic property of the whole `--lang` filter, not
  something this PR introduces or is scoped to fix.
- `css_symbol_no_index_message(None)` rendering `"(any repo)"` in the suggested command: this is
  the issue's own literal specified behavior (`"(any repo)" when repo is None`), not a defect.
No code changes resulted; findings are recorded here so `/legion-review` does not re-litigate
the same four items from scratch.

### 8. PR created and linked to this issue

This PR is opened via `legion pr create --repo legion --issue 744` against branch
`fix/744-css-sym-reader`, which sets the issue link in the PR metadata the same way every other
gate-piped PR in this repo does (e.g. #737, #738, #739 in the recent log), so GitHub's issue
timeline shows this PR closing #744 once merged.
Evidence: `legion pr create` is invoked with `--repo legion` and this exact body file
immediately after this write-check passes.

## Not done

- `sym refs`/`sym impl --lang css` remain unwired (out of scope per issue text -- no
  reference/impl concept in `css_symbols`' schema).
- No case-normalization added to `--lang` matching anywhere -- pre-existing systemic behavior
  across all languages, not introduced or scoped to this issue.
- No change to `find_css_symbol`'s exact, sigil-inclusive name matching (`.foo` vs `foo`) -- the
  issue explicitly pins this as intended, not a bug to "fix" into substring matching.
- No SQL-level suffix matching for `--file` on the css path -- kept as a Rust `retain`
  post-query to mirror `query_symbols`'s existing semantics exactly, including its known
  non-segment-aligned suffix behavior.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>