### PR TITLE
fix(#669): simplify validator refinements

### DIFF
--- a/plugin/skills/legion-simplify/SKILL.md
+++ b/plugin/skills/legion-simplify/SKILL.md
@@ -6,7 +6,7 @@ description: |
   file, what you checked and why the verdict holds; `legion quality-gate check` validates the
   articulation (coverage + non-boilerplate + located evidence) and records the gate so `legion
   pr create` can verify clean state before opening a PR. Run this on every feature branch before a PR.
-version: 2.1.0
+version: 2.1.1
 user-invocable: true
 allowed-tools: Bash, Read
 ---
@@ -79,7 +79,20 @@ Error paths propagate via `?`. No stringly-typed state. Verdict: clean.
    `origin/main...HEAD`) -- this is your coverage list. The `-c core.quotePath=false` flag
    ensures paths with non-ASCII characters are returned unescaped, matching the headings you
    write in step 2. Use `### <path>` headings that are repo-root-relative paths exactly as
-   git reports them (e.g. `### src/café.rs`, not an escaped or shortened form).
+   git reports them (e.g. `### src/café.rs`, not an escaped or shortened form) -- no `./`
+   prefix, no trailing text after the path on the heading line. Coverage matching is exact
+   string equality against what git printed; a heading that does not match byte-for-byte is
+   refused as missing, no matter how much prose you add under it.
+
+   **Renames**: a rename git still recognizes as such (similarity above its threshold --
+   the common case, even with a real edit alongside the move) reports as one `R` line and
+   `--name-only` prints just the new path, so it needs only the one new-path entry. Only a
+   rewrite heavy enough to drop below git's similarity threshold splits into two separate
+   paths -- the old path (deleted) and the new path (added) -- and both then need their own
+   `### <path>` entry, including the old one, even though it no longer exists in the tree.
+   That old-path entry still has to clear the same substance and locator bars as any other:
+   a short paragraph noting where the content moved, with an `Evidence:` line pointing at the
+   new path, clears both; a bare "moved to new_name.rs" does not.
 2. For EACH changed file: read it, review its hunks against the categories above, and write its
    `### <path>` entry with real reasoning.
 3. Write the articulation to a file (e.g. `/tmp/simplify-<branch>.md`).
@@ -106,3 +119,13 @@ Error paths propagate via `?`. No stringly-typed state. Verdict: clean.
 exists for the current HEAD commit hash with `result = "clean"`. Because the gate is recorded
 only by `legion quality-gate check`, a clean row now means an accepted per-file articulation
 exists -- not merely that someone typed "clean".
+
+## Notes
+
+- The validator checks structure, not reasoning quality: file coverage, a word count per
+  entry (~12 words after the heading is stripped), and a within-file locator (`file:line`,
+  `line N`, a symbol, or an `Evidence:` line). It cannot tell a correct verdict from a
+  plausible-sounding wrong one -- that stays the reviewer's job, same division of labor as
+  `legion pr write-check`. It can tell when an entry is empty, boilerplate, or points at
+  nothing locatable, and it refuses those.
+- If you commit again after a clean gate, the gate no longer matches HEAD -- re-run step 4.

--- a/src/cli/util.rs
+++ b/src/cli/util.rs
@@ -172,7 +172,16 @@ pub(crate) fn git_changed_files() -> Result<std::collections::HashSet<String>, e
                     .to_owned(),
             ));
         }
-        // HEAD has no parent: genuine initial commit, vacuously valid.
+        // HEAD has no parent: genuine initial commit, vacuously valid. This is
+        // unreachable in the normal branch-off-main workflow (HEAD always has
+        // a parent once `main` exists), but note it on stderr rather than
+        // passing silently -- a vacuous pass should never be invisible to
+        // whoever is watching the gate run.
+        eprintln!(
+            "[legion] no base ref ('main' or 'origin/main') found and HEAD has no parent \
+             commit -- treating this as the initial commit. The changed-file set is empty \
+             and any articulation is accepted vacuously."
+        );
         return Ok(std::collections::HashSet::new());
     };
 

--- a/src/pr_write.rs
+++ b/src/pr_write.rs
@@ -172,8 +172,13 @@ fn split_entries(mapping: &str) -> Vec<String> {
 /// criterion and the evidence line is checked separately, so neither should
 /// count toward the substance threshold.
 ///
-/// Shared with `simplify_check`, which uses the same strip-then-count logic
-/// to validate per-file simplify articulation entries.
+/// pr-write-only (#669): `simplify_check` deliberately does NOT share this
+/// stripper. Dropping the `Evidence:` line is correct here because pr-write
+/// checks that line's presence separately from the word count, but in
+/// simplify articulation an `Evidence:` line IS the within-file locator
+/// (see `simplify_check::entry_body`), so stripping it there silently
+/// discarded a legitimate entry's substance. Sharing this function again
+/// would reintroduce that leak.
 pub(crate) fn strip_evidence_lines(entry: &str) -> String {
     entry
         .lines()

--- a/src/simplify_check.rs
+++ b/src/simplify_check.rs
@@ -18,7 +18,7 @@
 
 use std::collections::HashSet;
 
-use crate::pr_write::{MIN_MAPPING_WORDS, has_within_file_locator, strip_evidence_lines};
+use crate::pr_write::{MIN_MAPPING_WORDS, has_within_file_locator};
 
 /// Minimum words of prose per file entry, after the heading is stripped.
 /// Aliased to `pr_write::MIN_MAPPING_WORDS` so both gates share a single
@@ -85,10 +85,12 @@ pub fn parse_articulation(articulation: &str) -> Vec<ArticulationEntry> {
 }
 
 /// Strip the `### <path>` heading line(s) from an articulation entry, leaving
-/// the body for the located-evidence check. Unlike `strip_evidence_lines` this
-/// KEEPS any `Evidence:` line (so an explicit citation counts) and removes only
-/// the heading -- the heading restates the file path and would otherwise
-/// satisfy `has_evidence`'s source-path test for free.
+/// the body for both the substance count and the located-evidence check.
+/// Unlike `pr_write::strip_evidence_lines` this KEEPS any `Evidence:` line (so
+/// an explicit citation counts toward both the word threshold and
+/// `has_within_file_locator`'s source-path test) and removes only the heading
+/// -- the heading restates the file path and would otherwise satisfy that
+/// test for free.
 fn entry_body(raw: &str) -> String {
     raw.lines()
         .filter(|l| !l.trim_start().starts_with("### "))
@@ -146,13 +148,15 @@ pub fn validate_articulation(
         ));
     }
 
-    // Substance check: each entry must have enough prose.
-    // strip_evidence_lines already drops `### ` heading lines (they start with
-    // "### "), so the heading path tokens do not count toward the word
-    // threshold -- only the body prose does.
+    // Both checks below read the same stripped body -- see `entry_body`'s doc
+    // comment for why it (not `pr_write::strip_evidence_lines`) is the right
+    // stripper for simplify: an `Evidence:` line is simplify's own
+    // within-file locator, not a foreign convention to discard.
     for entry in &entries {
-        let prose = strip_evidence_lines(&entry.raw);
-        let words = prose.split_whitespace().count();
+        let body = entry_body(&entry.raw);
+
+        // Substance check: each entry must have enough prose.
+        let words = body.split_whitespace().count();
         if words < MIN_ENTRY_WORDS {
             findings.push(format!(
                 "entry '{}' is too thin ({} words) -- explain which checks were \
@@ -168,7 +172,7 @@ pub fn validate_articulation(
         // strict `has_within_file_locator` (symbol / file:line / Evidence:
         // line) -- neither a behavioral cue word nor a BARE filename (which
         // just repeats the heading) clears this structural gate.
-        if !has_within_file_locator(&entry_body(&entry.raw)) {
+        if !has_within_file_locator(&body) {
             findings.push(format!(
                 "entry '{}' cites no located evidence -- point at the construct \
                  you examined (a file:line, a `fn`/`::` symbol, or an \
@@ -328,6 +332,66 @@ mod tests {
              focused, with no duplication or abstraction-altitude problems worth changing.\n\
              Evidence: src/foo.rs:12 the single match in handle_event\n";
         let report = validate_articulation(&files, body);
+        assert!(report.ok, "expected clean, got {:?}", report.findings);
+    }
+
+    #[test]
+    fn accepts_entry_whose_substance_is_on_the_evidence_line() {
+        // Regression guard for the strip_evidence_lines convention leak (#669):
+        // simplify_check must not reuse pr_write's evidence-line-dropping
+        // stripper for the word count. An entry that packs its reasoning onto
+        // the `Evidence:` line must still count those words toward the
+        // substance threshold rather than losing them silently.
+        let files = changed(&["src/foo.rs"]);
+        let body = "### src/foo.rs\n\
+             Evidence: src/foo.rs:12 fn handle_event has a single match arm per variant, \
+             propagates errors via `?`, and duplicates nothing worth extracting here.\n";
+        let report = validate_articulation(&files, body);
+        assert!(
+            report.ok,
+            "prose on the Evidence: line must count toward substance, got {:?}",
+            report.findings
+        );
+    }
+
+    #[test]
+    fn refuses_rename_when_old_path_entry_missing() {
+        // Renames below git's similarity threshold are reported by
+        // `git diff --name-only` as a delete of the old path plus an add of
+        // the new path (two separate entries), not a single rename line.
+        // Coverage must be exact-path: an articulation addressing only the
+        // new path still leaves the old path uncovered, and the gate refuses
+        // by name -- an agent cannot clear this by adding more prose about
+        // the new path, since the old path simply will not match.
+        let files = changed(&["src/old_name.rs", "src/new_name.rs"]);
+        let only_new_path = "### src/new_name.rs\n\
+             Renamed from old_name.rs and reviewed for duplicate logic, stringly-typed \
+             state, and unnecessary abstraction. `fn parse` at line 10 is unchanged \
+             behaviorally aside from the move; nothing to extract.\n";
+        let report = validate_articulation(&files, only_new_path);
+        assert!(
+            !report.ok,
+            "expected a refusal for the uncovered old path, got clean"
+        );
+        assert!(
+            report
+                .findings
+                .iter()
+                .any(|f| f.contains("missing coverage") && f.contains("src/old_name.rs")),
+            "expected a missing-coverage finding naming the old path exactly, got {:?}",
+            report.findings
+        );
+
+        // Only when BOTH git-reported paths get an exact-match entry does the
+        // articulation pass -- there is no way to satisfy coverage for the
+        // old path other than heading it with the exact path git reports.
+        let both_paths = format!(
+            "{only_new_path}\n### src/old_name.rs\n\
+             Deleted as part of the rename to new_name.rs; the content now lives there and \
+             was reviewed under that heading, so nothing further to check under this path.\n\
+             Evidence: content moved to src/new_name.rs, reviewed there in full\n"
+        );
+        let report = validate_articulation(&files, &both_paths);
         assert!(report.ok, "expected clean, got {:?}", report.findings);
     }
 

--- a/tests/integration/worksource_pr.rs
+++ b/tests/integration/worksource_pr.rs
@@ -1873,6 +1873,63 @@ fn quality_gate_check_no_base_ref_with_parent_commit_exits_nonzero() {
     );
 }
 
+/// quality-gate check: a genuine initial commit (no `main`/`origin/main` ref
+/// AND HEAD has no parent) passes vacuously -- but must not do so silently.
+/// #669: the vacuous-pass branch now warns on stderr even though the command
+/// exits zero and records a clean gate.
+#[cfg(unix)]
+#[test]
+fn quality_gate_check_initial_commit_vacuous_pass_warns_on_stderr() {
+    let _config_guard = RealRepoConfigGuard::new();
+    let repo = tempfile::tempdir().unwrap();
+    let rp = repo.path();
+
+    // A non-standard branch name (neither `main` nor `origin/main`) with a
+    // single commit -- HEAD has no parent, so this is a genuine initial
+    // commit, not a misconfigured base ref.
+    run_git_fixture(rp, &["init", "-b", "trunk"]);
+    std::fs::write(rp.join("README.md"), "seed\n").unwrap();
+    run_git_fixture(rp, &["add", "README.md"]);
+    run_git_fixture(rp, &["commit", "-m", "seed"]);
+
+    let data_dir = tempfile::tempdir().unwrap();
+    // The changed-file set is empty on this path, so an articulation with no
+    // entries at all is vacuously accepted.
+    let artic_file = tempfile::NamedTempFile::new().unwrap();
+    std::fs::write(artic_file.path(), "# No changed files\n").unwrap();
+
+    let out = run_ok_output(legion_cmd(data_dir.path()).current_dir(rp).args([
+        "quality-gate",
+        "check",
+        "--skill",
+        "legion-simplify",
+        "--result",
+        "clean",
+        "--articulation-file",
+        artic_file.path().to_str().unwrap(),
+    ]));
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("initial commit") && stderr.contains("vacuously"),
+        "expected the vacuous-pass path to warn on stderr, got: {stderr}"
+    );
+
+    // The gate is still recorded -- this is a pass, just a noted one.
+    let list_out = run_ok(legion_cmd(data_dir.path()).args([
+        "quality-gate",
+        "list",
+        "--skill",
+        "legion-simplify",
+        "--json",
+    ]));
+    let rows: serde_json::Value = serde_json::from_str(&list_out).expect("expected JSON");
+    assert_eq!(
+        rows.as_array().unwrap().len(),
+        1,
+        "expected one gate row recorded on the vacuous pass, got: {list_out}"
+    );
+}
+
 /// quality-gate check: non-ASCII file paths with core.quotePath are handled
 /// correctly. The path returned by git (unescaped, with core.quotePath=false)
 /// must match the `### <path>` heading, and the articulation must pass.


### PR DESCRIPTION
## Summary

Four non-blocking refinements to the legion-simplify articulation validator that the pre-push
review of PR #668 (#665) raised: a silent vacuous-pass path, brittle exact-path rename
coverage, a borrowed evidence-line stripper that silently dropped legitimate substance, and
SKILL.md wording that overstated what the validator actually checks.

## Acceptance criteria mapping

### 1. Initial-commit empty-set path warns to stderr

`git_changed_files` in `src/cli/util.rs` returns an empty changed-file set (vacuously valid)
when no base ref resolves and HEAD has no parent commit. This path is unreachable in the
normal branch-off-main workflow, but it was previously silent. It now emits an `eprintln!`
noting that no base ref was found, HEAD has no parent, and the changed-file set is empty so
any articulation is accepted vacuously.

Evidence: src/cli/util.rs:175-183 adds the `eprintln!` immediately before returning
`Ok(std::collections::HashSet::new())`. Covered by
`tests/integration/worksource_pr.rs::quality_gate_check_initial_commit_vacuous_pass_warns_on_stderr`,
which builds a fresh one-commit repo on a non-`main` branch (so no base ref resolves and HEAD
has no parent), runs `quality-gate check`, and asserts the captured stderr contains both
"initial commit" and "vacuously". Ran locally: `cargo test --test integration
quality_gate_check_initial_commit_vacuous_pass_warns_on_stderr` -- 1 passed.

### 2. Rename/path-quoting behavior tested and documented

Renames below git's similarity threshold split into a delete-of-old-path plus an add-of-new-path
(two separate entries in `git diff --name-only`), not a single rename line, so an articulation
that only addresses the new path leaves the old path uncovered. This already failed safe
(refused), but it was untested and undocumented, and an agent hitting the refusal had no way to
know the fix was "add an entry headed with the exact old path."

Evidence: `src/simplify_check.rs::tests::refuses_rename_when_old_path_entry_missing` (added)
exercises a two-path changed-file set, first with only the new-path entry (asserts the gate
refuses with a "missing coverage" finding naming `src/old_name.rs` exactly), then with both
paths headed exactly as git reports them (asserts the gate passes). Ran locally: `cargo test
simplify_check::` -- 15 passed, including this one.
`plugin/skills/legion-simplify/SKILL.md` (the "Renames" paragraph, added under step 1) now
documents that coverage matching is exact string equality against what git prints, that a
similarity-preserved rename needs only the one new-path entry, and that a below-threshold
rewrite needs both the old and new path each with their own `### <path>` entry -- including the
now-deleted old path.

### 3. simplify word-count no longer silently drops Evidence-prefixed prose

`simplify_check` previously reused `pr_write::strip_evidence_lines` for its substance word
count, which drops any line starting with `Evidence:` -- a pr-write document convention that
doesn't apply to simplify articulation, where an `Evidence:` line is simplify's own
within-file locator. An entry that packed its reasoning onto the `Evidence:` line lost those
words from the count and could be falsely refused as "too thin."

Evidence: `src/simplify_check.rs:21` no longer imports `strip_evidence_lines` from
`pr_write`; the substance-check loop at `src/simplify_check.rs:158-160` now computes `words`
from `entry_body(&entry.raw)` (which keeps `Evidence:` lines and strips only the `### `
heading) instead of `strip_evidence_lines(&entry.raw)`. `src/pr_write.rs:172-181`'s doc
comment on `strip_evidence_lines` now states explicitly (with a `#669` reference) that
`simplify_check` deliberately does not share this stripper, so a future edit doesn't
reintroduce the leak by re-sharing it. Regression test:
`src/simplify_check.rs::tests::accepts_entry_whose_substance_is_on_the_evidence_line`, which
builds an entry whose entire substantive sentence is on the `Evidence:` line and asserts the
gate now accepts it. Ran locally: `cargo test simplify_check::` -- 15 passed, including this
one.

### 4. SKILL.md wording matches what is actually enforced

The SKILL.md description and body previously read as though the validator judges reasoning
quality. It only checks structure: file coverage, a ~12-word threshold per entry after the
heading is stripped, and a within-file locator (`file:line`, `line N`, a symbol, or an
`Evidence:` line) -- it cannot distinguish a correct verdict from a plausible-sounding wrong
one.

Evidence: `plugin/skills/legion-simplify/SKILL.md` gains a "Notes" section (end of file)
stating the validator "checks structure, not reasoning quality" and explicitly assigning
correctness judgment to the reviewer, "same division of labor as `legion pr write-check`."
Frontmatter `version` bumped `2.1.0` -> `2.1.1` to reflect the documentation-only behavior
clarification (`plugin/skills/legion-simplify/SKILL.md` frontmatter, line 9).

### 5. Simplify + review passes; PR linked

This PR is that link, and its final line closes #669. `cargo test simplify_check::` (15
passed) and `cargo test --test integration quality_gate_check_initial_commit_vacuous_pass_warns_on_stderr`
(1 passed) were run locally on this branch's HEAD before opening this PR, and the
`legion-simplify` and `legion pr write-check` gates for this branch are recorded ahead of
`legion pr create`, per this repo's workflow (`plugin/skills/legion-simplify/SKILL.md`).

## Deliberately not done

- No re-architecture of the quality-gate mechanism itself -- explicitly out of scope per the
  issue; the gate already fails safe on all four points, these are UX/documentation hardening.
- No retrofit of the pre-commit simplify hook to share these fixes -- tracked as its own
  separate issue per the issue's "Out of Scope" note.
- No change to the ~12-word `MIN_ENTRY_WORDS`/`MIN_MAPPING_WORDS` threshold value or to
  `has_within_file_locator`'s matching rules -- only which stripper feeds the word count
  changed, not the threshold or the locator logic itself.
- No handling added for similarity-preserved renames (single `R` line) beyond what already
  worked (`--name-only` already prints just the new path in that case) -- only the
  below-threshold split-rename path needed a new test and documentation, per the issue's
  framing.

Closes #669