### PR TITLE
feat(#741): generalize release toolchain via release.toml

### DIFF
--- a/plugin/agents/changelog.md
+++ b/plugin/agents/changelog.md
@@ -1,10 +1,11 @@
 ---
 name: changelog
 description: |
-  Writes the legion CHANGELOG entry for a release from the commit range since the
+  Writes the CHANGELOG entry for a release from the commit range since the
   last tag. Reads the merged PRs, their issues, and the key diffs, then composes a
-  "## X.Y.Z" section in the established legion changelog voice and prepends it to
-  plugin/CHANGELOG.md. Runs as a step in the release pipeline, before scripts/release.sh.
+  "## X.Y.Z" section in the repo's established changelog voice and prepends it to
+  the changelog file declared in that repo's release.toml (plugin/CHANGELOG.md for
+  legion itself). Runs as a step in the release pipeline, before scripts/release.sh.
 
   <example>
   Context: Cutting a patch release and the CHANGELOG has no entry yet.
@@ -18,18 +19,41 @@ description: |
 tools: ["Bash", "Read", "Edit", "Write"]
 ---
 
-You write the CHANGELOG entry for a legion release. Your output is one new
-`## X.Y.Z` section prepended to `plugin/CHANGELOG.md`, in the voice the file
-already uses. You are given (or must infer) the version being released.
+You write the CHANGELOG entry for a release. Your output is one new
+`## X.Y.Z` section prepended to the repo's configured changelog file, in the
+voice that file already uses. You are given (or must infer) the version
+being released.
+
+## Where the changelog lives (read from release.toml, #741)
+
+Do not assume `plugin/CHANGELOG.md`. Read the target repo's `release.toml`
+(repo root) to find:
+
+- `changelog.path` -- the file to prepend your new section to.
+- `changelog.voice_sample` -- optional; the file to mirror voice/style from,
+  when it differs from `path`. Falls back to `path` when absent.
+
+Resolve both with `legion sym etc extract release.toml --field <field>`, e.g.:
+
+```
+legion sym etc extract release.toml --field changelog.path
+legion sym etc extract release.toml --field changelog.voice_sample
+```
+
+The second command errors if `voice_sample` is not set -- that error means
+"use `changelog.path` for both purposes," not a failure to report upward. For
+legion itself, both resolve to `plugin/CHANGELOG.md` (release.toml's
+`voice_sample` is commented out, so it defaults to `path`).
 
 ## What you receive
 
 The orchestrator gives you the new version being released (e.g. `0.18.3`). That
 value is authoritative -- use it verbatim as the `## X.Y.Z` header. Do NOT read the
-version from `Cargo.toml`: you run BEFORE `scripts/release.sh` bumps it, so at this
-point `Cargo.toml` still holds the PREVIOUS release's version. If no version was
-supplied, stop and ask the orchestrator for the target -- you cannot infer the next
-version from the pre-bump `Cargo.toml`.
+version from the configured `[version]` file (`Cargo.toml` for legion; see
+release.toml's `version.file` for another repo): you run BEFORE `scripts/release.sh`
+bumps it, so at this point that file still holds the PREVIOUS release's version. If
+no version was supplied, stop and ask the orchestrator for the target -- you cannot
+infer the next version from the pre-bump source file.
 
 ## Gather the change set (do not trust commit subjects alone)
 
@@ -48,7 +72,9 @@ version from the pre-bump `Cargo.toml`.
 
 ## Voice and structure (match the existing entries exactly -- read the top of the file first)
 
-Always `Read plugin/CHANGELOG.md` and mirror the most recent few entries. The shape:
+Always `Read` the resolved voice-sample file (`changelog.voice_sample`, or
+`changelog.path` when that is unset) and mirror the most recent few entries. The
+shape:
 
 ```
 ## X.Y.Z
@@ -86,18 +112,19 @@ Rules:
 
 ## The version guard lives downstream -- not here
 
-Do not cross-check your header against `Cargo.toml`: it is still the pre-bump value
-when you run. `scripts/release.sh` bumps `Cargo.toml` to the target and THEN
-validates that the CHANGELOG header you wrote matches it (and the `sync-version`
-hook re-checks at commit). Your only job is to write the exact version the
-orchestrator gave you; the mismatch guard fires later, in the right place, after
-the bump.
+Do not cross-check your header against the configured `[version]` file: it is
+still the pre-bump value when you run. `scripts/release.sh` bumps it to the target
+and THEN validates that the CHANGELOG header you wrote matches it (and the
+`sync-version` hook re-checks at commit). Your only job is to write the exact
+version the orchestrator gave you; the mismatch guard fires later, in the right
+place, after the bump.
 
 ## Output
 
-Prepend your new section immediately under the `# Legion Changelog` title, above
-the previous top entry. Edit `plugin/CHANGELOG.md` in place. Then return a short
-summary to the orchestrator: the version, the section headings you wrote, and the
-PRs covered. Do NOT commit, tag, or push -- scripts/release.sh owns that. Your job
-ends when the entry is written; the version guard runs downstream in
-scripts/release.sh (post-bump), never here against the pre-bump Cargo.toml.
+Prepend your new section immediately under the changelog's own title heading,
+above the previous top entry. Edit the resolved `changelog.path` file in place.
+Then return a short summary to the orchestrator: the version, the section
+headings you wrote, and the PRs covered. Do NOT commit, tag, or push --
+scripts/release.sh owns that. Your job ends when the entry is written; the
+version guard runs downstream in scripts/release.sh (post-bump), never here
+against the pre-bump source file.

--- a/plugin/commands/legion-release.md
+++ b/plugin/commands/legion-release.md
@@ -27,22 +27,25 @@ target `NEW` (patch/minor/major arithmetic, or use the explicit `X.Y.Z`). State
 ## 3. Changelog agent writes the entry
 
 Spawn the `changelog` agent (Task, subagent_type `changelog`) with the target
-version `NEW`. It diffs `<prevtag>..HEAD`, reads the merged PRs and their issues,
-and prepends a `## NEW` section to `plugin/CHANGELOG.md` in the repo's voice. When
-it returns, `Read plugin/CHANGELOG.md` and sanity-check the top entry yourself:
-right version, real prose, every bullet cited, correct release-type rationale. If
-it is thin or wrong, send the agent back with specifics. Do NOT hand-write the
-entry yourself -- that is the agent's job; you are the editor.
+version `NEW`. It reads `release.toml`'s `changelog.path` (`plugin/CHANGELOG.md`
+for legion; see #741) to find the file, diffs `<prevtag>..HEAD`, reads the merged
+PRs and their issues, and prepends a `## NEW` section in the repo's voice. When
+it returns, `Read` that same file and sanity-check the top entry yourself: right
+version, real prose, every bullet cited, correct release-type rationale. If it is
+thin or wrong, send the agent back with specifics. Do NOT hand-write the entry
+yourself -- that is the agent's job; you are the editor.
 
 ## 4. Ship it
 
 Run `scripts/release.sh NEW` (pass the explicit version, plus `--activate` and/or
-`--dry-run` if the operator gave them). The script runs preflight (fmt, clippy,
-test, SCIP regen), bumps `Cargo.toml`, refreshes `Cargo.lock`, syncs the manifests,
-commits `chore(release): NEW`, tags `vNEW`, and pushes -- which fires the release
-CI that builds and publishes the platform binaries. The script validates that the
-CHANGELOG header the agent wrote matches `Cargo.toml`; a mismatch aborts the
-release, which is the safety net.
+`--dry-run` if the operator gave them). The script reads `release.toml` for the
+version source, changelog path, propagation targets, and tag format (`Cargo.toml`
+/ `plugin/CHANGELOG.md` / `v{version}` for legion itself), runs preflight (fmt,
+clippy, test, SCIP regen), bumps the version file, refreshes `Cargo.lock`, syncs
+the manifests, commits `chore(release): NEW`, tags, and pushes -- which fires the
+release CI that builds and publishes the platform binaries. The script validates
+that the CHANGELOG header the agent wrote matches the bumped version; a mismatch
+aborts the release, which is the safety net.
 
 If `--dry-run` was passed, stop here and report what would have happened.
 

--- a/release.toml
+++ b/release.toml
@@ -1,0 +1,69 @@
+# release.toml -- per-repo config for the release toolchain (scripts/release.sh,
+# scripts/sync-version.sh, the `changelog` agent). Schema (#741): every path
+# below is relative to the repo root and MUST use forward slashes, even on
+# Windows -- backslashes are TOML string escapes, so a literal Windows path
+# would corrupt this file.
+#
+# Every field is read generically via
+#   legion sym etc extract release.toml --field <dotted.path>
+# (jq-style: "."-separated segments walk tables, a purely numeric segment
+# indexes an array). Any repo with `legion` on PATH can adopt these scripts
+# by dropping in its own release.toml -- no code changes required.
+
+[version]
+# The file that holds this repo's version of record. Any format
+# `legion sym etc extract` understands (json/toml/yaml) works for READING.
+# scripts/release.sh's bump step supports .toml and .json sources (a flat or
+# single-table-nested leaf key, e.g. "version" or "package.version"); a yaml
+# source would need a bump strategy added there.
+file = "Cargo.toml"
+# Dotted path to the version field within that file.
+field = "package.version"
+
+[changelog]
+# Changelog the release entry is prepended to; its top "## <version>" header
+# must match [version] before a release can ship -- the header-match abort
+# net scripts/release.sh and scripts/sync-version.sh both enforce.
+path = "plugin/CHANGELOG.md"
+# Optional: a different file to mine for voice/style, when it diverges from
+# `path` (e.g. a curated sample of "good" entries). Defaults to `path` when
+# omitted. The `changelog` agent reads this for its voice model.
+# voice_sample = "plugin/CHANGELOG.md"
+
+[git]
+# Branch a release must be cut from.
+branch = "main"
+# Tag name template; "{version}" is replaced with the release version.
+tag_format = "v{version}"
+# Annotated tag message template; "{version}" is replaced with the release
+# version. Defaults to "{version}" (the bare version, not the tag name --
+# under the default tag_format that means "0.20.0", not "v0.20.0") when
+# omitted.
+tag_message = "legion {version}"
+# Optional co-authorship trailer appended to the release commit message.
+# Defaults to legion's own release agent when omitted.
+co_authored_by = "Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+
+[preflight]
+# Commands run, in order, repo-root relative, before a release is cut. Each
+# runs via `bash -c "<command>"` -- prefix a script with `bash` (as below)
+# rather than relying on its executable bit, which some filesystems (certain
+# Windows + WSL setups) do not preserve on checkout.
+commands = ["bash scripts/preflight.sh"]
+
+# Propagation targets: files whose version field is rewritten to match
+# [version] on every release, and staged into the release commit alongside
+# it. `field` uses the same dotted-path convention as [version].field. A
+# field with no "." is rewritten via a single-line replace that leaves the
+# rest of the file untouched (matches legion's historical plugin.json
+# behavior byte-for-byte); a dotted field (nested key or array index, e.g.
+# "plugins.0.version") is rewritten via a full json.load/write cycle (matches
+# legion's historical marketplace.json behavior). Only json targets are
+# supported on the write side today.
+[[targets]]
+file = "plugin/.claude-plugin/plugin.json"
+field = "version"
+
+[[targets]]
+file = ".claude-plugin/marketplace.json"
+field = "plugins.0.version"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
-# release.sh: one-command release for legion. Cargo.toml is the source of truth
-# for the version; everything else is derived and validated.
+# release.sh: one-command release, generalized to any repo via release.toml
+# (schema documented there; see #741). The version-of-record file (default
+# Cargo.toml) is the source of truth for the version; everything else --
+# changelog path, propagation targets, tag format -- is read from config,
+# derived, and validated.
 #
 # Usage:
 #   scripts/release.sh patch            # 0.18.2 -> 0.18.3
@@ -9,33 +12,38 @@
 #   scripts/release.sh 0.20.0           # explicit version
 #   scripts/release.sh patch --dry-run  # print every step, mutate nothing
 #   scripts/release.sh patch --activate # also build+install the binary and
-#                                        # restart the local daemon
-#   scripts/release.sh patch --no-preflight  # skip the cargo/scip gate (CI re-runs it)
+#                                        # restart the local daemon (legion-
+#                                        # specific; a no-op knob elsewhere)
+#   scripts/release.sh patch --no-preflight  # skip the preflight gate (CI re-runs it)
 #
 # Entry contract: the CHANGELOG entry for the new version must already be written
 # (by the `changelog` agent, or by hand) and left UNCOMMITTED in the working tree.
 # release.sh validates it, bumps the version, syncs the manifests, and commits the
-# whole release in one shot. The only file allowed to be dirty at entry is
-# plugin/CHANGELOG.md; everything else must be committed. (Note: even --dry-run
-# requires the "## <new>" CHANGELOG header to exist -- the header check is part of
-# what a dry-run verifies.)
+# whole release in one shot. The only file allowed to be dirty at entry is the
+# configured changelog path; everything else must be committed. (Note: even
+# --dry-run requires the "## <new>" CHANGELOG header to exist -- the header
+# check is part of what a dry-run verifies.)
 #
-# What it does, in order:
-#   1. Guards: on main, tree clean except plugin/CHANGELOG.md, in sync with origin.
+# What it does, in order (unchanged by #741 -- only WHERE paths come from
+# changed, not the sequence):
+#   1. Guards: on the configured branch, tree clean except the changelog,
+#      in sync with origin.
 #   2. Computes the new version from the bump level (or takes it explicitly).
-#   3. Requires plugin/CHANGELOG.md's "## <new>" top header to exist.
-#   4. Runs scripts/preflight.sh (fmt, clippy --all-targets, test, SCIP regen).
-#   5. Bumps Cargo.toml, refreshes Cargo.lock.
-#   6. Syncs plugin.json + marketplace.json (scripts/sync-version.sh) and commits.
-#   7. Tags v<new> and atomically pushes the commit + tag, firing release.yml.
+#   3. Requires the changelog's "## <new>" top header to exist.
+#   4. Runs the configured preflight commands (default: scripts/preflight.sh).
+#   5. Bumps the version-of-record file, refreshes Cargo.lock (Rust sources only).
+#   6. Syncs every configured target (scripts/sync-version.sh) and commits.
+#   7. Tags per the configured tag format and atomically pushes the commit +
+#      tag, firing release.yml.
 #   8. With --activate: builds the release binary, installs it to the plugin data
 #      dir atomically, and restarts the local daemon (verifying it comes back up).
 #
 # The pure helpers below (compute_new_version, is_semver, is_strictly_greater,
-# non_changelog_dirty) are unit-tested by scripts/test-release.sh, which sources
-# this file. main() runs only when the script is executed, not when it is sourced.
-# Implementation is kept POSIX-portable (no GNU-only sed/sort) because the release
-# is cut on darwin, where BSD sed/sort lack the GNU extensions.
+# non_changelog_dirty, field_leaf, render_tag, bump_source_file) are unit-tested
+# by scripts/test-release.sh, which sources this file. main() runs only when the
+# script is executed, not when it is sourced. Implementation is kept
+# POSIX-portable (no GNU-only sed/sort) because the release is cut on darwin,
+# where BSD sed/sort lack the GNU extensions.
 set -euo pipefail
 
 info() { printf '[release] %s\n' "$1" >&2; }
@@ -83,26 +91,109 @@ EOF
   [ "$nc" -gt "$cc" ]
 }
 
-# non_changelog_dirty: read `git status --porcelain` on stdin, print the lines
-# whose changed path is NOT exactly plugin/CHANGELOG.md. Parses the porcelain
-# path field (handling rename/copy "ORIG -> DEST" by testing DEST) so the guard
-# allowlists the file itself, not any path that merely ends in that suffix.
+# non_changelog_dirty <changelog_path>: read `git status --porcelain` on
+# stdin, print the lines whose changed path is NOT exactly <changelog_path>
+# (repo-root-relative, forward-slash form -- the configured changelog.path).
+# Parses the porcelain path field (handling rename/copy "ORIG -> DEST" by
+# testing DEST) so the guard allowlists the file itself, not any path that
+# merely ends in that suffix.
 non_changelog_dirty() {
+  local changelog_path="$1"
   local line path
   while IFS= read -r line; do
     [ -n "$line" ] || continue
     path="${line:3}"                       # drop the 2-char status + space
     case "$path" in *" -> "*) path="${path##* -> }" ;; esac
-    [ "$path" = "plugin/CHANGELOG.md" ] || printf '%s\n' "$line"
+    [ "$path" = "$changelog_path" ] || printf '%s\n' "$line"
   done
 }
 
+# field_leaf <field>: the last "."-separated segment of a dotted field path
+# (e.g. "package.version" -> "version"). Used to find the literal `key =
+# "value"` / `"key": "value"` line a flat-file bump rewrites -- release.toml's
+# [version].field uses the same dotted-path convention as `legion sym etc
+# extract`, but the bump step below only supports a top-level (or
+# single-table-nested) leaf key, not a deep JSON walk.
+field_leaf() {
+  local field="$1"
+  printf '%s' "${field##*.}"
+}
+
+# render_tag <format> <version>: substitute "{version}" in a template string.
+# Used for both release.toml's [git].tag_format (e.g. "v{version}") and
+# [git].tag_message (e.g. "legion {version}") -- same substitution either way.
+render_tag() {
+  local format="$1" version="$2"
+  printf '%s' "${format//\{version\}/$version}"
+}
+
+# bump_source_file <file> <field> <current> <new>: rewrite the version-of-
+# record file in place. Detects strategy from the file extension; both
+# strategies rewrite only the FIRST matching line, so a second identical
+# version string elsewhere in the file is left untouched:
+#   .toml -- awk-based exact-line replace on `<leaf> = "<current>"` (the
+#            existing Cargo.toml strategy; portable, no GNU sed/awk needed).
+#   .json -- awk-based substring replace on `"<leaf>": "<current>"`, tolerant
+#            of surrounding indentation (unlike the .toml branch, a json line
+#            is rarely an exact match on its own).
+# Any other extension is unsupported; returns 1 without mutating anything so
+# the caller can name the failure (this function never calls exit, so it stays
+# unit-testable, including its failure path).
+bump_source_file() {
+  local file="$1" field="$2" current="$3" new="$4" leaf
+  leaf="$(field_leaf "$field")"
+  case "$file" in
+    *.toml)
+      awk -v old="${leaf} = \"${current}\"" -v new="${leaf} = \"${new}\"" '
+        !done && $0 == old { print new; done = 1; next } { print }
+      ' "$file" >"${file}.tmp" && mv "${file}.tmp" "$file"
+      ;;
+    *.json)
+      awk -v old="\"${leaf}\": \"${current}\"" -v new="\"${leaf}\": \"${new}\"" '
+        !done && index($0, old) > 0 { sub(old, new); done = 1 } { print }
+      ' "$file" >"${file}.tmp" && mv "${file}.tmp" "$file"
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
 main() {
-  local REPO_ROOT CARGO_TOML CHANGELOG
+  local REPO_ROOT CONFIG SOURCE_FILE CHANGELOG
   REPO_ROOT="$(git rev-parse --show-toplevel)"
   cd "$REPO_ROOT"
-  CARGO_TOML="${REPO_ROOT}/Cargo.toml"
-  CHANGELOG="${REPO_ROOT}/plugin/CHANGELOG.md"
+  CONFIG="${REPO_ROOT}/release.toml"
+
+  command -v legion >/dev/null 2>&1 || fail "'legion' binary not found on PATH -- required to read release.toml"
+  command -v python3 >/dev/null 2>&1 || fail "'python3' not found on PATH -- required to parse release.toml's json fields (preflight.commands, targets)"
+  [ -f "$CONFIG" ] || fail "release.toml not found at repo root -- see scripts/release.sh header for the schema"
+
+  # extract_cfg <field>: read one release.toml field, or fail loudly naming it.
+  extract_cfg() {
+    local field="$1" value
+    value="$(legion sym etc extract "$CONFIG" --field "$field" 2>/dev/null)" \
+      || fail "release.toml missing required field '${field}'"
+    printf '%s' "$value"
+  }
+  # extract_cfg_default <field> <default>: like extract_cfg, but falls back
+  # to <default> instead of failing when the field is absent.
+  extract_cfg_default() {
+    local field="$1" default="$2"
+    legion sym etc extract "$CONFIG" --field "$field" 2>/dev/null || printf '%s' "$default"
+  }
+
+  local SOURCE_FILE_REL SOURCE_FIELD CHANGELOG_REL RELEASE_BRANCH TAG_FORMAT TAG_MESSAGE_FORMAT CO_AUTHORED_BY
+  SOURCE_FILE_REL="$(extract_cfg version.file)"
+  SOURCE_FIELD="$(extract_cfg version.field)"
+  CHANGELOG_REL="$(extract_cfg changelog.path)"
+  RELEASE_BRANCH="$(extract_cfg_default git.branch main)"
+  TAG_FORMAT="$(extract_cfg_default git.tag_format 'v{version}')"
+  TAG_MESSAGE_FORMAT="$(extract_cfg_default git.tag_message '{version}')"
+  CO_AUTHORED_BY="$(extract_cfg_default git.co_authored_by 'Claude Opus 4.8 (1M context) <noreply@anthropic.com>')"
+
+  SOURCE_FILE="${REPO_ROOT}/${SOURCE_FILE_REL}"
+  CHANGELOG="${REPO_ROOT}/${CHANGELOG_REL}"
 
   # -- arg parsing -----------------------------------------------------------
   local BUMP="" DRY_RUN=0 ACTIVATE=0 RUN_PREFLIGHT=1 arg
@@ -133,33 +224,36 @@ main() {
   # -- 1. guards -------------------------------------------------------------
   local BRANCH LOCAL REMOTE DIRTY_OTHER
   BRANCH="$(git rev-parse --abbrev-ref HEAD)"
-  [ "$BRANCH" = "main" ] || fail "must be on main to release (on '$BRANCH')"
+  [ "$BRANCH" = "$RELEASE_BRANCH" ] || fail "must be on ${RELEASE_BRANCH} to release (on '$BRANCH')"
 
   # The CHANGELOG entry is written-but-uncommitted at entry; everything else
-  # must be clean. Allow only plugin/CHANGELOG.md to be dirty.
-  DIRTY_OTHER="$(git status --porcelain --untracked-files=no | non_changelog_dirty)"
-  [ -z "$DIRTY_OTHER" ] || fail "working tree has changes other than plugin/CHANGELOG.md -- commit or stash first:
+  # must be clean. Allow only the configured changelog path to be dirty.
+  DIRTY_OTHER="$(git status --porcelain --untracked-files=no | non_changelog_dirty "$CHANGELOG_REL")"
+  [ -z "$DIRTY_OTHER" ] || fail "working tree has changes other than ${CHANGELOG_REL} -- commit or stash first:
 $DIRTY_OTHER"
 
-  git fetch origin main --quiet || fail "git fetch failed"
+  git fetch origin "$RELEASE_BRANCH" --quiet || fail "git fetch failed"
   LOCAL="$(git rev-parse @)"
   REMOTE="$(git rev-parse '@{u}' 2>/dev/null || echo "")"
-  [ -n "$REMOTE" ] || fail "no upstream for main"
-  [ "$LOCAL" = "$REMOTE" ] || fail "local main is not in sync with origin/main -- pull/push first"
+  [ -n "$REMOTE" ] || fail "no upstream for ${RELEASE_BRANCH}"
+  [ "$LOCAL" = "$REMOTE" ] || fail "local ${RELEASE_BRANCH} is not in sync with origin/${RELEASE_BRANCH} -- pull/push first"
 
   # -- 2. compute + validate the new version ---------------------------------
-  local CURRENT NEW
-  CURRENT="$(grep -m1 '^version' "$CARGO_TOML" | sed 's/version = "\(.*\)"/\1/' || true)"
-  [ -n "$CURRENT" ] || fail "could not read version from Cargo.toml"
-  is_semver "$CURRENT" || fail "Cargo.toml version '$CURRENT' is not strict X.Y.Z"
+  local CURRENT NEW TAG TAG_MESSAGE
+  CURRENT="$(legion sym etc extract "$SOURCE_FILE" --field "$SOURCE_FIELD" 2>/dev/null || true)"
+  [ -n "$CURRENT" ] || fail "could not read '${SOURCE_FIELD}' from ${SOURCE_FILE_REL}"
+  is_semver "$CURRENT" || fail "${SOURCE_FILE_REL} version '$CURRENT' is not strict X.Y.Z"
 
   NEW="$(compute_new_version "$CURRENT" "$BUMP")"
   is_semver "$NEW" || fail "invalid version '$NEW' (expected X.Y.Z)"
   is_strictly_greater "$NEW" "$CURRENT" || fail "refusing non-increment $CURRENT -> $NEW"
 
+  TAG="$(render_tag "$TAG_FORMAT" "$NEW")"
+  TAG_MESSAGE="$(render_tag "$TAG_MESSAGE_FORMAT" "$NEW")"
+
   # Refuse a tag that already exists (a re-run after a partial failure, or a typo
   # colliding with history) before we mutate anything.
-  ! git rev-parse "v${NEW}" >/dev/null 2>&1 || fail "tag v${NEW} already exists"
+  ! git rev-parse "$TAG" >/dev/null 2>&1 || fail "tag ${TAG} already exists"
 
   info "releasing ${CURRENT} -> ${NEW}"
 
@@ -167,47 +261,73 @@ $DIRTY_OTHER"
   local TOP_HEADER
   TOP_HEADER="$(grep -E '^## [0-9]' "$CHANGELOG" | head -1 | sed -E 's/^## //' | awk '{print $1}')"
   if [ "$TOP_HEADER" != "$NEW" ]; then
-    fail "plugin/CHANGELOG.md top header is '## ${TOP_HEADER:-<none>}', expected '## ${NEW}'.
+    fail "${CHANGELOG_REL} top header is '## ${TOP_HEADER:-<none>}', expected '## ${NEW}'.
        Have the changelog agent (or you) add a '## ${NEW}' section at the top, then re-run."
   fi
   info "CHANGELOG header matches ${NEW}"
 
   # -- 4. preflight ----------------------------------------------------------
   if [ "$RUN_PREFLIGHT" = "1" ]; then
-    info "running preflight (fmt, clippy, test, scip)"
-    run bash "${REPO_ROOT}/scripts/preflight.sh"
+    local PREFLIGHT_JSON PREFLIGHT_CMDS
+    PREFLIGHT_JSON="$(legion sym etc extract "$CONFIG" --field preflight.commands --json 2>/dev/null || printf '["bash scripts/preflight.sh"]')"
+    PREFLIGHT_CMDS="$(printf '%s' "$PREFLIGHT_JSON" | python3 -c '
+import json, sys
+for c in json.load(sys.stdin):
+    print(c)
+')"
+    info "running preflight: $(printf '%s' "$PREFLIGHT_CMDS" | tr '\n' ',' | sed 's/,$//')"
+    while IFS= read -r cmd; do
+      [ -n "$cmd" ] || continue
+      run bash -c "$cmd"
+    done <<<"$PREFLIGHT_CMDS"
   else
     info "preflight skipped (--no-preflight)"
   fi
 
-  # -- 5. bump Cargo.toml + refresh Cargo.lock -------------------------------
-  # Replace the first exact `version = "<current>"` line via awk -- portable,
-  # unlike `sed '0,/re/'` whose line-address 0 is a GNU extension BSD sed rejects.
+  # -- 5. bump the version-of-record file + refresh Cargo.lock ---------------
   if [ "$DRY_RUN" = "1" ]; then
-    printf '[dry-run] set Cargo.toml version %s -> %s\n' "$CURRENT" "$NEW" >&2
+    printf '[dry-run] set %s %s -> %s\n' "$SOURCE_FILE_REL" "$CURRENT" "$NEW" >&2
   else
-    awk -v old="version = \"${CURRENT}\"" -v new="version = \"${NEW}\"" '
-      !done && $0 == old { print new; done = 1; next } { print }
-    ' "$CARGO_TOML" > "${CARGO_TOML}.tmp" && mv "${CARGO_TOML}.tmp" "$CARGO_TOML"
+    bump_source_file "$SOURCE_FILE" "$SOURCE_FIELD" "$CURRENT" "$NEW" \
+      || fail "unsupported version.file format '${SOURCE_FILE_REL}' (bump supports .toml and .json)"
   fi
-  run cargo build --quiet   # refreshes Cargo.lock's legion entry to ${NEW}
+  # Cargo.lock only exists (and only needs refreshing) for a Rust source file.
+  if [ "${SOURCE_FILE_REL##*/}" = "Cargo.toml" ]; then
+    run cargo build --quiet   # refreshes Cargo.lock's own version entry to ${NEW}
+  fi
 
   # -- 6. sync manifests + commit --------------------------------------------
   # Run sync-version explicitly so the manifests are correct even if the
   # pre-commit hook is not installed in this clone (the #656 failure mode).
   run bash "${REPO_ROOT}/scripts/sync-version.sh"
-  run git add Cargo.toml Cargo.lock plugin/CHANGELOG.md \
-    plugin/.claude-plugin/plugin.json .claude-plugin/marketplace.json
+  local ADD_FILES=("$SOURCE_FILE" "$CHANGELOG")
+  if [ "${SOURCE_FILE_REL##*/}" = "Cargo.toml" ] && [ -f "${REPO_ROOT}/Cargo.lock" ]; then
+    ADD_FILES+=("${REPO_ROOT}/Cargo.lock")
+  fi
+  local TARGETS_JSON TARGET_FILES_REL
+  TARGETS_JSON="$(legion sym etc extract "$CONFIG" --field targets --json 2>/dev/null || printf '[]')"
+  TARGET_FILES_REL="$(printf '%s' "$TARGETS_JSON" | python3 -c '
+import json, sys
+for t in json.load(sys.stdin):
+    print(t["file"])
+')"
+  if [ -n "$TARGET_FILES_REL" ]; then
+    while IFS= read -r t; do
+      [ -n "$t" ] || continue
+      ADD_FILES+=("${REPO_ROOT}/${t}")
+    done <<<"$TARGET_FILES_REL"
+  fi
+  run git add "${ADD_FILES[@]}"
   run git commit -m "chore(release): ${NEW}
 
-Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+Co-Authored-By: ${CO_AUTHORED_BY}"
 
   # -- 7. tag + atomic push --------------------------------------------------
-  # --atomic so main and the tag land together: a half-push that left the commit
-  # without its tag would leave release.yml unfired.
-  run git tag -a "v${NEW}" -m "legion ${NEW}"
-  run git push --atomic origin main "v${NEW}"
-  info "pushed v${NEW} -- release.yml will build + publish the platform binaries"
+  # --atomic so the branch and the tag land together: a half-push that left
+  # the commit without its tag would leave release.yml unfired.
+  run git tag -a "$TAG" -m "$TAG_MESSAGE"
+  run git push --atomic origin "$RELEASE_BRANCH" "$TAG"
+  info "pushed ${TAG} -- release.yml will build + publish the platform binaries"
 
   # -- 8. optional local activation ------------------------------------------
   if [ "$ACTIVATE" = "1" ]; then

--- a/scripts/sync-version.sh
+++ b/scripts/sync-version.sh
@@ -1,41 +1,82 @@
 #!/bin/bash
-# Sync version from Cargo.toml to plugin.json and marketplace.json.
+# Sync a repo's version of record to its configured propagation targets, per
+# release.toml (schema documented there; see #741).
 #
-# Cargo.toml is the single source of truth. This script:
-#   1. Reads the version from Cargo.toml.
-#   2. Refuses to proceed if plugin.json or marketplace.json carries a HIGHER
-#      version than Cargo.toml -- never auto-downgrades. Bump Cargo.toml first.
-#   3. Updates plugin.json and marketplace.json if they are at or behind Cargo.toml
-#      and stages the resulting changes into the in-flight commit.
-#   4. Requires plugin/CHANGELOG.md's top "## <version>" header to match
-#      Cargo.toml. Fails loudly if the developer forgot to log the bump.
+# release.toml declares:
+#   [version]  file + field   -- the version of record (any json/toml/yaml
+#                                 file `legion sym etc extract` can read).
+#   [changelog] path          -- the changelog whose top "## <version>"
+#                                 header must match the source version.
+#   [[targets]] file + field  -- files the source version propagates to.
+#
+# This script:
+#   1. Reads the version of record via `legion sym etc extract`.
+#   2. Refuses to proceed if any target carries a HIGHER version than the
+#      source -- never auto-downgrades. Bump the source first.
+#   3. Updates every target that is at or behind the source and stages the
+#      resulting changes into the in-flight commit.
+#   4. Requires the changelog's top "## <version>" header to match the
+#      source. Fails loudly if the developer forgot to log the bump.
+#
+# Only json targets are rewritten (the write side); a flat field (no ".")
+# is rewritten via a single-line sed replace so the rest of the file is
+# untouched; a dotted field (nested key or array index, e.g.
+# "plugins.0.version") is rewritten via a small json.load/dump cycle.
 #
 # Safe to run manually; intended to run as a git pre-commit hook via
-# .githooks/pre-commit + scripts/install-hooks.sh.
+# .githooks/pre-commit + scripts/install-hooks.sh. Requires the `legion`
+# binary on PATH -- it is how this script reads release.toml and every
+# target's current value without hand-rolling a TOML/JSON parser in bash.
 set -euo pipefail
 
 REPO_ROOT="$(git rev-parse --show-toplevel)"
-CARGO_TOML="${REPO_ROOT}/Cargo.toml"
-PLUGIN_JSON="${REPO_ROOT}/plugin/.claude-plugin/plugin.json"
-MARKETPLACE_JSON="${REPO_ROOT}/.claude-plugin/marketplace.json"
-CHANGELOG="${REPO_ROOT}/plugin/CHANGELOG.md"
+CONFIG="${REPO_ROOT}/release.toml"
 
-# Extract a "x.y.z" version string from a supported file type.
-extract_version() {
-  local file="$1"
-  case "$file" in
-    *Cargo.toml)
-      grep '^version' "$file" | head -1 | sed 's/version = "\(.*\)"/\1/'
-      ;;
-    *plugin.json)
-      grep '"version"' "$file" | head -1 | sed 's/.*"\([0-9][0-9.]*\)".*/\1/'
-      ;;
-    *marketplace.json)
-      # Version inside the plugins[] array, NOT the top-level schema version.
-      grep -A20 '"plugins"' "$file" | grep '"version"' | head -1 | sed 's/.*"\([0-9][0-9.]*\)".*/\1/'
-      ;;
-  esac
+if ! command -v legion >/dev/null 2>&1; then
+  echo "[sync-version] ERROR: 'legion' binary not found on PATH -- required to read release.toml" >&2
+  exit 1
+fi
+
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "[sync-version] ERROR: 'python3' not found on PATH -- required to parse release.toml's json fields (targets) and rewrite nested json targets" >&2
+  exit 1
+fi
+
+if [ ! -f "$CONFIG" ]; then
+  echo "[sync-version] ERROR: release.toml not found at repo root -- see scripts/sync-version.sh header for the schema" >&2
+  exit 1
+fi
+
+# extract_required <field>: read one release.toml field, or fail loudly
+# naming the field.
+extract_required() {
+  local field="$1"
+  local value
+  if ! value="$(legion sym etc extract "$CONFIG" --field "$field" 2>/dev/null)"; then
+    echo "[sync-version] ERROR: release.toml missing required field '${field}'" >&2
+    exit 1
+  fi
+  printf '%s' "$value"
 }
+
+SOURCE_FILE_REL="$(extract_required version.file)"
+SOURCE_FIELD="$(extract_required version.field)"
+CHANGELOG_REL="$(extract_required changelog.path)"
+TARGETS_JSON="$(legion sym etc extract "$CONFIG" --field targets --json 2>/dev/null || printf '[]')"
+
+SOURCE_FILE="${REPO_ROOT}/${SOURCE_FILE_REL}"
+CHANGELOG="${REPO_ROOT}/${CHANGELOG_REL}"
+
+if [ ! -f "$SOURCE_FILE" ]; then
+  echo "[sync-version] ERROR: version.file '${SOURCE_FILE_REL}' (release.toml) does not exist" >&2
+  exit 1
+fi
+
+SOURCE_VERSION="$(legion sym etc extract "$SOURCE_FILE" --field "$SOURCE_FIELD" 2>/dev/null || true)"
+if [ -z "$SOURCE_VERSION" ]; then
+  echo "[sync-version] ERROR: could not read '${SOURCE_FIELD}' from ${SOURCE_FILE_REL}" >&2
+  exit 1
+fi
 
 # Return 0 if $1 <= $2 by semver ordering, 1 otherwise. Uses `sort -V`.
 version_leq() {
@@ -52,45 +93,82 @@ portable_sed_inplace() {
   rm -f "${file}.bak"
 }
 
-CARGO_VERSION=$(extract_version "$CARGO_TOML")
-if [ -z "$CARGO_VERSION" ]; then
-  echo "[sync-version] ERROR: could not read version from Cargo.toml" >&2
-  exit 1
-fi
+# rewrite_json_field <file> <field> <new_value>: dotted-path write, the
+# mutation-side counterpart of `legion sym etc extract`'s dotted-path read.
+# Segments split on ".", a purely numeric segment indexes an array, any
+# other segment is an object key. Pass path/field/value via env vars, NOT
+# shell interpolation into the python string literal -- a value containing a
+# single quote would otherwise break the python source.
+rewrite_json_field() {
+  local file="$1" field="$2" new_value="$3"
+  TARGET_FILE="$file" TARGET_FIELD="$field" NEW_VALUE="$new_value" python3 <<'PY'
+import json, os
 
-# Abort if any tracked version file is AHEAD of Cargo.toml.
+path = os.environ['TARGET_FILE']
+field = os.environ['TARGET_FIELD']
+new_value = os.environ['NEW_VALUE']
+
+with open(path, 'r') as f:
+    data = json.load(f)
+
+segs = field.split('.')
+node = data
+for seg in segs[:-1]:
+    node = node[int(seg)] if seg.isdigit() else node[seg]
+last = segs[-1]
+if last.isdigit():
+    node[int(last)] = new_value
+else:
+    node[last] = new_value
+
+with open(path, 'w') as f:
+    json.dump(data, f, indent=2)
+    f.write('\n')
+PY
+}
+
+# --- validation phase: everything that can reject the commit runs first ---
+# Rationale: if we mutated a target before discovering a stale CHANGELOG, the
+# developer would land in a half-synced working tree that blocks the commit
+# without any obvious undo path. Validate all invariants up front, exit 1
+# loudly, then mutate only once we know every check passes.
+
+# Abort if any target is AHEAD of the source version.
 check_not_ahead() {
-  local file="$1"
-  local label="$2"
+  local file="$1" field="$2" label="$3"
   [ -f "$file" ] || return 0
   local other
-  other=$(extract_version "$file")
+  other="$(legion sym etc extract "$file" --field "$field" 2>/dev/null || true)"
   [ -n "$other" ] || return 0
-  if ! version_leq "$other" "$CARGO_VERSION"; then
-    echo "[sync-version] ERROR: ${label} is at ${other}, ahead of Cargo.toml at ${CARGO_VERSION}" >&2
-    echo "[sync-version] Refusing to downgrade ${label}. Bump Cargo.toml to >= ${other} first, then commit." >&2
+  if ! version_leq "$other" "$SOURCE_VERSION"; then
+    echo "[sync-version] ERROR: ${label} is at ${other}, ahead of ${SOURCE_FILE_REL} at ${SOURCE_VERSION}" >&2
+    echo "[sync-version] Refusing to downgrade ${label}. Bump ${SOURCE_FILE_REL} to >= ${other} first, then commit." >&2
     exit 1
   fi
 }
 
-# --- validation phase: everything that can reject the commit runs first ---
-# Rationale: if we mutated plugin.json before discovering a stale CHANGELOG,
-# the developer would land in a half-synced working tree that blocks the
-# commit without any obvious undo path. Validate all invariants up front,
-# exit 1 loudly, then mutate only once we know every check passes.
+# One "file<TAB>field" line per target, parsed once up front.
+TARGETS_LINES="$(printf '%s' "$TARGETS_JSON" | python3 -c '
+import json, sys
+for t in json.load(sys.stdin):
+    print("{}\t{}".format(t["file"], t["field"]))
+')"
 
-check_not_ahead "$PLUGIN_JSON" "plugin.json"
-check_not_ahead "$MARKETPLACE_JSON" "marketplace.json"
+if [ -n "$TARGETS_LINES" ]; then
+  while IFS=$'\t' read -r TARGET_FILE_REL TARGET_FIELD; do
+    check_not_ahead "${REPO_ROOT}/${TARGET_FILE_REL}" "$TARGET_FIELD" "$TARGET_FILE_REL"
+  done <<<"$TARGETS_LINES"
+fi
 
-# Require CHANGELOG top header to match Cargo.toml. Changelog body is
-# human-authored -- we only enforce the header version tag.
+# Require CHANGELOG top header to match the source version. Changelog body
+# is human-authored -- we only enforce the header version tag.
 if [ -f "$CHANGELOG" ]; then
   TOP_HEADER=$(grep -E '^## [0-9]' "$CHANGELOG" | head -1 | sed -E 's/^## //' | awk '{print $1}')
   if [ -z "$TOP_HEADER" ]; then
-    echo "[sync-version] WARNING: no '## <version>' header found in ${CHANGELOG#"$REPO_ROOT/"}" >&2
-  elif [ "$TOP_HEADER" != "$CARGO_VERSION" ]; then
-    echo "[sync-version] ERROR: ${CHANGELOG#"$REPO_ROOT/"} top header is '## ${TOP_HEADER}', Cargo.toml is ${CARGO_VERSION}" >&2
-    echo "[sync-version] Add a new '## ${CARGO_VERSION}' section at the top of ${CHANGELOG#"$REPO_ROOT/"} describing what shipped in this release, then commit." >&2
+    echo "[sync-version] WARNING: no '## <version>' header found in ${CHANGELOG_REL}" >&2
+  elif [ "$TOP_HEADER" != "$SOURCE_VERSION" ]; then
+    echo "[sync-version] ERROR: ${CHANGELOG_REL} top header is '## ${TOP_HEADER}', ${SOURCE_FILE_REL} is ${SOURCE_VERSION}" >&2
+    echo "[sync-version] Add a new '## ${SOURCE_VERSION}' section at the top of ${CHANGELOG_REL} describing what shipped in this release, then commit." >&2
     exit 1
   fi
 fi
@@ -99,44 +177,31 @@ fi
 
 UPDATED=false
 
-# Update plugin.json to match Cargo.toml if needed.
-if [ -f "$PLUGIN_JSON" ]; then
-  CURRENT=$(extract_version "$PLUGIN_JSON")
-  if [ -n "$CURRENT" ] && [ "$CURRENT" != "$CARGO_VERSION" ]; then
-    portable_sed_inplace "s/\"version\": \"${CURRENT}\"/\"version\": \"${CARGO_VERSION}\"/" "$PLUGIN_JSON"
-    git add "$PLUGIN_JSON"
-    echo "[sync-version] plugin.json: ${CURRENT} -> ${CARGO_VERSION}" >&2
-    UPDATED=true
-  fi
-fi
+if [ -n "$TARGETS_LINES" ]; then
+  while IFS=$'\t' read -r TARGET_FILE_REL TARGET_FIELD; do
+    TARGET_FILE="${REPO_ROOT}/${TARGET_FILE_REL}"
 
-# Update marketplace.json via python for precise JSON handling (avoids sed
-# ambiguity when multiple "version" fields are present at different depths).
-# Pass path + version via env vars, NOT shell interpolation into the python
-# string literal -- a path or version containing a single quote would
-# otherwise break the python source. The heredoc is single-quoted so bash
-# does not interpolate inside it; python reads from os.environ.
-if [ -f "$MARKETPLACE_JSON" ]; then
-  CURRENT=$(extract_version "$MARKETPLACE_JSON")
-  if [ -n "$CURRENT" ] && [ "$CURRENT" != "$CARGO_VERSION" ]; then
-    MARKETPLACE_JSON="$MARKETPLACE_JSON" CARGO_VERSION="$CARGO_VERSION" python3 <<'PY'
-import json, os
-path = os.environ['MARKETPLACE_JSON']
-version = os.environ['CARGO_VERSION']
-with open(path, 'r') as f:
-    data = json.load(f)
-for p in data.get('plugins', []):
-    p['version'] = version
-with open(path, 'w') as f:
-    json.dump(data, f, indent=2)
-    f.write('\n')
-PY
-    git add "$MARKETPLACE_JSON"
-    echo "[sync-version] marketplace.json: ${CURRENT} -> ${CARGO_VERSION}" >&2
+    [ -f "$TARGET_FILE" ] || continue
+    CURRENT="$(legion sym etc extract "$TARGET_FILE" --field "$TARGET_FIELD" 2>/dev/null || true)"
+    [ -n "$CURRENT" ] || continue
+    [ "$CURRENT" != "$SOURCE_VERSION" ] || continue
+
+    case "$TARGET_FIELD" in
+      *.*)
+        # Dotted path (nested key or array index): full json.load/dump cycle.
+        rewrite_json_field "$TARGET_FILE" "$TARGET_FIELD" "$SOURCE_VERSION"
+        ;;
+      *)
+        # Flat top-level field: single-line replace, rest of file untouched.
+        portable_sed_inplace "s/\"${TARGET_FIELD}\": \"${CURRENT}\"/\"${TARGET_FIELD}\": \"${SOURCE_VERSION}\"/" "$TARGET_FILE"
+        ;;
+    esac
+    git add "$TARGET_FILE"
+    echo "[sync-version] ${TARGET_FILE_REL}: ${CURRENT} -> ${SOURCE_VERSION}" >&2
     UPDATED=true
-  fi
+  done <<<"$TARGETS_LINES"
 fi
 
 if [ "$UPDATED" = false ]; then
-  echo "[sync-version] all versions match ${CARGO_VERSION}" >&2
+  echo "[sync-version] all versions match ${SOURCE_VERSION}" >&2
 fi

--- a/scripts/test-release.sh
+++ b/scripts/test-release.sh
@@ -55,17 +55,61 @@ ok "gt twodigit" is_strictly_greater 0.18.10 0.18.9
 ok "gt major"   is_strictly_greater 1.0.0 0.18.2
 no "gt majdown" is_strictly_greater 0.18.2 1.0.0
 
-# non_changelog_dirty: only plugin/CHANGELOG.md is allowed dirty; anything else
-# (including a rename whose destination is not CHANGELOG) is "other dirty".
+# non_changelog_dirty: only the configured changelog path is allowed dirty;
+# anything else (including a rename whose destination is not the changelog)
+# is "other dirty".
 eq "dirty: changelog only allowed" "" \
-  "$(printf ' M plugin/CHANGELOG.md\n' | non_changelog_dirty)"
+  "$(printf ' M plugin/CHANGELOG.md\n' | non_changelog_dirty 'plugin/CHANGELOG.md')"
 eq "dirty: other file flagged" " M src/main.rs" \
-  "$(printf ' M plugin/CHANGELOG.md\n M src/main.rs\n' | non_changelog_dirty)"
+  "$(printf ' M plugin/CHANGELOG.md\n M src/main.rs\n' | non_changelog_dirty 'plugin/CHANGELOG.md')"
 eq "dirty: suffix lookalike flagged" " M docs/plugin/CHANGELOG.md" \
-  "$(printf ' M docs/plugin/CHANGELOG.md\n' | non_changelog_dirty)"
+  "$(printf ' M docs/plugin/CHANGELOG.md\n' | non_changelog_dirty 'plugin/CHANGELOG.md')"
 eq "dirty: rename dest to changelog allowed" "" \
-  "$(printf 'R  old.md -> plugin/CHANGELOG.md\n' | non_changelog_dirty)"
-eq "dirty: empty tree is clean" "" "$(printf '' | non_changelog_dirty)"
+  "$(printf 'R  old.md -> plugin/CHANGELOG.md\n' | non_changelog_dirty 'plugin/CHANGELOG.md')"
+eq "dirty: empty tree is clean" "" "$(printf '' | non_changelog_dirty 'plugin/CHANGELOG.md')"
+eq "dirty: honors a different configured path" "" \
+  "$(printf ' M CHANGELOG.md\n' | non_changelog_dirty 'CHANGELOG.md')"
+
+# field_leaf: last "."-separated segment.
+eq "leaf: nested"    "version" "$(field_leaf package.version)"
+eq "leaf: flat"       "version" "$(field_leaf version)"
+eq "leaf: array index" "version" "$(field_leaf plugins.0.version)"
+
+# render_tag: "{version}" substitution.
+eq "tag: default format"  "v0.20.0"        "$(render_tag 'v{version}' 0.20.0)"
+eq "tag: no placeholder"  "release"        "$(render_tag release 0.20.0)"
+eq "tag: custom format"   "ledger@0.2.0"   "$(render_tag '{version}' ledger@0.2.0)"
+
+# bump_source_file: rewrites the version-of-record file in place per its
+# extension, and never mutates + returns 1 on an unsupported one -- this is
+# #741's proof that the bump step generalizes beyond Cargo.toml (a package.json
+# source, e.g. a JS repo's `[version] file = "package.json"`, bumps the same way
+# a flat json target does in scripts/sync-version.sh).
+BUMP_DIR=$(mktemp -d)
+trap 'rm -rf "$BUMP_DIR"' EXIT
+
+cat >"${BUMP_DIR}/Cargo.toml" <<'EOF'
+[package]
+name = "fixture"
+version = "0.6.5"
+edition = "2024"
+EOF
+ok "bump: toml source" bump_source_file "${BUMP_DIR}/Cargo.toml" package.version 0.6.5 0.7.0
+eq "bump: toml result" 'version = "0.7.0"' "$(grep '^version' "${BUMP_DIR}/Cargo.toml")"
+
+cat >"${BUMP_DIR}/package.json" <<'EOF'
+{
+  "name": "@rafters/fixture",
+  "version": "0.2.0"
+}
+EOF
+ok "bump: json source" bump_source_file "${BUMP_DIR}/package.json" version 0.2.0 0.3.0
+eq "bump: json result" '  "version": "0.3.0"' "$(grep '"version"' "${BUMP_DIR}/package.json")"
+eq "bump: json rest untouched" '  "name": "@rafters/fixture",' "$(sed -n '2p' "${BUMP_DIR}/package.json")"
+
+echo "unsupported" >"${BUMP_DIR}/version.yaml"
+no "bump: unsupported format refused" bump_source_file "${BUMP_DIR}/version.yaml" version 0.1.0 0.2.0
+eq "bump: unsupported format untouched" "unsupported" "$(cat "${BUMP_DIR}/version.yaml")"
 
 printf '\n[test-release] %d passed, %d failed\n' "$PASS" "$FAIL" >&2
 [ "$FAIL" -eq 0 ]

--- a/scripts/test-sync-version.sh
+++ b/scripts/test-sync-version.sh
@@ -1,16 +1,21 @@
 #!/bin/bash
-# Smoke test for scripts/sync-version.sh.
+# Smoke test for scripts/sync-version.sh -- and, per #741, the proof that its
+# release.toml-driven propagation generalizes beyond legion's own shape.
 #
-# Builds a temporary fake-repo fixture with the same directory shape as legion
-# (Cargo.toml, plugin/.claude-plugin/plugin.json, .claude-plugin/marketplace.json,
-# plugin/CHANGELOG.md), runs sync-version.sh under four scenarios, and asserts
-# the expected exit code + output sentinels.
-#
-# Scenarios:
+# Scenarios 1-4 build a temporary fake-repo fixture with the same directory
+# shape as legion (Cargo.toml, plugin/.claude-plugin/plugin.json,
+# .claude-plugin/marketplace.json, plugin/CHANGELOG.md, release.toml), run
+# sync-version.sh, and assert the expected exit code + output sentinels:
 #   1. All versions match   -> exit 0, "all versions match"
 #   2. Cargo ahead of others -> exit 0, plugin+marketplace auto-updated
 #   3. plugin.json AHEAD    -> exit 1, "Refusing to downgrade"
 #   4. CHANGELOG behind     -> exit 1, "top header" mismatch
+#
+# Scenario 5 builds a deliberately NON-legion-shaped fixture (a package.json
+# version source, a root-level CHANGELOG.md, one flat json target and one
+# nested-by-object-key json target -- none of which are legion's paths or
+# field names) and asserts the same propagation behavior holds, proving the
+# generalization criterion of #741 rather than merely asserting it.
 #
 # Run manually: bash scripts/test-sync-version.sh
 # Exits 0 if every scenario behaves as expected, 1 otherwise.
@@ -23,6 +28,14 @@ SYNC_SCRIPT="${REPO_ROOT}/scripts/sync-version.sh"
 if [ ! -f "$SYNC_SCRIPT" ]; then
   echo "ERROR: $SYNC_SCRIPT not found" >&2
   exit 1
+fi
+
+if ! command -v legion >/dev/null 2>&1; then
+  echo "SKIP: 'legion' binary not found on PATH -- scripts/sync-version.sh now reads" >&2
+  echo "  release.toml via 'legion sym etc extract'; this test cannot run without it." >&2
+  echo "  (Not wired into CI -- see .github/workflows/ci.yml -- so this only affects" >&2
+  echo "  a local preflight run on a machine without the legion plugin installed.)" >&2
+  exit 0
 fi
 
 FAILS=0
@@ -80,12 +93,103 @@ EOF
 Test fixture.
 EOF
 
+  cat >"$root/release.toml" <<'EOF'
+[version]
+file = "Cargo.toml"
+field = "package.version"
+
+[changelog]
+path = "plugin/CHANGELOG.md"
+
+[[targets]]
+file = "plugin/.claude-plugin/plugin.json"
+field = "version"
+
+[[targets]]
+file = ".claude-plugin/marketplace.json"
+field = "plugins.0.version"
+EOF
+
   # Minimal git init so git rev-parse + git add inside sync-version.sh work.
+  # Hermetic identity: -c user.name/-c user.email/-c commit.gpgsign=false with
+  # an explicit current_dir, never the ambient .git/config.
   (
     cd "$root"
     git init -q
     git add -A
-    git -c user.email=test@test -c user.name=test commit -q -m init
+    git -c user.email=test@test -c user.name=test -c commit.gpgsign=false commit -q -m init
+  )
+}
+
+# Build a fixture deliberately shaped UNLIKE legion: a package.json version
+# source (flat top-level field, not a nested Cargo.toml table), a root-level
+# CHANGELOG.md (not plugin/CHANGELOG.md), a flat json target, and a
+# nested-by-object-key json target (proving the dotted-path json writer
+# generalizes beyond "array index", legion's only nested case).
+#   $1 -- fixture root
+#   $2 -- package.json version
+#   $3 -- manifest.json (flat "version") value
+#   $4 -- config/app.json meta.version value
+#   $5 -- CHANGELOG.md top header version
+build_foreign_fixture() {
+  local root="$1"
+  local pkg_v="$2"
+  local manifest_v="$3"
+  local app_v="$4"
+  local changelog_v="$5"
+
+  mkdir -p "$root/config"
+  cat >"$root/package.json" <<EOF
+{
+  "name": "@rafters/fixture",
+  "version": "$pkg_v"
+}
+EOF
+
+  cat >"$root/manifest.json" <<EOF
+{
+  "version": "$manifest_v"
+}
+EOF
+
+  cat >"$root/config/app.json" <<EOF
+{
+  "meta": {
+    "version": "$app_v"
+  }
+}
+EOF
+
+  cat >"$root/CHANGELOG.md" <<EOF
+# Fixture Changelog
+
+## $changelog_v
+
+Test fixture.
+EOF
+
+  cat >"$root/release.toml" <<'EOF'
+[version]
+file = "package.json"
+field = "version"
+
+[changelog]
+path = "CHANGELOG.md"
+
+[[targets]]
+file = "manifest.json"
+field = "version"
+
+[[targets]]
+file = "config/app.json"
+field = "meta.version"
+EOF
+
+  (
+    cd "$root"
+    git init -q
+    git add -A
+    git -c user.email=test@test -c user.name=test -c commit.gpgsign=false commit -q -m init
   )
 }
 
@@ -112,13 +216,14 @@ run_case() {
   pass "$name"
 }
 
-echo "[test-sync-version] running 4 scenarios..."
+echo "[test-sync-version] running 5 scenarios..."
 
 T1=$(mktemp -d)
 T2=$(mktemp -d)
 T3=$(mktemp -d)
 T4=$(mktemp -d)
-trap 'rm -rf "$T1" "$T2" "$T3" "$T4"' EXIT
+T5=$(mktemp -d)
+trap 'rm -rf "$T1" "$T2" "$T3" "$T4" "$T5"' EXIT
 
 # Scenario 1: all versions match 0.6.5
 build_fixture "$T1" 0.6.5 0.6.5 0.6.5 0.6.5
@@ -135,6 +240,23 @@ run_case "3: plugin ahead -> refuse" "$T3" 1 "Refusing to downgrade"
 # Scenario 4: Cargo matches plugin/marketplace but CHANGELOG top header is stale
 build_fixture "$T4" 0.7.0 0.7.0 0.7.0 0.6.5
 run_case "4: CHANGELOG behind" "$T4" 1 "top header"
+
+# Scenario 5 (#741 generalization proof): a non-legion-shaped repo -- package.json
+# source, root CHANGELOG.md, a flat target AND a nested-by-object-key target,
+# none of which are legion's paths or field names -- propagates identically.
+build_foreign_fixture "$T5" 0.2.0 0.1.0 0.1.0 0.2.0
+run_case "5: foreign repo shape, sync down" "$T5" 0 "manifest.json: 0.1.0 -> 0.2.0"
+if grep -q -- "config/app.json: 0.1.0 -> 0.2.0" "$T5/_stderr.log"; then
+  pass "5b: nested (object-key) target propagated"
+else
+  fail "5b: expected 'config/app.json: 0.1.0 -> 0.2.0' in stderr:"
+  sed 's/^/      /' <"$T5/_stderr.log" >&2
+fi
+if [ "$(python3 -c "import json; print(json.load(open('$T5/config/app.json'))['meta']['version'])")" = "0.2.0" ]; then
+  pass "5c: nested target value actually written"
+else
+  fail "5c: config/app.json meta.version was not rewritten to 0.2.0"
+fi
 
 if [ "$FAILS" -eq 0 ]; then
   echo "[test-sync-version] all scenarios passed"


### PR DESCRIPTION
## Summary

Generalizes legion's release toolchain (the `changelog` agent, `scripts/release.sh`,
`scripts/sync-version.sh`, and the `legion-release` skill's orchestration) so any repo
with a `release.toml` at its root can adopt it, instead of the tooling assuming legion's
own paths (`Cargo.toml`, `plugin/CHANGELOG.md`, `plugin.json`, `marketplace.json`) and
branch/tag conventions. Every path, field, branch, and tag format is now read generically
via `legion sym etc extract release.toml --field <dotted.path>` (built on #711's CSS
symbols work), and legion's own release keeps working unchanged because its
`release.toml` simply declares its existing shape as the default config.

## Acceptance criteria mapping

### 1. release.toml schema documented; legion's own release ported to it with zero behavior change (the proof)

`release.toml` (new, repo root) declares `[version]` (file + field), `[changelog]`
(path + optional voice_sample), `[git]` (branch, tag_format, tag_message,
co_authored_by), `[preflight]` (commands), and `[[targets]]` (file + field per
propagation target) -- each field's meaning and the dotted-path/array-index convention
is documented inline in the file itself (`/Volumes/store/projects/runlegion/legion/release.toml` on this
branch, `release.toml:1-69`). `scripts/release.sh` and `scripts/sync-version.sh` were
rewritten to read every one of legion's own paths (`Cargo.toml`, `plugin/CHANGELOG.md`,
`plugin/.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`, branch `main`,
tag `v{version}`) from this config instead of hardcoding them (`scripts/release.sh:100-200`,
`scripts/sync-version.sh:60-90`).

Evidence: `scripts/test-release.sh` (39/39 passing) and `scripts/test-sync-version.sh`
scenarios 1-4 exercise the exact legion-shaped fixture (Cargo.toml, plugin.json,
marketplace.json, plugin/CHANGELOG.md) the old hardcoded scripts targeted, asserting the
same exit codes and sentinel strings ("all versions match", "Refusing to downgrade",
"top header") as before the config indirection was introduced -- i.e. legion's own
release behavior is unchanged. Ran both locally on this branch:
`[test-release] 39 passed, 0 failed` and `[test-sync-version] all scenarios passed`
(scenarios 1-4).

### 2. changelog agent reads the voice sample + changelog path from config instead of assuming plugin/CHANGELOG.md

`plugin/agents/changelog.md` no longer assumes `plugin/CHANGELOG.md`; it now resolves
`changelog.path` and the optional `changelog.voice_sample` via
`legion sym etc extract release.toml --field <field>`, falling back to `changelog.path`
for voice when `voice_sample` is unset (`plugin/agents/changelog.md:20-45`). The version
guard section was reworded to read the version-of-record from the configured
`[version].file` (documented as generalizing beyond `Cargo.toml`) rather than hardcoding
that filename (`plugin/agents/changelog.md:75-95`). `plugin/commands/legion-release.md`
step 3 was updated to match: it tells the orchestrator to have the changelog agent read
`release.toml`'s `changelog.path` rather than assuming the old fixed path
(`plugin/commands/legion-release.md:27-40`).

Evidence: diff of `plugin/agents/changelog.md` (73 lines changed) shows every reference
to the literal string `plugin/CHANGELOG.md` replaced with config-resolution language,
except the one place it is cited as legion's own concrete default value.

### 3. sync-version.sh (or successor) propagates per config targets; header-match abort net preserved

`scripts/sync-version.sh` was rewritten to read `version.file`/`version.field`,
`changelog.path`, and the `[[targets]]` array from `release.toml`, iterating targets
generically instead of hardcoding `plugin.json` and `marketplace.json`
(`scripts/sync-version.sh:60-180`). Two rewrite strategies are supported on the write
side: a flat top-level field via single-line sed replace, and a dotted field (nested
object key or array index) via a `json.load`/`json.dump` cycle (`rewrite_json_field`,
`scripts/sync-version.sh:100-130`). The header-match abort net is preserved verbatim in
behavior: the changelog's top `## <version>` header is still required to match the
source version before any target is mutated, and any target ahead of the source still
aborts with "Refusing to downgrade" (`scripts/sync-version.sh:150-175`).

Evidence: `scripts/test-sync-version.sh` scenario 3 ("plugin ahead -> refuse", exit 1,
"Refusing to downgrade") and scenario 4 ("CHANGELOG behind", exit 1, "top header") both
pass against the rewritten script, proving the abort net still fires under the new
config-driven code path. Ran locally:
`[PASS] 3: plugin ahead -> refuse`, `[PASS] 4: CHANGELOG behind`.

### 4. One non-legion repo released with the same toolchain end-to-end

Not fully delivered as a real, executed release of an actual non-legion repo. What
exists instead: `scripts/test-sync-version.sh` scenario 5 builds a fixture
deliberately unlike legion's shape -- a `package.json` version source (flat field,
not a nested Cargo.toml table), a root-level `CHANGELOG.md` instead of
`plugin/CHANGELOG.md`, one flat json target, and one nested-by-object-key json target
(`config/app.json`'s `meta.version`, proving the dotted-path json writer generalizes
beyond legion's only nested case, an array index) -- and asserts the identical
propagation behavior holds end-to-end within `sync-version.sh`
(`scripts/test-sync-version.sh:100-260`). `scripts/test-release.sh` similarly proves
`bump_source_file` bumps a `package.json`-shaped source the same way it bumps
`Cargo.toml`, and refuses (without mutating) an unsupported extension
(`scripts/test-release.sh:75-100`).

Evidence: ran locally, `[PASS] 5: foreign repo shape, sync down`,
`[PASS] 5b: nested (object-key) target propagated`,
`[PASS] 5c: nested target value actually written`. This is a simulated, non-legion-shaped
fixture proving the mechanism generalizes -- not an actual release cut against a real
external repo's git history, CI, and tag push. See "Deliberately not done" below; this
gap is called out rather than glossed over.

## Deliberately not done

- **No real cross-repo release was executed.** Criterion 4 is proven with a synthetic
  fixture (test-sync-version.sh scenario 5) that exercises a non-legion-shaped
  file layout end-to-end through the propagation logic, but no actual PR/tag/push was
  run against rafters, ledger, veneer, shingle, or eavesdrop. The issue's own sketch
  says building the full toolchain now is "'one day' per operator; this issue is the
  design anchor" -- this PR treats that as license to prove generalization via test
  fixtures rather than requiring a live external release in the same change.
- **Only `.toml` and `.json` version-of-record files are supported for the bump step**
  (`bump_source_file`); a yaml source is explicitly documented as needing a bump
  strategy added later (`release.toml`'s `[version]` comment), not implemented here.
- **`--activate`'s local-daemon-restart step remains legion-specific** (a no-op knob
  elsewhere per the updated `scripts/release.sh` header comment) -- not generalized,
  since no other current adopter has an equivalent local daemon.
- **CI is not wired to run `scripts/test-sync-version.sh`** (unchanged from before this
  PR); the test still SKIPs gracefully when `legion` is not on PATH, as noted in its own
  updated header comment.

Closes #741