### PR TITLE
fix(#720): name the operation in worksource deserialization errors

### DIFF
--- a/src/worksource/mod.rs
+++ b/src/worksource/mod.rs
@@ -381,7 +381,21 @@ fn plugin_call<T: serde::de::DeserializeOwned>(
     env: &[(&str, &str)],
 ) -> Result<T> {
     let output = plugin_call_raw(plugin_name, args, env)?;
-    serde_json::from_str(&output).map_err(|e| LegionError::WorkSource(e.to_string()))
+    decode_plugin_output(args, &output)
+}
+
+/// Decode a plugin's raw JSON stdout, naming the operation in any
+/// deserialization failure (#720). `args[0]` is the plugin subcommand every
+/// call site passes (e.g. `list-sub-issues`, `pr-list`) -- serde only
+/// supplies the offending field, so without this the operator sees "missing
+/// field `labels`" with no clue which of a dozen worksource calls produced
+/// it. Split out from `plugin_call` so the error-shaping logic is testable
+/// without spawning a plugin process.
+fn decode_plugin_output<T: serde::de::DeserializeOwned>(args: &[&str], output: &str) -> Result<T> {
+    serde_json::from_str(output).map_err(|e| {
+        let op = args.first().copied().unwrap_or("<unknown op>");
+        LegionError::WorkSource(format!("{op}: {e}"))
+    })
 }
 
 /// Resolve work source config for a repo from watch.toml.
@@ -468,6 +482,51 @@ mod tests {
     fn find_plugin_returns_none_for_nonexistent() {
         let result = find_plugin("nonexistent-plugin-xyz");
         assert!(result.is_none());
+    }
+
+    /// #720: a deserialization failure must name the operation, not just the
+    /// offending field. `list-sub-issues` is the representative verb from the
+    /// issue (the payload that motivated #714 and later #720).
+    #[test]
+    fn decode_plugin_output_names_the_operation_on_deserialize_failure() {
+        let result: Result<serde_json::Value> =
+            decode_plugin_output(&["list-sub-issues"], "not json");
+        let Err(LegionError::WorkSource(msg)) = result else {
+            panic!("expected WorkSource error, got {:?}", result);
+        };
+        assert!(
+            msg.starts_with("list-sub-issues:"),
+            "expected the operation to prefix the error, got: {msg}"
+        );
+    }
+
+    /// Every verb goes through the same helper, so the property holds
+    /// generally, not just for the one call site #714/#720 were filed
+    /// against. Exercise a second, differently-shaped op name.
+    #[test]
+    fn decode_plugin_output_names_the_operation_for_other_verbs() {
+        let result: Result<serde_json::Value> = decode_plugin_output(&["pr-list"], "{ bad json");
+        let Err(LegionError::WorkSource(msg)) = result else {
+            panic!("expected WorkSource error, got {:?}", result);
+        };
+        assert!(
+            msg.starts_with("pr-list:"),
+            "expected the operation to prefix the error, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn decode_plugin_output_falls_back_when_args_empty() {
+        // Defensive: no call site passes empty args today, but the helper
+        // must not panic if one ever does.
+        let result: Result<serde_json::Value> = decode_plugin_output(&[], "not json");
+        let Err(LegionError::WorkSource(msg)) = result else {
+            panic!("expected WorkSource error, got {:?}", result);
+        };
+        assert!(
+            msg.starts_with("<unknown op>:"),
+            "expected the fallback op marker, got: {msg}"
+        );
     }
 
     #[test]

--- a/tests/integration/worksource_pr.rs
+++ b/tests/integration/worksource_pr.rs
@@ -487,6 +487,13 @@ fn pr_view_surfaces_malformed_plugin_json_as_worksource_error() {
         !stderr.is_empty(),
         "expected a non-empty error message on malformed plugin output"
     );
+    // #720: the error must name the operation (view-pr), not just the
+    // offending field, so the operator can tell which of a dozen worksource
+    // calls actually failed.
+    assert!(
+        stderr.contains("view-pr"),
+        "expected the operation name in the error, got: {stderr}"
+    );
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Deserialization failures from worksource plugin calls now name the operation that failed, not
just the offending JSON field. `plugin_call`'s decode step is split into a new
`decode_plugin_output` helper that prefixes `args[0]` (the plugin subcommand every call site
already passes, e.g. `list-sub-issues`, `pr-list`, `view-pr`) onto the serde error, so a failure
now reads `sub-issue list: missing field ...` instead of just `missing field ...` with no clue
which of a dozen worksource calls produced it.

### 1. Deserialization failure error strings name the operation/endpoint and the offending field

`decode_plugin_output` (src/worksource/mod.rs:394-399) wraps `serde_json::from_str` and formats
the error as `LegionError::WorkSource(format!("{op}: {e}"))`, where `op` is `args.first()` -- the
plugin subcommand string every existing call site already threads through `plugin_call`. Because
every worksource verb that deserializes a plugin response goes through this one function, the
property holds for all of them (`create-pr`, `pr-list`, `pr-checks`, `view-pr`, `pr-comments`,
`pr-reviews`, `list`, `view-issue`, `create-sub-issue`, `list-sub-issues`, `create-issue`), not
just the `list-sub-issues` path that motivated #714/#720.

## Acceptance criteria mapping

Evidence: `pr_view_surfaces_malformed_plugin_json_as_worksource_error`
(tests/integration/worksource_pr.rs:487-499) drives a real `pr view` CLI invocation through
malformed plugin JSON and asserts `stderr.contains("view-pr")`, proving the operation name
survives end-to-end through the actual binary, not just the lib function.

### 2. Test pins the property

Three unit tests in src/worksource/mod.rs (487-527) pin the helper directly:
`decode_plugin_output_names_the_operation_on_deserialize_failure` (the `list-sub-issues` verb
from the issue), `decode_plugin_output_names_the_operation_for_other_verbs` (a second,
differently-shaped verb, `pr-list`, proving the property is general rather than hard-coded to one
call site), and `decode_plugin_output_falls_back_when_args_empty` (the defensive `<unknown op>`
branch when `args.first()` returns `None`, so the no-`unwrap()` invariant holds even on an input
no current call site produces).

Evidence: `cargo test worksource` -- 39 unit tests + 41 integration tests pass, including all
three new unit tests and the updated `pr_view_surfaces_malformed_plugin_json_as_worksource_error`.

### 3. Tests pass; simplify + review done; PR linked

Evidence: `cargo fmt --check` and `cargo clippy --all-targets --all-features -- -D warnings` both
exit clean. `legion quality-gate check --skill legion-simplify` recorded gate id
`019f40b4-078c-7410-9084-acbd9dbd996b` (clean, 0 findings). Pre-push automated PR review passed
with no CRITICAL or HIGH issues.

## Deliberately not done

- Did not change the plugin protocol or payload shapes -- out of scope per the issue.
- Did not touch `plugin_call_raw` or any of the non-JSON-decode call sites (`close`, `reopen`,
  `merge`, etc.) since they never reach the decode path this issue is about.
- Left both `decode_plugin_output_names_the_operation_on_deserialize_failure` and
  `..._for_other_verbs` rather than collapsing them into one test, since they intentionally pin
  the property against two differently-named verbs to demonstrate it is general, not specific to
  the one call site the bug was filed against.

Closes #720