### PR TITLE
feat(#630): pr merge enqueues on merge-queue-configured branches

### DIFF
--- a/plugin/worksources/github
+++ b/plugin/worksources/github
@@ -435,16 +435,80 @@ case "${1:-}" in
         exit 1
         ;;
     esac
-    ARGS=(pr merge "$PR_NUMBER" --repo "$REPO")
+    # Validate the strategy unconditionally, before the queue check below --
+    # even though the queue path ignores it (the queue's own configuration
+    # picks the merge method), an unknown strategy value is still a caller
+    # error that must not silently pass just because the base happens to
+    # have a queue.
     case "$STRATEGY" in
-      squash) ARGS+=(--squash) ;;
-      merge)  ARGS+=(--merge) ;;
-      rebase) ARGS+=(--rebase) ;;
-      *)      echo "Unknown strategy: $STRATEGY" >&2; exit 1 ;;
+      squash|merge|rebase) ;;
+      *) echo "Unknown strategy: $STRATEGY" >&2; exit 1 ;;
     esac
-    [ "$DELETE_BRANCH" = "true" ] && ARGS+=(--delete-branch)
-    gh "${ARGS[@]}" >/dev/null || { echo "gh pr merge failed" >&2; exit 1; }
-    echo '{"ok":true}'
+    # Merge-queue detection (#630): a base branch protected by a GitHub merge
+    # queue rejects an explicit merge strategy and branch-deletion flag with
+    # ('merge strategy for main is set by the merge queue', 'Auto merge is
+    # not allowed (enablePullRequestAutoMerge)'). Query the base branch's
+    # mergeQueue via GraphQL before attempting the strategy merge, and
+    # enqueue instead when one is configured. Branch deletion after a queue
+    # merge is the queue/repo's own setting, not something the CLI flag
+    # controls -- so the queue path never passes --delete-branch.
+    #
+    # One `gh pr view` fetches both baseRefName (for the queue lookup) and
+    # id (the PR's GraphQL node id, needed only if the enqueue path fires)
+    # so a non-queue merge still costs a single lookup, not two.
+    #
+    # The detection query itself fails open (`|| true`): a query error here
+    # (older GHE without the `mergeQueue` field, a transient API hiccup)
+    # falls through to the existing strategy-merge path, which is exactly
+    # today's behavior for a repo this plugin has never seen a queue on. The
+    # enqueue mutation below is the opposite -- fail-closed -- since that is
+    # the actual merge action and its failure must not be swallowed.
+    #
+    # `-f` (not `-F`) for the owner/name/branch variables: `-F` type-sniffs
+    # its value (numeric-looking strings become GraphQL Int, `true`/`false`
+    # become Boolean), which would break the `String!` binding for a
+    # numeric GitHub owner/repo or a branch literally named `123` or
+    # `true`. `-f` always sends a literal string, which is what these three
+    # String! variables need.
+    OWNER="${REPO%%/*}"
+    REPO_NAME="${REPO#*/}"
+    PR_META=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json baseRefName,id 2>/dev/null || true)
+    BASE_REF=""
+    PR_NODE_ID=""
+    if [ -n "$PR_META" ]; then
+      BASE_REF=$(echo "$PR_META" | jq -r '.baseRefName // empty')
+      PR_NODE_ID=$(echo "$PR_META" | jq -r '.id // empty')
+    fi
+    QUEUE_ID=""
+    if [ -n "$BASE_REF" ]; then
+      QUEUE_ID=$(gh api graphql -f query="query(\$o: String!, \$n: String!, \$b: String!) { repository(owner: \$o, name: \$n) { mergeQueue(branch: \$b) { id } } }" \
+        -f o="$OWNER" -f n="$REPO_NAME" -f b="$BASE_REF" --jq '.data.repository.mergeQueue.id // empty' 2>/dev/null || true)
+    fi
+
+    if [ -n "$QUEUE_ID" ]; then
+      if [ -z "$PR_NODE_ID" ]; then
+        echo "could not resolve node id for PR #${PR_NUMBER} to enqueue" >&2
+        exit 1
+      fi
+      ENQUEUE_ERR=$(mktemp)
+      trap 'rm -f "$ENQUEUE_ERR"' EXIT
+      if ! gh api graphql -f query="mutation(\$id: ID!) { enqueuePullRequest(input: { pullRequestId: \$id }) { mergeQueueEntry { id } } }" \
+        -f id="$PR_NODE_ID" >/dev/null 2>"$ENQUEUE_ERR"; then
+        echo "enqueuePullRequest failed: $(tr '\n' ' ' < "$ENQUEUE_ERR")" >&2
+        exit 1
+      fi
+      echo '{"queued":true}'
+    else
+      ARGS=(pr merge "$PR_NUMBER" --repo "$REPO")
+      case "$STRATEGY" in
+        squash) ARGS+=(--squash) ;;
+        merge)  ARGS+=(--merge) ;;
+        rebase) ARGS+=(--rebase) ;;
+      esac
+      [ "$DELETE_BRANCH" = "true" ] && ARGS+=(--delete-branch)
+      gh "${ARGS[@]}" >/dev/null || { echo "gh pr merge failed" >&2; exit 1; }
+      echo '{"queued":false}'
+    fi
     ;;
 
   pr-close)

--- a/src/cli/pr.rs
+++ b/src/cli/pr.rs
@@ -741,51 +741,69 @@ pub(crate) fn handle(action: PrAction) -> error::Result<()> {
                 ));
             }
 
-            worksource::merge_pr(&plugin_name, &source_repo, number, &strategy, !keep_branch)?;
+            let merge_outcome =
+                worksource::merge_pr(&plugin_name, &source_repo, number, &strategy, !keep_branch)?;
 
-            // Transition kanban card to done if linked
-            if let Some(ref task_id) = task {
-                match kanban::transition_card(
-                    &database,
-                    task_id,
-                    kanban::Action::Done,
-                    Some(&format!("PR #{} merged", number)),
-                ) {
-                    Ok(_) => eprintln!("[legion] card {} marked done", task_id),
-                    Err(e) => eprintln!(
-                        "[legion] warning: could not complete card {}: {}",
-                        task_id, e
-                    ),
-                }
-
-                // Close the linked issue if the card has a source URL,
-                // using a generated merge comment so the GitHub issue
-                // records which PR merge closed it.
-                if let Some(card) = database.get_card_by_id(task_id)?
-                    && let Some(ref url) = card.source_url
-                    && let Some(issue_num) = worksource::extract_issue_number(url)
-                    && let Some(ref source) = card.source_type
-                {
-                    let merge_comment =
-                        format!("Closed by PR #{number} merge via legion kanban propagation.");
-                    if let Err(e) = worksource::close_issue(
-                        source,
-                        &source_repo,
-                        issue_num,
-                        Some(&merge_comment),
+            // A queued PR (#630) has not actually merged yet -- the base
+            // branch's merge queue completes it asynchronously, possibly
+            // after re-running CI. Firing the kanban-done transition and
+            // issue-close side effects here would mark the card/issue done
+            // before the merge has happened, so both are skipped when
+            // queued and left for the queue's own completion to be
+            // reconciled later.
+            if !merge_outcome.queued {
+                // Transition kanban card to done if linked
+                if let Some(ref task_id) = task {
+                    match kanban::transition_card(
+                        &database,
+                        task_id,
+                        kanban::Action::Done,
+                        Some(&format!("PR #{} merged", number)),
                     ) {
-                        eprintln!(
-                            "[legion] warning: could not close issue #{}: {}",
-                            issue_num, e
-                        );
-                    } else {
-                        eprintln!("[legion] closed issue #{}", issue_num);
+                        Ok(_) => eprintln!("[legion] card {} marked done", task_id),
+                        Err(e) => eprintln!(
+                            "[legion] warning: could not complete card {}: {}",
+                            task_id, e
+                        ),
+                    }
+
+                    // Close the linked issue if the card has a source URL,
+                    // using a generated merge comment so the GitHub issue
+                    // records which PR merge closed it.
+                    if let Some(card) = database.get_card_by_id(task_id)?
+                        && let Some(ref url) = card.source_url
+                        && let Some(issue_num) = worksource::extract_issue_number(url)
+                        && let Some(ref source) = card.source_type
+                    {
+                        let merge_comment =
+                            format!("Closed by PR #{number} merge via legion kanban propagation.");
+                        if let Err(e) = worksource::close_issue(
+                            source,
+                            &source_repo,
+                            issue_num,
+                            Some(&merge_comment),
+                        ) {
+                            eprintln!(
+                                "[legion] warning: could not close issue #{}: {}",
+                                issue_num, e
+                            );
+                        } else {
+                            eprintln!("[legion] closed issue #{}", issue_num);
+                        }
                     }
                 }
             }
 
+            // delete_branch records the effective outcome, not just the
+            // request: the queue path never passes --delete-branch (branch
+            // deletion after a queue merge is the queue/repo's own setting,
+            // not something this CLI flag controls), so recording
+            // `!keep_branch` there would claim an effect that did not
+            // happen.
             let details = serde_json::json!({
-                "strategy": strategy, "delete_branch": !keep_branch,
+                "strategy": strategy,
+                "delete_branch": !keep_branch && !merge_outcome.queued,
+                "queued": merge_outcome.queued,
             });
             let details_str = details.to_string();
             audit(
@@ -802,7 +820,14 @@ pub(crate) fn handle(action: PrAction) -> error::Result<()> {
                 },
             );
 
-            println!("PR #{} merged on {}", number, source_repo);
+            if merge_outcome.queued {
+                println!(
+                    "PR #{} enqueued on {} merge queue -- the queue will complete the merge",
+                    number, source_repo
+                );
+            } else {
+                println!("PR #{} merged on {}", number, source_repo);
+            }
         }
         PrAction::Close {
             repo,

--- a/src/worksource/mod.rs
+++ b/src/worksource/mod.rs
@@ -375,8 +375,12 @@ fn require_plugin(plugin_name: &str) -> Result<PathBuf> {
 }
 
 /// Run a plugin subcommand and return its raw stdout. The no-decode variant
-/// of [`plugin_call`], for ops whose output is empty (close, merge, review)
-/// or plain text (CI logs).
+/// of [`plugin_call`], for ops whose output is empty (close, review) or
+/// plain text (CI logs). `merge_pr` (#630) also calls this directly rather
+/// than going through `plugin_call`: its output now carries a `queued` flag
+/// worth decoding, but a plugin predating #630 may still emit the old
+/// empty-stdout contract, which `merge_pr` handles as a fallback before
+/// decoding.
 fn plugin_call_raw(plugin_name: &str, args: &[&str], env: &[(&str, &str)]) -> Result<String> {
     let plugin_path = require_plugin(plugin_name)?;
     call_plugin(&plugin_path, args, env)

--- a/src/worksource/prs.rs
+++ b/src/worksource/prs.rs
@@ -3,7 +3,7 @@
 
 use crate::error::Result;
 
-use super::{plugin_call, plugin_call_raw};
+use super::{decode_plugin_output, plugin_call, plugin_call_raw};
 
 /// Result of creating a PR via a work source plugin.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
@@ -193,14 +193,43 @@ pub fn review_pr(
     Ok(())
 }
 
+/// Outcome of a `merge_pr` call (#630). A base branch protected by a GitHub
+/// merge queue cannot be merged directly -- the plugin enqueues the PR
+/// instead and the queue completes the merge asynchronously. Callers must
+/// not treat `queued` the same as an actual merge: kanban transitions and
+/// issue-closing side effects that assume the PR is now merged would fire
+/// too early against a PR that has only been queued, not merged.
+///
+/// `#[serde(default)]` on `queued`: a plugin predating #630 (or a
+/// third-party one) that still emits the old `{"ok":true}` shape decodes
+/// as `queued: false`, i.e. today's direct-merge behavior, rather than
+/// failing the whole merge on a missing field. `merge_pr` itself handles
+/// the other half of the old contract -- blank stdout -- since that is not
+/// valid JSON `serde` can decode at all; see its doc comment.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Deserialize)]
+pub struct MergeOutcome {
+    #[serde(default)]
+    pub queued: bool,
+}
+
 /// Merge a PR via a work source plugin. Refuses if not approved.
+///
+/// Returns [`MergeOutcome`] so the caller can tell a direct merge apart from
+/// an enqueue onto the base branch's merge queue (#630).
+///
+/// A plugin predating #630 (or a third-party one) may still honor the old
+/// contract of empty stdout on success -- `merge` was listed among the
+/// empty-output ops in `plugin_call_raw`'s doc comment before this change.
+/// Blank stdout is not valid JSON, so decoding it would fail the whole
+/// merge even though it actually succeeded; treat it as `queued: false`
+/// (today's direct-merge behavior) instead.
 pub fn merge_pr(
     plugin_name: &str,
     github_repo: &str,
     pr_number: u64,
     strategy: &str,
     delete_branch: bool,
-) -> Result<()> {
+) -> Result<MergeOutcome> {
     let pr_num_str = pr_number.to_string();
     let delete_str = if delete_branch { "true" } else { "false" };
     let env: Vec<(&str, &str)> = vec![
@@ -210,8 +239,11 @@ pub fn merge_pr(
         ("LEGION_WS_DELETE_BRANCH", delete_str),
     ];
 
-    plugin_call_raw(plugin_name, &["merge"], &env)?;
-    Ok(())
+    let output = plugin_call_raw(plugin_name, &["merge"], &env)?;
+    if output.trim().is_empty() {
+        return Ok(MergeOutcome { queued: false });
+    }
+    decode_plugin_output(&["merge"], &output)
 }
 
 /// Close a PR via a work source plugin without merging.
@@ -388,6 +420,24 @@ mod tests {
             link: String::new(),
             description: String::new(),
         }
+    }
+
+    /// A plugin predating #630 (or a third-party one) that still emits the
+    /// old empty-ish merge output must decode as `queued: false` -- today's
+    /// direct-merge behavior -- rather than failing on a missing field.
+    #[test]
+    fn merge_outcome_defaults_queued_false_for_pre_630_plugin_output() {
+        let outcome: MergeOutcome = serde_json::from_str(r#"{"ok":true}"#).unwrap();
+        assert_eq!(outcome, MergeOutcome { queued: false });
+
+        let outcome: MergeOutcome = serde_json::from_str("{}").unwrap();
+        assert_eq!(outcome, MergeOutcome { queued: false });
+    }
+
+    #[test]
+    fn merge_outcome_decodes_queued_true() {
+        let outcome: MergeOutcome = serde_json::from_str(r#"{"queued":true}"#).unwrap();
+        assert_eq!(outcome, MergeOutcome { queued: true });
     }
 
     #[test]

--- a/tests/integration/worksource_pr.rs
+++ b/tests/integration/worksource_pr.rs
@@ -557,6 +557,229 @@ fn pr_merge_refuses_when_head_has_zero_runs() {
     );
 }
 
+// ---------------------------------------------------------------------------
+// #630: merge-queue support. The plugin's `merge` subcommand now reports
+// whether it merged the PR directly or enqueued it onto the base branch's
+// merge queue via `{"queued": <bool>}`. These tests stub that boundary --
+// the plugin's own GraphQL queue-detection and enqueue calls are mocked here
+// (no live queue-enabled repo is available in CI); confirming the real
+// GraphQL shape against a live merge-queue repo is a post-merge operator
+// step, not something these tests can exercise.
+// ---------------------------------------------------------------------------
+
+/// Stub worksource plugin for `legion pr merge` tests: `pr-checks` always
+/// reports one passing check (so the zero-runs gate never fires here), and
+/// `merge` echoes the caller-supplied JSON verbatim -- letting a single stub
+/// stand in for both the direct-merge and the enqueued outcome. `close`
+/// exits 0 so linked-issue close propagation (when exercised) succeeds too.
+#[cfg(unix)]
+fn pr_merge_stub_plugin(merge_output: &str) -> String {
+    format!(
+        r#"#!/bin/bash
+set -e
+case "${{1:-}}" in
+  pr-checks)
+    cat <<'BODY'
+{{"headSha":"cafef00d","checks":[{{"name":"CI","state":"SUCCESS","workflow":"CI","link":"https://github.com/ex/ex/actions/runs/1/job/1","description":""}}]}}
+BODY
+    ;;
+  merge)
+    echo '{merge_output}'
+    ;;
+  close)
+    exit 0
+    ;;
+  *)
+    echo "stub: unknown subcommand $1" >&2
+    exit 2
+    ;;
+esac
+"#
+    )
+}
+
+/// Stub whose `merge` subcommand fails the way a real enqueue failure would
+/// -- exits non-zero with the plugin's own error text on stderr, the same
+/// shape `enqueuePullRequest` failing in the real plugin produces.
+#[cfg(unix)]
+fn pr_merge_failing_stub_plugin() -> String {
+    r#"#!/bin/bash
+set -e
+case "${1:-}" in
+  pr-checks)
+    cat <<'BODY'
+{"headSha":"cafef00d","checks":[{"name":"CI","state":"SUCCESS","workflow":"CI","link":"https://github.com/ex/ex/actions/runs/1/job/1","description":""}]}
+BODY
+    ;;
+  merge)
+    echo "enqueuePullRequest failed: some GraphQL error" >&2
+    exit 1
+    ;;
+  *)
+    echo "stub: unknown subcommand $1" >&2
+    exit 2
+    ;;
+esac
+"#
+    .to_string()
+}
+
+/// Stub whose `merge` subcommand prints nothing on success -- the pre-#630
+/// contract (`merge` was listed among the empty-output ops in
+/// `plugin_call_raw`'s doc comment). `merge_pr` must treat blank stdout as
+/// `queued: false`, not fail the whole merge on unparseable JSON: the merge
+/// already happened on GitHub by the time this plugin call returns, so
+/// erroring here would skip the kanban-done transition and issue-close
+/// while incorrectly reporting the merge as failed.
+#[cfg(unix)]
+fn pr_merge_pre_630_empty_output_stub_plugin() -> String {
+    r#"#!/bin/bash
+set -e
+case "${1:-}" in
+  pr-checks)
+    cat <<'BODY'
+{"headSha":"cafef00d","checks":[{"name":"CI","state":"SUCCESS","workflow":"CI","link":"https://github.com/ex/ex/actions/runs/1/job/1","description":""}]}
+BODY
+    ;;
+  merge)
+    exit 0
+    ;;
+  close)
+    exit 0
+    ;;
+  *)
+    echo "stub: unknown subcommand $1" >&2
+    exit 2
+    ;;
+esac
+"#
+    .to_string()
+}
+
+#[cfg(unix)]
+#[test]
+fn pr_merge_treats_pre_630_empty_output_as_direct_merge() {
+    let data_dir = tempfile::tempdir().unwrap();
+    let plugin_root = tempfile::tempdir().unwrap();
+    setup_pr_read_stub(
+        data_dir.path(),
+        plugin_root.path(),
+        &pr_merge_pre_630_empty_output_stub_plugin(),
+    );
+    let card = setup_linked_done_eligible_card(data_dir.path());
+
+    let out = run_ok_output(pr_read_cmd(data_dir.path(), plugin_root.path()).args([
+        "pr", "merge", "--repo", "stub", "--number", "42", "--task", &card,
+    ]));
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stdout.contains("PR #42 merged on owner/stub"),
+        "expected blank stdout to be treated as a direct merge, got: {stdout}"
+    );
+    assert!(
+        stderr.contains(&format!("card {} marked done", card)),
+        "expected the kanban-done transition to still fire on the legacy empty-output contract, got: {stderr}"
+    );
+}
+
+/// Non-queue repo (AC #2): `merge` reports `{"queued": false}` and `pr merge`
+/// must behave exactly as before this change -- the same "PR #N merged on
+/// R" message, plus the kanban-done transition and linked-issue close still
+/// fire when `--task` is given.
+#[cfg(unix)]
+#[test]
+fn pr_merge_direct_when_not_queued_behaves_as_before() {
+    let data_dir = tempfile::tempdir().unwrap();
+    let plugin_root = tempfile::tempdir().unwrap();
+    setup_pr_read_stub(
+        data_dir.path(),
+        plugin_root.path(),
+        &pr_merge_stub_plugin(r#"{"queued":false}"#),
+    );
+    let card = setup_linked_done_eligible_card(data_dir.path());
+
+    let out = run_ok_output(pr_read_cmd(data_dir.path(), plugin_root.path()).args([
+        "pr", "merge", "--repo", "stub", "--number", "42", "--task", &card,
+    ]));
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stdout.contains("PR #42 merged on owner/stub"),
+        "expected the unchanged direct-merge message, got: {stdout}"
+    );
+    assert!(
+        stderr.contains(&format!("card {} marked done", card)),
+        "expected the kanban-done transition to still fire, got: {stderr}"
+    );
+    assert!(
+        stderr.contains("closed issue #42"),
+        "expected the linked-issue close to still fire, got: {stderr}"
+    );
+}
+
+/// Queue-enabled base branch (AC #1): `merge` reports `{"queued": true}` and
+/// `pr merge` must enqueue instead of failing, report the enqueue (not
+/// "merged") in its message, and must NOT fire the kanban-done transition or
+/// linked-issue close -- the PR has not actually merged yet.
+#[cfg(unix)]
+#[test]
+fn pr_merge_enqueues_when_queued_skips_done_side_effects() {
+    let data_dir = tempfile::tempdir().unwrap();
+    let plugin_root = tempfile::tempdir().unwrap();
+    setup_pr_read_stub(
+        data_dir.path(),
+        plugin_root.path(),
+        &pr_merge_stub_plugin(r#"{"queued":true}"#),
+    );
+    let card = setup_linked_done_eligible_card(data_dir.path());
+
+    let out = run_ok_output(pr_read_cmd(data_dir.path(), plugin_root.path()).args([
+        "pr", "merge", "--repo", "stub", "--number", "42", "--task", &card,
+    ]));
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stdout.contains("enqueued") && stdout.contains("owner/stub"),
+        "expected an enqueue message naming the repo, got: {stdout}"
+    );
+    assert!(
+        !stdout.contains("PR #42 merged on owner/stub"),
+        "must not claim the PR merged when it was only enqueued, got: {stdout}"
+    );
+    assert!(
+        !stderr.contains("marked done"),
+        "must not transition the kanban card before the queue actually merges, got: {stderr}"
+    );
+    assert!(
+        !stderr.contains("closed issue"),
+        "must not close the linked issue before the queue actually merges, got: {stderr}"
+    );
+}
+
+/// AC #3: an enqueue failure from `gh`/GraphQL must surface as a loud error,
+/// not be swallowed into a false success.
+#[cfg(unix)]
+#[test]
+fn pr_merge_surfaces_enqueue_failure() {
+    let data_dir = tempfile::tempdir().unwrap();
+    let plugin_root = tempfile::tempdir().unwrap();
+    setup_pr_read_stub(
+        data_dir.path(),
+        plugin_root.path(),
+        &pr_merge_failing_stub_plugin(),
+    );
+
+    let (_stdout, stderr) = run_fail(
+        pr_read_cmd(data_dir.path(), plugin_root.path())
+            .args(["pr", "merge", "--repo", "stub", "--number", "42"]),
+    );
+    assert!(
+        stderr.contains("enqueuePullRequest failed"),
+        "expected the plugin's enqueue-failure text to be surfaced, got: {stderr}"
+    );
+}
+
 #[cfg(unix)]
 #[test]
 fn pr_view_surfaces_malformed_plugin_json_as_worksource_error() {


### PR DESCRIPTION
## Summary

`legion pr merge` used to unconditionally pass a merge strategy (`--squash`/`--merge`/`--rebase`) and `--delete-branch` to `gh pr merge`. Against a base branch protected by a GitHub merge queue, both of those are rejected by GitHub ("merge strategy for main is set by the merge queue", "Auto merge is not allowed (enablePullRequestAutoMerge)"), making `pr merge` unusable on queue-enabled repos (real-world hit: rafters PR #1657).

The `github` worksource plugin now detects a merge queue on the PR's base branch via GraphQL (`repository.mergeQueue(branch:)`) before merging. If a queue is configured, it calls `enqueuePullRequest` instead of `gh pr merge`, and reports `{"queued": true}`. Otherwise it falls through to the existing strategy-merge path, unchanged, reporting `{"queued": false}`.

On the Rust side, `merge_pr` now returns a `MergeOutcome { queued: bool }` instead of `()`. When `queued` is true, `legion pr merge` prints an enqueue message instead of "merged", and skips the kanban-done transition and linked-issue-close side effects, since the PR has not actually merged yet -- the queue completes it asynchronously. `delete_branch` in the audit-log details now reflects the effective outcome (`!keep_branch && !queued`), not just the request, since the queue path never passes `--delete-branch`.

Backward compatibility: a plugin predating #630 (or a third-party one) that still emits the old empty-stdout contract on `merge` is treated as `queued: false` (today's direct-merge behavior) rather than failing on unparseable JSON.

## Acceptance criteria mapping

### 1. `pr merge` against a queue-enabled base branch enqueues the PR instead of failing

The plugin queries `repository(owner, name).mergeQueue(branch: baseRefName) { id }` via `gh api graphql`. When a queue id comes back, it resolves the PR's GraphQL node id (from the same `gh pr view --json baseRefName,id` call used for the queue lookup) and calls the `enqueuePullRequest` mutation instead of `gh pr merge`, reporting `{"queued":true}`.

Evidence: `plugin/worksources/github` merge case, `QUEUE_ID` detection and `enqueuePullRequest` mutation block; `src/cli/pr.rs` prints `"PR #{} enqueued on {} merge queue -- the queue will complete the merge"` when `merge_outcome.queued` is true. Test `pr_merge_enqueues_when_queued_skips_done_side_effects` (`tests/integration/worksource_pr.rs`) asserts the enqueue message is shown, the direct-merge message is *not* shown, and neither the kanban-done transition nor the issue-close fires.

### 2. `pr merge` against a non-queue repo behaves exactly as today (strategy + delete-branch)

When the GraphQL queue lookup returns no queue id (or fails open on a query error, e.g. older GHE without the `mergeQueue` field), the plugin falls through unchanged to `gh pr merge` with the strategy flag (`--squash`/`--merge`/`--rebase`) and `--delete-branch` when requested, reporting `{"queued":false}`.

Evidence: `plugin/worksources/github`, `else` branch of the `QUEUE_ID` check, identical `ARGS` construction to the pre-#630 code. Test `pr_merge_direct_when_not_queued_behaves_as_before` asserts the unchanged `"PR #42 merged on owner/stub"` message plus the kanban-done transition (`"card {} marked done"`) and linked-issue close (`"closed issue #42"`) still fire. Test `pr_merge_treats_pre_630_empty_output_as_direct_merge` covers the legacy empty-stdout plugin contract, confirming callers unaffected by #630 keep working identically.

### 3. Error from `gh` is surfaced, not swallowed, if enqueue itself fails

The `enqueuePullRequest` mutation's stderr is captured to a temp file; on non-zero exit the plugin prints `"enqueuePullRequest failed: <captured stderr>"` to stderr and exits 1 -- it does not fall back to the strategy-merge path or report false success. `merge_pr`/`plugin_call_raw` propagate a non-zero plugin exit as a `WorksourceError`, which `legion pr merge` surfaces to the caller.

Evidence: `plugin/worksources/github`, `ENQUEUE_ERR` capture and `enqueuePullRequest failed: ...` message. Test `pr_merge_surfaces_enqueue_failure` asserts the command exits non-zero and stderr contains `"enqueuePullRequest failed"`.

## Deliberately not done

- No live merge-queue-enabled repository was available to exercise the real GraphQL shapes end to end; the queue-detection and enqueue calls are stubbed at the plugin boundary in tests (noted in the test file's header comment). Confirming the exact GraphQL response shape against a live queue-enabled repo is a post-merge operator step.
- No reconciliation path was added for a queued PR that later completes (or fails) in the queue -- the kanban card and linked issue are simply left untouched at merge-queue time; picking those up again (to mark the card done once the queue actually merges) is out of scope for this issue.
- Branch deletion policy on the queue path was not made configurable -- per the issue, deletion after a queue merge is entirely the queue/repo's own setting, so the CLI's `--delete-branch`/`keep_branch` flag is simply ignored (never passed) on the enqueue path rather than surfaced as an error or warning to the caller.

Closes #630