### PR TITLE
fix(#736): pin pr-checks to the PR head SHA, fail closed on zero runs

### DIFF
--- a/plugin/worksources/github
+++ b/plugin/worksources/github
@@ -402,21 +402,90 @@ case "${1:-}" in
       echo "gh CLI not found" >&2
       exit 1
     fi
-    # gh pr checks exits non-zero when any check is failing -- that is data,
-    # not an error from our perspective. Capture stdout and stderr separately
-    # so a gh warning printed to stderr cannot slip into the JSON blob jq
-    # then accepts. Only fail if stdout is empty or not valid JSON
-    # (network error, auth failure, missing PR).
+    # Pin to the PR's head commit (#736). `gh pr checks` resolves checks
+    # against whatever commit gh's own PR-checks view considers current,
+    # which was observed live on PR #735 echoing a PARENT commit's completed
+    # (green) suite when the head itself had zero runs -- a false "7/7
+    # SUCCESS" for an untested commit. Resolving headRefOid ourselves and
+    # querying the head SHA's own check state removes that ambiguity: the
+    # result is either checks for the head commit, or none.
+    HEAD_SHA_STDERR=$(mktemp)
+    # `|| true` matters under `set -e`: a command substitution's exit status
+    # propagates to the assignment, so an unguarded `gh pr view` failure
+    # (auth, network, no such PR) would kill the script right here instead
+    # of reaching the explicit check below -- silently dropping the captured
+    # stderr and leaking the temp file.
+    HEAD_SHA=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json headRefOid -q '.headRefOid' 2>"$HEAD_SHA_STDERR") || true
+    if [ -z "$HEAD_SHA" ] || [ "$HEAD_SHA" = "null" ]; then
+      echo "gh pr view failed to resolve head SHA for PR #$PR_NUMBER: $(cat "$HEAD_SHA_STDERR")" >&2
+      rm -f "$HEAD_SHA_STDERR"
+      exit 1
+    fi
+    rm -f "$HEAD_SHA_STDERR"
+    OWNER="${REPO%%/*}"
+    REPO_NAME="${REPO##*/}"
+    # Two sources feed the head commit's CI state, matching what `gh pr
+    # checks` itself combines: the Checks API (commits/{sha}/check-runs,
+    # what GitHub Actions and most modern apps report to) and the legacy
+    # combined-status endpoint (commits/{sha}/status, what older
+    # integrations -- classic CircleCI, Jenkins, codecov contexts -- still
+    # post to). Checks-API-only would silently drop the latter: a failing
+    # legacy status would read as simply absent, and any check-run existing
+    # would make the PR look all-green -- the same false-green class this
+    # fix exists to close, via a different door.
+    #
+    # check-runs is a paginated collection: `--paginate` on an object-shaped
+    # response concatenates one JSON object per page rather than merging
+    # them, so `--slurp` collects the page objects into an array before jq
+    # flattens their check_runs. The status endpoint returns a single object
+    # (GitHub caps it at 100 statuses) and is not paginated.
+    # Same `|| true` reasoning as HEAD_SHA above, for both gh api calls.
     STDERR_FILE=$(mktemp)
-    OUTPUT=$(gh pr checks "$PR_NUMBER" --repo "$REPO" \
-      --json name,state,workflow,link,description 2>"$STDERR_FILE")
-    if [ -z "$OUTPUT" ] || ! printf '%s' "$OUTPUT" | jq -e . >/dev/null 2>&1; then
-      echo "gh pr checks failed: $(cat "$STDERR_FILE")" >&2
+    CHECK_RUNS=$(gh api "repos/${OWNER}/${REPO_NAME}/commits/${HEAD_SHA}/check-runs" --paginate --slurp 2>"$STDERR_FILE") || true
+    if [ -z "$CHECK_RUNS" ] || ! printf '%s' "$CHECK_RUNS" | jq -e . >/dev/null 2>&1; then
+      echo "gh api check-runs failed: $(cat "$STDERR_FILE")" >&2
+      rm -f "$STDERR_FILE"
+      exit 1
+    fi
+    STATUS=$(gh api "repos/${OWNER}/${REPO_NAME}/commits/${HEAD_SHA}/status" 2>"$STDERR_FILE") || true
+    if [ -z "$STATUS" ] || ! printf '%s' "$STATUS" | jq -e . >/dev/null 2>&1; then
+      echo "gh api commit status failed: $(cat "$STDERR_FILE")" >&2
       rm -f "$STDERR_FILE"
       exit 1
     fi
     rm -f "$STDERR_FILE"
-    printf '%s\n' "$OUTPUT"
+    # Map each source's own state vocabulary into gh's check-state vocabulary
+    # (SUCCESS/FAILURE/QUEUED/...) so ExternalPRCheck::is_failing's allow-list
+    # keeps working unchanged:
+    #   check-runs: status != completed -> the status itself uppercased
+    #     (QUEUED/IN_PROGRESS); completed -> the conclusion uppercased (a
+    #     null conclusion on a completed run is fail-closed to FAILURE
+    #     rather than dropped). No direct "workflow name" field, so
+    #     `workflow` falls back to the reporting app's name (e.g. "GitHub
+    #     Actions") -- display-only, not used by is_failing.
+    #   status contexts: state uppercased as-is (success/failure/pending/
+    #     error); an unrecognized value still fails closed via
+    #     is_failing's default, so no explicit allow-list is needed here.
+    jq -n --arg sha "$HEAD_SHA" --argjson runs "$CHECK_RUNS" --argjson status "$STATUS" '{
+      headSha: $sha,
+      checks: (
+        [ $runs[].check_runs[]? | {
+          name: .name,
+          state: (if .status == "completed" then (.conclusion // "FAILURE" | ascii_upcase) else (.status | ascii_upcase) end),
+          workflow: (.app.name // .name),
+          link: (.html_url // .details_url // ""),
+          description: (.output.title // .output.summary // "")
+        } ]
+        +
+        [ $status.statuses[]? | {
+          name: .context,
+          state: (.state | ascii_upcase),
+          workflow: .context,
+          link: (.target_url // ""),
+          description: (.description // "")
+        } ]
+      )
+    }'
     ;;
 
   view-pr)

--- a/src/cli/pr.rs
+++ b/src/cli/pr.rs
@@ -224,6 +224,17 @@ pub(crate) enum PrAction {
     },
 }
 
+/// Shared refusal for a PR head with zero check runs (#736). `legion pr
+/// checks` and `legion pr merge` both hit this state and must present
+/// identical wording so the merge gate's failure reads the same everywhere
+/// it can fire.
+fn no_runs_for_head_error(head_sha: &str, number: u64, source_repo: &str) -> error::LegionError {
+    error::LegionError::WorkSource(format!(
+        "no runs for head {head_sha}: PR #{number} on {source_repo} has zero check runs \
+         for its head commit (not the branch's last suite)"
+    ))
+}
+
 pub(crate) fn handle(action: PrAction) -> error::Result<()> {
     match action {
         PrAction::Create {
@@ -406,27 +417,23 @@ pub(crate) fn handle(action: PrAction) -> error::Result<()> {
         } => {
             let (plugin_name, source_repo, _workdir) = worksource::require_worksource(&repo)?;
 
-            let checks = worksource::pr_checks(&plugin_name, &source_repo, number)?;
+            let result = worksource::pr_checks(&plugin_name, &source_repo, number)?;
+            let checks = &result.checks;
 
             if json {
                 println!(
                     "{}",
-                    serde_json::to_string_pretty(&checks)
+                    serde_json::to_string_pretty(checks)
                         .expect("ExternalPRCheck serializes infallibly")
                 );
-            } else if checks.is_empty() {
-                eprintln!(
-                    "[legion] no checks reported for PR #{} on {}",
-                    number, source_repo
-                );
-            } else {
+            } else if !checks.is_empty() {
                 let mut name_w = 0usize;
                 let mut wf_w = 0usize;
-                for c in &checks {
+                for c in checks {
                     name_w = name_w.max(c.name.len());
                     wf_w = wf_w.max(c.workflow.len());
                 }
-                for c in &checks {
+                for c in checks {
                     println!(
                         "{:<8} {:<name_w$}  {:<wf_w$}  {}",
                         c.state,
@@ -459,6 +466,18 @@ pub(crate) fn handle(action: PrAction) -> error::Result<()> {
                         }
                     }
                 }
+            }
+
+            // Zero runs for the pinned head SHA is a distinct non-passing
+            // state, not a vacuous pass (#736): a fresh push whose CI has not
+            // started yet, or gh's checks view lagging the head commit, must
+            // not read as "nothing failing" to a merge gate.
+            if checks.is_empty() {
+                return Err(no_runs_for_head_error(
+                    &result.head_sha,
+                    number,
+                    &source_repo,
+                ));
             }
 
             let failed: Vec<&str> = checks
@@ -652,6 +671,28 @@ pub(crate) fn handle(action: PrAction) -> error::Result<()> {
         } => {
             let (plugin_name, source_repo, _workdir) = worksource::require_worksource(&repo)?;
             let database = open_db()?;
+
+            // Same fail-closed gate as `legion pr checks` (#736): a head SHA
+            // with zero check runs must refuse the merge, not inherit the
+            // branch's last-green suite through some other path. Checked
+            // here (not left to branch protection) because a repo without a
+            // required-status-checks rule would otherwise let an untested
+            // head merge silently.
+            //
+            // Deliberately narrow: this refuses only the zero-runs state,
+            // not a head with checks that are actively failing. Merge never
+            // gated on failing checks before this change either (the plugin's
+            // own merge case only inspects reviewDecision) -- expanding that
+            // is a separate concern from #736's zero-runs false-green bug and
+            // left to the repo's own branch protection / required checks.
+            let checks_result = worksource::pr_checks(&plugin_name, &source_repo, number)?;
+            if checks_result.checks.is_empty() {
+                return Err(no_runs_for_head_error(
+                    &checks_result.head_sha,
+                    number,
+                    &source_repo,
+                ));
+            }
 
             worksource::merge_pr(&plugin_name, &source_repo, number, &strategy, !keep_branch)?;
 

--- a/src/worksource/prs.rs
+++ b/src/worksource/prs.rs
@@ -135,16 +135,28 @@ impl ExternalPRCheck {
     }
 }
 
-/// Fetch CI check status for a PR via a work source plugin.
+/// Result of resolving CI checks for a PR (#736). Carries the head SHA the
+/// plugin actually queried alongside the checks themselves, so a caller can
+/// tell "zero checks reported" apart from "zero checks for the commit we
+/// pinned to" -- and can name that commit in the refusal message. The plugin
+/// contract is to query `commits/{head_sha}/check-runs` for that exact SHA,
+/// never a branch's latest suite (observed live on PR #735: the head had no
+/// runs, but the branch's last-green parent commit's suite leaked through).
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PrChecksResult {
+    pub head_sha: String,
+    pub checks: Vec<ExternalPRCheck>,
+}
+
+/// Fetch CI check status for a PR via a work source plugin, pinned to the
+/// PR's head commit.
 ///
 /// Returns `Err` when the named plugin is not installed. Callers gate merges
-/// on this; an empty `Ok(Vec)` would render as a clean green and let a
-/// misconfigured `watch.toml` auto-approve a PR with no checks ever run.
-pub fn pr_checks(
-    plugin_name: &str,
-    github_repo: &str,
-    pr_number: u64,
-) -> Result<Vec<ExternalPRCheck>> {
+/// on this; an empty checks list is not silently treated as "nothing
+/// failing" -- see `PrChecksResult` and the `no runs for head` refusal in
+/// `legion pr checks` / `legion pr merge`.
+pub fn pr_checks(plugin_name: &str, github_repo: &str, pr_number: u64) -> Result<PrChecksResult> {
     plugin_call(
         plugin_name,
         &["pr-checks"],
@@ -537,5 +549,30 @@ mod tests {
             "expected WorkSource error, got {:?}",
             result
         );
+    }
+
+    /// The plugin protocol wraps checks in `{"headSha": ..., "checks": [...]}`
+    /// (#736) rather than a bare array, precisely so a zero-length `checks`
+    /// list can still name the head commit it is zero-length FOR. Guards the
+    /// camelCase wire shape against an accidental rename.
+    #[test]
+    fn pr_checks_result_deserializes_camel_case_wire_shape() {
+        let json = r#"{"headSha":"ec3825b","checks":[{"name":"Tests","state":"SUCCESS","workflow":"CI","link":"https://x","description":""}]}"#;
+        let parsed: PrChecksResult = serde_json::from_str(json).expect("valid PrChecksResult");
+        assert_eq!(parsed.head_sha, "ec3825b");
+        assert_eq!(parsed.checks.len(), 1);
+        assert_eq!(parsed.checks[0].name, "Tests");
+    }
+
+    /// Zero check runs for the head SHA still deserializes cleanly -- an
+    /// empty `checks` array with a populated `headSha` is the exact shape
+    /// the plugin emits when the Checks API returns `total_count: 0` for
+    /// that commit (#736).
+    #[test]
+    fn pr_checks_result_deserializes_zero_runs() {
+        let json = r#"{"headSha":"ec3825b","checks":[]}"#;
+        let parsed: PrChecksResult = serde_json::from_str(json).expect("valid PrChecksResult");
+        assert_eq!(parsed.head_sha, "ec3825b");
+        assert!(parsed.checks.is_empty());
     }
 }

--- a/tests/integration/worksource_pr.rs
+++ b/tests/integration/worksource_pr.rs
@@ -123,16 +123,19 @@ BODY
 BODY
     ;;
   pr-checks)
-    # Minimal fixture matching ExternalPRCheck shape so `pr checks --log-failed`
-    # has something to iterate. One failing check, one success, plus one
-    # failure whose link does not match the Actions pattern so the
-    # non-Actions-link branch runs.
+    # Minimal fixture matching PrChecksResult shape (#736: headSha + checks)
+    # so `pr checks --log-failed` has something to iterate. One failing
+    # check, one success, plus one failure whose link does not match the
+    # Actions pattern so the non-Actions-link branch runs.
     cat <<'BODY'
-[
-  {{"name":"Clippy","state":"FAILURE","workflow":"CI","link":"https://github.com/ex/ex/actions/runs/1/job/42","description":""}},
-  {{"name":"Tests","state":"SUCCESS","workflow":"CI","link":"https://github.com/ex/ex/actions/runs/1/job/99","description":""}},
-  {{"name":"External","state":"FAILURE","workflow":"CI","link":"https://dashboard.example.com/checks/abc","description":""}}
-]
+{{
+  "headSha": "deadbeef",
+  "checks": [
+    {{"name":"Clippy","state":"FAILURE","workflow":"CI","link":"https://github.com/ex/ex/actions/runs/1/job/42","description":""}},
+    {{"name":"Tests","state":"SUCCESS","workflow":"CI","link":"https://github.com/ex/ex/actions/runs/1/job/99","description":""}},
+    {{"name":"External","state":"FAILURE","workflow":"CI","link":"https://dashboard.example.com/checks/abc","description":""}}
+  ]
+}}
 BODY
     ;;
   pr-check-log)
@@ -387,7 +390,7 @@ set -e
 case "${1:-}" in
   pr-checks)
     cat <<'BODY'
-[{"name":"Clippy","state":"FAILURE","workflow":"CI","link":"https://github.com/ex/ex/actions/runs/1/job/42","description":""}]
+{"headSha":"deadbeef","checks":[{"name":"Clippy","state":"FAILURE","workflow":"CI","link":"https://github.com/ex/ex/actions/runs/1/job/42","description":""}]}
 BODY
     ;;
   pr-check-log)
@@ -459,6 +462,99 @@ fn pr_checks_log_failed_suppressed_under_json() {
     let parsed: serde_json::Value =
         serde_json::from_str(&stdout).expect("stdout must be a single valid JSON array");
     assert!(parsed.is_array(), "expected JSON array, got {parsed}");
+}
+
+// ---------------------------------------------------------------------------
+// #736: pr-checks pinned to the PR head SHA. A plugin response distinguishes
+// "checks reported for this exact head commit" from "zero runs for the head"
+// -- the latter must be a distinct non-passing state, not a silent pass
+// inherited from wherever the branch's last suite happened to be.
+// ---------------------------------------------------------------------------
+
+#[cfg(unix)]
+fn pr_checks_only_stub(pr_checks_body: &str) -> String {
+    format!(
+        r#"#!/bin/bash
+set -e
+case "${{1:-}}" in
+  pr-checks)
+    cat <<'BODY'
+{pr_checks_body}
+BODY
+    ;;
+  *)
+    echo "stub: unknown subcommand $1" >&2
+    exit 2
+    ;;
+esac
+"#
+    )
+}
+
+/// A plugin that resolved zero check-runs for the PR's head SHA must fail
+/// `legion pr checks` with a distinct, named state -- not silently exit 0
+/// because an empty `checks` array has nothing to iterate and "finds
+/// nothing failing" (the exact false-green shape observed live on PR #735).
+#[cfg(unix)]
+#[test]
+fn pr_checks_zero_runs_for_head_is_non_passing() {
+    let data_dir = tempfile::tempdir().unwrap();
+    let plugin_root = tempfile::tempdir().unwrap();
+    let body = pr_checks_only_stub(r#"{"headSha":"ec3825b","checks":[]}"#);
+    setup_pr_read_stub(data_dir.path(), plugin_root.path(), &body);
+
+    let (_stdout, stderr) = run_fail(
+        pr_read_cmd(data_dir.path(), plugin_root.path())
+            .args(["pr", "checks", "--repo", "stub", "--number", "735"]),
+    );
+    assert!(
+        stderr.contains("no runs for head ec3825b"),
+        "expected 'no runs for head <sha>' in stderr, got: {stderr}"
+    );
+}
+
+/// Contrast case: when the plugin reports checks FOR THE HEAD SHA and they
+/// are all in a passing state, `legion pr checks` must exit clean. Guards
+/// against a fix that over-corrects into always failing.
+#[cfg(unix)]
+#[test]
+fn pr_checks_head_sha_with_passing_runs_succeeds() {
+    let data_dir = tempfile::tempdir().unwrap();
+    let plugin_root = tempfile::tempdir().unwrap();
+    let body = pr_checks_only_stub(
+        r#"{"headSha":"abc1234","checks":[{"name":"Tests","state":"SUCCESS","workflow":"CI","link":"https://github.com/ex/ex/actions/runs/1/job/1","description":""}]}"#,
+    );
+    setup_pr_read_stub(data_dir.path(), plugin_root.path(), &body);
+
+    let stdout = run_ok(
+        pr_read_cmd(data_dir.path(), plugin_root.path())
+            .args(["pr", "checks", "--repo", "stub", "--number", "1"]),
+    );
+    assert!(stdout.contains("SUCCESS"));
+    assert!(stdout.contains("Tests"));
+}
+
+/// `legion pr merge` must refuse with the SAME "no runs for head <sha>"
+/// wording as `legion pr checks` (#736 criterion 3) -- and must refuse
+/// before ever invoking the plugin's `merge` subcommand, which this stub
+/// does not implement (a call to it would fail the test with "unknown
+/// subcommand" instead of the expected refusal, proving merge is gated).
+#[cfg(unix)]
+#[test]
+fn pr_merge_refuses_when_head_has_zero_runs() {
+    let data_dir = tempfile::tempdir().unwrap();
+    let plugin_root = tempfile::tempdir().unwrap();
+    let body = pr_checks_only_stub(r#"{"headSha":"ec3825b","checks":[]}"#);
+    setup_pr_read_stub(data_dir.path(), plugin_root.path(), &body);
+
+    let (_stdout, stderr) = run_fail(
+        pr_read_cmd(data_dir.path(), plugin_root.path())
+            .args(["pr", "merge", "--repo", "stub", "--number", "735"]),
+    );
+    assert!(
+        stderr.contains("no runs for head ec3825b"),
+        "expected the same 'no runs for head <sha>' refusal as `pr checks`, got: {stderr}"
+    );
 }
 
 #[cfg(unix)]


### PR DESCRIPTION
## Summary

`legion pr checks` and `legion pr merge` relied on `gh pr checks`, which resolves check state
against whatever commit gh's own PR-checks view considers current -- observed live on PR #735
echoing a parent commit's completed green suite when the actual head SHA had zero runs, a
false "all passing" for an untested commit. This change resolves the PR's `headRefOid`
directly and queries that exact SHA's check-runs and combined-status via the GitHub REST API,
and makes zero runs for the pinned head SHA a distinct refusal rather than a vacuous pass.

## Acceptance criteria mapping

### 1. `pr-checks` is pinned to the PR's actual head SHA, not gh's ambient view

`plugin/worksources/github` now resolves `headRefOid` via `gh pr view` and queries
`commits/{sha}/check-runs` and `commits/{sha}/status` for that exact commit, replacing the
prior `gh pr checks` call whose result could echo a different commit's suite.

Evidence: plugin/worksources/github:402-475; `src/worksource/prs.rs:143-154` documents the
plugin contract ("query commits/{head_sha}/check-runs for that exact SHA, never a branch's
latest suite").

### 2. Zero check runs for the head SHA is a distinct non-passing state, not a silent pass

`PrChecksResult` (`src/worksource/prs.rs:147-149`) carries `head_sha` alongside `checks` so a
caller can name the exact commit a zero-runs refusal applies to. Both `legion pr checks` and
`legion pr merge` now return the shared `no_runs_for_head_error` when `checks` is empty,
instead of exiting clean because there was nothing to iterate.

Evidence: `src/cli/pr.rs:471-478` (checks path), tests `pr_checks_zero_runs_for_head_is_non_passing`
and `pr_checks_head_sha_with_passing_runs_succeeds` in
`tests/integration/worksource_pr.rs:483-527` (the latter guards against over-correcting into
always-fail).

### 3. `legion pr merge` refuses with the same wording as `legion pr checks` for the same state

`no_runs_for_head_error` (`src/cli/pr.rs:227-234`) is a single shared helper so both commands
present identical text for the zero-runs state, and the merge path checks this before ever
calling the plugin's `merge` subcommand.

Evidence: `src/cli/pr.rs:688-694`; test `pr_merge_refuses_when_head_has_zero_runs` in
`tests/integration/worksource_pr.rs:530-547`, whose stub deliberately has no `merge` case so
removing the gate would surface as "unknown subcommand" rather than a silent pass.

### 4. Regression test with a mocked plugin response distinguishing head-sha runs from branch-latest

`tests/integration/worksource_pr.rs` gained a dedicated `pr_checks_only_stub` helper that
emits a controlled `{"headSha": ..., "checks": [...]}` body, used by three new tests: zero
runs for the head SHA (the exact PR #735 shape), a passing head-sha response (contrast case),
and the merge-refusal path. The two pre-existing `pr-checks` stub fixtures were also migrated
to the new wire shape so they keep exercising the real contract instead of the old bare-array
shape the production code no longer parses.

Evidence: `tests/integration/worksource_pr.rs:483-547` (three new tests);
`tests/integration/worksource_pr.rs:123-141,390-393` (existing fixtures updated to
`{"headSha", "checks"}`).

## Deliberately not done

- Merge is not gated on individual *failing* checks, only on zero runs for the head -- that
  was true before this change too (merge only inspected `reviewDecision`), and expanding it is
  a separate concern left to each repo's own branch protection / required-status-checks rule.
  Called out explicitly at `src/cli/pr.rs:679-687`.
- No changes to `gh pr view`'s own resolution of `headRefOid` -- that call is trusted as the
  PR's canonical head; only the checks-lookup step (which was observed drifting) is replaced.

Closes #736