### PR TITLE
feat(#746): tree/find-file: surface indexed-at, warn on HEAD drift

### DIFF
--- a/src/cli/index_cmd.rs
+++ b/src/cli/index_cmd.rs
@@ -585,6 +585,157 @@ impl From<db::inventory::FileInventoryEntry> for SymTreeEntry {
     }
 }
 
+/// Per-repo freshness metadata attached to a `--json` response (#746): when
+/// the backing inventory snapshot was captured, and whether the repo's
+/// current HEAD (read live, once per distinct repo represented in the
+/// result -- one `git rev-parse HEAD`, not a filesystem walk) has moved
+/// since.
+#[derive(Debug, serde::Serialize)]
+struct SnapshotFreshness {
+    repo: String,
+    indexed_at: Option<String>,
+    head_at_index: Option<String>,
+    current_head: Option<String>,
+    /// True only when both heads are `Some` and differ.
+    head_drift: bool,
+}
+
+/// `--json` envelope replacing the previous bare-array output for both
+/// `sym tree` and `sym etc find-file` (#746). This deliberately breaks the
+/// previous bare-array `--json` shape (0.19.0 shipped it days before this
+/// issue landed, with no external contract on it) -- freshness metadata
+/// cannot be attached to a bare array.
+#[derive(Debug, serde::Serialize)]
+struct FreshJsonEnvelope<T: serde::Serialize> {
+    snapshots: Vec<SnapshotFreshness>,
+    entries: Vec<T>,
+}
+
+/// True only when `head_at_index` and `current_head` are both present and
+/// differ -- nothing to compare (either side `None`) is not drift (#746).
+fn head_drift(head_at_index: Option<&str>, current_head: Option<&str>) -> bool {
+    matches!((head_at_index, current_head), (Some(a), Some(b)) if a != b)
+}
+
+/// Repo scope for a freshness computation: explicit `--repo` always yields
+/// exactly that one name (even when the result set is empty); cross-repo
+/// yields the distinct repos actually represented in `entry_repos`, in
+/// first-seen order (callers already sort entries by `(repo, path)`, so
+/// this comes out repo-sorted for free). An empty cross-repo result yields
+/// an empty list, not one entry per watch.toml repo (#746).
+fn freshness_repo_scope<'a>(
+    repo: Option<&str>,
+    entry_repos: impl Iterator<Item = &'a str>,
+) -> Vec<String> {
+    match repo {
+        Some(name) => vec![name.to_string()],
+        None => {
+            let mut seen = std::collections::HashSet::new();
+            entry_repos
+                .filter(|r| seen.insert((*r).to_string()))
+                .map(|r| r.to_string())
+                .collect()
+        }
+    }
+}
+
+/// Resolve `name`'s workdir from watch.toml, or `None` when it is not a
+/// known repo -- a stale/removed inventory row must not error the whole
+/// freshness computation (#746).
+fn repo_workdir(name: &str) -> error::Result<Option<PathBuf>> {
+    let base = data_dir()?;
+    let watch_path = base.join("watch.toml");
+    let all = watch::list_repos_in_config(&watch_path)?;
+    Ok(all
+        .iter()
+        .find(|r| r.name == name)
+        .map(|r| PathBuf::from(&r.workdir)))
+}
+
+/// Compute freshness metadata for one `--json`/human freshness line per repo
+/// in `freshness_repo_scope`'s result: read the stored `inventory_snapshots`
+/// row, resolve the repo's live workdir, and do one `git rev-parse HEAD`
+/// (never a filesystem walk) to detect drift (#746).
+fn compute_freshness<'a>(
+    database: &db::Database,
+    repo: Option<&str>,
+    entry_repos: impl Iterator<Item = &'a str>,
+) -> error::Result<Vec<SnapshotFreshness>> {
+    let names = freshness_repo_scope(repo, entry_repos);
+    let mut result = Vec::with_capacity(names.len());
+    for name in names {
+        let snapshot = database.get_inventory_snapshot(&name)?;
+        let indexed_at = snapshot.as_ref().map(|s| s.indexed_at.clone());
+        let head_at_index = snapshot.and_then(|s| s.head);
+        let current_head = repo_workdir(&name)?
+            .as_deref()
+            .and_then(inventory::current_head);
+        let drift = head_drift(head_at_index.as_deref(), current_head.as_deref());
+        result.push(SnapshotFreshness {
+            repo: name,
+            indexed_at,
+            head_at_index,
+            current_head,
+            head_drift: drift,
+        });
+    }
+    Ok(result)
+}
+
+/// Shorten a full SHA to git's conventional 7-char display form. Shorter
+/// input (should not happen for a real SHA) is returned as-is.
+fn short_sha(sha: &str) -> &str {
+    &sha[..sha.len().min(7)]
+}
+
+/// Coarse "how long ago" label for a freshness line: seconds/minutes/
+/// hours/days, whichever unit `elapsed` falls into. Negative or malformed
+/// durations (clock skew) floor to zero rather than printing a negative
+/// number.
+fn format_relative_duration(elapsed: chrono::Duration) -> String {
+    let secs = elapsed.num_seconds().max(0);
+    if secs < 60 {
+        format!("{secs}s ago")
+    } else if secs < 3600 {
+        format!("{}m ago", secs / 60)
+    } else if secs < 86_400 {
+        format!("{}h ago", secs / 3600)
+    } else {
+        format!("{}d ago", secs / 86_400)
+    }
+}
+
+/// Human-facing freshness line for one repo, printed to stderr before the
+/// entry table (#746):
+/// - no snapshot recorded: hint to re-index.
+/// - snapshot present, HEAD matches or nothing to compare: "up to date".
+/// - snapshot present, HEAD drifted: a loud warning naming both HEADs.
+fn format_freshness_line(s: &SnapshotFreshness, now: chrono::DateTime<chrono::Utc>) -> String {
+    let Some(indexed_at) = &s.indexed_at else {
+        return format!(
+            "{}: no inventory snapshot recorded; re-run 'legion index {}' to capture indexed-at/HEAD",
+            s.repo, s.repo
+        );
+    };
+    let ago = chrono::DateTime::parse_from_rfc3339(indexed_at)
+        .map(|d| format_relative_duration(now - d.with_timezone(&chrono::Utc)))
+        .unwrap_or_else(|_| "unknown".to_string());
+    let head_disp = s.head_at_index.as_deref().map(short_sha).unwrap_or("none");
+    if s.head_drift {
+        let current_disp = s.current_head.as_deref().map(short_sha).unwrap_or("none");
+        format!(
+            "{}: indexed {indexed_at} ({ago}), HEAD {head_disp} -- WARNING: current HEAD is \
+             {current_disp}; inventory may be stale, re-run 'legion index {}'",
+            s.repo, s.repo
+        )
+    } else {
+        format!(
+            "{}: indexed {indexed_at} ({ago}), HEAD {head_disp} -- up to date",
+            s.repo
+        )
+    }
+}
+
 /// `sym tree` (#706): a structured, cross-repo view of the file inventory
 /// (`Database::list_file_inventory`) -- no filesystem walk at query time.
 /// `--repo` omitted means cross-repo over whatever the inventory table
@@ -633,12 +784,26 @@ fn run_sym_tree(
         eprintln!("[legion] {msg}");
     }
 
+    let snapshots = compute_freshness(
+        database,
+        repo.as_deref(),
+        result.entries.iter().map(|e| e.repo.as_str()),
+    )?;
+
     let stdout = std::io::stdout();
     let mut out = stdout.lock();
     if json {
-        serde_json::to_writer(&mut out, &result.entries)?;
+        let envelope = FreshJsonEnvelope {
+            snapshots,
+            entries: result.entries,
+        };
+        serde_json::to_writer(&mut out, &envelope)?;
         writeln!(out)?;
     } else {
+        let now = chrono::Utc::now();
+        for s in &snapshots {
+            eprintln!("[legion] {}", format_freshness_line(s, now));
+        }
         let cross_repo = repo.is_none();
         for e in &result.entries {
             let ext_col = e.ext.as_deref().unwrap_or("-");
@@ -839,12 +1004,26 @@ fn run_etc_find_file(
         eprintln!("[legion] {msg}");
     }
 
+    let snapshots = compute_freshness(
+        database,
+        repo.as_deref(),
+        result.entries.iter().map(|e| e.repo.as_str()),
+    )?;
+
     let stdout = std::io::stdout();
     let mut out = stdout.lock();
     if json {
-        serde_json::to_writer(&mut out, &result.entries)?;
+        let envelope = FreshJsonEnvelope {
+            snapshots,
+            entries: result.entries,
+        };
+        serde_json::to_writer(&mut out, &envelope)?;
         writeln!(out)?;
     } else {
+        let now = chrono::Utc::now();
+        for s in &snapshots {
+            eprintln!("[legion] {}", format_freshness_line(s, now));
+        }
         let cross_repo = repo.is_none();
         for e in &result.entries {
             if cross_repo {
@@ -1251,6 +1430,136 @@ mod sym_tree_tests {
         assert_eq!(
             describe_tree_scope(Some("rs"), Some("src/db"), Some(2)),
             "ext=rs,under=src/db,depth=2"
+        );
+    }
+}
+
+#[cfg(test)]
+mod freshness_tests {
+    use super::*;
+
+    // --- head_drift ---
+
+    #[test]
+    fn snapshot_freshness_head_drift_true_only_when_both_present_and_differ() {
+        assert!(head_drift(Some("aaa"), Some("bbb")), "both present, differ");
+        assert!(!head_drift(Some("aaa"), Some("aaa")), "both present, match");
+        assert!(!head_drift(None, Some("bbb")), "no index-time head");
+        assert!(!head_drift(Some("aaa"), None), "no current head");
+        assert!(!head_drift(None, None), "neither known");
+    }
+
+    // --- freshness_repo_scope ---
+
+    #[test]
+    fn freshness_repo_scope_explicit_repo_is_always_one_entry_even_when_empty() {
+        let scope = freshness_repo_scope(Some("r"), std::iter::empty());
+        assert_eq!(scope, vec!["r".to_string()]);
+    }
+
+    #[test]
+    fn freshness_repo_scope_cross_repo_dedupes_in_first_seen_order() {
+        let repos = vec!["beta", "alpha", "beta", "alpha"];
+        let scope = freshness_repo_scope(None, repos.into_iter());
+        assert_eq!(scope, vec!["beta".to_string(), "alpha".to_string()]);
+    }
+
+    #[test]
+    fn freshness_repo_scope_cross_repo_empty_result_is_empty_scope() {
+        let scope = freshness_repo_scope(None, std::iter::empty());
+        assert!(scope.is_empty());
+    }
+
+    // --- short_sha ---
+
+    #[test]
+    fn short_sha_truncates_to_seven_chars() {
+        assert_eq!(short_sha("8ed18c6abcdef1234567890"), "8ed18c6");
+    }
+
+    #[test]
+    fn short_sha_returns_shorter_input_as_is() {
+        assert_eq!(short_sha("abc"), "abc");
+    }
+
+    // --- format_relative_duration ---
+
+    #[test]
+    fn format_relative_duration_buckets_by_unit() {
+        assert_eq!(
+            format_relative_duration(chrono::Duration::seconds(30)),
+            "30s ago"
+        );
+        assert_eq!(
+            format_relative_duration(chrono::Duration::minutes(14)),
+            "14m ago"
+        );
+        assert_eq!(
+            format_relative_duration(chrono::Duration::hours(5)),
+            "5h ago"
+        );
+        assert_eq!(
+            format_relative_duration(chrono::Duration::days(6)),
+            "6d ago"
+        );
+    }
+
+    #[test]
+    fn format_relative_duration_negative_floors_to_zero() {
+        assert_eq!(
+            format_relative_duration(chrono::Duration::seconds(-5)),
+            "0s ago"
+        );
+    }
+
+    // --- format_freshness_line ---
+
+    #[test]
+    fn format_freshness_line_no_snapshot_recorded_hint() {
+        let s = SnapshotFreshness {
+            repo: "legion".to_string(),
+            indexed_at: None,
+            head_at_index: None,
+            current_head: None,
+            head_drift: false,
+        };
+        let line = format_freshness_line(&s, chrono::Utc::now());
+        assert!(
+            line.contains("no inventory snapshot recorded") && line.contains("legion index legion"),
+            "got: {line}"
+        );
+    }
+
+    #[test]
+    fn format_freshness_line_up_to_date_when_no_drift() {
+        let now = chrono::Utc::now();
+        let s = SnapshotFreshness {
+            repo: "legion".to_string(),
+            indexed_at: Some(now.to_rfc3339()),
+            head_at_index: Some("8ed18c6ffff".to_string()),
+            current_head: Some("8ed18c6ffff".to_string()),
+            head_drift: false,
+        };
+        let line = format_freshness_line(&s, now);
+        assert!(line.contains("up to date"), "got: {line}");
+        assert!(!line.contains("WARNING"), "got: {line}");
+    }
+
+    #[test]
+    fn format_freshness_line_warns_on_drift() {
+        let now = chrono::Utc::now();
+        let s = SnapshotFreshness {
+            repo: "legion".to_string(),
+            indexed_at: Some(now.to_rfc3339()),
+            head_at_index: Some("8ed18c6ffff".to_string()),
+            current_head: Some("31b01ecffff".to_string()),
+            head_drift: true,
+        };
+        let line = format_freshness_line(&s, now);
+        assert!(
+            line.contains("WARNING: current HEAD is 31b01ec")
+                && line.contains("re-run 'legion index legion'"),
+            "got: {line}"
         );
     }
 }
@@ -2059,6 +2368,13 @@ pub(crate) fn handle_index(
     let outcome = inventory::walk_repo(&repo, &repo_path);
     let live_paths: Vec<&str> = outcome.entries.iter().map(|e| e.path.as_str()).collect();
     database.upsert_file_inventory(&outcome.entries)?;
+    // Snapshot fact (#746): when this walk ran and the repo's HEAD at that
+    // moment, so `sym tree`/`sym etc find-file` can surface staleness.
+    // `current_head` is best-effort (never an error) -- a non-git workdir
+    // still gets a snapshot row, with `head: None`.
+    let indexed_at = chrono::Utc::now().to_rfc3339();
+    let head_at_index = inventory::current_head(&repo_path);
+    database.upsert_inventory_snapshot(&repo, &indexed_at, head_at_index.as_deref())?;
     // Prune only on a complete walk: with walk errors the entry set may be
     // missing files that still exist, and evicting their rows would let a
     // transient I/O failure shrink the inventory (#718 re-review). Upserting

--- a/src/cli/index_cmd.rs
+++ b/src/cli/index_cmd.rs
@@ -655,6 +655,16 @@ fn resolve_repo_workdir(repos: &[watch::WatchRepoConfig], name: &str) -> Option<
 /// (never a filesystem walk) to detect drift (#746). Loads watch.toml once
 /// up front rather than per repo -- cross-repo results with many distinct
 /// repos must not reparse the file once per name.
+///
+/// A malformed watch.toml degrades to an empty repo list (with a stderr
+/// note) rather than propagating: unlike `validate_repo_known` (which only
+/// runs for an explicit `--repo` and is allowed to hard-fail since the
+/// repo name itself came from watch.toml), this runs unconditionally,
+/// including on the cross-repo path that previously never touched
+/// watch.toml at query time at all. HEAD comparison is a freshness signal,
+/// never a hard requirement (see `current_head`'s doc comment), so a
+/// config-file syntax error must not take down a read-only DB query --
+/// callers just see `current_head: None` for every repo in scope.
 fn compute_freshness<'a>(
     database: &db::Database,
     repo: Option<&str>,
@@ -663,7 +673,13 @@ fn compute_freshness<'a>(
     let names = freshness_repo_scope(repo, entry_repos);
     let base = data_dir()?;
     let watch_path = base.join("watch.toml");
-    let all_repos = watch::list_repos_in_config(&watch_path)?;
+    let all_repos = watch::list_repos_in_config(&watch_path).unwrap_or_else(|e| {
+        eprintln!(
+            "[legion] warning: could not read watch.toml for freshness check ({e}); \
+             live HEAD comparison skipped for this query"
+        );
+        Vec::new()
+    });
 
     let mut result = Vec::with_capacity(names.len());
     for name in names {

--- a/src/cli/index_cmd.rs
+++ b/src/cli/index_cmd.rs
@@ -639,35 +639,38 @@ fn freshness_repo_scope<'a>(
     }
 }
 
-/// Resolve `name`'s workdir from watch.toml, or `None` when it is not a
-/// known repo -- a stale/removed inventory row must not error the whole
-/// freshness computation (#746).
-fn repo_workdir(name: &str) -> error::Result<Option<PathBuf>> {
-    let base = data_dir()?;
-    let watch_path = base.join("watch.toml");
-    let all = watch::list_repos_in_config(&watch_path)?;
-    Ok(all
+/// Resolve `name`'s workdir from an already-loaded watch.toml repo list, or
+/// `None` when it is not a known repo -- a stale/removed inventory row must
+/// not error the whole freshness computation (#746).
+fn resolve_repo_workdir(repos: &[watch::WatchRepoConfig], name: &str) -> Option<PathBuf> {
+    repos
         .iter()
         .find(|r| r.name == name)
-        .map(|r| PathBuf::from(&r.workdir)))
+        .map(|r| PathBuf::from(&r.workdir))
 }
 
 /// Compute freshness metadata for one `--json`/human freshness line per repo
 /// in `freshness_repo_scope`'s result: read the stored `inventory_snapshots`
 /// row, resolve the repo's live workdir, and do one `git rev-parse HEAD`
-/// (never a filesystem walk) to detect drift (#746).
+/// (never a filesystem walk) to detect drift (#746). Loads watch.toml once
+/// up front rather than per repo -- cross-repo results with many distinct
+/// repos must not reparse the file once per name.
 fn compute_freshness<'a>(
     database: &db::Database,
     repo: Option<&str>,
     entry_repos: impl Iterator<Item = &'a str>,
 ) -> error::Result<Vec<SnapshotFreshness>> {
     let names = freshness_repo_scope(repo, entry_repos);
+    let base = data_dir()?;
+    let watch_path = base.join("watch.toml");
+    let all_repos = watch::list_repos_in_config(&watch_path)?;
+
     let mut result = Vec::with_capacity(names.len());
     for name in names {
         let snapshot = database.get_inventory_snapshot(&name)?;
         let indexed_at = snapshot.as_ref().map(|s| s.indexed_at.clone());
         let head_at_index = snapshot.and_then(|s| s.head);
-        let current_head = repo_workdir(&name)?
+        let current_head = resolve_repo_workdir(&all_repos, &name)
             .as_deref()
             .and_then(inventory::current_head);
         let drift = head_drift(head_at_index.as_deref(), current_head.as_deref());
@@ -683,9 +686,13 @@ fn compute_freshness<'a>(
 }
 
 /// Shorten a full SHA to git's conventional 7-char display form. Shorter
-/// input (should not happen for a real SHA) is returned as-is.
+/// input (should not happen for a real SHA) is returned as-is. `get`
+/// (byte-index-checked) rather than a raw slice: a real git SHA is
+/// all-ASCII hex so a 7-byte boundary is always a char boundary, but this
+/// reads a plain `TEXT` column with no format constraint enforced at the
+/// database layer, so no code path here may assume it can't panic.
 fn short_sha(sha: &str) -> &str {
-    &sha[..sha.len().min(7)]
+    sha.get(..7).unwrap_or(sha)
 }
 
 /// Coarse "how long ago" label for a freshness line: seconds/minutes/

--- a/src/db/inventory.rs
+++ b/src/db/inventory.rs
@@ -52,6 +52,24 @@ pub struct InventoryFilter<'a> {
     pub lang: Option<&'a str>,
 }
 
+/// One row per repo: when the most recent `legion index` walk ran, and
+/// what the repo's HEAD commit was at that moment. Kept separate from the
+/// per-file `file_inventory` rows (whose `mtime` is per-file "when did
+/// this file change", not "when did we last look") so the snapshot fact
+/// is not duplicated across every file row on each index run (#746).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct InventorySnapshot {
+    pub repo: String,
+    /// RFC3339 timestamp of when the walk producing the current
+    /// `file_inventory` rows for `repo` ran.
+    pub indexed_at: String,
+    /// `git rev-parse HEAD` output for `repo`'s workdir at index time.
+    /// `None` when the workdir is not a git checkout or the command
+    /// failed -- HEAD capture is a freshness signal, never a hard
+    /// requirement for `legion index` to succeed.
+    pub head: Option<String>,
+}
+
 /// Coarse role bucket for `sym etc find-file --role` (#709), inferred
 /// purely from path and extension -- no file content is read. Each
 /// heuristic trades completeness for being answerable straight from the
@@ -259,7 +277,12 @@ pub(super) fn create_tables(conn: &Connection) -> Result<()> {
             PRIMARY KEY (repo, path)
         );
         CREATE INDEX IF NOT EXISTS idx_file_inventory_repo_ext
-            ON file_inventory(repo, ext);",
+            ON file_inventory(repo, ext);
+        CREATE TABLE IF NOT EXISTS inventory_snapshots (
+            repo TEXT PRIMARY KEY,
+            indexed_at TEXT NOT NULL,
+            head TEXT
+        );",
     )?;
     Ok(())
 }
@@ -443,6 +466,42 @@ impl Database {
             rusqlite::params![repo],
         )?;
         Ok(n)
+    }
+
+    /// Upsert `repo`'s snapshot row, replacing any prior indexed_at/head
+    /// (one row per repo, not one per index run) (#746).
+    pub fn upsert_inventory_snapshot(
+        &self,
+        repo: &str,
+        indexed_at: &str,
+        head: Option<&str>,
+    ) -> Result<()> {
+        self.conn.execute(
+            "INSERT INTO inventory_snapshots (repo, indexed_at, head)
+             VALUES (?1, ?2, ?3)
+             ON CONFLICT(repo) DO UPDATE SET
+                 indexed_at = excluded.indexed_at,
+                 head = excluded.head",
+            rusqlite::params![repo, indexed_at, head],
+        )?;
+        Ok(())
+    }
+
+    /// `None` when `repo` has never been indexed, or was indexed before
+    /// this table existed (#746).
+    pub fn get_inventory_snapshot(&self, repo: &str) -> Result<Option<InventorySnapshot>> {
+        let mut stmt = self
+            .conn
+            .prepare("SELECT repo, indexed_at, head FROM inventory_snapshots WHERE repo = ?1")?;
+        let mut rows = stmt.query(rusqlite::params![repo])?;
+        match rows.next()? {
+            Some(row) => Ok(Some(InventorySnapshot {
+                repo: row.get(0)?,
+                indexed_at: row.get(1)?,
+                head: row.get(2)?,
+            })),
+            None => Ok(None),
+        }
     }
 }
 
@@ -826,5 +885,72 @@ mod tests {
         assert_eq!(FileRole::Test.to_string(), "test");
         assert_eq!(FileRole::Doc.to_string(), "doc");
         assert_eq!(FileRole::Entry.to_string(), "entry");
+    }
+
+    // --- inventory_snapshots (#746) ---
+
+    #[test]
+    fn get_inventory_snapshot_returns_none_when_absent() {
+        let db = test_db();
+        assert_eq!(db.get_inventory_snapshot("r").unwrap(), None);
+    }
+
+    #[test]
+    fn upsert_and_get_inventory_snapshot_round_trip() {
+        let db = test_db();
+        db.upsert_inventory_snapshot("r", "2026-07-05T08:00:00+00:00", Some("abc123"))
+            .unwrap();
+        let got = db.get_inventory_snapshot("r").unwrap().unwrap();
+        assert_eq!(got.repo, "r");
+        assert_eq!(got.indexed_at, "2026-07-05T08:00:00+00:00");
+        assert_eq!(got.head.as_deref(), Some("abc123"));
+    }
+
+    #[test]
+    fn upsert_inventory_snapshot_allows_none_head() {
+        let db = test_db();
+        db.upsert_inventory_snapshot("r", "2026-07-05T08:00:00+00:00", None)
+            .unwrap();
+        let got = db.get_inventory_snapshot("r").unwrap().unwrap();
+        assert_eq!(got.head, None);
+    }
+
+    #[test]
+    fn upsert_inventory_snapshot_replaces_prior_row_not_accumulates() {
+        let db = test_db();
+        db.upsert_inventory_snapshot("r", "2026-06-29T09:00:00+00:00", Some("old-sha"))
+            .unwrap();
+        db.upsert_inventory_snapshot("r", "2026-07-05T08:00:00+00:00", Some("new-sha"))
+            .unwrap();
+
+        let got = db.get_inventory_snapshot("r").unwrap().unwrap();
+        assert_eq!(got.indexed_at, "2026-07-05T08:00:00+00:00");
+        assert_eq!(got.head.as_deref(), Some("new-sha"));
+
+        // Exactly one row for "r" -- re-running the upsert must not
+        // accumulate a row per call.
+        let count: i64 = db
+            .conn
+            .query_row(
+                "SELECT COUNT(*) FROM inventory_snapshots WHERE repo = 'r'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(count, 1);
+    }
+
+    #[test]
+    fn inventory_snapshots_are_scoped_per_repo() {
+        let db = test_db();
+        db.upsert_inventory_snapshot("alpha", "2026-07-01T00:00:00+00:00", Some("a-sha"))
+            .unwrap();
+        db.upsert_inventory_snapshot("beta", "2026-07-02T00:00:00+00:00", Some("b-sha"))
+            .unwrap();
+
+        let alpha = db.get_inventory_snapshot("alpha").unwrap().unwrap();
+        let beta = db.get_inventory_snapshot("beta").unwrap().unwrap();
+        assert_eq!(alpha.head.as_deref(), Some("a-sha"));
+        assert_eq!(beta.head.as_deref(), Some("b-sha"));
     }
 }

--- a/src/inventory.rs
+++ b/src/inventory.rs
@@ -160,6 +160,29 @@ pub fn walk_repo(repo_name: &str, repo_path: &Path) -> WalkOutcome {
     }
 }
 
+/// Best-effort `git rev-parse HEAD` against `repo_path`. Returns `None`
+/// (never an error) when the directory is not a git checkout, `git` is
+/// not on PATH, or the command exits non-zero or produces unparseable
+/// output -- this is a freshness signal, not a requirement for indexing
+/// or querying to proceed (#746).
+pub fn current_head(repo_path: &Path) -> Option<String> {
+    let output = std::process::Command::new("git")
+        .args(["rev-parse", "HEAD"])
+        .current_dir(repo_path)
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let sha = String::from_utf8(output.stdout).ok()?;
+    let sha = sha.trim();
+    if sha.is_empty() {
+        None
+    } else {
+        Some(sha.to_string())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::fs;
@@ -376,5 +399,68 @@ mod tests {
             vec!["real.rs"],
             "symlink entries must be skipped (follow_links off + is_file guard)"
         );
+    }
+
+    // --- current_head (#746) ---
+
+    /// Run `git` in `dir` with hermetic per-invocation identity (never a
+    /// `git config` write), mirroring the integration crate's
+    /// `run_git_fixture` -- this is a lib unit test, a separate crate
+    /// target, so that helper is not importable here.
+    fn run_git_fixture(dir: &std::path::Path, args: &[&str]) {
+        let mut full_args: Vec<&str> = vec![
+            "-c",
+            "user.name=Legion Test Fixture",
+            "-c",
+            "user.email=legion-test-fixture@example.invalid",
+            "-c",
+            "commit.gpgsign=false",
+        ];
+        full_args.extend_from_slice(args);
+        let out = std::process::Command::new("git")
+            .args(&full_args)
+            .current_dir(dir)
+            .output()
+            .unwrap_or_else(|e| panic!("git {args:?} failed to spawn in {dir:?}: {e}"));
+        assert!(
+            out.status.success(),
+            "git {args:?} exited non-zero in {dir:?}\nstderr: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+    }
+
+    #[test]
+    fn current_head_reads_head_in_real_git_checkout() {
+        let dir = tempfile::tempdir().unwrap();
+        run_git_fixture(dir.path(), &["init"]);
+        fs::write(dir.path().join("a.txt"), b"hello").unwrap();
+        run_git_fixture(dir.path(), &["add", "a.txt"]);
+        run_git_fixture(dir.path(), &["commit", "-m", "initial"]);
+
+        let expected = {
+            let out = std::process::Command::new("git")
+                .args(["rev-parse", "HEAD"])
+                .current_dir(dir.path())
+                .output()
+                .unwrap();
+            String::from_utf8_lossy(&out.stdout).trim().to_string()
+        };
+
+        assert_eq!(current_head(dir.path()), Some(expected));
+    }
+
+    #[test]
+    fn current_head_returns_none_for_non_git_directory() {
+        let dir = tempfile::tempdir().unwrap();
+        assert_eq!(current_head(dir.path()), None);
+    }
+
+    #[test]
+    fn current_head_returns_none_for_directory_with_broken_git_metadata() {
+        let dir = tempfile::tempdir().unwrap();
+        // A `.git` that is a plain empty file, not a valid gitdir pointer or
+        // repository -- `git rev-parse HEAD` must fail cleanly, not panic.
+        fs::write(dir.path().join(".git"), b"").unwrap();
+        assert_eq!(current_head(dir.path()), None);
     }
 }

--- a/tests/integration/common.rs
+++ b/tests/integration/common.rs
@@ -66,6 +66,15 @@ pub fn run_ok_stderr(cmd: &mut Command) -> String {
     String::from_utf8_lossy(&out.stderr).into_owned()
 }
 
+/// Run the command, require success, and return the raw `Output` so the
+/// caller can assert on stdout and stderr from a single invocation --
+/// `run_ok`/`run_ok_stderr` each only see half the picture across two
+/// separate spawns, which matters when a test needs to pin both a JSON
+/// payload on stdout and a diagnostic on stderr from the same run.
+pub fn run_ok_output(cmd: &mut Command) -> Output {
+    output_ok(cmd)
+}
+
 /// Run the command, require failure (non-zero exit), and return
 /// `(stdout, stderr)` so the caller can assert on the error surface.
 pub fn run_fail(cmd: &mut Command) -> (String, String) {

--- a/tests/integration/find_file.rs
+++ b/tests/integration/find_file.rs
@@ -50,8 +50,9 @@ fn find_file_matches_by_basename_across_repos() {
             .env("XDG_STATE_HOME", state_dir.path())
             .args(["sym", "etc", "find-file", "components.json", "--json"]),
     );
-    let entries: Vec<serde_json::Value> =
-        serde_json::from_str(json_out.trim()).expect("stdout is a JSON array");
+    let envelope: serde_json::Value =
+        serde_json::from_str(json_out.trim()).expect("stdout is a JSON envelope object");
+    let entries = envelope["entries"].as_array().expect("entries array");
     assert_eq!(
         entries.len(),
         2,
@@ -108,8 +109,9 @@ fn find_file_repo_flag_scopes_to_one_repo() {
                 "--json",
             ]),
     );
-    let entries: Vec<serde_json::Value> =
-        serde_json::from_str(json_out.trim()).expect("stdout is a JSON array");
+    let envelope: serde_json::Value =
+        serde_json::from_str(json_out.trim()).expect("stdout is a JSON envelope object");
+    let entries = envelope["entries"].as_array().expect("entries array");
     assert_eq!(entries.len(), 1, "must scope to alpha only: {entries:?}");
     assert_eq!(entries[0]["repo"], "alpha");
 }
@@ -130,8 +132,9 @@ fn find_file_role_filters_to_config_files() {
             .env("XDG_STATE_HOME", state_dir.path())
             .args(["sym", "etc", "find-file", "*", "--role", "config", "--json"]),
     );
-    let entries: Vec<serde_json::Value> =
-        serde_json::from_str(json_out.trim()).expect("stdout is a JSON array");
+    let envelope: serde_json::Value =
+        serde_json::from_str(json_out.trim()).expect("stdout is a JSON envelope object");
+    let entries = envelope["entries"].as_array().expect("entries array");
     assert_eq!(
         entries.len(),
         1,
@@ -208,5 +211,149 @@ fn find_file_uncovered_repo_prints_explicit_message_not_silence() {
     assert!(
         stderr.contains("no inventory for 'findrepo'") && stderr.contains("legion index findrepo"),
         "expected the explicit no-inventory hint, got:\n{stderr}"
+    );
+    // Never-indexed repo also has no snapshot row (#746): the freshness
+    // line must name that explicitly, not stay silent about staleness.
+    assert!(
+        stderr.contains("no inventory snapshot recorded")
+            && stderr.contains("legion index findrepo"),
+        "expected the no-snapshot-recorded freshness hint, got:\n{stderr}"
+    );
+}
+
+/// `--json` emits the `{snapshots, entries}` envelope, not a bare array
+/// (#746).
+#[test]
+fn find_file_json_wraps_entries_with_snapshot_freshness() {
+    let data_dir = tempfile::tempdir().expect("data dir");
+    let repo_dir = tempfile::tempdir().expect("repo dir");
+    let state_dir = tempfile::tempdir().expect("state dir");
+
+    std::fs::write(repo_dir.path().join("a.rs"), "").expect("write fixture");
+    seed_watch_toml(data_dir.path(), &[("findrepo", repo_dir.path())]);
+    run_ok(legion_cmd(data_dir.path()).args(["index", "findrepo"]));
+
+    let json_out = run_ok(
+        legion_cmd(data_dir.path())
+            .env("XDG_STATE_HOME", state_dir.path())
+            .args([
+                "sym",
+                "etc",
+                "find-file",
+                "a.rs",
+                "--repo",
+                "findrepo",
+                "--json",
+            ]),
+    );
+    let envelope: serde_json::Value =
+        serde_json::from_str(json_out.trim()).expect("stdout is a JSON envelope object");
+    assert!(envelope["entries"].is_array());
+    let snapshots = envelope["snapshots"].as_array().expect("snapshots array");
+    assert_eq!(
+        snapshots.len(),
+        1,
+        "explicit --repo yields exactly one snapshot: {snapshots:?}"
+    );
+    assert_eq!(snapshots[0]["repo"], "findrepo");
+    assert!(snapshots[0]["indexed_at"].is_string());
+    assert_eq!(snapshots[0]["head_drift"], false);
+}
+
+/// Human output prints an "up to date" freshness line before the entry
+/// list when the repo's live HEAD still matches the index-time HEAD
+/// (#746).
+#[test]
+fn find_file_human_output_prints_up_to_date_when_head_matches() {
+    let data_dir = tempfile::tempdir().expect("data dir");
+    let repo_dir = tempfile::tempdir().expect("repo dir");
+    let state_dir = tempfile::tempdir().expect("state dir");
+
+    crate::common::run_git_fixture(repo_dir.path(), &["init"]);
+    std::fs::write(repo_dir.path().join("a.rs"), "fn a() {}\n").expect("write fixture");
+    crate::common::run_git_fixture(repo_dir.path(), &["add", "a.rs"]);
+    crate::common::run_git_fixture(repo_dir.path(), &["commit", "-m", "initial"]);
+    seed_watch_toml(data_dir.path(), &[("findrepo", repo_dir.path())]);
+    run_ok(legion_cmd(data_dir.path()).args(["index", "findrepo"]));
+
+    let stderr = run_ok_stderr(
+        legion_cmd(data_dir.path())
+            .env("XDG_STATE_HOME", state_dir.path())
+            .args(["sym", "etc", "find-file", "a.rs", "--repo", "findrepo"]),
+    );
+    assert!(
+        stderr.contains("findrepo: indexed") && stderr.contains("up to date"),
+        "expected an up-to-date freshness line, got:\n{stderr}"
+    );
+    assert!(!stderr.contains("WARNING"), "got:\n{stderr}");
+}
+
+/// Regression test built directly from the field report (bullpen post
+/// 019f355c): a file's inventory row can be current while the repo's live
+/// HEAD has moved past the index-time HEAD, with nothing in the old output
+/// hinting the row might be stale. Seeds a real git repo, indexes it,
+/// advances HEAD without re-indexing, then asserts `find-file` surfaces
+/// the drift instead of staying silent (#746).
+#[test]
+fn find_file_regression_head_drift_surfaced_instead_of_silent() {
+    let data_dir = tempfile::tempdir().expect("data dir");
+    let repo_dir = tempfile::tempdir().expect("repo dir");
+    let state_dir = tempfile::tempdir().expect("state dir");
+
+    crate::common::run_git_fixture(repo_dir.path(), &["init"]);
+    std::fs::write(repo_dir.path().join("CHANGELOG.md"), "# v1\n").expect("write fixture");
+    crate::common::run_git_fixture(repo_dir.path(), &["add", "CHANGELOG.md"]);
+    crate::common::run_git_fixture(repo_dir.path(), &["commit", "-m", "v1"]);
+    seed_watch_toml(data_dir.path(), &[("legion", repo_dir.path())]);
+    run_ok(legion_cmd(data_dir.path()).args(["index", "legion"]));
+
+    // The repo moves past the indexed HEAD -- the release edit the field
+    // report named -- without a follow-up `legion index` run.
+    std::fs::write(repo_dir.path().join("CHANGELOG.md"), "# v2\n").expect("write fixture");
+    crate::common::run_git_fixture(repo_dir.path(), &["add", "CHANGELOG.md"]);
+    crate::common::run_git_fixture(repo_dir.path(), &["commit", "-m", "v2"]);
+
+    let json_out = run_ok(
+        legion_cmd(data_dir.path())
+            .env("XDG_STATE_HOME", state_dir.path())
+            .args([
+                "sym",
+                "etc",
+                "find-file",
+                "CHANGELOG.md",
+                "--repo",
+                "legion",
+                "--json",
+            ]),
+    );
+    let envelope: serde_json::Value =
+        serde_json::from_str(json_out.trim()).expect("stdout is a JSON envelope object");
+    let snapshots = envelope["snapshots"].as_array().expect("snapshots array");
+    assert_eq!(snapshots.len(), 1);
+    assert_eq!(
+        snapshots[0]["head_drift"], true,
+        "the field report's exact scenario must now be visible: {snapshots:?}"
+    );
+    assert!(snapshots[0]["head_at_index"].is_string());
+    assert!(snapshots[0]["current_head"].is_string());
+    assert_ne!(snapshots[0]["head_at_index"], snapshots[0]["current_head"]);
+
+    // Human output warns loudly instead of staying silent.
+    let stderr = run_ok_stderr(
+        legion_cmd(data_dir.path())
+            .env("XDG_STATE_HOME", state_dir.path())
+            .args([
+                "sym",
+                "etc",
+                "find-file",
+                "CHANGELOG.md",
+                "--repo",
+                "legion",
+            ]),
+    );
+    assert!(
+        stderr.contains("WARNING: current HEAD is")
+            && stderr.contains("re-run 'legion index legion'"),
+        "expected a head-drift warning, got:\n{stderr}"
     );
 }

--- a/tests/integration/inventory_freshness.rs
+++ b/tests/integration/inventory_freshness.rs
@@ -1,0 +1,160 @@
+//! CLI end-to-end tests for `legion index`'s inventory-snapshot recording
+//! (#746): every `legion index <repo>` run upserts one `inventory_snapshots`
+//! row per repo (indexed-at timestamp + HEAD at index time), which `sym
+//! tree`/`sym etc find-file --json` then surface via the `snapshots` field
+//! of the `--json` envelope (see sym_tree.rs/find_file.rs for the
+//! freshness/drift-detection tests built on top of this).
+
+use crate::common::{legion_cmd, run_git_fixture, run_ok};
+
+/// Seed a watch.toml in the data dir pointing at `repos` (name, workdir).
+/// Backslashes are TOML escape syntax, so Windows paths interpolated raw
+/// into a basic string make the whole file unparseable -- normalize to
+/// forward slashes, which Windows path APIs accept.
+fn seed_watch_toml(data_dir: &std::path::Path, repos: &[(&str, &std::path::Path)]) {
+    let mut toml = String::new();
+    for (name, workdir) in repos {
+        toml.push_str(&format!(
+            "[[repos]]\nname = \"{}\"\nworkdir = \"{}\"\n\n",
+            name,
+            workdir.display().to_string().replace('\\', "/")
+        ));
+    }
+    std::fs::write(data_dir.join("watch.toml"), toml).expect("seed watch.toml");
+}
+
+/// `legion index` in a real git checkout records the checkout's actual
+/// HEAD sha alongside the indexed-at timestamp.
+#[test]
+fn legion_index_records_inventory_snapshot_with_head_in_git_checkout() {
+    let data_dir = tempfile::tempdir().expect("data dir");
+    let repo_dir = tempfile::tempdir().expect("repo dir");
+    let state_dir = tempfile::tempdir().expect("state dir");
+
+    run_git_fixture(repo_dir.path(), &["init"]);
+    std::fs::write(repo_dir.path().join("a.rs"), "fn a() {}\n").expect("write fixture");
+    run_git_fixture(repo_dir.path(), &["add", "a.rs"]);
+    run_git_fixture(repo_dir.path(), &["commit", "-m", "initial"]);
+
+    let expected_head = {
+        let out = std::process::Command::new("git")
+            .args(["rev-parse", "HEAD"])
+            .current_dir(repo_dir.path())
+            .output()
+            .expect("git rev-parse HEAD");
+        String::from_utf8_lossy(&out.stdout).trim().to_string()
+    };
+
+    seed_watch_toml(data_dir.path(), &[("gitrepo", repo_dir.path())]);
+    let before = chrono::Utc::now();
+    run_ok(legion_cmd(data_dir.path()).args(["index", "gitrepo"]));
+    let after = chrono::Utc::now();
+
+    let json_out = run_ok(
+        legion_cmd(data_dir.path())
+            .env("XDG_STATE_HOME", state_dir.path())
+            .args(["sym", "tree", "--repo", "gitrepo", "--json"]),
+    );
+    let envelope: serde_json::Value =
+        serde_json::from_str(json_out.trim()).expect("stdout is a JSON envelope object");
+    let snapshot = &envelope["snapshots"][0];
+    assert_eq!(
+        snapshot["head_at_index"].as_str(),
+        Some(expected_head.as_str()),
+        "recorded head must match `git rev-parse HEAD` for the checkout: {snapshot:?}"
+    );
+
+    let indexed_at = snapshot["indexed_at"]
+        .as_str()
+        .expect("indexed_at must be a string");
+    let parsed =
+        chrono::DateTime::parse_from_rfc3339(indexed_at).expect("indexed_at must parse as RFC3339");
+    assert!(
+        parsed >= before && parsed <= after,
+        "indexed_at ({indexed_at}) must fall within the index call's window"
+    );
+}
+
+/// A non-git workdir still gets a snapshot row -- with `head: None`, never
+/// an error.
+#[test]
+fn legion_index_records_snapshot_with_none_head_for_non_git_workdir() {
+    let data_dir = tempfile::tempdir().expect("data dir");
+    let repo_dir = tempfile::tempdir().expect("repo dir");
+    let state_dir = tempfile::tempdir().expect("state dir");
+
+    std::fs::write(repo_dir.path().join("a.rs"), "fn a() {}\n").expect("write fixture");
+    seed_watch_toml(data_dir.path(), &[("plainrepo", repo_dir.path())]);
+    run_ok(legion_cmd(data_dir.path()).args(["index", "plainrepo"]));
+
+    let json_out = run_ok(
+        legion_cmd(data_dir.path())
+            .env("XDG_STATE_HOME", state_dir.path())
+            .args(["sym", "tree", "--repo", "plainrepo", "--json"]),
+    );
+    let envelope: serde_json::Value =
+        serde_json::from_str(json_out.trim()).expect("stdout is a JSON envelope object");
+    let snapshot = &envelope["snapshots"][0];
+    assert!(
+        snapshot["indexed_at"].is_string(),
+        "a snapshot row must still be recorded: {snapshot:?}"
+    );
+    assert!(
+        snapshot["head_at_index"].is_null(),
+        "non-git workdir must record head=None, not an error: {snapshot:?}"
+    );
+    assert_eq!(snapshot["head_drift"], false);
+}
+
+/// Re-running `legion index <repo>` replaces the prior snapshot row rather
+/// than accumulating one row per run: after a second index run following a
+/// HEAD advance, the snapshot reflects only the latest run.
+#[test]
+fn reindex_replaces_prior_snapshot_row_not_accumulates() {
+    let data_dir = tempfile::tempdir().expect("data dir");
+    let repo_dir = tempfile::tempdir().expect("repo dir");
+    let state_dir = tempfile::tempdir().expect("state dir");
+
+    run_git_fixture(repo_dir.path(), &["init"]);
+    std::fs::write(repo_dir.path().join("a.rs"), "fn a() {}\n").expect("write fixture");
+    run_git_fixture(repo_dir.path(), &["add", "a.rs"]);
+    run_git_fixture(repo_dir.path(), &["commit", "-m", "initial"]);
+    seed_watch_toml(data_dir.path(), &[("gitrepo", repo_dir.path())]);
+    run_ok(legion_cmd(data_dir.path()).args(["index", "gitrepo"]));
+
+    std::fs::write(repo_dir.path().join("b.rs"), "fn b() {}\n").expect("write fixture");
+    run_git_fixture(repo_dir.path(), &["add", "b.rs"]);
+    run_git_fixture(repo_dir.path(), &["commit", "-m", "second"]);
+    run_ok(legion_cmd(data_dir.path()).args(["index", "gitrepo"]));
+
+    let expected_head = {
+        let out = std::process::Command::new("git")
+            .args(["rev-parse", "HEAD"])
+            .current_dir(repo_dir.path())
+            .output()
+            .expect("git rev-parse HEAD");
+        String::from_utf8_lossy(&out.stdout).trim().to_string()
+    };
+
+    let json_out = run_ok(
+        legion_cmd(data_dir.path())
+            .env("XDG_STATE_HOME", state_dir.path())
+            .args(["sym", "tree", "--repo", "gitrepo", "--json"]),
+    );
+    let envelope: serde_json::Value =
+        serde_json::from_str(json_out.trim()).expect("stdout is a JSON envelope object");
+    let snapshots = envelope["snapshots"].as_array().expect("snapshots array");
+    assert_eq!(
+        snapshots.len(),
+        1,
+        "one snapshot per repo, not one per index run: {snapshots:?}"
+    );
+    assert_eq!(
+        snapshots[0]["head_at_index"].as_str(),
+        Some(expected_head.as_str())
+    );
+    assert_eq!(
+        snapshots[0]["head_drift"], false,
+        "no drift right after a fresh index"
+    );
+}

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -15,6 +15,7 @@ mod etc;
 mod find_file;
 mod governance;
 mod index_telemetry;
+mod inventory_freshness;
 mod kanban;
 mod mcp;
 mod memory;

--- a/tests/integration/sym_tree.rs
+++ b/tests/integration/sym_tree.rs
@@ -7,7 +7,7 @@
 //! real `legion index` run, cross-repo tagging, and the telemetry side
 //! effect landing in etc-usage.jsonl.
 
-use crate::common::{legion_cmd, run_fail, run_ok, run_ok_stderr};
+use crate::common::{legion_cmd, run_fail, run_ok, run_ok_output, run_ok_stderr};
 
 /// Seed a watch.toml in the data dir pointing at `repos` (name, workdir).
 /// Backslashes are TOML escape syntax, so Windows paths interpolated raw
@@ -401,11 +401,21 @@ fn tree_survives_malformed_watch_toml_on_cross_repo_path() {
     std::fs::write(data_dir.path().join("watch.toml"), "not valid toml [[[")
         .expect("corrupt watch.toml");
 
-    let json_out = run_ok(
+    // A single invocation, checked for both stdout (still a valid JSON
+    // envelope) and stderr (the degrade warning the doc comment promises) --
+    // two separate runs would each only see half the contract.
+    let output = run_ok_output(
         legion_cmd(data_dir.path())
             .env("XDG_STATE_HOME", state_dir.path())
             .args(["sym", "tree", "--json"]),
     );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("could not read watch.toml"),
+        "expected the degrade warning on stderr, got:\n{stderr}"
+    );
+
+    let json_out = String::from_utf8_lossy(&output.stdout);
     let envelope: serde_json::Value = serde_json::from_str(json_out.trim())
         .expect("malformed watch.toml must not abort the query -- stdout is still a JSON envelope");
     let entries = envelope["entries"].as_array().expect("entries array");

--- a/tests/integration/sym_tree.rs
+++ b/tests/integration/sym_tree.rs
@@ -51,8 +51,9 @@ fn tree_cli_end_to_end_with_json_ext_and_telemetry() {
             .env("XDG_STATE_HOME", state_dir.path())
             .args(["sym", "tree", "--repo", "treerepo", "--ext", "rs", "--json"]),
     );
-    let entries: Vec<serde_json::Value> =
-        serde_json::from_str(json_out.trim()).expect("stdout is a JSON array");
+    let envelope: serde_json::Value =
+        serde_json::from_str(json_out.trim()).expect("stdout is a JSON envelope object");
+    let entries = envelope["entries"].as_array().expect("entries array");
     assert_eq!(entries.len(), 1, "only the .rs file should match --ext rs");
     assert_eq!(entries[0]["repo"], "treerepo");
     assert_eq!(entries[0]["path"], "src/db/inventory.rs");
@@ -65,8 +66,9 @@ fn tree_cli_end_to_end_with_json_ext_and_telemetry() {
             .env("XDG_STATE_HOME", state_dir.path())
             .args(["sym", "tree", "--repo", "treerepo", "--json"]),
     );
-    let all: Vec<serde_json::Value> =
-        serde_json::from_str(all_out.trim()).expect("stdout is a JSON array");
+    let all_envelope: serde_json::Value =
+        serde_json::from_str(all_out.trim()).expect("stdout is a JSON envelope object");
+    let all = all_envelope["entries"].as_array().expect("entries array");
     assert_eq!(all.len(), 3, "every inventoried file must appear: {all:?}");
     let readme = all
         .iter()
@@ -113,8 +115,9 @@ fn tree_under_scopes_to_subtree() {
                 "sym", "tree", "--repo", "treerepo", "--under", "src/db", "--json",
             ]),
     );
-    let entries: Vec<serde_json::Value> =
-        serde_json::from_str(json_out.trim()).expect("stdout is a JSON array");
+    let envelope: serde_json::Value =
+        serde_json::from_str(json_out.trim()).expect("stdout is a JSON envelope object");
+    let entries = envelope["entries"].as_array().expect("entries array");
     assert_eq!(
         entries.len(),
         1,
@@ -144,8 +147,9 @@ fn tree_no_repo_is_cross_repo_and_tags_each_entry() {
             .env("XDG_STATE_HOME", state_dir.path())
             .args(["sym", "tree", "--json"]),
     );
-    let entries: Vec<serde_json::Value> =
-        serde_json::from_str(json_out.trim()).expect("stdout is a JSON array");
+    let envelope: serde_json::Value =
+        serde_json::from_str(json_out.trim()).expect("stdout is a JSON envelope object");
+    let entries = envelope["entries"].as_array().expect("entries array");
     let repos: std::collections::HashSet<&str> = entries
         .iter()
         .map(|e| e["repo"].as_str().unwrap())
@@ -153,6 +157,19 @@ fn tree_no_repo_is_cross_repo_and_tags_each_entry() {
     assert!(
         repos.contains("alpha") && repos.contains("beta"),
         "cross-repo tree must tag entries from every indexed repo: {entries:?}"
+    );
+
+    // Cross-repo snapshots cover exactly the distinct repos in `entries`,
+    // not every watched repo (#746).
+    let snapshots = envelope["snapshots"].as_array().expect("snapshots array");
+    let snapshot_repos: std::collections::HashSet<&str> = snapshots
+        .iter()
+        .map(|s| s["repo"].as_str().unwrap())
+        .collect();
+    assert_eq!(
+        snapshot_repos,
+        std::collections::HashSet::from(["alpha", "beta"]),
+        "cross-repo snapshots must cover exactly the repos represented in entries: {snapshots:?}"
     );
 
     // Human output prefixes cross-repo lines with the repo name.
@@ -214,4 +231,148 @@ fn tree_uncovered_repo_prints_explicit_message_not_silence() {
         stderr.contains("no inventory for 'treerepo'") && stderr.contains("legion index treerepo"),
         "expected the explicit no-inventory hint, got:\n{stderr}"
     );
+    // Never-indexed repo also has no snapshot row (#746): the freshness
+    // line must name that explicitly, not stay silent about staleness.
+    assert!(
+        stderr.contains("no inventory snapshot recorded")
+            && stderr.contains("legion index treerepo"),
+        "expected the no-snapshot-recorded freshness hint, got:\n{stderr}"
+    );
+}
+
+/// `--json` emits the `{snapshots, entries}` envelope, not a bare array
+/// (#746): the explicit-repo case always yields exactly one snapshot for
+/// that repo, with `indexed_at`/`head_at_index` recorded by the `legion
+/// index` run above.
+#[test]
+fn sym_tree_json_wraps_entries_with_snapshot_freshness() {
+    let data_dir = tempfile::tempdir().expect("data dir");
+    let repo_dir = tempfile::tempdir().expect("repo dir");
+    let state_dir = tempfile::tempdir().expect("state dir");
+
+    std::fs::write(repo_dir.path().join("a.rs"), "").expect("write fixture");
+    seed_watch_toml(data_dir.path(), &[("treerepo", repo_dir.path())]);
+    run_ok(legion_cmd(data_dir.path()).args(["index", "treerepo"]));
+
+    let json_out = run_ok(
+        legion_cmd(data_dir.path())
+            .env("XDG_STATE_HOME", state_dir.path())
+            .args(["sym", "tree", "--repo", "treerepo", "--json"]),
+    );
+    let envelope: serde_json::Value =
+        serde_json::from_str(json_out.trim()).expect("stdout is a JSON envelope object");
+    assert!(envelope["entries"].is_array());
+    let snapshots = envelope["snapshots"].as_array().expect("snapshots array");
+    assert_eq!(
+        snapshots.len(),
+        1,
+        "explicit --repo yields exactly one snapshot: {snapshots:?}"
+    );
+    assert_eq!(snapshots[0]["repo"], "treerepo");
+    assert!(
+        snapshots[0]["indexed_at"].is_string(),
+        "indexed_at must be recorded by `legion index`: {snapshots:?}"
+    );
+    assert_eq!(snapshots[0]["head_drift"], false);
+}
+
+/// Cross-repo `--json` with zero matching entries yields an empty
+/// `snapshots` array -- not one row per watch.toml repo (#746).
+#[test]
+fn sym_tree_json_cross_repo_empty_result_yields_empty_snapshots() {
+    let data_dir = tempfile::tempdir().expect("data dir");
+    let repo_dir = tempfile::tempdir().expect("repo dir");
+    let state_dir = tempfile::tempdir().expect("state dir");
+    // In watch.toml but never indexed -- zero inventory rows anywhere.
+    seed_watch_toml(data_dir.path(), &[("treerepo", repo_dir.path())]);
+
+    let json_out = run_ok(
+        legion_cmd(data_dir.path())
+            .env("XDG_STATE_HOME", state_dir.path())
+            .args(["sym", "tree", "--json"]),
+    );
+    let envelope: serde_json::Value =
+        serde_json::from_str(json_out.trim()).expect("stdout is a JSON envelope object");
+    assert_eq!(envelope["entries"].as_array().unwrap().len(), 0);
+    assert_eq!(
+        envelope["snapshots"].as_array().unwrap().len(),
+        0,
+        "empty cross-repo result must not synthesize one row per watch.toml repo: {envelope}"
+    );
+}
+
+/// Human output prints an "up to date" freshness line before the entry
+/// table when the repo's live HEAD still matches the index-time HEAD
+/// (#746).
+#[test]
+fn tree_human_output_prints_up_to_date_when_head_matches() {
+    let data_dir = tempfile::tempdir().expect("data dir");
+    let repo_dir = tempfile::tempdir().expect("repo dir");
+    let state_dir = tempfile::tempdir().expect("state dir");
+
+    crate::common::run_git_fixture(repo_dir.path(), &["init"]);
+    std::fs::write(repo_dir.path().join("a.rs"), "fn a() {}\n").expect("write fixture");
+    crate::common::run_git_fixture(repo_dir.path(), &["add", "a.rs"]);
+    crate::common::run_git_fixture(repo_dir.path(), &["commit", "-m", "initial"]);
+    seed_watch_toml(data_dir.path(), &[("treerepo", repo_dir.path())]);
+    run_ok(legion_cmd(data_dir.path()).args(["index", "treerepo"]));
+
+    let stderr = run_ok_stderr(
+        legion_cmd(data_dir.path())
+            .env("XDG_STATE_HOME", state_dir.path())
+            .args(["sym", "tree", "--repo", "treerepo"]),
+    );
+    assert!(
+        stderr.contains("treerepo: indexed") && stderr.contains("up to date"),
+        "expected an up-to-date freshness line, got:\n{stderr}"
+    );
+    assert!(!stderr.contains("WARNING"), "got:\n{stderr}");
+}
+
+/// Human output prints a loud WARNING freshness line naming both HEADs
+/// when the repo's live HEAD has moved past the index-time HEAD (#746) --
+/// the exact scenario bullpen post 019f355c reported as silently invisible.
+#[test]
+fn tree_human_output_prints_freshness_warning_on_head_drift() {
+    let data_dir = tempfile::tempdir().expect("data dir");
+    let repo_dir = tempfile::tempdir().expect("repo dir");
+    let state_dir = tempfile::tempdir().expect("state dir");
+
+    crate::common::run_git_fixture(repo_dir.path(), &["init"]);
+    std::fs::write(repo_dir.path().join("a.rs"), "fn a() {}\n").expect("write fixture");
+    crate::common::run_git_fixture(repo_dir.path(), &["add", "a.rs"]);
+    crate::common::run_git_fixture(repo_dir.path(), &["commit", "-m", "initial"]);
+    seed_watch_toml(data_dir.path(), &[("treerepo", repo_dir.path())]);
+    run_ok(legion_cmd(data_dir.path()).args(["index", "treerepo"]));
+
+    // The repo moves past the indexed HEAD -- `legion index` is not re-run.
+    std::fs::write(repo_dir.path().join("b.rs"), "fn b() {}\n").expect("write fixture");
+    crate::common::run_git_fixture(repo_dir.path(), &["add", "b.rs"]);
+    crate::common::run_git_fixture(repo_dir.path(), &["commit", "-m", "second"]);
+
+    let stderr = run_ok_stderr(
+        legion_cmd(data_dir.path())
+            .env("XDG_STATE_HOME", state_dir.path())
+            .args(["sym", "tree", "--repo", "treerepo"]),
+    );
+    assert!(
+        stderr.contains("WARNING: current HEAD is")
+            && stderr.contains("inventory may be stale")
+            && stderr.contains("re-run 'legion index treerepo'"),
+        "expected a head-drift warning, got:\n{stderr}"
+    );
+
+    let json_out = run_ok(
+        legion_cmd(data_dir.path())
+            .env("XDG_STATE_HOME", state_dir.path())
+            .args(["sym", "tree", "--repo", "treerepo", "--json"]),
+    );
+    let envelope: serde_json::Value =
+        serde_json::from_str(json_out.trim()).expect("stdout is a JSON envelope object");
+    let snapshots = envelope["snapshots"].as_array().expect("snapshots array");
+    assert_eq!(snapshots.len(), 1);
+    assert_eq!(snapshots[0]["head_drift"], true);
+    assert!(snapshots[0]["head_at_index"].is_string());
+    assert!(snapshots[0]["current_head"].is_string());
+    assert_ne!(snapshots[0]["head_at_index"], snapshots[0]["current_head"]);
 }

--- a/tests/integration/sym_tree.rs
+++ b/tests/integration/sym_tree.rs
@@ -376,3 +376,49 @@ fn tree_human_output_prints_freshness_warning_on_head_drift() {
     assert!(snapshots[0]["current_head"].is_string());
     assert_ne!(snapshots[0]["head_at_index"], snapshots[0]["current_head"]);
 }
+
+/// A malformed watch.toml must not hard-fail `sym tree` (#746 review
+/// follow-up): the cross-repo path (`--repo` omitted) previously never
+/// touched watch.toml at query time at all -- `sym tree`/`find-file`
+/// answer from the inventory DB alone. `compute_freshness` now reads
+/// watch.toml unconditionally to resolve live workdirs, but HEAD
+/// comparison is a freshness *signal*, never a hard requirement, so a
+/// syntax error in watch.toml must degrade to "can't compare" (`snapshots`
+/// still present, `current_head: null`, `head_drift: false`) rather than
+/// aborting the whole query.
+#[test]
+fn tree_survives_malformed_watch_toml_on_cross_repo_path() {
+    let data_dir = tempfile::tempdir().expect("data dir");
+    let repo_dir = tempfile::tempdir().expect("repo dir");
+    let state_dir = tempfile::tempdir().expect("state dir");
+
+    std::fs::write(repo_dir.path().join("a.rs"), "").expect("write fixture");
+    seed_watch_toml(data_dir.path(), &[("treerepo", repo_dir.path())]);
+    run_ok(legion_cmd(data_dir.path()).args(["index", "treerepo"]));
+
+    // Corrupt watch.toml only *after* indexing -- the inventory rows
+    // already written by `legion index` must still be queryable.
+    std::fs::write(data_dir.path().join("watch.toml"), "not valid toml [[[")
+        .expect("corrupt watch.toml");
+
+    let json_out = run_ok(
+        legion_cmd(data_dir.path())
+            .env("XDG_STATE_HOME", state_dir.path())
+            .args(["sym", "tree", "--json"]),
+    );
+    let envelope: serde_json::Value = serde_json::from_str(json_out.trim())
+        .expect("malformed watch.toml must not abort the query -- stdout is still a JSON envelope");
+    let entries = envelope["entries"].as_array().expect("entries array");
+    assert_eq!(
+        entries.len(),
+        1,
+        "inventory rows written before watch.toml was corrupted must still be readable: {entries:?}"
+    );
+    let snapshots = envelope["snapshots"].as_array().expect("snapshots array");
+    assert_eq!(snapshots.len(), 1);
+    assert!(
+        snapshots[0]["current_head"].is_null(),
+        "workdir cannot be resolved without a parseable watch.toml: {snapshots:?}"
+    );
+    assert_eq!(snapshots[0]["head_drift"], false);
+}


### PR DESCRIPTION
## Summary

`sym tree`/`sym etc find-file` serve inventory rows with no signal about when
the inventory was last captured, or whether the repo's HEAD has moved since.
This closes that gap: `legion index <repo>` now records a per-repo
`inventory_snapshots` row (indexed-at timestamp + HEAD at that moment), and
both query commands surface freshness -- via a `{snapshots, entries}` JSON
envelope and a stderr freshness line in human output -- computed with one
live `git rev-parse HEAD` per distinct repo in the result, never a
filesystem walk.

## Acceptance criteria mapping

### 1. `legion index <repo>` records one `inventory_snapshots` row per repo on every run

`handle_index` upserts the snapshot immediately after the existing
`database.upsert_file_inventory(&outcome.entries)?` call, with
`indexed_at = chrono::Utc::now().to_rfc3339()` and
`head = inventory::current_head(&repo_path)` (src/cli/index_cmd.rs, inside
`handle_index`). Test:
`legion_index_records_inventory_snapshot_with_head_in_git_checkout` runs the
binary against a real `git init` + one-commit tempdir and asserts the
recorded `head_at_index` matches `git rev-parse HEAD` for that checkout, and
`indexed_at` parses as RFC3339 within the call's time window.

### 2. Non-git workdirs still get a snapshot row, with `head: None`, never an error

`current_head` (src/inventory.rs) returns `Option`, never `Err`, across three
failure modes (spawn failure, non-zero exit, unparseable/empty stdout).
Evidence: `legion_index_records_snapshot_with_none_head_for_non_git_workdir`
(tests/integration/inventory_freshness.rs) indexes a plain (non-git) tempdir
and asserts `head_at_index` is JSON `null`, not an error exit; unit tests
`current_head_returns_none_for_non_git_directory` and
`current_head_returns_none_for_directory_with_broken_git_metadata`
(src/inventory.rs) cover the same at the function level, including a `.git`
that is a plain empty file rather than a valid gitdir pointer.

### 3. Re-running `legion index` replaces the prior snapshot row, not accumulates

`upsert_inventory_snapshot` uses `INSERT ... ON CONFLICT(repo) DO UPDATE`
(src/db/inventory.rs) against a `repo TEXT PRIMARY KEY` table. Evidence:
`upsert_inventory_snapshot_replaces_prior_row_not_accumulates`
(src/db/inventory.rs) asserts exactly one row survives two upserts for the
same repo; `reindex_replaces_prior_snapshot_row_not_accumulates`
(tests/integration/inventory_freshness.rs) exercises the same through two
real `legion index` runs across a HEAD advance and asserts `snapshots.len()
== 1` in the resulting `--json` output.

### 4. `sym tree --json` / `sym etc find-file --json` emit the `{snapshots, entries}` envelope

`FreshJsonEnvelope<T>` (src/cli/index_cmd.rs) wraps both commands' existing
per-file output. This is a deliberate breaking change to the `--json` shape
-- 0.19.0 shipped the prior bare-array shape days before this issue, with no
external contract on it, and freshness metadata cannot be attached to a bare
array. Every pre-existing `--json` test in tests/integration/sym_tree.rs and
tests/integration/find_file.rs was updated in place to unwrap
`envelope["entries"]`, so `--ext`/`--under`/`--role`/cross-repo-tagging
coverage did not silently regress. New tests:
`sym_tree_json_wraps_entries_with_snapshot_freshness`,
`find_file_json_wraps_entries_with_snapshot_freshness`.

### 5. Cross-repo scoping: `snapshots` covers exactly the repos in `entries`, not every watched repo

`freshness_repo_scope` (src/cli/index_cmd.rs) yields exactly one entry for
an explicit `--repo`, or the distinct repos actually present in the result
for cross-repo queries, deduped by first-seen order (callers already sort
entries by `(repo, path)`, so this comes out repo-sorted for free). Evidence:
`freshness_repo_scope_cross_repo_dedupes_in_first_seen_order` (unit test),
`sym_tree_json_cross_repo_empty_result_yields_empty_snapshots` (an empty
cross-repo result yields an empty `snapshots` array, not one row per
watch.toml entry), and `tree_no_repo_is_cross_repo_and_tags_each_entry`'s
extended assertion that `snapshot_repos == {"alpha", "beta"}` matches exactly
the repos represented in `entries`.

### 6. `head_drift` semantics: true only when both HEADs are known and differ

`head_drift(a, b)` (src/cli/index_cmd.rs) is `matches!((a, b), (Some(x),
Some(y)) if x != y)`. Evidence:
`snapshot_freshness_head_drift_true_only_when_both_present_and_differ` table-
tests all four `(Option, Option)` combinations.

### 7. Human output: one freshness line per repo before the entry table

`format_freshness_line` (src/cli/index_cmd.rs) renders the three states the
issue specifies -- up to date, drift WARNING naming both SHAs, or a
no-snapshot-recorded re-index hint -- printed to stderr via the existing
`[legion] {msg}` convention. Evidence:
`tree_human_output_prints_up_to_date_when_head_matches`,
`tree_human_output_prints_freshness_warning_on_head_drift`,
`tree_uncovered_repo_prints_explicit_message_not_silence`'s extended
assertion on the no-snapshot hint, and the `find_file` equivalents of all
three.

### 8. Regression test built from the field report

`find_file_regression_head_drift_surfaced_instead_of_silent`
(tests/integration/find_file.rs) reproduces bullpen post 019f355c exactly: a
file whose inventory row is current while the repo's live HEAD has moved
past the index-time HEAD -- previously invisible, now `head_drift: true`
plus a WARNING line naming both SHAs.

### 9. Cost distinction (issue-mandated)

Live HEAD resolution costs exactly one `git rev-parse HEAD` per **distinct
repo represented in the result set**, computed once in `compute_freshness`
(src/cli/index_cmd.rs) -- never once per entry, and never a filesystem walk.
`compute_freshness` also loads `watch.toml` once per call rather than once
per repo name (fixed in bb7e311 after an initial per-repo reload). This is
why surfacing drift here does not reintroduce the per-query filesystem-walk
cost the inventory-backed `tree`/`find-file` design (#705/#706/#709) exists
to avoid: the walk still only happens on `legion index`; queries add one
cheap subprocess call per distinct repo, not a re-scan of any tree.

### 10. Design question resolution (issue-mandated)

Declined the live-walk / opt-in `--verify` fallback the issue raises as an
open question, and kept the inventory-backed design as-is. Reasoning: a
live-walk fallback on detected drift reintroduces exactly the per-query
filesystem cost that made `tree`/`find-file` inventory-backed in the first
place, and #707 already fought this same tradeoff for `find-content` by
choosing a direct-scan redesign specifically because *that* command's
content-query need for staleness-proofing outweighed the cost -- `tree`/
`find-file` were deliberately not built for that tradeoff. No automatic,
unbounded live-walk fallback was built; no bounded `--verify` flag was
built either, since the issue does not require picking one, only naming and
reasoning about the choice. Evidence: this reasoning is recorded verbatim
in commit 64a9a0f's message ("Design question from the issue (resolved,
not silently picked)..."), and is observable in the diff itself -- the
`sym tree`/`sym etc find-file` clap arg definitions (src/cli/index_cmd.rs)
gained no `--verify` flag, and `compute_freshness` contains no filesystem
walk, only the one `git rev-parse HEAD` per distinct repo described above.

## Two assumptions verified during this work (so `/legion-review` does not re-chase them)

- **Schema upgrade path is safe for existing databases.** `Database::open`
  calls `Self::init_schema(&conn)` on every open (src/db/mod.rs), which
  calls `inventory::create_tables(conn)?` inside the same transaction as
  every other domain table -- all `CREATE TABLE IF NOT EXISTS`. A
  pre-upgrade `.legion.db` gains `inventory_snapshots` on its next open;
  `get_inventory_snapshot`'s `SELECT` never runs against a missing table.
- **Missing (not malformed) watch.toml does not trigger the new degrade
  warning.** `watch::list_repos_in_config` -> `read_or_default`
  (src/watch/config.rs) returns `Ok(WatchConfig::default())` when the file
  does not exist at all, and only `Err`s on an actual parse failure of an
  existing file. The stderr degrade warning added in 92238b8 therefore
  fires only on a genuinely malformed watch.toml, not on every fresh
  install before one is created.

## Review observations deferred to `/legion-review`

The pre-push review hook ran three times across this branch's history and
surfaced findings beyond the two real regressions already fixed in-branch
(92238b8's malformed-watch.toml hard-failure, 217c864's shared-helper
duplication). Recording the remaining ones here rather than silently
absorbing or silently dropping them:

- **HEAD captured after `walk_repo` completes, not before**
  (src/cli/index_cmd.rs, `handle_index`). A commit landing in the narrow
  window between the walk finishing and `current_head` running would record
  a HEAD newer than the tree actually walked -- a false "up to date" signal
  in the rare case it fires. The issue's own interface spec places the
  snapshot write "alongside the existing walk...around the existing
  `upsert_file_inventory` call," i.e. post-walk, which is what's
  implemented. Flagging this as a considered tradeoff rather than fixing
  unilaterally, since moving it pre-walk deviates from the written spec and
  changes which side of the walk race the (already narrow) window sits on.
- **`current_head` does not bound git's upward directory search**
  (src/inventory.rs). For a watched workdir that is itself always a repo
  root (the only configuration this feature targets), this does not
  misbehave. A workdir nested inside a git repo it doesn't own would report
  the ancestor's HEAD, which is arguably still a meaningful staleness signal
  (a parent checkout/pull is exactly the kind of event this feature exists
  to surface) rather than a wrong one. Not changed, since watch.toml
  workdirs are documented and expected to be repo roots and the issue does
  not ask for directory-discovery bounding.
- **Human "up to date" line does not distinguish "verified, unchanged" from
  "nothing to compare"** (`format_freshness_line`, `head_at_index: Some` /
  `current_head: None`, e.g. workdir removed from watch.toml or `git`
  unavailable at query time). Checked against the issue's own Behavior
  section, which defines exactly three human-output states and puts
  "nothing to compare" in the no-drift bucket by `head_drift`'s own
  definition ("false when either is `None`... or when they match"). The
  JSON envelope already disambiguates (`current_head: null`), so this is a
  human-output wording judgment call, not a defect against the written
  spec -- left as-is; a future issue could split the wording into a fourth
  human-output state if that turns out to matter in practice.

## Deliberately not done

- No automatic, unbounded live-walk fallback on detected drift, and no
  bounded `--verify`/per-row `stat()` flag either -- see design-question
  resolution above.
- No gating of snapshot recording on `outcome.walk_errors > 0`. The issue's
  Behavior section says the snapshot is recorded "on every run"; a partial
  walk still stamps `indexed_at`/HEAD as specified. Considered gating this
  on walk errors (a pre-push review raised it) and left it out as scope
  expansion beyond the acceptance criteria -- worth a follow-up issue if
  partial-walk freshness proves misleading in practice.
- The `--no-ignore` gap on `find-content`/the inventory walk, and the
  `css_symbols` read-side gap -- both explicitly out of scope in the issue,
  separate concerns.
- No change to `sym tree`'s existing per-file `mtime` column -- that is a
  separate, pre-existing design choice (src/cli/index_cmd.rs) about a
  single file's own timestamp, not this issue's repo-level snapshot signal.
- No `EtcUsageRecord` telemetry extension to log freshness/drift outcomes --
  not required by the acceptance criteria; a possible follow-up.

## Test plan

- `cargo fmt -- --check`: clean.
- `cargo clippy --all-targets --all-features -- -D warnings`: clean.
- `cargo test --bin legion`: 1350 passed, 0 failed, 2 ignored.
- `cargo test --test integration`: 247 passed, 0 failed, 2 ignored
  (includes every test named above).