### PR TITLE
feat(#751): legion pr create --closes injects GitHub closing keyword

### DIFF
--- a/plugin/skills/legion-pr-write/SKILL.md
+++ b/plugin/skills/legion-pr-write/SKILL.md
@@ -63,6 +63,9 @@ simplify gate).
    line of evidence. The mapping must be composed prose, not a checklist -- a fill-in form
    defeats the purpose.
 
+   The body also needs a GitHub closing keyword (`Closes #<issue>`) so the merge auto-closes
+   the issue -- see step 5, `--closes` appends it for you.
+
 4. **Validate.** This records the gate and refuses boilerplate:
 
    ```bash
@@ -74,11 +77,14 @@ simplify gate).
      Do not pad to clear the word count; write the real explanation. If a criterion genuinely
      is not addressed, that is a signal the work is not done.
 
-5. **Open the PR** with the validated body:
+5. **Open the PR** with the validated body, passing `--closes` for the issue it satisfies so
+   the merge auto-closes it (#751; repeatable for more than one issue, quote the cross-repo
+   form since `#` starts a shell comment):
 
    ```bash
    legion pr create --repo <repo> --title "<type>(#<issue>): <summary>" \
-     --body "$(cat /tmp/pr-body-<issue>.md)" --task <card-id>
+     --body "$(cat /tmp/pr-body-<issue>.md)" --task <card-id> --closes <issue>
+   # cross-repo: --closes 'owner/repo#<issue>'
    ```
 
 ## Notes
@@ -91,3 +97,10 @@ simplify gate).
 - Re-running write-check overwrites the previous gate row for HEAD; the most recent wins.
 - Bootstrap only: a branch that ships these skills themselves cannot gate on them. Use
   `legion pr create --skip-gates` (it writes an audit row so the skip is never silent).
+- `legion pr write-check` warns (does not fail, v1) when the validated body has no closing
+  keyword for `--issue`. `legion pr create --closes <issue>` appends `Closes #<issue>` (or
+  `Closes owner/repo#<issue>` cross-repo) itself unless one is already present -- idempotent,
+  so re-running it never duplicates the line.
+- GitHub only auto-closes the *first* keyword'd issue on a merged PR. When a PR ships more
+  than one issue, pass `--closes` for all of them (audit trail) but expect to close the
+  secondary ones manually, or run `legion kanban reconcile` after merge to catch the drift.

--- a/plugin/skills/legion-pr-write/SKILL.md
+++ b/plugin/skills/legion-pr-write/SKILL.md
@@ -101,6 +101,8 @@ simplify gate).
   keyword for `--issue`. `legion pr create --closes <issue>` appends `Closes #<issue>` (or
   `Closes owner/repo#<issue>` cross-repo) itself unless one is already present -- idempotent,
   so re-running it never duplicates the line.
-- GitHub only auto-closes the *first* keyword'd issue on a merged PR. When a PR ships more
-  than one issue, pass `--closes` for all of them (audit trail) but expect to close the
-  secondary ones manually, or run `legion kanban reconcile` after merge to catch the drift.
+- GitHub requires the closing keyword to immediately precede EACH reference -- `Closes #1,
+  #2` closes only #1, not #2 (`Closes #1, closes #2` closes both). Repeatable `--closes`
+  handles this correctly (one `Closes #N` line per issue); if you hand-write a body instead,
+  repeat the keyword per issue rather than comma-joining bare references, or run
+  `legion kanban reconcile` after merge to catch anything that silently stayed open.

--- a/src/cli/pr.rs
+++ b/src/cli/pr.rs
@@ -52,6 +52,15 @@ pub(crate) enum PrAction {
         /// An audit entry is written so this cannot be done silently.
         #[arg(long)]
         skip_gates: bool,
+
+        /// Issue this PR closes on merge (repeatable). Accepts a same-repo
+        /// issue number ("751") or a cross-repo reference
+        /// ("owner/repo#751" -- quote it in the shell, `#` starts a
+        /// comment). Appends a `Closes #N` line to the body unless a
+        /// recognized closing keyword for that issue is already present;
+        /// idempotent across repeated invocations.
+        #[arg(long)]
+        closes: Vec<String>,
     },
 
     /// List open pull requests with review status
@@ -237,6 +246,7 @@ pub(crate) fn handle(action: PrAction) -> error::Result<()> {
             reviewer,
             task,
             skip_gates,
+            closes,
         } => {
             // One database handle for the whole arm (#610): the gate
             // check, the skip-gates audit entry, the card link, the
@@ -304,7 +314,32 @@ pub(crate) fn handle(action: PrAction) -> error::Result<()> {
                 }
             }
 
+            // Parse --closes eagerly, before worksource resolution, so a
+            // malformed value fails fast without needing a live PR round
+            // trip (mirrors the gate checks above).
+            let mut close_refs: Vec<pr_write::CloseRef> = Vec::with_capacity(closes.len());
+            for spec in &closes {
+                match pr_write::CloseRef::parse(spec) {
+                    Ok(cr) => close_refs.push(cr),
+                    Err(e) => {
+                        eprintln!("[legion] error: {e}");
+                        return Err(error::LegionError::ExitWith(1));
+                    }
+                }
+            }
+
             let (plugin_name, source_repo, _workdir) = worksource::require_worksource(&repo)?;
+
+            // Append a `Closes #N` line per --closes unless the body already
+            // carries a recognized closing keyword for that issue (#751).
+            let body = if close_refs.is_empty() {
+                body
+            } else {
+                Some(pr_write::append_closing_lines(
+                    body.as_deref().unwrap_or(""),
+                    &close_refs,
+                ))
+            };
 
             let created = worksource::create_pr(
                 &plugin_name,
@@ -506,6 +541,18 @@ pub(crate) fn handle(action: PrAction) -> error::Result<()> {
             let body = read_file_or_stdin(body_file.as_deref(), "--body-file")?;
 
             let report = pr_write::validate_pr_body(&parsed.acceptance, &body);
+
+            // Warn (never fail, v1 -- #751) when the body lacks a recognized
+            // GitHub closing keyword for this issue. Printed unconditionally,
+            // ahead of the ok/fail branch below, so a body that also fails
+            // the mapping check still surfaces the missing linkage.
+            if !pr_write::has_closing_keyword(&body, &pr_write::CloseRef::same_repo(issue)) {
+                eprintln!(
+                    "[legion] warning: body has no closing keyword for issue #{issue} -- add \
+                     'Closes #{issue}' (or pass `--closes {issue}` to `pr create`, which appends \
+                     it automatically) so the merge auto-closes it."
+                );
+            }
 
             // Record the gate on HEAD so `legion pr create` can gate on it,
             // exactly as it does for legion-simplify.

--- a/src/pr_write.rs
+++ b/src/pr_write.rs
@@ -293,6 +293,156 @@ fn has_source_path_with_line(entry: &str) -> bool {
     })
 }
 
+/// GitHub's recognized issue-closing keywords, case-insensitive:
+/// <https://docs.github.com/articles/closing-issues-using-keywords>
+const CLOSING_KEYWORDS: [&str; 9] = [
+    "close", "closes", "closed", "fix", "fixes", "fixed", "resolve", "resolves", "resolved",
+];
+
+/// A single `--closes` argument to `legion pr create` (#751): either a
+/// same-repo issue number (`"751"`, or `"#751"`) or a cross-repo reference
+/// (`"owner/repo#751"`).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CloseRef {
+    owner_repo: Option<String>,
+    number: u64,
+}
+
+impl CloseRef {
+    /// Parse a `--closes` value. Accepts a bare issue number (`"751"`), the
+    /// same with a leading `#` (`"#751"`), or a cross-repo reference
+    /// (`"owner/repo#751"`). Callers passing the cross-repo form on a shell
+    /// command line must quote it -- an unquoted `#` starts a comment.
+    pub fn parse(spec: &str) -> Result<Self, String> {
+        let spec = spec.trim();
+        let stripped = spec.strip_prefix('#').unwrap_or(spec);
+        match stripped.split_once('#') {
+            Some((owner_repo, num)) => {
+                if owner_repo.is_empty() || !owner_repo.contains('/') {
+                    return Err(format!(
+                        "invalid --closes value '{spec}': cross-repo form is 'owner/repo#N'"
+                    ));
+                }
+                let number = num.parse::<u64>().map_err(|_| {
+                    format!("invalid --closes value '{spec}': '{num}' is not an issue number")
+                })?;
+                Ok(Self {
+                    owner_repo: Some(owner_repo.to_owned()),
+                    number,
+                })
+            }
+            None => {
+                let number = stripped.parse::<u64>().map_err(|_| {
+                    format!("invalid --closes value '{spec}': expected 'N' or 'owner/repo#N'")
+                })?;
+                Ok(Self {
+                    owner_repo: None,
+                    number,
+                })
+            }
+        }
+    }
+
+    /// A same-repo reference to `number`, bypassing string parsing. Used by
+    /// `pr write-check`, which already has the issue number as a `u64`.
+    pub fn same_repo(number: u64) -> Self {
+        Self {
+            owner_repo: None,
+            number,
+        }
+    }
+
+    /// The bare reference text GitHub matches: `#N` or `owner/repo#N`.
+    fn reference(&self) -> String {
+        match &self.owner_repo {
+            Some(or) => format!("{or}#{}", self.number),
+            None => format!("#{}", self.number),
+        }
+    }
+
+    /// The `Closes #N` / `Closes owner/repo#N` line to append to a PR body.
+    pub fn closing_line(&self) -> String {
+        format!("Closes {}", self.reference())
+    }
+}
+
+/// True when `tok` (after trimming trailing sentence punctuation) has the
+/// shape of an issue reference: `#N` or `owner/repo#N`.
+fn looks_like_issue_ref(tok: &str) -> bool {
+    let tok = tok.trim_end_matches([',', '.', ';', ':']);
+    match tok.rsplit_once('#') {
+        Some((prefix, digits)) => {
+            !digits.is_empty()
+                && digits.chars().all(|c| c.is_ascii_digit())
+                && prefix
+                    .chars()
+                    .all(|c| c.is_alphanumeric() || matches!(c, '-' | '_' | '/'))
+        }
+        None => false,
+    }
+}
+
+/// True when `body` already carries a recognized GitHub closing keyword
+/// (case-insensitive) applying to `close_ref` -- `Closes #N`, `Fixes
+/// owner/repo#N`, or a comma-separated group (`Closes #1, #2`). Scoped per
+/// line and per keyword-then-reference-run, mirroring how GitHub itself
+/// parses closing keywords: a keyword stays "active" across a run of
+/// comma-separated reference tokens and resets on anything else, so `Closes
+/// #999 but not #751` does NOT count as closing #751. Used both to keep
+/// `pr create --closes` idempotent and by `pr write-check` to warn when
+/// linkage is missing.
+pub fn has_closing_keyword(body: &str, close_ref: &CloseRef) -> bool {
+    let target = close_ref.reference().to_lowercase();
+
+    for line in body.lines() {
+        let mut keyword_active = false;
+        for raw_tok in line.split_whitespace() {
+            let tok = raw_tok.trim_end_matches([',', '.', ';', ':']);
+            let lower_tok = tok.to_lowercase();
+            if CLOSING_KEYWORDS.contains(&lower_tok.as_str()) {
+                keyword_active = true;
+                continue;
+            }
+            if keyword_active && looks_like_issue_ref(tok) {
+                if lower_tok == target {
+                    return true;
+                }
+                // Still inside a comma-separated group of references.
+                continue;
+            }
+            keyword_active = false;
+        }
+    }
+    false
+}
+
+/// Append a `Closes #N` (or `Closes owner/repo#N`) line for each of
+/// `close_refs` that `body` does not already carry a recognized closing
+/// keyword for. Idempotent: calling this again on its own output appends
+/// nothing new. Inserted lines are grouped as a single block, separated
+/// from any existing body content by one blank line.
+pub fn append_closing_lines(body: &str, close_refs: &[CloseRef]) -> String {
+    let mut out = body.to_owned();
+    let mut first_insertion = true;
+    for cr in close_refs {
+        if has_closing_keyword(&out, cr) {
+            continue;
+        }
+        if first_insertion {
+            if !out.is_empty() {
+                if !out.ends_with('\n') {
+                    out.push('\n');
+                }
+                out.push('\n');
+            }
+            first_insertion = false;
+        }
+        out.push_str(&cr.closing_line());
+        out.push('\n');
+    }
+    out
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -440,5 +590,106 @@ mod tests {
         // behavioral cue both still count.
         assert!(has_evidence("src/foo.rs reads cleanly"));
         assert!(has_evidence("the observable behavior is unchanged"));
+    }
+
+    #[test]
+    fn close_ref_parses_same_repo_and_cross_repo() {
+        assert_eq!(
+            CloseRef::parse("751").unwrap(),
+            CloseRef {
+                owner_repo: None,
+                number: 751
+            }
+        );
+        assert_eq!(
+            CloseRef::parse("#751").unwrap(),
+            CloseRef {
+                owner_repo: None,
+                number: 751
+            }
+        );
+        assert_eq!(
+            CloseRef::parse("owner/repo#751").unwrap(),
+            CloseRef {
+                owner_repo: Some("owner/repo".to_owned()),
+                number: 751
+            }
+        );
+        assert!(CloseRef::parse("abc").is_err());
+        assert!(
+            CloseRef::parse("owner#751").is_err(),
+            "no slash -- not owner/repo"
+        );
+        assert!(CloseRef::parse("owner/repo#abc").is_err());
+    }
+
+    #[test]
+    fn closing_line_formats_same_and_cross_repo() {
+        assert_eq!(
+            CloseRef::parse("751").unwrap().closing_line(),
+            "Closes #751"
+        );
+        assert_eq!(
+            CloseRef::parse("owner/repo#751").unwrap().closing_line(),
+            "Closes owner/repo#751"
+        );
+    }
+
+    #[test]
+    fn has_closing_keyword_detects_common_forms() {
+        let same_repo = CloseRef::same_repo(751);
+        assert!(has_closing_keyword("Closes #751", &same_repo));
+        assert!(has_closing_keyword("closes #751", &same_repo));
+        assert!(has_closing_keyword("Fixes #751", &same_repo));
+        assert!(has_closing_keyword(
+            "This PR resolves #751 finally.",
+            &same_repo
+        ));
+        // Comma-separated group: keyword stays active across the run.
+        assert!(has_closing_keyword("Closes #1, #751", &same_repo));
+
+        let cross_repo = CloseRef::parse("owner/repo#751").unwrap();
+        assert!(has_closing_keyword("Resolves owner/repo#751", &cross_repo));
+    }
+
+    #[test]
+    fn has_closing_keyword_rejects_non_matches() {
+        let target = CloseRef::same_repo(751);
+        // Different issue number entirely.
+        assert!(!has_closing_keyword("Closes #999", &target));
+        // Keyword group broken by intervening prose -- must not count #751.
+        assert!(!has_closing_keyword("Closes #999 but not #751", &target));
+        // "prefix" must not match the "fix" keyword (word-boundary check).
+        assert!(!has_closing_keyword("prefix #751 is unrelated", &target));
+        // A bare mention with no keyword at all.
+        assert!(!has_closing_keyword("See #751 for context", &target));
+        // Cross-repo target must not match a same-repo mention and vice versa.
+        let cross_repo = CloseRef::parse("owner/repo#751").unwrap();
+        assert!(!has_closing_keyword("Closes #751", &cross_repo));
+    }
+
+    #[test]
+    fn append_closing_lines_is_idempotent_and_never_duplicates() {
+        let refs = vec![CloseRef::same_repo(751)];
+        let once = append_closing_lines("## Summary\n\nDoes the thing.\n", &refs);
+        assert!(once.contains("Closes #751"));
+        let twice = append_closing_lines(&once, &refs);
+        assert_eq!(once, twice, "re-running must not duplicate the line");
+        assert_eq!(twice.matches("Closes #751").count(), 1);
+    }
+
+    #[test]
+    fn append_closing_lines_skips_when_keyword_already_present() {
+        let refs = vec![CloseRef::same_repo(751)];
+        let body = "## Summary\n\nFixes #751 already.\n";
+        let out = append_closing_lines(body, &refs);
+        assert_eq!(out, body, "existing manual keyword must be left unchanged");
+    }
+
+    #[test]
+    fn append_closing_lines_handles_empty_body_and_multiple_refs() {
+        let refs = vec![CloseRef::same_repo(1), CloseRef::same_repo(2)];
+        let out = append_closing_lines("", &refs);
+        assert_eq!(out, "Closes #1\nCloses #2\n");
     }
 }

--- a/src/pr_write.rs
+++ b/src/pr_write.rs
@@ -302,7 +302,7 @@ const CLOSING_KEYWORDS: [&str; 9] = [
 /// A single `--closes` argument to `legion pr create` (#751): either a
 /// same-repo issue number (`"751"`, or `"#751"`) or a cross-repo reference
 /// (`"owner/repo#751"`).
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct CloseRef {
     owner_repo: Option<String>,
     number: u64,
@@ -369,7 +369,7 @@ impl CloseRef {
 /// True when `tok` (after trimming trailing sentence punctuation) has the
 /// shape of an issue reference: `#N` or `owner/repo#N`.
 fn looks_like_issue_ref(tok: &str) -> bool {
-    let tok = tok.trim_end_matches([',', '.', ';', ':']);
+    let tok = tok.trim_end_matches([',', '.', ';']);
     match tok.rsplit_once('#') {
         Some((prefix, digits)) => {
             !digits.is_empty()
@@ -383,34 +383,31 @@ fn looks_like_issue_ref(tok: &str) -> bool {
 }
 
 /// True when `body` already carries a recognized GitHub closing keyword
-/// (case-insensitive) applying to `close_ref` -- `Closes #N`, `Fixes
-/// owner/repo#N`, or a comma-separated group (`Closes #1, #2`). Scoped per
-/// line and per keyword-then-reference-run, mirroring how GitHub itself
-/// parses closing keywords: a keyword stays "active" across a run of
-/// comma-separated reference tokens and resets on anything else, so `Closes
-/// #999 but not #751` does NOT count as closing #751. Used both to keep
+/// (case-insensitive) directly followed by a reference to `close_ref` --
+/// `Closes #N`, `Fixes owner/repo#N`. GitHub requires the keyword to
+/// immediately precede the reference it closes, so a comma-separated group
+/// like `Closes #1, #2` closes ONLY #1 -- #2 needs its own keyword (`Closes
+/// #1, closes #2`). This mirrors that exactly: the keyword only "covers" the
+/// single token right after it, so `Closes #999 but not #751` does not count
+/// as closing #751, and neither does `Closes #1, #751`. Used both to keep
 /// `pr create --closes` idempotent and by `pr write-check` to warn when
 /// linkage is missing.
 pub fn has_closing_keyword(body: &str, close_ref: &CloseRef) -> bool {
     let target = close_ref.reference().to_lowercase();
 
     for line in body.lines() {
-        let mut keyword_active = false;
+        let mut prev_was_keyword = false;
         for raw_tok in line.split_whitespace() {
-            let tok = raw_tok.trim_end_matches([',', '.', ';', ':']);
+            let tok = raw_tok.trim_end_matches([',', '.', ';']);
             let lower_tok = tok.to_lowercase();
             if CLOSING_KEYWORDS.contains(&lower_tok.as_str()) {
-                keyword_active = true;
+                prev_was_keyword = true;
                 continue;
             }
-            if keyword_active && looks_like_issue_ref(tok) {
-                if lower_tok == target {
-                    return true;
-                }
-                // Still inside a comma-separated group of references.
-                continue;
+            if prev_was_keyword && looks_like_issue_ref(tok) && lower_tok == target {
+                return true;
             }
-            keyword_active = false;
+            prev_was_keyword = false;
         }
     }
     false
@@ -645,8 +642,8 @@ mod tests {
             "This PR resolves #751 finally.",
             &same_repo
         ));
-        // Comma-separated group: keyword stays active across the run.
-        assert!(has_closing_keyword("Closes #1, #751", &same_repo));
+        // Repeated keyword, one per reference -- GitHub closes both.
+        assert!(has_closing_keyword("Closes #1, closes #751", &same_repo));
 
         let cross_repo = CloseRef::parse("owner/repo#751").unwrap();
         assert!(has_closing_keyword("Resolves owner/repo#751", &cross_repo));
@@ -663,6 +660,10 @@ mod tests {
         assert!(!has_closing_keyword("prefix #751 is unrelated", &target));
         // A bare mention with no keyword at all.
         assert!(!has_closing_keyword("See #751 for context", &target));
+        // A single keyword shared across a comma-separated group does NOT
+        // carry to the second reference on GitHub -- #751 here would stay
+        // open, so this must not read as already-closed.
+        assert!(!has_closing_keyword("Closes #1, #751", &target));
         // Cross-repo target must not match a same-repo mention and vice versa.
         let cross_repo = CloseRef::parse("owner/repo#751").unwrap();
         assert!(!has_closing_keyword("Closes #751", &cross_repo));

--- a/src/pr_write.rs
+++ b/src/pr_write.rs
@@ -667,6 +667,9 @@ mod tests {
         // Cross-repo target must not match a same-repo mention and vice versa.
         let cross_repo = CloseRef::parse("owner/repo#751").unwrap();
         assert!(!has_closing_keyword("Closes #751", &cross_repo));
+        // A trailing colon breaks GitHub's own auto-linking too -- "Closes:"
+        // must not register as the keyword.
+        assert!(!has_closing_keyword("Closes: #751", &target));
     }
 
     #[test]

--- a/tests/integration/worksource_pr.rs
+++ b/tests/integration/worksource_pr.rs
@@ -634,6 +634,43 @@ esac
     .to_string()
 }
 
+/// A body that satisfies `validate_pr_body` against the two-criterion issue
+/// `view_issue_stub_plugin` returns: one substantive `### ` entry per
+/// criterion, each with an `Evidence:` line, plus a non-empty `Not done`
+/// section. Shared by every write-check test that needs a passing mapping so
+/// the fixture only needs updating in one place if the gate's structural
+/// requirements change.
+fn substantive_body() -> &'static str {
+    "## Summary\n\nDoes the thing.\n\n\
+     ## Acceptance criteria mapping\n\n\
+     ### 1. crit one\n\
+     The handler now threads the flag through the dispatch table so the \
+     first criterion is satisfied end to end.\n\
+     Evidence: tests/integration/worksource_pr.rs::stub_test\n\n\
+     ### 2. crit two\n\
+     The second path is covered by the new guard clause, which refuses \
+     the malformed input before it reaches the store.\n\
+     Evidence: src/pr_write.rs:49 validate_pr_body\n\n\
+     ## Not done\n\n\
+     Did not migrate old rows -- out of scope, tracked separately.\n"
+}
+
+/// `pr write-check`'s repeated `--repo stub --issue 7 --body-file <path>`
+/// arg block, shared by every test in this file that drives the stub
+/// write-check plugin.
+fn write_check_args(body_file: &std::path::Path) -> Vec<String> {
+    vec![
+        "pr".to_string(),
+        "write-check".to_string(),
+        "--repo".to_string(),
+        "stub".to_string(),
+        "--issue".to_string(),
+        "7".to_string(),
+        "--body-file".to_string(),
+        body_file.display().to_string(),
+    ]
+}
+
 /// `legion pr write-check` with a substantive body: exits 0, reports the
 /// gate clean, and counts one mapping entry per acceptance criterion
 /// (#519 forcing function, #608 coverage net).
@@ -648,31 +685,11 @@ fn pr_write_check_passes_substantive_body_and_reports_clean() {
         &view_issue_stub_plugin(),
     );
 
-    let body = "## Summary\n\nDoes the thing.\n\n\
-        ## Acceptance criteria mapping\n\n\
-        ### 1. crit one\n\
-        The handler now threads the flag through the dispatch table so the \
-        first criterion is satisfied end to end.\n\
-        Evidence: tests/integration/worksource_pr.rs::stub_test\n\n\
-        ### 2. crit two\n\
-        The second path is covered by the new guard clause, which refuses \
-        the malformed input before it reaches the store.\n\
-        Evidence: src/pr_write.rs:49 validate_pr_body\n\n\
-        ## Not done\n\n\
-        Did not migrate old rows -- out of scope, tracked separately.\n";
     let body_file = data_dir.path().join("pr-body.md");
-    std::fs::write(&body_file, body).unwrap();
+    std::fs::write(&body_file, substantive_body()).unwrap();
 
-    let stdout = run_ok(pr_read_cmd(data_dir.path(), plugin_root.path()).args([
-        "pr",
-        "write-check",
-        "--repo",
-        "stub",
-        "--issue",
-        "7",
-        "--body-file",
-        body_file.to_str().unwrap(),
-    ]));
+    let stdout =
+        run_ok(pr_read_cmd(data_dir.path(), plugin_root.path()).args(write_check_args(&body_file)));
     assert!(
         stdout.contains("pr-write gate clean"),
         "expected clean gate message, got: {stdout}"
@@ -699,16 +716,9 @@ fn pr_write_check_refuses_boilerplate_body_with_gaps() {
     let body_file = data_dir.path().join("pr-body.md");
     std::fs::write(&body_file, "## Summary\n\nDid stuff.\n").unwrap();
 
-    let (_stdout, stderr) = run_fail(pr_read_cmd(data_dir.path(), plugin_root.path()).args([
-        "pr",
-        "write-check",
-        "--repo",
-        "stub",
-        "--issue",
-        "7",
-        "--body-file",
-        body_file.to_str().unwrap(),
-    ]));
+    let (_stdout, stderr) = run_fail(
+        pr_read_cmd(data_dir.path(), plugin_root.path()).args(write_check_args(&body_file)),
+    );
     assert!(
         stderr.contains("pr-write gate FAILED"),
         "expected gate failure banner, got: {stderr}"
@@ -720,6 +730,98 @@ fn pr_write_check_refuses_boilerplate_body_with_gaps() {
     assert!(
         stderr.contains("Not done"),
         "expected the missing not-done finding, got: {stderr}"
+    );
+}
+
+/// `legion pr write-check` warns (does not fail, v1 -- #751) when the
+/// validated body has no GitHub closing keyword for `--issue`. The warning
+/// must not affect the exit code or the gate result: `run_ok_output` already
+/// asserts success, so a regression that turned this into a hard failure
+/// would fail this test even before the stderr assertions run.
+#[cfg(unix)]
+#[test]
+fn pr_write_check_warns_on_missing_closing_keyword() {
+    let data_dir = tempfile::tempdir().unwrap();
+    let plugin_root = tempfile::tempdir().unwrap();
+    setup_pr_read_stub(
+        data_dir.path(),
+        plugin_root.path(),
+        &view_issue_stub_plugin(),
+    );
+
+    let body_file = data_dir.path().join("pr-body.md");
+    std::fs::write(&body_file, substantive_body()).unwrap();
+
+    let out = run_ok_output(
+        pr_read_cmd(data_dir.path(), plugin_root.path()).args(write_check_args(&body_file)),
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stdout.contains("pr-write gate clean"),
+        "missing closing keyword must warn, not fail the gate; got stdout: {stdout}"
+    );
+    assert!(
+        stderr.contains("no closing keyword for issue #7"),
+        "expected the missing-closing-keyword warning, got: {stderr}"
+    );
+}
+
+/// The same body with a `Closes #7` line: the write-check warning is absent.
+#[cfg(unix)]
+#[test]
+fn pr_write_check_silent_when_closing_keyword_present() {
+    let data_dir = tempfile::tempdir().unwrap();
+    let plugin_root = tempfile::tempdir().unwrap();
+    setup_pr_read_stub(
+        data_dir.path(),
+        plugin_root.path(),
+        &view_issue_stub_plugin(),
+    );
+
+    let body = format!("{}\nCloses #7\n", substantive_body());
+    let body_file = data_dir.path().join("pr-body.md");
+    std::fs::write(&body_file, body).unwrap();
+
+    let out = run_ok_output(
+        pr_read_cmd(data_dir.path(), plugin_root.path()).args(write_check_args(&body_file)),
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        !stderr.contains("no closing keyword"),
+        "closing keyword is present -- warning must not fire, got: {stderr}"
+    );
+}
+
+/// `legion pr create --closes` is repeatable: clap accepts multiple
+/// occurrences and the command proceeds past argument parsing to worksource
+/// resolution (#751), rather than erroring on the flag shape.
+#[test]
+fn pr_create_accepts_repeated_closes_flag() {
+    let dir = tempfile::tempdir().unwrap();
+
+    let out = legion_cmd(dir.path())
+        .args([
+            "pr",
+            "create",
+            "--repo",
+            "no-such-repo",
+            "--title",
+            "Bootstrap PR",
+            "--skip-gates",
+            "--closes",
+            "751",
+            "--closes",
+            "752",
+        ])
+        .output()
+        .unwrap();
+
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("no work source configured for repo 'no-such-repo' in watch.toml"),
+        "both --closes values should parse and the command should reach worksource \
+         resolution (not fail on argument parsing), got: {stderr}"
     );
 }
 


### PR DESCRIPTION
## Summary

Wires a GitHub issue-closing keyword into the PR pipeline so merges auto-close the issue they
satisfy, instead of leaving it open until someone remembers to close it by hand (the operator's
concrete example: #711 sat open for two days after shipping in PR #739). `legion pr create` gains
a repeatable `--closes <issue>` flag that appends `Closes #N` to the body, and `legion pr
write-check` now warns when the validated body has no closing keyword for the issue it is
checking. Both share one core primitive, `has_closing_keyword` in `src/pr_write.rs`, which mirrors
GitHub's actual keyword-adjacency semantics (a keyword only covers the single reference right
after it) rather than a loose substring match.

## Acceptance criteria mapping

### 1. `legion pr create` gains `--closes <issue>` (repeatable), appends idempotently

Added `--closes: Vec<String>` to `PrAction::Create` (`src/cli/pr.rs:56-62`). Each value is parsed
into a `CloseRef` (`src/pr_write.rs:302-367`, accepting `"751"`, `"#751"`, or
`"owner/repo#751"`) before worksource resolution runs, so a malformed value fails fast
(`src/cli/pr.rs:317-329`). The parsed refs are passed to `append_closing_lines`
(`src/pr_write.rs:426-446`), which appends one `Closes #N` line per ref unless
`has_closing_keyword` already finds a recognized keyword immediately before that exact
reference in the body -- so re-running the same `--closes` never duplicates the line.
Evidence: `append_closing_lines_is_idempotent_and_never_duplicates` and
`append_closing_lines_skips_when_keyword_already_present` in `src/pr_write.rs`; the CLI plumbing
itself is exercised end-to-end by `pr_create_accepts_repeated_closes_flag` in
`tests/integration/worksource_pr.rs:800`, which passes `--closes 751 --closes 752` through the
real binary and confirms both parse and the command reaches worksource resolution.

### 2. `legion pr write-check --issue N` warns when the body lacks a closing keyword for N

Chose warn, not fail (the issue left this as a design decision): `pr write-check` already gates
hard on mapping/not-done structure, and closing-keyword linkage is a separate, additive concern
that composing agents may reasonably fix in a later step (e.g. via `pr create --closes`), so
failing it outright would block otherwise-valid bodies on a check the create step can fix for
free. Implemented at `src/cli/pr.rs:545-555`: after `validate_pr_body` runs, an unconditional
`eprintln!` fires when `has_closing_keyword(&body, &CloseRef::same_repo(issue))` is false, printed
ahead of the ok/fail branch so a body that also fails mapping validation still surfaces the
missing-linkage warning. Evidence:
`pr_write_check_warns_on_missing_closing_keyword` and
`pr_write_check_silent_when_closing_keyword_present` in `tests/integration/worksource_pr.rs:743`
and `:773` -- the first asserts the gate still reports "pr-write gate clean" (exit 0) alongside the
stderr warning, the second confirms the warning disappears once a `Closes #7` line is present.

### 3. The PR-body template guidance in legion-pr-write mentions the closing line

`plugin/skills/legion-pr-write/SKILL.md` updated in three spots: a sentence after the step-3
mapping instructions telling the agent the body needs a closing keyword (lines 66-67); the step-5
example command now shows `--closes <issue>` with a cross-repo comment (lines 80-88); and two new
`## Notes` bullets (lines 100-107) documenting that write-check warns rather than fails and
explaining GitHub's per-reference keyword-adjacency rule for anyone hand-writing a body with more
than one issue reference. Evidence: `plugin/skills/legion-pr-write/SKILL.md:66-107`.

### 4. Existing bodies with a manual closing keyword pass unchanged

`has_closing_keyword` recognizes all nine of GitHub's documented keywords (close/closes/closed,
fix/fixes/fixed, resolve/resolves/resolved) case-insensitively, so a body that already says
`Fixes #751` is detected and `append_closing_lines` skips it -- no second line is appended, and
`pr write-check`'s warning does not fire. Evidence:
`has_closing_keyword_detects_common_forms` and `append_closing_lines_skips_when_keyword_already_present`
in `src/pr_write.rs`, plus the integration-level `pr_write_check_silent_when_closing_keyword_present`
in `tests/integration/worksource_pr.rs:773`, which drives the same scenario through the real
write-check CLI path rather than only the library function.

## Not done

Did not make `pr write-check` fail (vs. warn) on a missing closing keyword -- the issue left this
as an explicit design choice for v1, and warn keeps the check additive rather than blocking
otherwise-valid bodies on a linkage gap that `pr create --closes` can still fix. Did not add a
`legion issue list` / backlog-enumeration surface -- the issue calls that out as a companion issue,
tracked separately. Did not change squash-merge title generation or any GitHub Actions workflow --
this PR only touches the body text the agent composes and validates locally.

Closes #751