### PR TITLE
refactor(#672): retire recall-first.sh Explore branch

### DIFF
--- a/plugin/hooks/hooks.json
+++ b/plugin/hooks/hooks.json
@@ -121,11 +121,6 @@
             "type": "command",
             "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/no-harness-explore.sh",
             "timeout": 5
-          },
-          {
-            "type": "command",
-            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/recall-first.sh",
-            "timeout": 5
           }
         ]
       },

--- a/plugin/hooks/recall-clamp.conf
+++ b/plugin/hooks/recall-clamp.conf
@@ -2,11 +2,11 @@
 # One tool name per line. Lines starting with # are ignored.
 # Edit this to tune token spend vs recall coverage.
 #
-# recall-first.sh handles: WebFetch, WebSearch, Agent (Explore)
+# recall-first.sh handles: WebFetch, WebSearch
 # pre-grep.sh handles: Grep, Glob (separate hook)
+# no-harness-explore.sh handles: Agent/Explore (#672)
 #
 # Uncomment a line to skip recall for that tool.
 
 WebSearch
 # WebFetch
-# Agent

--- a/plugin/hooks/recall-first.sh
+++ b/plugin/hooks/recall-first.sh
@@ -2,12 +2,10 @@
 # Legion PreToolUse hook: run recall on the search query and inject matching
 # reflections as additionalContext before the search tool fires.
 #
-# Fires on WebFetch, WebSearch, and Agent (Explore only). Grep and Glob are
-# handled by pre-grep.sh which has better query sanitization for those.
-#
-# For Explore agent spawns: if recall has strong hits (score >= threshold),
-# the hook DENIES the spawn and returns recall results instead. This prevents
-# agents from burning tokens on Explore when legion already has the answer.
+# Fires on WebFetch and WebSearch. Grep and Glob are handled by pre-grep.sh
+# which has better query sanitization for those. Agent/Explore spawns are
+# not handled here -- no-harness-explore.sh is the sole decider for Explore
+# (#672); this hook is no longer wired to the Agent matcher in hooks.json.
 #
 # Relies on session-start.sh having warmed the Tantivy index; cold ~2.2s,
 # warm ~170ms per call.
@@ -43,9 +41,8 @@ if [ -f "$CLAMP_FILE" ] && grep -qx "$TOOL" "$CLAMP_FILE"; then
   exit 0
 fi
 
-# Extract the search query based on the tool
+# Extract the search query based on the tool.
 QUERY=""
-IS_EXPLORE=false
 case "$TOOL" in
   WebFetch)
     # Use the prompt (user intent), not the URL -- URL path components
@@ -54,17 +51,6 @@ case "$TOOL" in
     ;;
   WebSearch)
     QUERY=$(legion_hook_field '.tool_input.query')
-    ;;
-  Agent)
-    # For Explore agents, try recall first and deny the spawn if we have
-    # strong hits. Other agent types pass through.
-    AGENT_TYPE=$(legion_hook_field '.tool_input.subagent_type')
-    if [ "$AGENT_TYPE" = "Explore" ]; then
-      IS_EXPLORE=true
-      QUERY=$(legion_hook_field '.tool_input.prompt')
-    else
-      exit 0
-    fi
     ;;
   *)
     exit 0
@@ -91,116 +77,4 @@ ${HITS}
 
 If these answer your question, skip the ${TOOL}. Otherwise continue -- but consider whether the reflection explains WHY before you search for WHAT."
 
-# For Explore agents (#413): run the full cheap chain before deciding.
-# recall alone is too narrow -- consult catches cross-agent memory,
-# surface catches recent cross-repo activity, sym catches code-intel
-# answers when the prompt mentions identifiers, consult --symbol covers
-# cross-repo code intel.
-#
-# Decision: deny when ANY source returns informative content. The closing
-# guidance points at Read with concrete paths from the results, not Grep
-# (the pre-#413 fallback shifted cost sideways instead of dropping it --
-# see reflection 019d84c7).
-DECISION="allow"
-REASON="legion recall hits for the query"
-if [ "$IS_EXPLORE" = true ]; then
-  # Source 1 already done: HITS (recall). Score-based hit detection.
-  RECALL_HIT=false
-  if [ -n "$HITS" ]; then
-    TOP_SCORE=$(echo "$HITS" | grep -oE 'score: [0-9]+\.[0-9]+' | head -1 | awk '{print $2}')
-    THRESHOLD="${LEGION_EXPLORE_THRESHOLD:-0.60}"
-    if [ -n "$TOP_SCORE" ] && awk "BEGIN{exit !($TOP_SCORE >= $THRESHOLD)}"; then
-      RECALL_HIT=true
-    fi
-  fi
-
-  # Source 2: cross-agent memory. Best-effort; never errors out the hook.
-  CONSULT=$("$LEGION" consult --context "$QUERY" --limit 3 2>>"$LOG" || true)
-  CONSULT_HIT=false
-  if [ -n "$CONSULT" ] && echo "$CONSULT" | grep -q '^- '; then
-    CONSULT_HIT=true
-  fi
-
-  # Source 3: recent cross-repo activity. Topical surface for in-flight work.
-  SURFACE=$("$LEGION" surface --repo "$REPO" 2>>"$LOG" || true)
-  SURFACE_HIT=false
-  if [ -n "$SURFACE" ] && echo "$SURFACE" | grep -q '^- '; then
-    SURFACE_HIT=true
-  fi
-
-  # Source 4: code intelligence. Only fires when the prompt mentions an
-  # identifier-shaped token. Floor raised to 5 chars to filter out
-  # English stopwords (the, and, this, that, etc.) and the
-  # CASE_PATTERN excludes a small set of common-word-shapes that pass
-  # the regex but are obviously natural language.
-  #
-  # Both same-repo (sym def) and cross-repo (consult --symbol). The
-  # cross-repo flag may not exist yet (#285); the failure is silently
-  # absorbed by the trailing `|| true`.
-  IDENT=$(echo "$QUERY" \
-    | grep -oE '[A-Z][A-Za-z0-9_]{4,}|[a-z_][a-z_0-9]{4,}' \
-    | grep -viE '^(should|would|could|where|which|there|their|these|those|about|after|before|other|first|under|legion|claude|hooks|files|using)$' \
-    | head -1)
-  SYM=""
-  SYM_XREPO=""
-  SYM_HIT=false
-  if [ -n "$IDENT" ]; then
-    SYM=$("$LEGION" sym def --json "$IDENT" 2>>"$LOG" || true)
-    if [ -n "$SYM" ] && [ "$SYM" != "[]" ] && [ "$SYM" != "null" ]; then
-      SYM_HIT=true
-    fi
-    SYM_XREPO=$("$LEGION" consult --symbol "$IDENT" 2>>"$LOG" || true)
-    if [ -n "$SYM_XREPO" ] && echo "$SYM_XREPO" | grep -q '^- '; then
-      SYM_HIT=true
-    fi
-  fi
-
-  if [ "$RECALL_HIT" = true ] || [ "$CONSULT_HIT" = true ] || [ "$SURFACE_HIT" = true ] || [ "$SYM_HIT" = true ]; then
-    DECISION="deny"
-    REASON="legion's cheap-paths chain answered this. Use the injected results, then Read specific files if you need detail."
-
-    SECTIONS=""
-    if [ -n "$HITS" ]; then
-      SECTIONS="${SECTIONS}### legion recall (this repo)
-${HITS}
-
-"
-    fi
-    if [ -n "$CONSULT" ]; then
-      SECTIONS="${SECTIONS}### legion consult (cross-agent memory)
-${CONSULT}
-
-"
-    fi
-    if [ -n "$SURFACE" ]; then
-      SECTIONS="${SECTIONS}### legion surface (recent cross-repo activity)
-${SURFACE}
-
-"
-    fi
-    if [ -n "$SYM" ] && [ "$SYM" != "[]" ] && [ "$SYM" != "null" ]; then
-      SECTIONS="${SECTIONS}### legion sym def \`${IDENT}\` (this repo, SCIP)
-\`\`\`json
-${SYM}
-\`\`\`
-
-"
-    fi
-    if [ -n "$SYM_XREPO" ]; then
-      SECTIONS="${SECTIONS}### legion consult --symbol \`${IDENT}\` (cross-repo SCIP)
-${SYM_XREPO}
-
-"
-    fi
-
-    CTX="[Legion] Explore BLOCKED -- the cheap-paths chain already covers this:
-
-${SECTIONS}Read the specific files referenced in these results for detail. Do NOT switch to Grep -- it is not cheaper. The point is to skip the file scan, not to do it under a different tool name."
-  fi
-fi
-
-if [ "$DECISION" = "deny" ]; then
-  emit_deny "$REASON" "$CTX"
-else
-  emit_allow "$CTX" "$REASON"
-fi
+emit_allow "$CTX" "legion recall hits for the query"

--- a/plugin/hooks/test-recall-first.sh
+++ b/plugin/hooks/test-recall-first.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+# Test runner for the recall-first PreToolUse hook (#672).
+#
+# Verifies recall-first.sh still injects recall hits before WebFetch
+# (unchanged; WebSearch is clamped off by default via recall-clamp.conf).
+# recall-first.sh is no longer wired to the Agent matcher in hooks.json
+# (#672: no-harness-explore.sh is the sole decider for Agent/Explore), but
+# these Agent-input cases are still exercised by direct invocation here as
+# a regression guard against re-wiring or the case statement growing an
+# Agent branch back.
+#
+# Run from anywhere:
+#
+#   bash plugin/hooks/test-recall-first.sh
+
+set -u
+
+# shellcheck source=tests/testutil.sh
+source "$(dirname "${BASH_SOURCE[0]}")/tests/testutil.sh"
+
+make_plugin_root recall-first.sh recall-clamp.conf
+
+# The hook gates on legion coverage; make the test repo covered via the
+# stub's watch-list fixture.
+export FAKE_WATCH="legion-test	/tmp/legion-test"
+
+HOOK="$CLAUDE_PLUGIN_ROOT/hooks/recall-first.sh"
+
+run_hook() {
+  printf '%s' "$1" | bash "$HOOK"
+}
+
+echo "==> WebFetch with recall hits injects context and allows"
+export FAKE_RECALL="- some reflection body (score: 0.91)"
+out=$(run_hook '{"tool_input":{"prompt":"how does the sync engine work"},"cwd":"/tmp/legion-test","session_id":"test","tool_name":"WebFetch"}')
+assert_contains "injects recall hits" "$out" "some reflection body"
+assert_not_contains "does not deny" "$out" '"permissionDecision": "deny"'
+assert_contains "allows" "$out" '"permissionDecision": "allow"'
+
+echo "==> WebSearch is clamped by default (recall-clamp.conf), unchanged"
+out=$(run_hook '{"tool_input":{"query":"how does the sync engine work"},"cwd":"/tmp/legion-test","session_id":"test","tool_name":"WebSearch"}')
+assert_empty "WebSearch clamped -- no output" "$out"
+unset FAKE_RECALL
+
+echo "==> WebFetch with no recall hits injects nothing"
+out=$(run_hook '{"tool_input":{"prompt":"how does the sync engine work"},"cwd":"/tmp/legion-test","session_id":"test","tool_name":"WebFetch"}')
+assert_empty "no hits, no output" "$out"
+
+echo "==> Explore agent spawn: no permissionDecision from recall-first (#672 criterion 2)"
+export FAKE_RECALL="- some reflection body (score: 0.91)"
+out=$(run_hook '{"tool_input":{"subagent_type":"Explore","prompt":"how does the sync engine work"},"cwd":"/tmp/legion-test","session_id":"test","tool_name":"Agent"}')
+assert_empty "recall-first never decides on Explore" "$out"
+
+echo "==> non-Explore agent spawn: unchanged pass-through"
+out=$(run_hook '{"tool_input":{"subagent_type":"Plan","prompt":"how does the sync engine work"},"cwd":"/tmp/legion-test","session_id":"test","tool_name":"Agent"}')
+assert_empty "Plan agent passes through" "$out"
+unset FAKE_RECALL
+
+echo "==> uncovered repo passes through"
+out=$(run_hook '{"tool_input":{"prompt":"how does the sync engine work"},"cwd":"/tmp/uncovered-repo","session_id":"test","tool_name":"WebFetch"}')
+assert_empty "WebFetch allowed to pass through in a repo legion does not cover" "$out"
+
+finish_tests


### PR DESCRIPTION
## Summary

`no-harness-explore.sh` (#670) now unconditionally denies every built-in `Explore` spawn
on the `Agent` matcher. `recall-first.sh` still ran its own Explore branch on the same
matcher -- a full cheap-paths chain (recall + consult + surface + `sym def` +
`consult --symbol`, up to 5 legion subprocesses, ~2.2s cold) that was dead work, plus a
`permissionDecision` that only avoided conflicting with `no-harness-explore.sh` because
Claude Code resolves PreToolUse ties as deny-precedence -- undocumented coupling. This PR
retires the Explore arm so `no-harness-explore.sh` is the sole decider for Explore, and
`recall-first.sh` keeps its WebFetch/WebSearch/non-Explore-Agent behavior unchanged.

## Acceptance criteria mapping

### 1. recall-first.sh no longer runs its cheap-path chain for Explore

Removed the entire `IS_EXPLORE` block from `recall-first.sh`: the `Agent`/`Explore` case
arm, the `RECALL_HIT`/`CONSULT_HIT`/`SURFACE_HIT`/`SYM_HIT` scoring logic, and the
conditional `emit_deny`/`emit_allow` branching. The hook now always ends in a single
unconditional `emit_allow "$CTX" "legion recall hits for the query"` -- no chain, no
`consult`/`surface`/`sym def`/`consult --symbol` calls remain reachable for any input.

Evidence: `plugin/hooks/recall-first.sh` diff removes the `Agent)` case, the `IS_EXPLORE`
variable, and lines 91-206 of the old file (the scoring + deny chain), replacing them
with `emit_allow "$CTX" "legion recall hits for the query"` as the sole terminal
statement.

### 2. No two hooks emit a permissionDecision for an Explore spawn

`hooks.json`'s `Agent` matcher entry no longer wires `recall-first.sh` -- only
`no-harness-explore.sh` remains under that matcher. `recall-first.sh`'s case statement
has no `Agent)` arm left, so an Explore-shaped input (`tool_name: "Agent"`,
`subagent_type: "Explore"`) falls through to the `*)` default and exits 0 with no output
before ever reaching `emit_allow`/`emit_deny`.

Evidence: `plugin/hooks/hooks.json` diff removes the `recall-first.sh` command block
from the `Agent` matcher's hooks array (5 lines deleted), leaving only
`no-harness-explore.sh`. Confirmed live in the worktree -- `sed -n '95,135p'
plugin/hooks/hooks.json` shows the `Agent` matcher with a single hook entry
(`no-harness-explore.sh`). Test `test-recall-first.sh` case "Explore agent spawn: no
permissionDecision from recall-first (#672 criterion 2)" asserts `run_hook` on an
Explore-shaped payload produces empty output (`assert_empty`) -- passes.

### 3. recall-first's WebFetch/WebSearch/other-agent behavior unchanged + tested

`recall-first.sh`'s `WebFetch` and `WebSearch` case arms are untouched; only the `Agent`
arm and the trailing Explore-only logic were removed. New test file
`plugin/hooks/test-recall-first.sh` was added covering: WebFetch with recall hits
(injects context, allows), WebSearch clamped by default via `recall-clamp.conf`,
WebFetch with no recall hits (no output), Explore agent spawn (no decision, criterion 2),
non-Explore agent spawn (`Plan`, unchanged pass-through), and an uncovered-repo pass-through.

Evidence: ran `bash plugin/hooks/test-recall-first.sh` in the worktree --
`8 passed, 0 failed`, covering all six cases above including "Plan agent passes through"
and "WebFetch allowed to pass through in a repo legion does not cover".

### 4. Simplify + review passes; PR linked

`recall-clamp.conf` comments were updated to reflect the new ownership split
(`recall-first.sh handles: WebFetch, WebSearch` / `no-harness-explore.sh handles:
Agent/Explore (#672)`), and the `recall-first.sh` header comment was rewritten to
describe the current (post-#672) behavior instead of the retired Explore-deny design --
no stale comments referencing the removed chain remain. This PR is the link for the
criterion; simplify and review run against it as the standard pipeline gates before
merge.

Evidence: `plugin/hooks/recall-clamp.conf` diff and `plugin/hooks/recall-first.sh`
header-comment diff (both included above) show the updated ownership documentation.

## Deliberately not done

- No changes to `no-harness-explore.sh` -- it owns Explore now (out of scope per issue).
- No changes to recall-first's behavior for tools other than the removed Agent/Explore
  arm -- WebFetch and WebSearch logic is byte-for-byte the same aside from comments.
- No changes to `LEGION_EXPLORE_THRESHOLD` or other Explore-scoring env vars/config --
  the scoring logic they controlled was deleted outright rather than migrated, since
  `no-harness-explore.sh` does not use score-based decisions.

Closes #672