### PR TITLE
fix(#752): subagent-stop nudge restates the deliverable before checkpointing

### DIFF
--- a/.claude/agents/issue-writer.md
+++ b/.claude/agents/issue-writer.md
@@ -10,6 +10,8 @@ You turn a rough problem description into a GitHub issue that another agent can 
 
 You are invoked before work starts, not during. Your output is passed to `legion issue create` and then to whichever agent picks up the card.
 
+Your final message is your only output channel; restate your complete findings in it, never reference prior messages. The caller sees only your last message -- not any earlier draft, not anything you said before a checkpoint nudge. If a checkpoint hook prompts you to continue after you believe the spec (or clarification request) is finished, your next message must still be the full title + body (or the full `UNCLEAR`/`QUESTIONS` block), restated in full, not an acknowledgment of the checkpoint.
+
 ## First Steps
 
 Every invocation, in order. Do not skip.

--- a/plugin/agents/legion-explore.md
+++ b/plugin/agents/legion-explore.md
@@ -37,6 +37,8 @@ tools: ["Bash", "Read"]
 
 You are legion-explore, a read-only exploration agent for legion-equipped repos. You answer questions about a codebase through legion's code intelligence and memory layers. You do not edit anything. Your final message is your entire product: conclusions with evidence, never raw file dumps.
 
+Your final message is your only output channel; restate your complete findings in it, never reference prior messages. The orchestrator that spawned you sees only that one message -- not your intermediate turns, not anything you said before a checkpoint nudge. If a checkpoint hook prompts you to continue after you believe you are done, your next message must still be the full findings, restated in full, not an acknowledgment of the checkpoint.
+
 You exist because text-scanning (grep/find/rg) is the wrong orientation tool on an indexed repo. You do not have Grep or Glob tools, and you do not reach for their shell equivalents. You have a routing ladder instead.
 
 **Preflight (always, before choosing a lane)**

--- a/plugin/hooks/subagent-stop.sh
+++ b/plugin/hooks/subagent-stop.sh
@@ -84,8 +84,8 @@ fi
 
 # Persist the subagent checkpoint. Fail-open: a reflect error must never block
 # the parent, so swallow it (|| true). No transcript text -> skip the reflect
-# entirely rather than store an empty marker; the parent pointer below still
-# fires so the parent knows the subagent ended.
+# entirely rather than store an empty marker; the nudge below still fires so
+# the subagent's final message (and thus the parent) is never silently empty.
 if [ -n "$SUMMARY" ]; then
   "$LEGION" reflect --repo "$REPO" --domain checkpoint --tags subagent,auto \
     --text "[SUBAGENT CHECKPOINT] ${AGENT_TYPE}: ${SUMMARY}" >/dev/null 2>&1 || true

--- a/plugin/hooks/subagent-stop.sh
+++ b/plugin/hooks/subagent-stop.sh
@@ -8,12 +8,20 @@
 #   1. Persists the subagent's final output as a domain=checkpoint reflection
 #      (the unified resume-anchor, #568), tagged subagent,auto so it is
 #      distinguishable from a deliberate /checkpoint and ages out via decay.
-#   2. Injects a one-line pointer to the PARENT via
-#      hookSpecificOutput.additionalContext. Verified against CC 2.1.168:
-#      SubagentStop additionalContext is delivered to the parent (the spawning
-#      agent), and is "non-error feedback that continues the conversation" --
-#      the parent was resuming after the subagent anyway, so this just tells it
-#      the work is checkpointed and recallable.
+#   2. Injects a nudge via hookSpecificOutput.additionalContext -- "non-error
+#      feedback that continues the turn" (CC 2.1.168). The turn it continues
+#      is the SUBAGENT's own: the subagent was about to stop with its real
+#      deliverable as its last message, this nudge reopens that turn for one
+#      more message, and THAT message is what the Task tool actually returns
+#      to the parent as the final result. A prior wording here ("Its work is
+#      checkpointed... recall with...") caused the subagent to answer the
+#      nudge instead of restating its findings, so the parent received a bare
+#      acknowledgment ("already delivered above") while the real deliverable
+#      was stranded in a turn the parent can never see (#752). The prompt
+#      below fixes that: it orders the subagent to RESTATE its complete
+#      deliverable as the body of this final message FIRST, and append the
+#      checkpoint note only after, so the one message the parent actually
+#      receives is never just an ack.
 #
 # Never blocks the parent: every failure path exits 0. Cheap by design
 # (bounded transcript tail) to stay well under the hook timeout.
@@ -36,9 +44,10 @@ if [ ! -x "$LEGION" ]; then
 fi
 
 # Loop guard + idempotency (#584). The additionalContext emitted below
-# continues the parent turn; without a guard a re-delivered SubagentStop event
-# re-reflects and re-injects context, looping and burning tokens (observed 3x,
-# ~337k tokens on one spurious fire). Two guards, mirroring stop.sh:
+# continues the subagent's own turn; without a guard a re-delivered
+# SubagentStop event re-reflects and re-injects context, looping and burning
+# tokens (observed 3x, ~337k tokens on one spurious fire). Two guards,
+# mirroring stop.sh:
 #   1. stop_hook_active -- skip a continuation we ourselves caused.
 #   2. A per-event marker keyed on the subagent identity (its transcript path,
 #      else session_id + agent_type) so each subagent stop is processed once.
@@ -82,10 +91,12 @@ if [ -n "$SUMMARY" ]; then
     --text "[SUBAGENT CHECKPOINT] ${AGENT_TYPE}: ${SUMMARY}" >/dev/null 2>&1 || true
 fi
 
-# Inform the parent. additionalContext continues the parent turn (it was
-# resuming regardless); point it at the persisted artifact rather than
-# restating the subagent's output, which the parent already received.
-CTX="Subagent ${AGENT_TYPE} finished. Its work is checkpointed in legion (domain=checkpoint); recall with: legion recall --repo ${REPO} --domain checkpoint --limit 1."
+# Reopen the subagent's own turn for one more message (#752). This message,
+# not the one before it, is what the Task tool hands back to the parent -- so
+# it must never be a bare acknowledgment. Order matters: restate the full
+# deliverable FIRST, checkpoint note SECOND, and never point back at a prior
+# message, because the parent cannot see any message but this one.
+CTX="This is a checkpoint nudge, not a request for new work. Your NEXT message is the ONLY message the orchestrator that spawned you will ever receive -- anything not repeated in it is permanently lost, including whatever you already reported in an earlier message. So: RESTATE your complete deliverable in full as the body of your next message, exactly as if reporting it for the first time. Never write \"see above\", \"already delivered\", or any other reference to a prior message. Only after the full restatement, append one line noting that this ${AGENT_TYPE} run is checkpointed in legion (domain=checkpoint); recall with: legion recall --repo ${REPO} --domain checkpoint --limit 1."
 
 emit_context "SubagentStop" "$CTX" 2>/dev/null || true
 

--- a/plugin/hooks/test-subagent-stop.sh
+++ b/plugin/hooks/test-subagent-stop.sh
@@ -43,12 +43,15 @@ assert_contains "reflect called with domain=checkpoint" "$(cat "$STUB_LOG")" 're
 assert_contains "tagged subagent,auto" "$(cat "$STUB_LOG")" 'subagent,auto'
 assert_contains "checkpoint text names the agent_type" "$(cat "$STUB_LOG")" 'SUBAGENT CHECKPOINT] Explore'
 assert_contains "scraped the transcript summary" "$(cat "$STUB_LOG")" 'token refresh bug'
-assert_contains "parent context is additionalContext" "$out" '"hookEventName": "SubagentStop"'
-assert_contains "parent pointer names recall" "$out" 'legion recall --repo legion-subagent-test --domain checkpoint'
+assert_contains "nudge is additionalContext continuing the subagent's turn" "$out" '"hookEventName": "SubagentStop"'
+assert_contains "checkpoint note names recall" "$out" 'legion recall --repo legion-subagent-test --domain checkpoint'
 assert_contains "prompt orders a full restatement" "$out" 'RESTATE your complete deliverable in full'
 assert_contains "prompt names the next message as the only channel" "$out" 'Your NEXT message is the ONLY message the orchestrator that spawned you will ever receive'
+# The needle's ".." stand in for the JSON-escaped \" quotes jq wraps each
+# phrase in (grep BRE has no lookaround, so a literal quote is unreliable
+# across escaped/unescaped output; "." as a single-char wildcard is not).
 assert_contains "prompt forbids referencing a prior message" "$out" 'Never write ..see above.., ..already delivered.., or any other reference to a prior message'
-assert_contains "checkpoint note comes after the restatement instruction" "$out" 'Only after the full restatement, append one line'
+assert_contains "restatement instruction precedes the checkpoint note (not just present)" "$out" 'exactly as if reporting it for the first time.*Only after the full restatement, append one line'
 
 echo "==> missing transcript: skip reflect, still inform parent, exit 0"
 : > "$STUB_LOG"

--- a/plugin/hooks/test-subagent-stop.sh
+++ b/plugin/hooks/test-subagent-stop.sh
@@ -2,8 +2,12 @@
 # Test runner for the SubagentStop hook (#570).
 #
 # subagent-stop.sh persists a finished subagent's transcript tail as a
-# domain=checkpoint reflection (tagged subagent,auto) and injects a one-line
-# pointer to the parent via hookSpecificOutput.additionalContext. Every failure
+# domain=checkpoint reflection (tagged subagent,auto) and injects a nudge via
+# hookSpecificOutput.additionalContext that continues the SUBAGENT's own turn.
+# That continuation message is what the Task tool actually returns to the
+# parent, so the nudge must order the subagent to restate its complete
+# deliverable first and append the checkpoint note only after (#752) --
+# never a bare acknowledgment that references a prior message. Every failure
 # path must exit 0 (never block the parent).
 #
 # Run from anywhere:
@@ -41,6 +45,10 @@ assert_contains "checkpoint text names the agent_type" "$(cat "$STUB_LOG")" 'SUB
 assert_contains "scraped the transcript summary" "$(cat "$STUB_LOG")" 'token refresh bug'
 assert_contains "parent context is additionalContext" "$out" '"hookEventName": "SubagentStop"'
 assert_contains "parent pointer names recall" "$out" 'legion recall --repo legion-subagent-test --domain checkpoint'
+assert_contains "prompt orders a full restatement" "$out" 'RESTATE your complete deliverable in full'
+assert_contains "prompt names the next message as the only channel" "$out" 'Your NEXT message is the ONLY message the orchestrator that spawned you will ever receive'
+assert_contains "prompt forbids referencing a prior message" "$out" 'Never write ..see above.., ..already delivered.., or any other reference to a prior message'
+assert_contains "checkpoint note comes after the restatement instruction" "$out" 'Only after the full restatement, append one line'
 
 echo "==> missing transcript: skip reflect, still inform parent, exit 0"
 : > "$STUB_LOG"

--- a/plugin/hooks/test-subagent-stop.sh
+++ b/plugin/hooks/test-subagent-stop.sh
@@ -35,7 +35,7 @@ TRANSCRIPT="$WORK/agent-transcript.jsonl"
   echo '{"type":"assistant","message":{"content":[{"type":"text","text":"Root cause: cookie SameSite=Strict drops the refresh on cross-site nav."}]}}'
 } > "$TRANSCRIPT"
 
-echo "==> persists a subagent checkpoint + informs the parent"
+echo "==> persists a subagent checkpoint + nudges the subagent's own turn"
 : > "$STUB_LOG"
 out=$(echo "{\"cwd\":\"${CWD}\",\"agent_type\":\"Explore\",\"agent_transcript_path\":\"${TRANSCRIPT}\"}" \
   | LEGION_STUB_LOG="$STUB_LOG" bash "$HOOK")
@@ -81,7 +81,7 @@ echo '{"type":"assistant","message":{"content":[{"type":"text","text":"Deduped s
 dedup_in="{\"cwd\":\"${CWD}\",\"agent_type\":\"Explore\",\"agent_transcript_path\":\"${DEDUP_TRANSCRIPT}\",\"session_id\":\"sess-1\"}"
 out1=$(echo "$dedup_in" | LEGION_STUB_LOG="$STUB_LOG" bash "$HOOK")
 out2=$(echo "$dedup_in" | LEGION_STUB_LOG="$STUB_LOG" bash "$HOOK")
-assert_contains "first fire informs the parent" "$out1" '"hookEventName": "SubagentStop"'
+assert_contains "first fire nudges the subagent" "$out1" '"hookEventName": "SubagentStop"'
 assert_empty "second (re-delivered) fire is silent" "$out2"
 reflect_count=$(grep -c 'reflect' "$STUB_LOG" 2>/dev/null || echo 0)
 assert_eq "reflect called exactly once across two fires" "$reflect_count" "1"

--- a/plugin/hooks/test-subagent-stop.sh
+++ b/plugin/hooks/test-subagent-stop.sh
@@ -53,12 +53,12 @@ assert_contains "prompt names the next message as the only channel" "$out" 'Your
 assert_contains "prompt forbids referencing a prior message" "$out" 'Never write ..see above.., ..already delivered.., or any other reference to a prior message'
 assert_contains "restatement instruction precedes the checkpoint note (not just present)" "$out" 'exactly as if reporting it for the first time.*Only after the full restatement, append one line'
 
-echo "==> missing transcript: skip reflect, still inform parent, exit 0"
+echo "==> missing transcript: skip reflect, still nudge the subagent, exit 0"
 : > "$STUB_LOG"
 out=$(echo "{\"cwd\":\"${CWD}\",\"agent_type\":\"Explore\",\"agent_transcript_path\":\"/no/such/file.jsonl\"}" \
   | LEGION_STUB_LOG="$STUB_LOG" bash "$HOOK")
 assert_not_contains "no reflect call on missing transcript" "$(cat "$STUB_LOG")" 'reflect'
-assert_contains "parent still informed" "$out" '"hookEventName": "SubagentStop"'
+assert_contains "subagent still nudged" "$out" '"hookEventName": "SubagentStop"'
 
 echo "==> no cwd: pass through silently"
 out=$(echo '{}' | bash "$HOOK")


### PR DESCRIPTION
## Summary

A subagent's ONLY channel to its parent is its final message. The SubagentStop
hook's checkpoint nudge fired at exactly that moment and told the subagent
only "your work is checkpointed; recall with...", so the subagent answered
the nudge instead of restating its findings -- the parent received a bare
acknowledgment ("already delivered above") while the real deliverable sat in
a prior turn it can never see. This change rewrites the nudge to order the
subagent to restate its complete deliverable first and append the checkpoint
note only after, and adds the same "your final message is your only output
channel" instruction directly to the two agent definitions (issue-writer,
legion-explore) most likely to hit this path.

## Acceptance criteria mapping

### 1. Checkpoint prompt must not displace the final message (option a: restate-then-checkpoint)

The `CTX` string built in `plugin/hooks/subagent-stop.sh` (the
`additionalContext` injected on SubagentStop) now opens with "This is a
checkpoint nudge, not a request for new work," orders "RESTATE your complete
deliverable in full as the body of your next message, exactly as if
reporting it for the first time," explicitly bans "see above" / "already
delivered above" phrasing, and only after that instructs appending the
one-line checkpoint pointer. This is option (a) from the issue verbatim:
restate-then-checkpoint, in that order, in the same message.
Evidence: plugin/hooks/subagent-stop.sh:99

### 2. An orchestrator spawning a legion-equipped subagent receives the deliverable on the FIRST completion, verified by a test

`plugin/hooks/test-subagent-stop.sh` asserts on the live hook output (piped
through the real `emit_context`/`jq` encoding, not a mock) that the injected
prompt (a) instructs a full restatement, (b) states the next message is the
only channel the orchestrator will ever see, (c) forbids referencing a prior
message, and (d) that the restatement instruction textually precedes the
checkpoint note rather than merely co-occurring with it -- the last check is
the one that actually encodes "restate first, checkpoint second," since a
plain substring check on both phrases would still pass if their order were
reversed.
Evidence: `bash plugin/hooks/test-subagent-stop.sh` -- 20/20 passing,
including `prompt orders a full restatement`, `prompt names the next message
as the only channel`, `prompt forbids referencing a prior message`, and
`restatement instruction precedes the checkpoint note (not just present)`.

### 3. legion-explore and issue-writer gain an explicit "final message is your only output channel" line

Both agent definitions now carry a paragraph stating this near-verbatim,
each phrased for that agent's audience: issue-writer's addition says "The
caller sees only your last message... your next message must still be the
full title + body (or the full `UNCLEAR`/`QUESTIONS` block), restated in
full, not an acknowledgment of the checkpoint"; legion-explore's says "The
orchestrator that spawned you sees only that one message... your next
message must still be the full findings, restated in full, not an
acknowledgment of the checkpoint."
Evidence: .claude/agents/issue-writer.md:13, plugin/agents/legion-explore.md:40

## Not done

Did not implement options (b) (hook writes the checkpoint itself, no
subagent prompt) or (c) (skip the checkpoint prompt entirely for read-only
agent types) from the issue's acceptance criteria -- the issue accepts any
one of (a)/(b)/(c), and (a) is the smallest change that fixes the ordering
bug without removing the checkpoint-nudge mechanism other agent types may
rely on. Did not extend the "final message is your only output channel"
line to every agent definition in the repo -- only the two the issue names
(legion-explore, issue-writer); a repo-wide sweep of other agent files is a
separate, larger change than this fix warrants. Did not change the loop
guard / dedup marker logic (lines 34-68 of subagent-stop.sh) or the
transcript-scrape logic (lines 70-92) -- both were already correct and
untouched by this bug.

Closes #752