### PR TITLE
fix(#740): suite-start config-corruption guard + fixture git env isolation

### DIFF
--- a/src/inventory.rs
+++ b/src/inventory.rs
@@ -403,11 +403,35 @@ mod tests {
 
     // --- current_head (#746) ---
 
+    /// Suite-wide isolated (always-empty) `GIT_CONFIG_GLOBAL` /
+    /// `GIT_CONFIG_SYSTEM` file paths for this crate target's fixture git
+    /// invocations (#740). Mirrors the integration crate's
+    /// `isolated_git_config_paths` -- this is a lib unit test, a separate
+    /// crate target, so that helper is not importable here. The backing
+    /// tempdir is deliberately leaked: it must outlive every test in this
+    /// binary, and process exit reclaims it like any other tempfile.
+    fn isolated_git_config_paths() -> &'static (std::path::PathBuf, std::path::PathBuf) {
+        static ISOLATED_GIT_CONFIG: std::sync::OnceLock<(std::path::PathBuf, std::path::PathBuf)> =
+            std::sync::OnceLock::new();
+        ISOLATED_GIT_CONFIG.get_or_init(|| {
+            let dir = tempfile::tempdir().expect("create isolated git config dir");
+            let global = dir.path().join("global.gitconfig");
+            let system = dir.path().join("system.gitconfig");
+            fs::write(&global, "").expect("write isolated global gitconfig");
+            fs::write(&system, "").expect("write isolated system gitconfig");
+            std::mem::forget(dir);
+            (global, system)
+        })
+    }
+
     /// Run `git` in `dir` with hermetic per-invocation identity (never a
-    /// `git config` write), mirroring the integration crate's
-    /// `run_git_fixture` -- this is a lib unit test, a separate crate
-    /// target, so that helper is not importable here.
+    /// `git config` write) plus full config/dir isolation (#740:
+    /// `GIT_CONFIG_GLOBAL`/`GIT_CONFIG_SYSTEM` pinned to isolated empty
+    /// files, `GIT_DIR`/`GIT_WORK_TREE` pinned to `dir`), mirroring the
+    /// integration crate's `run_git_fixture` -- this is a lib unit test, a
+    /// separate crate target, so that helper is not importable here.
     fn run_git_fixture(dir: &std::path::Path, args: &[&str]) {
+        let (global_config, system_config) = isolated_git_config_paths();
         let mut full_args: Vec<&str> = vec![
             "-c",
             "user.name=Legion Test Fixture",
@@ -420,6 +444,10 @@ mod tests {
         let out = std::process::Command::new("git")
             .args(&full_args)
             .current_dir(dir)
+            .env("GIT_CONFIG_GLOBAL", global_config)
+            .env("GIT_CONFIG_SYSTEM", system_config)
+            .env("GIT_DIR", dir.join(".git"))
+            .env("GIT_WORK_TREE", dir)
             .output()
             .unwrap_or_else(|e| panic!("git {args:?} failed to spawn in {dir:?}: {e}"));
         assert!(
@@ -427,6 +455,27 @@ mod tests {
             "git {args:?} exited non-zero in {dir:?}\nstderr: {}",
             String::from_utf8_lossy(&out.stderr)
         );
+    }
+
+    /// Read-only counterpart to `run_git_fixture`, sharing the same
+    /// isolation, for queries whose stdout the caller needs.
+    fn run_git_fixture_output(dir: &std::path::Path, args: &[&str]) -> String {
+        let (global_config, system_config) = isolated_git_config_paths();
+        let out = std::process::Command::new("git")
+            .args(args)
+            .current_dir(dir)
+            .env("GIT_CONFIG_GLOBAL", global_config)
+            .env("GIT_CONFIG_SYSTEM", system_config)
+            .env("GIT_DIR", dir.join(".git"))
+            .env("GIT_WORK_TREE", dir)
+            .output()
+            .unwrap_or_else(|e| panic!("git {args:?} failed to spawn in {dir:?}: {e}"));
+        assert!(
+            out.status.success(),
+            "git {args:?} exited non-zero in {dir:?}\nstderr: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+        String::from_utf8_lossy(&out.stdout).trim().to_string()
     }
 
     #[test]
@@ -437,14 +486,7 @@ mod tests {
         run_git_fixture(dir.path(), &["add", "a.txt"]);
         run_git_fixture(dir.path(), &["commit", "-m", "initial"]);
 
-        let expected = {
-            let out = std::process::Command::new("git")
-                .args(["rev-parse", "HEAD"])
-                .current_dir(dir.path())
-                .output()
-                .unwrap();
-            String::from_utf8_lossy(&out.stdout).trim().to_string()
-        };
+        let expected = run_git_fixture_output(dir.path(), &["rev-parse", "HEAD"]);
 
         assert_eq!(current_head(dir.path()), Some(expected));
     }

--- a/tests/integration/common.rs
+++ b/tests/integration/common.rs
@@ -167,7 +167,7 @@ pub fn seed_rate_limit_sample(data_dir: &Path, five_hour_pct: f64, seven_day_pct
 }
 
 // ---------------------------------------------------------------------------
-// Hermetic git fixtures (#723).
+// Hermetic git fixtures (#723, hardened further by #740).
 //
 // A handful of quality-gate tests need a real `git` repo (so `git_changed_files`
 // has something to probe). Every such invocation must run with an explicit
@@ -177,7 +177,52 @@ pub fn seed_rate_limit_sample(data_dir: &Path, five_hour_pct: f64, seven_day_pct
 // real `.git/config`. That happened live (#723): a fixture's `git config
 // user.name` call poisoned the shared config (worktrees inherit it), mis-
 // attributing four real commits before it was caught.
+//
+// #740 (second live occurrence: `core.bare` flipped true on the real checkout
+// after a killed test run) adds a second, independent barrier on top of the
+// `current_dir` + `-c` discipline: every fixture invocation also pins
+// `GIT_CONFIG_GLOBAL`/`GIT_CONFIG_SYSTEM` to isolated empty files and
+// `GIT_DIR`/`GIT_WORK_TREE` directly to the fixture repo, so a misfire
+// cannot resolve the operator's real global/system git config or any
+// directory other than the tempdir even if `current_dir` were somehow wrong.
 // ---------------------------------------------------------------------------
+
+static ISOLATED_GIT_CONFIG: OnceLock<(PathBuf, PathBuf)> = OnceLock::new();
+
+/// Suite-wide isolated (always-empty) `GIT_CONFIG_GLOBAL` / `GIT_CONFIG_SYSTEM`
+/// file paths. Every fixture git invocation points at these instead of
+/// letting git resolve the operator's real `~/.gitconfig` / `/etc/gitconfig`,
+/// so even a command that forgets an identity override (or a future call
+/// site that never learned the `-c` discipline) cannot read or write real
+/// global state. The backing tempdir is deliberately leaked (`mem::forget`):
+/// it must outlive every test in this binary, and process exit reclaims it
+/// like any other tempfile.
+fn isolated_git_config_paths() -> &'static (PathBuf, PathBuf) {
+    ISOLATED_GIT_CONFIG.get_or_init(|| {
+        let dir = tempfile::tempdir().expect("create isolated git config dir");
+        let global = dir.path().join("global.gitconfig");
+        let system = dir.path().join("system.gitconfig");
+        std::fs::write(&global, "").expect("write isolated global gitconfig");
+        std::fs::write(&system, "").expect("write isolated system gitconfig");
+        std::mem::forget(dir);
+        (global, system)
+    })
+}
+
+/// Build a `git` `Command` scoped to `repo_dir`: explicit `current_dir` plus
+/// the `GIT_CONFIG_GLOBAL`/`GIT_CONFIG_SYSTEM`/`GIT_DIR`/`GIT_WORK_TREE`
+/// isolation described above. Callers still add their own args (and, for
+/// writes, their own `-c` identity overrides).
+fn fixture_git_command(repo_dir: &Path) -> Command {
+    let (global_config, system_config) = isolated_git_config_paths();
+    let mut cmd = Command::new("git");
+    cmd.current_dir(repo_dir)
+        .env("GIT_CONFIG_GLOBAL", global_config)
+        .env("GIT_CONFIG_SYSTEM", system_config)
+        .env("GIT_DIR", repo_dir.join(".git"))
+        .env("GIT_WORK_TREE", repo_dir);
+    cmd
+}
 
 /// Run `git` against a fixture repo with identity and signing baked in as
 /// per-invocation `-c` overrides (never as a `git config` write) plus an
@@ -193,9 +238,8 @@ pub fn run_git_fixture(repo_dir: &Path, args: &[&str]) {
         "commit.gpgsign=false",
     ];
     full_args.extend_from_slice(args);
-    let out = Command::new("git")
+    let out = fixture_git_command(repo_dir)
         .args(&full_args)
-        .current_dir(repo_dir)
         .output()
         .unwrap_or_else(|e| panic!("git {args:?} failed to spawn in {repo_dir:?}: {e}"));
     assert!(
@@ -203,6 +247,24 @@ pub fn run_git_fixture(repo_dir: &Path, args: &[&str]) {
         "git {args:?} exited non-zero in {repo_dir:?}\nstderr: {}",
         String::from_utf8_lossy(&out.stderr)
     );
+}
+
+/// Read-only counterpart to `run_git_fixture` for queries whose stdout the
+/// caller needs (e.g. `rev-parse HEAD`), sharing the same config/dir
+/// isolation so a read can no more resolve the enclosing checkout than a
+/// write can. Panics loudly on spawn failure or non-zero exit, same as
+/// `run_git_fixture`.
+pub fn run_git_fixture_output(repo_dir: &Path, args: &[&str]) -> String {
+    let out = fixture_git_command(repo_dir)
+        .args(args)
+        .output()
+        .unwrap_or_else(|e| panic!("git {args:?} failed to spawn in {repo_dir:?}: {e}"));
+    assert!(
+        out.status.success(),
+        "git {args:?} exited non-zero in {repo_dir:?}\nstderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8_lossy(&out.stdout).trim().to_string()
 }
 
 /// Resolve the real `.git/config` given a checkout root, following the
@@ -224,10 +286,148 @@ fn resolve_git_config_path(checkout_root: &Path) -> Option<PathBuf> {
     Some(Path::new(gitdir).join("..").join("..").join("config"))
 }
 
+/// Root of the checkout this test crate is compiled from. In a `git
+/// worktree add` checkout this is the worktree's own directory -- git still
+/// resolves `git config`/`git -C <this> ...` invocations through to the
+/// shared main-repo config via the worktree indirection, so it is the
+/// correct `current_dir` for both reading and (suite-start repair) writing
+/// that shared config.
+fn checkout_root() -> &'static Path {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+}
+
 /// `resolve_git_config_path` applied to the checkout this test crate is
 /// compiled from.
 fn real_repo_config_path() -> Option<PathBuf> {
-    resolve_git_config_path(Path::new(env!("CARGO_MANIFEST_DIR")))
+    resolve_git_config_path(checkout_root())
+}
+
+/// Read a single git config key from `root`'s LOCAL scope only (`git config
+/// --local --get`), using git's own parser rather than hand-rolled TOML/ini
+/// scanning. Scoping to `--local` matters for two reasons: the corruption
+/// this guards against is specifically a write into the checkout's own
+/// `.git/config`, not the operator's global config, so that is the only
+/// scope worth asking about; and it keeps this check's result independent
+/// of whatever the invoking machine's real `~/.gitconfig` happens to
+/// contain (an unscoped `--get` would fall through to it and could mask --
+/// or spuriously flag -- corruption depending on the operator's own
+/// identity). `None` when the key is unset locally or `git config` fails
+/// for any reason (e.g. `root` is not resolvable as a repo).
+fn query_config_value(root: &Path, key: &str) -> Option<String> {
+    let out = Command::new("git")
+        .args(["config", "--local", "--get", key])
+        .current_dir(root)
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    Some(String::from_utf8_lossy(&out.stdout).trim().to_string())
+}
+
+/// Pure decision, isolated from I/O so it is unit-testable without touching
+/// any real git state: does `(bare, name, email)` read like the corruption
+/// observed live? `bare == Some("true")` is the operationally blocking flip
+/// (every git command in the checkout fails with "this operation must be
+/// run in a work tree" until it's cleared). `name`/`email` are checked
+/// against both the historical pre-#723 poisoning values ("Test" /
+/// "test@example.com", from the live incident) and the current
+/// `run_git_fixture` literals, in case some future fixture regresses to a
+/// real `git config` write. Returns one human-readable string per
+/// signature found; empty means clean.
+fn corruption_signatures(
+    bare: Option<&str>,
+    name: Option<&str>,
+    email: Option<&str>,
+) -> Vec<String> {
+    let mut found = Vec::new();
+    if bare == Some("true") {
+        found.push("core.bare=true".to_string());
+    }
+    let name_poisoned = matches!(name, Some("Test") | Some("Legion Test Fixture"));
+    let email_poisoned = matches!(
+        email,
+        Some("test@example.com") | Some("legion-test-fixture@example.invalid")
+    );
+    if name_poisoned || email_poisoned {
+        found.push(format!(
+            "fixture-poisoned identity (user.name={name:?}, user.email={email:?})"
+        ));
+    }
+    found
+}
+
+/// Detect known corruption signatures on `root`'s git config and repair
+/// `core.bare` (the operationally blocking flip) if found -- a poisoned
+/// identity is reported but left untouched, since overwriting someone's
+/// name/email is not a call this function should make unilaterally. Panics
+/// if `core.bare=true` is found but the repair itself fails, so a failed
+/// repair is never silently swallowed. Returns the human-readable findings
+/// (empty = clean).
+fn detect_and_repair_corruption(root: &Path) -> Vec<String> {
+    let bare = query_config_value(root, "core.bare");
+    let name = query_config_value(root, "user.name");
+    let email = query_config_value(root, "user.email");
+    let found = corruption_signatures(bare.as_deref(), name.as_deref(), email.as_deref());
+
+    if found.iter().any(|f| f.starts_with("core.bare")) {
+        let repair = Command::new("git")
+            .args(["config", "core.bare", "false"])
+            .current_dir(root)
+            .output();
+        match repair {
+            Ok(out) if out.status.success() => {}
+            Ok(out) => panic!(
+                "detected core.bare=true corruption on {root:?} AND failed to repair it: {}",
+                String::from_utf8_lossy(&out.stderr)
+            ),
+            Err(e) => panic!(
+                "detected core.bare=true corruption on {root:?} AND failed to spawn the repair: {e}"
+            ),
+        }
+    }
+
+    found
+}
+
+static SUITE_START_CHECKED: OnceLock<()> = OnceLock::new();
+
+/// Suite-START corruption check (#740): #723's end-of-test `Drop` guard
+/// cannot fire when a test run is killed mid-fixture (agent turn ends,
+/// timeout, ctrl-c) -- the process dies before `Drop` ever runs, so a
+/// poisoned real checkout persists silently until someone hits a mystery
+/// git failure later. This runs once per test binary at the top of
+/// `RealRepoConfigGuard::new()`, BEFORE the end-of-suite baseline is
+/// captured: if the real checkout's config already shows a known corruption
+/// signature, it means a PRIOR suite run left it that way. Repairs
+/// `core.bare` and panics loudly, naming exactly what was found, rather
+/// than silently adopting the poisoned state as this run's new baseline.
+///
+/// Uses `OnceLock::get_or_init` (not a swapped `AtomicBool`) so concurrent
+/// test threads BLOCK on the first caller's check-and-repair rather than
+/// racing past it: an `AtomicBool` swap would let a second thread capture
+/// `config_baseline()`'s hash of the still-corrupted file while the first
+/// thread's repair is in flight, turning every later `Drop` guard's
+/// comparison into a false "changed during this run" report.
+fn check_suite_start_for_leftover_corruption() {
+    SUITE_START_CHECKED.get_or_init(|| {
+        if real_repo_config_path().is_none() {
+            return;
+        }
+        let found = detect_and_repair_corruption(checkout_root());
+        if found.is_empty() {
+            return;
+        }
+        panic!(
+            "enclosing checkout's real .git/config was corrupted BEFORE this suite run started \
+             ({}) at {:?} -- a previous integration-suite run was almost certainly killed \
+             mid-fixture (#723's end-of-suite guard cannot fire on a killed process). core.bare \
+             has been repaired to false; if a poisoned identity was found, verify user.name/\
+             user.email manually before committing. See #740.",
+            found.join("; "),
+            checkout_root(),
+        );
+    });
 }
 
 /// SHA-256 of the file at `path`, lowercase hex. `None` if it cannot be read.
@@ -249,9 +449,11 @@ fn config_baseline() -> &'static Option<String> {
 
 /// RAII suite guard against `.git/config` poisoning (#723). Construct one at
 /// the top of every test that drives real `git` fixture processes, before any
-/// fixture command runs: `new()` snapshots (or reuses) the suite-wide
-/// baseline hash of the real enclosing checkout's `.git/config`, and `Drop`
-/// re-hashes it and panics -- naming the file -- if it no longer matches.
+/// fixture command runs: `new()` first runs the suite-START leftover-
+/// corruption check (#740, see `check_suite_start_for_leftover_corruption`),
+/// then snapshots (or reuses) the suite-wide baseline hash of the real
+/// enclosing checkout's `.git/config`, and `Drop` re-hashes it and panics --
+/// naming the file -- if it no longer matches.
 ///
 /// Skips the check (never panics) when the real config cannot be resolved or
 /// read at all, and when already unwinding from a separate test failure (a
@@ -263,6 +465,7 @@ pub struct RealRepoConfigGuard {
 
 impl RealRepoConfigGuard {
     pub fn new() -> Self {
+        check_suite_start_for_leftover_corruption();
         let _ = config_baseline();
         Self { _private: () }
     }
@@ -378,5 +581,140 @@ mod config_guard_tests {
         let first = hash_config_file(&path).expect("file exists");
         let second = hash_config_file(&path).expect("file exists");
         assert_eq!(first, second);
+    }
+
+    // --- suite-start corruption detection (#740) ---
+
+    #[test]
+    fn corruption_signatures_clean_state_finds_nothing() {
+        assert!(
+            corruption_signatures(
+                Some("false"),
+                Some("Sean Silvius"),
+                Some("sean@example.com")
+            )
+            .is_empty()
+        );
+        assert!(corruption_signatures(None, None, None).is_empty());
+    }
+
+    #[test]
+    fn corruption_signatures_flags_bare_true() {
+        let found = corruption_signatures(Some("true"), None, None);
+        assert_eq!(found, vec!["core.bare=true".to_string()]);
+    }
+
+    #[test]
+    fn corruption_signatures_flags_historical_test_identity() {
+        // The exact pre-#723 live-incident poisoning: "[user] Test/test@example.com".
+        let found = corruption_signatures(None, Some("Test"), Some("test@example.com"));
+        assert_eq!(found.len(), 1);
+        assert!(found[0].contains("poisoned identity"));
+    }
+
+    #[test]
+    fn corruption_signatures_flags_current_fixture_identity() {
+        let found = corruption_signatures(
+            None,
+            Some("Legion Test Fixture"),
+            Some("legion-test-fixture@example.invalid"),
+        );
+        assert_eq!(found.len(), 1);
+    }
+
+    #[test]
+    fn corruption_signatures_flags_both_bare_and_identity_independently() {
+        let found = corruption_signatures(Some("true"), Some("Test"), Some("test@example.com"));
+        assert_eq!(
+            found.len(),
+            2,
+            "expected one entry per independent signature: {found:?}"
+        );
+    }
+
+    #[test]
+    fn query_config_value_returns_none_for_unset_local_key() {
+        let repo = tempfile::tempdir().unwrap();
+        run_git_fixture(repo.path(), &["init"]);
+        // run_git_fixture supplies identity via per-invocation `-c` overrides,
+        // never a persisted `git config` write (that is the whole point of
+        // #723) -- so the LOCAL scope has no user.name at all here.
+        assert_eq!(query_config_value(repo.path(), "user.name"), None);
+    }
+
+    /// Write `key = value` into `repo`'s local config, going through
+    /// `fixture_git_command` for the same isolation every other fixture
+    /// write uses (this is a disposable throwaway repo, never the real
+    /// checkout -- it exists precisely to *simulate* corruption to test
+    /// the detector against, and that simulation must not itself take the
+    /// unpinned shortcut #740 hardens everything else against).
+    fn set_fixture_config(repo: &Path, key: &str, value: &str) {
+        let out = fixture_git_command(repo)
+            .args(["config", key, value])
+            .output()
+            .unwrap_or_else(|e| {
+                panic!("git config {key} {value} failed to spawn in {repo:?}: {e}")
+            });
+        assert!(
+            out.status.success(),
+            "git config {key} {value} exited non-zero in {repo:?}\nstderr: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+    }
+
+    #[test]
+    fn query_config_value_reads_a_locally_set_key() {
+        let repo = tempfile::tempdir().unwrap();
+        run_git_fixture(repo.path(), &["init"]);
+        set_fixture_config(repo.path(), "core.bare", "true");
+        assert_eq!(
+            query_config_value(repo.path(), "core.bare").as_deref(),
+            Some("true")
+        );
+    }
+
+    /// `detect_and_repair_corruption` against a deliberately poisoned FAKE
+    /// repo (never the real enclosing checkout): finds `core.bare=true` and
+    /// repairs it, leaving identity alone since this function must never
+    /// unilaterally overwrite someone's name/email.
+    #[test]
+    fn detect_and_repair_corruption_repairs_bare_and_reports_identity() {
+        let repo = tempfile::tempdir().unwrap();
+        run_git_fixture(repo.path(), &["init"]);
+        // Poison it directly (this is a disposable fixture repo, not the
+        // real checkout) to simulate a killed run's leftover state.
+        set_fixture_config(repo.path(), "core.bare", "true");
+        set_fixture_config(repo.path(), "user.name", "Test");
+        set_fixture_config(repo.path(), "user.email", "test@example.com");
+
+        let found = detect_and_repair_corruption(repo.path());
+        assert_eq!(
+            found.len(),
+            2,
+            "expected bare + identity signatures: {found:?}"
+        );
+        assert!(found.iter().any(|f| f.contains("core.bare=true")));
+        assert!(found.iter().any(|f| f.contains("poisoned identity")));
+
+        // core.bare must now be repaired to false.
+        assert_eq!(
+            query_config_value(repo.path(), "core.bare").as_deref(),
+            Some("false"),
+            "core.bare must be repaired, not merely reported"
+        );
+        // Identity must be left untouched -- repairing it is not this
+        // function's call to make.
+        assert_eq!(
+            query_config_value(repo.path(), "user.name").as_deref(),
+            Some("Test"),
+            "identity must be reported, never silently rewritten"
+        );
+    }
+
+    #[test]
+    fn detect_and_repair_corruption_clean_repo_finds_nothing() {
+        let repo = tempfile::tempdir().unwrap();
+        run_git_fixture(repo.path(), &["init"]);
+        assert!(detect_and_repair_corruption(repo.path()).is_empty());
     }
 }

--- a/tests/integration/inventory_freshness.rs
+++ b/tests/integration/inventory_freshness.rs
@@ -5,7 +5,7 @@
 //! of the `--json` envelope (see sym_tree.rs/find_file.rs for the
 //! freshness/drift-detection tests built on top of this).
 
-use crate::common::{legion_cmd, run_git_fixture, run_ok};
+use crate::common::{legion_cmd, run_git_fixture, run_git_fixture_output, run_ok};
 
 /// Seed a watch.toml in the data dir pointing at `repos` (name, workdir).
 /// Backslashes are TOML escape syntax, so Windows paths interpolated raw
@@ -36,14 +36,7 @@ fn legion_index_records_inventory_snapshot_with_head_in_git_checkout() {
     run_git_fixture(repo_dir.path(), &["add", "a.rs"]);
     run_git_fixture(repo_dir.path(), &["commit", "-m", "initial"]);
 
-    let expected_head = {
-        let out = std::process::Command::new("git")
-            .args(["rev-parse", "HEAD"])
-            .current_dir(repo_dir.path())
-            .output()
-            .expect("git rev-parse HEAD");
-        String::from_utf8_lossy(&out.stdout).trim().to_string()
-    };
+    let expected_head = run_git_fixture_output(repo_dir.path(), &["rev-parse", "HEAD"]);
 
     seed_watch_toml(data_dir.path(), &[("gitrepo", repo_dir.path())]);
     let before = chrono::Utc::now();
@@ -127,14 +120,7 @@ fn reindex_replaces_prior_snapshot_row_not_accumulates() {
     run_git_fixture(repo_dir.path(), &["commit", "-m", "second"]);
     run_ok(legion_cmd(data_dir.path()).args(["index", "gitrepo"]));
 
-    let expected_head = {
-        let out = std::process::Command::new("git")
-            .args(["rev-parse", "HEAD"])
-            .current_dir(repo_dir.path())
-            .output()
-            .expect("git rev-parse HEAD");
-        String::from_utf8_lossy(&out.stdout).trim().to_string()
-    };
+    let expected_head = run_git_fixture_output(repo_dir.path(), &["rev-parse", "HEAD"]);
 
     let json_out = run_ok(
         legion_cmd(data_dir.path())

--- a/tests/integration/worksource_pr.rs
+++ b/tests/integration/worksource_pr.rs
@@ -1900,18 +1900,16 @@ fn quality_gate_check_non_ascii_path_roundtrips_correctly() {
     run_git_fixture(rp, &["commit", "-m", "add non-ascii file"]);
 
     // Ask git what name it reports (with core.quotePath=false).
-    let diff_out = Command::new("git")
-        .args([
+    let reported_path = run_git_fixture_output(
+        rp,
+        &[
             "-c",
             "core.quotePath=false",
             "diff",
             "--name-only",
             "main...HEAD",
-        ])
-        .current_dir(rp)
-        .output()
-        .expect("git diff failed");
-    let reported_path = String::from_utf8_lossy(&diff_out.stdout).trim().to_string();
+        ],
+    );
     // The path must be non-empty and not octal-quoted.
     assert!(
         !reported_path.is_empty(),


### PR DESCRIPTION
## Summary

#723 made fixture `git` calls hermetic and added an end-of-suite config-hash guard, but
that guard only detects poisoning that survives to a clean process exit -- a suite killed
mid-run (agent turn ends, timeout, ctrl-c) never reaches `Drop`, so a `core.bare=true` flip
on the real checkout persists silently until the next `git` command mysteriously fails
("this operation must be run in a work tree"). This happened live on 2026-07-05, a second
occurrence of the same class.

This PR closes the gap on both sides: it finds and re-isolates the fixture call sites #723's
sweep missed, and it adds a suite-**start** check so a corrupted config left by a killed run
is caught (and repaired) the moment the next test binary starts, instead of only being
detected after the fact.

## Acceptance criteria mapping

### 1. Identify the writer

`#723`'s sweep pinned `current_dir` and identity `-c` overrides on the shared
`run_git_fixture` helper, but several call sites still spawned `git` directly via
`std::process::Command::new("git")` without going through that helper -- each one a path
that inherits the process's ambient `GIT_CONFIG_GLOBAL`/`GIT_CONFIG_SYSTEM`/working-directory
resolution instead of being pinned to the fixture tempdir. Found and fixed:

- `src/inventory.rs` unit test `current_head_reads_head_in_real_git_checkout`: raw
  `rev-parse HEAD` call, now `run_git_fixture_output` (a new isolated helper added because
  this is a separate lib-test binary target that can't import the integration crate's
  `common.rs`).
- `tests/integration/inventory_freshness.rs`: two raw `rev-parse HEAD` calls (one per test,
  `legion_index_records_inventory_snapshot_with_head_in_git_checkout` and
  `reindex_replaces_prior_snapshot_row_not_accumulates`), both now `run_git_fixture_output`.
- `tests/integration/worksource_pr.rs`, `quality_gate_check_non_ascii_path_roundtrips_correctly`:
  a raw `git -c core.quotePath=false diff --name-only` call, now `run_git_fixture_output`.

Evidence: `git -C /Volumes/store/projects/runlegion/legion diff main...origin/fix/740-config-corruption-guard`
shows each of these four call sites converted from an unpinned `Command::new("git")` to the
isolated helper; `src/inventory.rs:489`, `tests/integration/inventory_freshness.rs:39`,
`tests/integration/worksource_pr.rs` (the `run_git_fixture_output` call replacing the old
`Command::new("git")` + manual stdout decode block in that test).

### 2. Prevention over detection

Every fixture git invocation across both crate targets now goes through a command
constructor that pins `GIT_CONFIG_GLOBAL`/`GIT_CONFIG_SYSTEM` to isolated, always-empty
files and `GIT_DIR`/`GIT_WORK_TREE` directly to the fixture tempdir, in addition to the
existing `current_dir` + per-invocation `-c` identity discipline from #723. This is the same
intent as the acceptance criterion's literal `/dev/null` suggestion, implemented instead as
leaked per-suite tempfiles: `/dev/null` has no portable equivalent on Windows and, more
importantly, several fixture tests (the corruption-detector's own test doubles) need to
`git config` a value into a repo, which requires a real writable file at the pinned path,
not a null sink. An always-empty tempfile gives the same "cannot resolve real global/system
config" guarantee while staying writable and cross-platform.

- `tests/integration/common.rs:200-225` (`isolated_git_config_paths`, `fixture_git_command`):
  suite-wide isolated config paths plus a `Command` builder that sets all four env vars;
  `run_git_fixture` (`common.rs:231-250`) and the new `run_git_fixture_output`
  (`common.rs:257-268`) both build on it.
- `src/inventory.rs:406-458`: the lib-crate mirror of the same isolation (duplicated rather
  than shared, since it's a separate test binary target that cannot import
  `tests/integration/common.rs`).

Evidence: `fixture_git_command` at `tests/integration/common.rs:216` sets all four env vars
on every fixture `Command`; every remaining fixture call site in the diff (`run_git_fixture`,
`run_git_fixture_output`, `set_fixture_config`) routes through it, and the four call sites
from criterion 1 were migrated onto it specifically because they weren't before.

### 3. Suite-start snapshot and restore-or-scream

`check_suite_start_for_leftover_corruption` (`tests/integration/common.rs:412-431`) runs
once per test binary at the very top of `RealRepoConfigGuard::new()`
(`common.rs:467-471`), before the end-of-suite baseline hash is even captured. It queries the
real checkout's local git config for known corruption signatures (`core.bare=true`, or a
fixture-identity leak into `user.name`/`user.email`) via `detect_and_repair_corruption`
(`common.rs:367-391`); if anything is found, it repairs `core.bare` and then panics loudly,
naming exactly what was found and citing #740, rather than silently adopting the poisoned
state as this run's new baseline. It's gated by an `OnceLock::get_or_init` rather than an
`AtomicBool` swap specifically so concurrent test threads block on the first caller's
check-and-repair instead of racing a stale baseline capture past it (documented at
`common.rs:406-411`).

Evidence: `check_suite_start_for_leftover_corruption` at `tests/integration/common.rs:412`,
wired into `RealRepoConfigGuard::new()` at `common.rs:468`; the pure decision function it
calls is covered directly by
`detect_and_repair_corruption_repairs_bare_and_reports_identity` and
`detect_and_repair_corruption_clean_repo_finds_nothing`
(`tests/integration/common.rs:681`, `715`), which drive it against a disposable fixture repo
poisoned with the exact historical signature (`core.bare=true`, `user.name=Test`,
`user.email=test@example.com`) and assert both the repair and the non-clobbering of
identity. The suite-start wiring itself operates on the real checkout rather than a fixture,
so it is exercised structurally (every `cargo test` run in this repo calls it) rather than by
a dedicated unit test against the live config.

### 4. Recovery documented in one place

`detect_and_repair_corruption` (`tests/integration/common.rs:367-391`) is the single place
that knows how to recover: it repairs `core.bare` to `false` via `git config core.bare
false` and checks `user.name`/`user.email` against both the historical live-incident values
and the current fixture literals, reporting (but deliberately never overwriting) a poisoned
identity since rewriting someone's real name/email is not a call this function should make
unilaterally. Both `check_suite_start_for_leftover_corruption` (leftover-from-killed-run path)
and any future caller needing the same repair share this one function rather than each
re-implementing the `core.bare false` fix inline.

Evidence: `corruption_signatures` (`common.rs:338-358`) and `detect_and_repair_corruption`
(`common.rs:367-391`), covered by six unit tests
(`corruption_signatures_clean_state_finds_nothing`, `corruption_signatures_flags_bare_true`,
`corruption_signatures_flags_historical_test_identity`,
`corruption_signatures_flags_current_fixture_identity`,
`corruption_signatures_flags_both_bare_and_identity_independently`,
`detect_and_repair_corruption_repairs_bare_and_reports_identity`) at
`tests/integration/common.rs:589-712`, asserting the repair fires on `core.bare` and the
identity is reported without being rewritten.

## Not done (deliberately)

- Did not use literal `/dev/null` for `GIT_CONFIG_GLOBAL`/`GIT_CONFIG_SYSTEM` as the
  acceptance criterion phrased it -- used isolated always-empty tempfiles instead, for
  Windows portability and because some fixture tests need a writable pinned config target
  (see criterion 2 above). The isolation guarantee (cannot resolve the operator's real
  global/system config) is the same.
- Did not add a dedicated unit test that spawns a second test-binary process against a
  pre-poisoned real-checkout-shaped fixture to exercise
  `check_suite_start_for_leftover_corruption`'s wiring end-to-end -- its pure decision logic
  (`corruption_signatures`, `detect_and_repair_corruption`) is fully unit-tested, but the
  wiring itself only runs against `checkout_root()` (this actual repo), so a full
  process-level rehearsal of "prior run left it corrupted" would mean deliberately poisoning
  this repo's own `.git/config` mid-test-suite, which is the exact failure mode this PR
  exists to prevent.
- Did not touch `RealRepoConfigGuard`'s end-of-suite `Drop` detection path (#723) beyond
  routing its baseline capture through the same `checkout_root()`/`fixture_git_command`
  plumbing -- the acceptance criteria ask for a start-of-suite addition, not a rewrite of the
  existing end-of-suite guard.

Closes #740