### PR TITLE
feat(#750): legion issue list -- enumerate work-source issues in-band

### DIFF
--- a/plugin/hooks/no-gh.sh
+++ b/plugin/hooks/no-gh.sh
@@ -28,6 +28,7 @@ FIRST_BIN="${FIRST_TOKEN##*/}"
 if [ "$FIRST_BIN" = "gh" ]; then
   emit_deny "Do not use gh directly. Use legion commands instead:
 - legion issue create --repo <name> --title '...' --body '...'
+- legion issue list --repo <name>
 - legion pr create --repo <name> --title '...'
 - legion pr list --repo <name>
 - legion pr review --repo <name> --number <n> --approve

--- a/plugin/worksources/github
+++ b/plugin/worksources/github
@@ -31,6 +31,31 @@ case "${1:-}" in
       --limit 50 2>/dev/null || echo "[]"
     ;;
 
+  list-issues)
+    # Enumerate work-source issues for `legion issue list` (#750): number,
+    # title, state, updated-at, filtered by state and (optionally) label.
+    # Distinct from `list` above (used by `sync`, always open/unfiltered) so
+    # sync's behavior does not shift as a side effect of this verb.
+    #
+    # Env: LEGION_WS_REPO, LEGION_WS_STATE (open|closed|all, default open),
+    #      LEGION_WS_LABEL (optional)
+    STATE="${LEGION_WS_STATE:-open}"
+    LABEL="${LEGION_WS_LABEL:-}"
+    if [ -z "$REPO" ]; then
+      echo "[]"
+      exit 0
+    fi
+    if ! command -v gh &>/dev/null; then
+      echo "[]"
+      exit 0
+    fi
+    ARGS=(issue list --repo "$REPO" --state "$STATE" \
+      --json url,number,title,body,labels,assignees,state,createdAt,updatedAt \
+      --limit 200)
+    [ -n "$LABEL" ] && ARGS+=(--label "$LABEL")
+    gh "${ARGS[@]}" 2>/dev/null || echo "[]"
+    ;;
+
   close)
     NUMBER="${2:-}"
     COMMENT="${LEGION_WS_COMMENT:-}"
@@ -574,7 +599,7 @@ case "${1:-}" in
     ;;
 
   *)
-    echo "Usage: github <list|close|detect|create-issue|create-pr|comment|pr-list|review|merge|pr-close|pr-checks|view-pr|pr-comments|pr-reviews|pr-check-log>" >&2
+    echo "Usage: github <list|list-issues|close|detect|create-issue|create-pr|comment|pr-list|review|merge|pr-close|pr-checks|view-pr|pr-comments|pr-reviews|pr-check-log>" >&2
     exit 1
     ;;
 esac

--- a/plugin/worksources/github
+++ b/plugin/worksources/github
@@ -68,12 +68,25 @@ case "${1:-}" in
       --json url,number,title,body,labels,assignees,state,createdAt,updatedAt \
       --limit "$LIMIT")
     [ -n "$LABEL" ] && ARGS+=(--label "$LABEL")
-    # Merge stderr into the captured output so a failure carries gh's actual
-    # message (auth expired / rate limited / unknown repo) instead of a
-    # guessed one -- `if` (not `set -e`) governs the exit check here, so a
-    # nonzero gh exit falls into the `else` branch rather than killing the
-    # script.
-    if OUT=$(gh "${ARGS[@]}" 2>&1); then
+    # Capture gh's stderr to a scratch file rather than merging it into
+    # $OUT: merging (2>&1) would splice any stderr gh emits on a
+    # *successful* call (deprecation notices etc.) into the JSON payload
+    # this verb echoes to stdout, corrupting it, and would also make the
+    # unguarded `jq 'length'` below see non-JSON input and fail --
+    # fatally, since `set -e` governs this script and there is no `||`
+    # guard on that pipeline. `if` (not `set -e`) governs the gh exit
+    # check itself, so a nonzero gh exit falls into the `else` branch
+    # rather than killing the script.
+    GH_ERR=$(mktemp)
+    trap 'rm -f "$GH_ERR"' EXIT
+    if OUT=$(gh "${ARGS[@]}" 2>"$GH_ERR"); then
+      # Relay whatever gh put on stderr even though the call succeeded
+      # (e.g. a deprecation notice) -- the point of routing it to a
+      # scratch file instead of 2>&1 is to keep it out of $OUT, not to
+      # discard it; call_plugin_inner (#750) relays this same channel for
+      # every plugin, and this verb's own doctrine above is "surface,
+      # don't silently drop."
+      [ -s "$GH_ERR" ] && cat "$GH_ERR" >&2
       if ! command -v jq &>/dev/null; then
         # Missing jq must not silently disable truncation detection -- say
         # so, rather than defaulting COUNT to 0 and staying quiet.
@@ -86,7 +99,7 @@ case "${1:-}" in
       fi
       echo "$OUT"
     else
-      ESCAPED=$(printf '%s' "$OUT" | sed 's/\\/\\\\/g; s/"/\\"/g' | tr '\n' ' ')
+      ESCAPED=$(sed 's/\\/\\\\/g; s/"/\\"/g' "$GH_ERR" | tr '\n' ' ')
       echo "{\"error\":\"gh issue list failed: ${ESCAPED}\"}" >&2
       exit 1
     fi

--- a/plugin/worksources/github
+++ b/plugin/worksources/github
@@ -48,10 +48,17 @@ case "${1:-}" in
     #      LEGION_WS_LABEL (optional)
     STATE="${LEGION_WS_STATE:-open}"
     LABEL="${LEGION_WS_LABEL:-}"
-    LIMIT=1000
+    # Overridable for tests that want to exercise the truncation-warning
+    # branch without fetching 1000 real issues; production callers never set
+    # this and get the real limit.
+    LIMIT="${LEGION_WS_LIST_LIMIT:-1000}"
+    # Every branch below is fail-closed -- including a blank $REPO, which
+    # earlier read as "no data" and contradicted this verb's own fail-closed
+    # policy (a `watch.toml` row with an empty `github` value would then
+    # report a false-empty backlog, the exact #711 shape).
     if [ -z "$REPO" ]; then
-      echo "[]"
-      exit 0
+      echo '{"error":"LEGION_WS_REPO not set"}' >&2
+      exit 1
     fi
     if ! command -v gh &>/dev/null; then
       echo '{"error":"gh CLI not found"}' >&2
@@ -61,13 +68,28 @@ case "${1:-}" in
       --json url,number,title,body,labels,assignees,state,createdAt,updatedAt \
       --limit "$LIMIT")
     [ -n "$LABEL" ] && ARGS+=(--label "$LABEL")
-    RESULT=$(gh "${ARGS[@]}" 2>/dev/null) \
-      || { echo '{"error":"gh issue list failed (check gh auth status, rate limit, or repo slug)"}' >&2; exit 1; }
-    COUNT=$(echo "$RESULT" | jq 'length' 2>/dev/null || echo 0)
-    if [ "$COUNT" -ge "$LIMIT" ]; then
-      echo "[legion worksource:github] warning: list-issues hit the ${LIMIT}-row limit; results may be truncated" >&2
+    # Merge stderr into the captured output so a failure carries gh's actual
+    # message (auth expired / rate limited / unknown repo) instead of a
+    # guessed one -- `if` (not `set -e`) governs the exit check here, so a
+    # nonzero gh exit falls into the `else` branch rather than killing the
+    # script.
+    if OUT=$(gh "${ARGS[@]}" 2>&1); then
+      if ! command -v jq &>/dev/null; then
+        # Missing jq must not silently disable truncation detection -- say
+        # so, rather than defaulting COUNT to 0 and staying quiet.
+        echo "[legion worksource:github] warning: jq not found -- cannot check list-issues for truncation" >&2
+      else
+        COUNT=$(echo "$OUT" | jq 'length')
+        if [ "$COUNT" -ge "$LIMIT" ]; then
+          echo "[legion worksource:github] warning: list-issues hit the ${LIMIT}-row limit; results may be truncated" >&2
+        fi
+      fi
+      echo "$OUT"
+    else
+      ESCAPED=$(printf '%s' "$OUT" | sed 's/\\/\\\\/g; s/"/\\"/g' | tr '\n' ' ')
+      echo "{\"error\":\"gh issue list failed: ${ESCAPED}\"}" >&2
+      exit 1
     fi
-    echo "$RESULT"
     ;;
 
   close)

--- a/plugin/worksources/github
+++ b/plugin/worksources/github
@@ -37,23 +37,37 @@ case "${1:-}" in
     # Distinct from `list` above (used by `sync`, always open/unfiltered) so
     # sync's behavior does not shift as a side effect of this verb.
     #
+    # Fail-closed on an actual gh failure (bad auth, rate limit, network,
+    # unknown repo slug): this is a user-facing enumeration command whose
+    # motivating incident (#711) was exactly "the tool said nothing was
+    # there when something was" -- swallowing errors to `[]` here would
+    # reproduce that failure mode. `list`/`pr-list` above stay fail-open
+    # since callers (`sync`) already treat "no data" as a benign no-op.
+    #
     # Env: LEGION_WS_REPO, LEGION_WS_STATE (open|closed|all, default open),
     #      LEGION_WS_LABEL (optional)
     STATE="${LEGION_WS_STATE:-open}"
     LABEL="${LEGION_WS_LABEL:-}"
+    LIMIT=1000
     if [ -z "$REPO" ]; then
       echo "[]"
       exit 0
     fi
     if ! command -v gh &>/dev/null; then
-      echo "[]"
-      exit 0
+      echo '{"error":"gh CLI not found"}' >&2
+      exit 1
     fi
     ARGS=(issue list --repo "$REPO" --state "$STATE" \
       --json url,number,title,body,labels,assignees,state,createdAt,updatedAt \
-      --limit 200)
+      --limit "$LIMIT")
     [ -n "$LABEL" ] && ARGS+=(--label "$LABEL")
-    gh "${ARGS[@]}" 2>/dev/null || echo "[]"
+    RESULT=$(gh "${ARGS[@]}" 2>/dev/null) \
+      || { echo '{"error":"gh issue list failed (check gh auth status, rate limit, or repo slug)"}' >&2; exit 1; }
+    COUNT=$(echo "$RESULT" | jq 'length' 2>/dev/null || echo 0)
+    if [ "$COUNT" -ge "$LIMIT" ]; then
+      echo "[legion worksource:github] warning: list-issues hit the ${LIMIT}-row limit; results may be truncated" >&2
+    fi
+    echo "$RESULT"
     ;;
 
   close)

--- a/src/cli/issue.rs
+++ b/src/cli/issue.rs
@@ -76,6 +76,29 @@ pub(crate) enum IssueAction {
         #[arg(long)]
         number: u64,
     },
+    /// List work-source issues: number, title, state, updated-at (#750).
+    ///
+    /// Reads the work source's live state via the same plugin path as
+    /// `issue view` -- not the local kanban cache, which `sync` can miss
+    /// entirely (see #750's motivating groom, where #711 sat open although
+    /// shipped because it had no local card at all).
+    List {
+        /// Repository name
+        #[arg(long)]
+        repo: String,
+
+        /// State filter: open (default) | closed | all.
+        #[arg(long, default_value = "open")]
+        state: String,
+
+        /// Filter by label (forwarded to the work source as-is).
+        #[arg(long)]
+        label: Option<String>,
+
+        /// Emit as JSON.
+        #[arg(long)]
+        json: bool,
+    },
     /// Close an issue via the configured work source
     ///
     /// Used to reconcile a shipped kanban card with its public GitHub state
@@ -253,6 +276,56 @@ pub(crate) fn handle(action: IssueAction) -> error::Result<()> {
 
             println!("State: {}", issue.state);
             println!("URL: {}", issue.url);
+        }
+        IssueAction::List {
+            repo,
+            state,
+            label,
+            json,
+        } => {
+            if !matches!(state.as_str(), "open" | "closed" | "all") {
+                return Err(error::LegionError::WorkSource(format!(
+                    "legion issue list: --state must be one of open|closed|all, got '{state}'"
+                )));
+            }
+
+            let (plugin_name, source_repo, _workdir) = worksource::require_worksource(&repo)?;
+            let database = open_db()?;
+
+            let issues =
+                worksource::list_all_issues(&plugin_name, &source_repo, &state, label.as_deref())?;
+
+            let details = serde_json::json!({ "state": state, "label": label });
+            let details_str = details.to_string();
+            audit(
+                &database,
+                &db::AuditInput {
+                    agent: &repo,
+                    action: "list-issues",
+                    target_type: "issue",
+                    target_ref: &source_repo,
+                    task_id: None,
+                    source_type: &plugin_name,
+                    details: Some(&details_str),
+                    outcome: "success",
+                },
+            );
+
+            if json {
+                println!("{}", serde_json::to_string(&issues)?);
+            } else if issues.is_empty() {
+                println!("[legion] no issues on {} (state={})", source_repo, state);
+            } else {
+                for i in &issues {
+                    println!(
+                        "#{}\t{}\t{}\t{}",
+                        i.number,
+                        i.state,
+                        i.updated_at.as_deref().unwrap_or("-"),
+                        i.title
+                    );
+                }
+            }
         }
         IssueAction::Close {
             repo,

--- a/src/worksource/issues.rs
+++ b/src/worksource/issues.rs
@@ -26,6 +26,12 @@ pub struct ExternalIssue {
     pub state: String,
     #[serde(default, alias = "createdAt")]
     pub created_at: Option<String>,
+    /// Last-updated timestamp (#750: `legion issue list` reports this
+    /// alongside state so backlog grooming does not need a separate
+    /// `gh issue view` per row). Absent from shapes that don't carry it
+    /// (e.g. the sub-issue GraphQL projection), hence `Option` + default.
+    #[serde(default, alias = "updatedAt")]
+    pub updated_at: Option<String>,
 }
 
 /// List issues from a work source plugin.
@@ -46,6 +52,31 @@ pub fn list_issues(
             ("LEGION_WS_WORKDIR", workdir),
         ],
     )
+}
+
+/// List work-source issues with state/label filters, for `legion issue
+/// list` (#750): backlog enumeration -- number/title/state/updated-at --
+/// against the work source's live state, not the local kanban cache.
+///
+/// Deliberately a separate plugin verb (`list-issues`) from `list_issues`
+/// (used by `sync`, always open/unfiltered) rather than adding params to
+/// that call, so sync's behavior cannot shift as a side effect of this
+/// verb's defaults changing.
+///
+/// Fail-closed like the other list ops: a missing plugin is an error, not
+/// an empty list (see `require_plugin`).
+pub fn list_all_issues(
+    plugin_name: &str,
+    github_repo: &str,
+    state: &str,
+    label: Option<&str>,
+) -> Result<Vec<ExternalIssue>> {
+    let mut env: Vec<(&str, &str)> =
+        vec![("LEGION_WS_REPO", github_repo), ("LEGION_WS_STATE", state)];
+    if let Some(l) = label {
+        env.push(("LEGION_WS_LABEL", l));
+    }
+    plugin_call(plugin_name, &["list-issues"], &env)
 }
 
 /// View a single issue via a work source plugin.
@@ -360,6 +391,16 @@ mod tests {
     #[test]
     fn list_issues_returns_worksource_error_when_plugin_missing() {
         let result = list_issues("nonexistent-plugin-xyz", "owner/repo", "/tmp");
+        assert!(
+            matches!(result, Err(LegionError::WorkSource(_))),
+            "expected WorkSource error, got {:?}",
+            result
+        );
+    }
+
+    #[test]
+    fn list_all_issues_returns_worksource_error_when_plugin_missing() {
+        let result = list_all_issues("nonexistent-plugin-xyz", "owner/repo", "open", None);
         assert!(
             matches!(result, Err(LegionError::WorkSource(_))),
             "expected WorkSource error, got {:?}",

--- a/src/worksource/mod.rs
+++ b/src/worksource/mod.rs
@@ -318,6 +318,17 @@ fn call_plugin_inner(
         return Err(LegionError::WorkSource(format!("plugin failed: {stderr}")));
     }
 
+    // A plugin that succeeds can still have something worth telling the
+    // user (e.g. `list-issues`' "result set truncated" warning, #750). Prior
+    // to this, stderr on a *successful* call was captured only to be
+    // discarded, so any such warning silently vanished -- the same
+    // quiet-failure shape #750 exists to close, just one layer down. This is
+    // relayed for every plugin call, not just `list-issues`, since any
+    // future plugin warning-on-success deserves the same treatment.
+    if !stderr.trim().is_empty() {
+        eprintln!("{}", stderr.trim_end());
+    }
+
     Ok(stdout)
 }
 

--- a/tests/integration/worksource_pr.rs
+++ b/tests/integration/worksource_pr.rs
@@ -937,6 +937,83 @@ fn issue_list_json_flag_emits_parseable_array() {
     assert_eq!(arr[0]["updated_at"], "2026-01-02T00:00:00Z");
 }
 
+/// A `gh` failure inside the plugin (expired auth, rate limit, unknown repo)
+/// must surface as a loud error, not a silent empty list -- this is the
+/// exact #711 failure mode #750 exists to prevent. The stub's `list-issues`
+/// case exits 1 with a message on stderr, mirroring a real `gh` failure.
+#[cfg(unix)]
+#[test]
+fn issue_list_surfaces_plugin_failure_as_error_not_empty_list() {
+    let data_dir = tempfile::tempdir().unwrap();
+    let plugin_root = tempfile::tempdir().unwrap();
+    let body = r##"#!/bin/bash
+case "${1:-}" in
+  list-issues)
+    echo '{"error":"gh issue list failed: HTTP 401: Bad credentials"}' >&2
+    exit 1
+    ;;
+  *)
+    echo "stub: unknown subcommand $1" >&2
+    exit 2
+    ;;
+esac
+"##;
+    setup_pr_read_stub(data_dir.path(), plugin_root.path(), body);
+
+    let (stdout, stderr) = run_fail(
+        pr_read_cmd(data_dir.path(), plugin_root.path()).args(["issue", "list", "--repo", "stub"]),
+    );
+    assert!(
+        stdout.trim().is_empty() || !stdout.contains("no issues"),
+        "a plugin failure must not be reported as an empty list, got stdout: {stdout}"
+    );
+    assert!(
+        !stderr.is_empty(),
+        "expected a non-empty error message on plugin failure, got: {stderr}"
+    );
+    assert!(
+        stderr.contains("Bad credentials"),
+        "expected the plugin's actual gh error text to propagate through \
+         call_plugin_inner, not a generic message, got: {stderr}"
+    );
+}
+
+/// A plugin can succeed but still have something worth telling the user --
+/// `list-issues`' own truncation warning (plugin/worksources/github) is the
+/// motivating case. Confirms `call_plugin_inner` relays non-empty stderr on
+/// a *successful* call rather than discarding it; before that fix this
+/// warning would have been silently dropped by the caller, which a pre-push
+/// review caught on this same branch (the CRITICAL finding on commit
+/// 51b90a5).
+#[cfg(unix)]
+#[test]
+fn issue_list_relays_plugin_stderr_warning_on_success() {
+    let data_dir = tempfile::tempdir().unwrap();
+    let plugin_root = tempfile::tempdir().unwrap();
+    let body = r##"#!/bin/bash
+case "${1:-}" in
+  list-issues)
+    echo "[legion worksource:github] warning: list-issues hit the 2-row limit; results may be truncated" >&2
+    echo '[{"url":"https://example.com/issues/1","number":1,"title":"x","body":"","labels":[],"assignees":null,"state":"OPEN","createdAt":"2026-01-01T00:00:00Z"}]'
+    ;;
+  *)
+    echo "stub: unknown subcommand $1" >&2
+    exit 2
+    ;;
+esac
+"##;
+    setup_pr_read_stub(data_dir.path(), plugin_root.path(), body);
+
+    let out = run_ok_output(
+        pr_read_cmd(data_dir.path(), plugin_root.path()).args(["issue", "list", "--repo", "stub"]),
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("results may be truncated"),
+        "expected the plugin's success-path warning to reach the user, got stderr: {stderr}"
+    );
+}
+
 /// Create a card on repo `stub` linked to external issue #42 and promote
 /// it to a Done-eligible state (Backlog -> assign -> accept). Shared by
 /// the Done propagation tests.

--- a/tests/integration/worksource_pr.rs
+++ b/tests/integration/worksource_pr.rs
@@ -794,6 +794,138 @@ fn issue_close_with_configured_worksource_writes_audit_row() {
     );
 }
 
+// ---------------------------------------------------------------------------
+// `legion issue list` (#750): enumerate work-source issues via the live
+// plugin path, not the local kanban cache.
+// ---------------------------------------------------------------------------
+
+/// Stub plugin that answers only `list-issues`, returning two fixed issues
+/// with distinct `updatedAt` values so the CLI's updated-at column has
+/// something to assert on.
+#[cfg(unix)]
+fn list_issues_stub_plugin() -> String {
+    r##"#!/bin/bash
+set -e
+case "${1:-}" in
+  list-issues)
+    cat <<'BODY'
+[
+  {"url":"https://example.com/issues/42","number":42,"title":"first issue","body":"","labels":[],"assignees":null,"state":"OPEN","createdAt":"2026-01-01T00:00:00Z","updatedAt":"2026-01-02T00:00:00Z"},
+  {"url":"https://example.com/issues/43","number":43,"title":"second issue","body":"","labels":[],"assignees":null,"state":"OPEN","createdAt":"2026-01-01T00:00:00Z","updatedAt":"2026-01-03T00:00:00Z"}
+]
+BODY
+    ;;
+  *)
+    echo "stub: unknown subcommand $1" >&2
+    exit 2
+    ;;
+esac
+"##
+    .to_string()
+}
+
+/// `legion issue list` fails with the canonical worksource error when the
+/// repo has no watch.toml entry -- confirms the command is wired up and
+/// resolves config before ever reaching a plugin.
+#[test]
+fn issue_list_errors_without_worksource_config() {
+    let dir = tempfile::tempdir().unwrap();
+
+    let (_stdout, stderr) =
+        run_fail(legion_cmd(dir.path()).args(["issue", "list", "--repo", "no-such-repo"]));
+    assert!(
+        stderr.contains("no work source configured"),
+        "expected 'no work source configured' error, got: {stderr}"
+    );
+}
+
+/// An invalid `--state` is rejected before any worksource resolution, with
+/// a message naming the allowed values.
+#[test]
+fn issue_list_rejects_invalid_state() {
+    let dir = tempfile::tempdir().unwrap();
+
+    let (_stdout, stderr) = run_fail(legion_cmd(dir.path()).args([
+        "issue",
+        "list",
+        "--repo",
+        "no-such-repo",
+        "--state",
+        "bogus",
+    ]));
+    assert!(
+        stderr.contains("--state must be one of open|closed|all"),
+        "expected state validation error, got: {stderr}"
+    );
+}
+
+/// With a configured work source, `issue list` prints number/state/updated-at
+/// /title per issue (live plugin state, #750 AC1) and writes an audit row
+/// (#750 AC4) carrying the requested state and label filters (#750 AC1).
+#[cfg(unix)]
+#[test]
+fn issue_list_prints_issues_and_writes_audit_row_with_filters() {
+    let data_dir = tempfile::tempdir().unwrap();
+    let plugin_root = tempfile::tempdir().unwrap();
+    setup_pr_read_stub(
+        data_dir.path(),
+        plugin_root.path(),
+        &list_issues_stub_plugin(),
+    );
+
+    let stdout = run_ok(
+        pr_read_cmd(data_dir.path(), plugin_root.path())
+            .args(["issue", "list", "--repo", "stub", "--label", "bug"]),
+    );
+    assert!(
+        stdout.contains("#42") && stdout.contains("first issue"),
+        "expected first issue row, got: {stdout}"
+    );
+    assert!(
+        stdout.contains("#43") && stdout.contains("second issue"),
+        "expected second issue row, got: {stdout}"
+    );
+    assert!(
+        stdout.contains("2026-01-02T00:00:00Z") && stdout.contains("2026-01-03T00:00:00Z"),
+        "expected updated-at column for both rows, got: {stdout}"
+    );
+
+    let audit_out =
+        run_ok(legion_cmd(data_dir.path()).args(["audit", "--action", "list-issues", "--json"]));
+    assert!(
+        audit_out.contains("\"action\": \"list-issues\""),
+        "expected a list-issues audit row, got: {audit_out}"
+    );
+    assert!(
+        audit_out.contains("label") && audit_out.contains("bug"),
+        "expected the audit details to carry the --label filter, got: {audit_out}"
+    );
+}
+
+/// `--json` emits a parseable array carrying the live plugin fields, for
+/// scripted callers (#750 AC1).
+#[cfg(unix)]
+#[test]
+fn issue_list_json_flag_emits_parseable_array() {
+    let data_dir = tempfile::tempdir().unwrap();
+    let plugin_root = tempfile::tempdir().unwrap();
+    setup_pr_read_stub(
+        data_dir.path(),
+        plugin_root.path(),
+        &list_issues_stub_plugin(),
+    );
+
+    let stdout = run_ok(
+        pr_read_cmd(data_dir.path(), plugin_root.path())
+            .args(["issue", "list", "--repo", "stub", "--json"]),
+    );
+    let parsed: serde_json::Value = serde_json::from_str(stdout.trim()).expect("valid JSON");
+    let arr = parsed.as_array().expect("expected a JSON array");
+    assert_eq!(arr.len(), 2, "expected both stub issues, got: {stdout}");
+    assert_eq!(arr[0]["number"], 42);
+    assert_eq!(arr[0]["updated_at"], "2026-01-02T00:00:00Z");
+}
+
 /// Create a card on repo `stub` linked to external issue #42 and promote
 /// it to a Done-eligible state (Backlog -> assign -> accept). Shared by
 /// the Done propagation tests.

--- a/tests/integration/worksource_pr.rs
+++ b/tests/integration/worksource_pr.rs
@@ -801,16 +801,22 @@ fn issue_close_with_configured_worksource_writes_audit_row() {
 
 /// Stub plugin that answers only `list-issues`, returning two fixed issues
 /// with distinct `updatedAt` values so the CLI's updated-at column has
-/// something to assert on.
+/// something to assert on. The first issue's title embeds the
+/// `LEGION_WS_STATE`/`LEGION_WS_LABEL` values the stub actually received, so
+/// tests can confirm `list_all_issues` forwards the filters rather than only
+/// checking the audit row (which records what the CLI *asked for*, not what
+/// the plugin *got*).
 #[cfg(unix)]
 fn list_issues_stub_plugin() -> String {
     r##"#!/bin/bash
 set -e
 case "${1:-}" in
   list-issues)
-    cat <<'BODY'
+    STATE="${LEGION_WS_STATE:-unset}"
+    LABEL="${LEGION_WS_LABEL:-unset}"
+    cat <<BODY
 [
-  {"url":"https://example.com/issues/42","number":42,"title":"first issue","body":"","labels":[],"assignees":null,"state":"OPEN","createdAt":"2026-01-01T00:00:00Z","updatedAt":"2026-01-02T00:00:00Z"},
+  {"url":"https://example.com/issues/42","number":42,"title":"first issue (state=$STATE label=$LABEL)","body":"","labels":[],"assignees":null,"state":"OPEN","createdAt":"2026-01-01T00:00:00Z","updatedAt":"2026-01-02T00:00:00Z"},
   {"url":"https://example.com/issues/43","number":43,"title":"second issue","body":"","labels":[],"assignees":null,"state":"OPEN","createdAt":"2026-01-01T00:00:00Z","updatedAt":"2026-01-03T00:00:00Z"}
 ]
 BODY
@@ -884,6 +890,11 @@ fn issue_list_prints_issues_and_writes_audit_row_with_filters() {
     assert!(
         stdout.contains("#43") && stdout.contains("second issue"),
         "expected second issue row, got: {stdout}"
+    );
+    assert!(
+        stdout.contains("state=open") && stdout.contains("label=bug"),
+        "expected the plugin to actually receive LEGION_WS_STATE=open and \
+         LEGION_WS_LABEL=bug (not just the audit row asking for them), got: {stdout}"
     );
     assert!(
         stdout.contains("2026-01-02T00:00:00Z") && stdout.contains("2026-01-03T00:00:00Z"),


### PR DESCRIPTION
## Summary

Adds `legion issue list --repo <name>` -- number/title/state/updated-at enumeration of
a work source's live issue backlog, filterable by `--state` and `--label`, with a
`--json` flag. Motivated by #711 sitting open in GitHub after shipping, discoverable
only by luck via the audit log because nothing could list what was actually open.
Also hardens the work-source plugin protocol along the way: `list-issues` fails
closed on a real `gh` error or missing repo config instead of reporting an empty
list (the exact false-negative shape #711 was), and `call_plugin_inner` now relays
a plugin's stderr on success as well as failure, so warnings like the truncation
notice below reach the user instead of being silently dropped.

## Acceptance criteria mapping

### 1. `legion issue list --repo <name>` lists number/title/state/updated-at; `--state open|closed|all` (default open); `--label`; `--json`

`IssueAction::List` (src/cli/issue.rs:79-101 for the flags, 280-329 for the handler)
adds `--repo`, `--state` (default `"open"`), `--label`, and `--json`. The
human-readable branch prints `#<number>\t<state>\t<updated_at>\t<title>` per row
(src/cli/issue.rs:320-327); `--json` serializes the same `Vec<ExternalIssue>`
(src/cli/issue.rs:315-316), which now carries `updated_at` (src/worksource/issues.rs:29-33,
aliased from GitHub's `updatedAt`). `--state` is validated against
`open|closed|all` before any plugin call (src/cli/issue.rs:284-287).
Evidence: `issue_list_prints_issues_and_writes_audit_row_with_filters` and
`issue_list_json_flag_emits_parseable_array` (tests/integration/worksource_pr.rs:873,
909) exercise the table output, the `--state`/`--label` filters, and the JSON shape
including `updated_at`; `issue_list_rejects_invalid_state` (tests/integration/worksource_pr.rs:845)
covers the validation guard.

### 2. Output is the work source's live state (same plugin path as `issue view`), not a local cache

`list_all_issues` (src/worksource/issues.rs:57-79) calls `plugin_call` directly --
the same primitive `view_issue` uses a few lines above it -- against a new
`list-issues` plugin verb, not the kanban database. It is deliberately kept
separate from `list_issues` (which backs `sync`'s cache-populating path) so this
command's behavior can never be affected by cache state; the doc comment on
`list_all_issues` states this directly. The GitHub plugin's `list-issues` case
(plugin/worksources/github:34-101) calls `gh issue list` fresh on every
invocation, no caching.
Evidence: `issue_list_prints_issues_and_writes_audit_row_with_filters` drives a
stub plugin (not the kanban DB) and asserts the CLI's output reflects exactly what
the stub returned.

### 3. The gh-block hook's guidance text includes `legion issue list`

`plugin/hooks/no-gh.sh:31` adds `- legion issue list --repo <name>` to the
`emit_deny` guidance list, alongside the pre-existing `issue create`/`pr create`/
`pr list` lines.
Evidence: `git diff main...HEAD -- plugin/hooks/no-gh.sh` shows the single added
line; no other change to the hook's blocking logic.

### 4. Audit-logged like the other work-source verbs

The `List` handler calls the same `audit()` / `db::AuditInput` helper the `Close`/
`View` arms use two variants away (src/cli/issue.rs:290-303), recording action
`"list-issues"`, target `source_repo`, and a `details` JSON blob carrying the
`state`/`label` filters that were applied.
Evidence: `issue_list_prints_issues_and_writes_audit_row_with_filters`
(tests/integration/worksource_pr.rs:873) asserts an audit row is written with the
filter values present.

## Hardening beyond the stated criteria

Building criterion 2's fail-closed requirement surfaced two related gaps, fixed on
the same branch rather than deferred, since they sit squarely inside "the tool must
not report an empty backlog when something failed":

- `plugin/worksources/github`'s new `list-issues` case exits 1 with a JSON error on
  a real `gh` failure, missing `gh`, or a blank `$REPO` -- the last one closes the
  exact #711 false-empty shape for a misconfigured `watch.toml` row. `gh`'s stderr
  is captured to a scratch file rather than merged via `2>&1` (a pre-commit
  simplify review on this branch flagged `2>&1` as a hazard: it would splice
  success-path stderr into the JSON stdout payload and break the unguarded `jq
  'length'` truncation check under this script's `set -e`).
- `call_plugin_inner` (src/worksource/mod.rs:321-330) now relays a plugin's
  non-empty stderr to the user on a *successful* call too, not just on failure, so
  `list-issues`'s own truncation warning (when a repo has >= the row limit) is
  never silently dropped.
  Evidence: `issue_list_surfaces_plugin_failure_as_error_not_empty_list` and
  `issue_list_relays_plugin_stderr_warning_on_success`
  (tests/integration/worksource_pr.rs:946 and the test immediately above it).

## Not done

Deliberately not done in this PR:

- The plugin's own bash-level behavior (truncation check, jq-missing warning,
  blank-`$REPO` exit, sed-based error escaping) is exercised only indirectly, via
  Rust integration tests against stub plugins that simulate the github plugin's
  contract -- not a shell-level test invoking the real script against a fake `gh`
  on `PATH`. Flagged by the pre-push review as a real coverage gap; left as a
  follow-up rather than expanding this branch's scope.
- A failed `list_all_issues(...)?` call propagates before the `audit()` call runs,
  so a failed enumeration attempt leaves no audit row (the existing `Close`/`View`
  arms have the same success-only audit shape; not changed here to keep this PR
  scoped to #750's stated criteria).
- `pr-checks`'s existing manual `rm -f`-per-path temp-file cleanup (further down in
  the same plugin script) was not converged onto the new `trap ... EXIT` idiom used
  in `list-issues` -- noted as a follow-up, out of scope for this issue.
- The companion issue on `legion pr create` auto-appending closing keywords
  (mentioned in #750's context) is separate and not addressed here.

## Test evidence

`cargo test --test integration issue_list` -> 6 passed, 0 failed. Full suite
`cargo test --quiet` -> 1362 passed (main binary) + 270 passed (integration
binary), 0 failed, 2 ignored. `cargo fmt --check` and
`cargo clippy --all-targets -- -D warnings` both clean. `bash -n
plugin/worksources/github` clean.

Closes #750