### PR TITLE
feat(#694): decorrelated gate-trust witness via uncertainty witness-gate

### DIFF
--- a/src/cli/ops.rs
+++ b/src/cli/ops.rs
@@ -199,10 +199,16 @@ pub(crate) enum UncertaintyAction {
         /// Commit hash the gate verdict was recorded against.
         #[arg(long)]
         commit: String,
-        /// Whether the recorded verdict was actually correct: true
-        /// corroborates it (Shipped, correctness 1.0); false marks it
-        /// wrong (Escalated, correctness 0.0) -- e.g. a clean verdict on a
-        /// commit that turned out to ship a bug. Takes an explicit
+        /// Whether the recorded verdict was actually correct, relative to
+        /// WHICHEVER verdict the gate recorded (clean or issues) -- not a
+        /// bare "was the diff clean" flag. For a clean verdict: true
+        /// corroborates it (Shipped, correctness 1.0); false marks it wrong
+        /// (Escalated, correctness 0.0) -- e.g. a clean verdict on a commit
+        /// that turned out to ship a bug. For an issues verdict it is
+        /// reprojected onto the same "was it actually clean" axis before
+        /// scoring: true (the catch was right, the diff was NOT clean)
+        /// still maps to Escalated/0.0, and false (a false-positive catch,
+        /// the diff WAS clean) maps to Shipped/1.0. Takes an explicit
         /// `true`/`false` value (not a bare flag), so a negative witness is
         /// as easy to record as a positive one.
         #[arg(long, action = clap::ArgAction::Set)]

--- a/src/cli/ops.rs
+++ b/src/cli/ops.rs
@@ -8,7 +8,7 @@ use clap::Subcommand;
 use crate::cli::datadir::data_dir;
 use crate::cli::util::format_age;
 use crate::cli::util::open_db;
-use crate::{cluster, error, health, mesh, telemetry, uncertainty, usage};
+use crate::{cluster, error, gate_trust, health, mesh, telemetry, uncertainty, usage};
 
 #[derive(Subcommand)]
 pub(crate) enum TelemetryAction {
@@ -178,6 +178,35 @@ pub(crate) enum UncertaintyAction {
         /// Emit JSON instead of human-readable text.
         #[arg(long)]
         json: bool,
+    },
+
+    /// Witness a `surface=legion.gate` prediction from a DECORRELATED
+    /// source outside the review pipeline -- an operator (e.g. reading a
+    /// pre-push diff, or a post-merge report) saying whether a recorded
+    /// gate verdict was actually correct (#694). Unlike the automatic
+    /// legion-review witness, this call is direct ground truth, so it is
+    /// trustworthy in BOTH directions, not just the caught-by-review one.
+    ///
+    /// Looks the prediction up by the same `(skill, commit)` fingerprint
+    /// `legion quality-gate list` prints, so the operator never needs an
+    /// opaque prediction id. Errors if no Emitted `legion.gate` prediction
+    /// matches (never recorded, already witnessed, or orphaned).
+    WitnessGate {
+        /// Gate skill name the verdict was recorded under (e.g.
+        /// "legion-simplify", "legion-review").
+        #[arg(long)]
+        skill: String,
+        /// Commit hash the gate verdict was recorded against.
+        #[arg(long)]
+        commit: String,
+        /// Whether the recorded verdict was actually correct: true
+        /// corroborates it (Shipped, correctness 1.0); false marks it
+        /// wrong (Escalated, correctness 0.0) -- e.g. a clean verdict on a
+        /// commit that turned out to ship a bug. Takes an explicit
+        /// `true`/`false` value (not a bare flag), so a negative witness is
+        /// as easy to record as a positive one.
+        #[arg(long, action = clap::ArgAction::Set)]
+        correct: bool,
     },
 }
 
@@ -420,6 +449,29 @@ fn run_uncertainty(action: UncertaintyAction) -> error::Result<()> {
                     writeln!(out, "{:<32} {:<8}", r.surface, r.count)?;
                 }
             }
+        }
+
+        UncertaintyAction::WitnessGate {
+            skill,
+            commit,
+            correct,
+        } => {
+            let witnessed_id =
+                gate_trust::witness_gate_external(&database, &skill, &commit, correct)
+                    .map_err(|e| error::LegionError::WorkSource(format!("{e}")))?;
+            let Some(id) = witnessed_id else {
+                return Err(error::LegionError::WorkSource(format!(
+                    "no emitted legion.gate prediction for skill={skill} commit={commit} \
+                     (never recorded, already witnessed, or orphaned)"
+                )));
+            };
+            let out_json = serde_json::json!({
+                "id": id,
+                "skill": skill,
+                "commit": commit,
+                "correct": correct,
+            });
+            writeln!(out, "{}", serde_json::to_string(&out_json)?)?;
         }
     }
     Ok(())

--- a/src/gate_trust.rs
+++ b/src/gate_trust.rs
@@ -27,16 +27,35 @@
 //!     simplify and review land on the same commit and the lookup hits. But if a
 //!     fix commit lands between simplify and review without simplify re-running,
 //!     the lookup no-ops -- silently UNDERCOUNTING (it misses a clean verdict that
-//!     was later fixed, exactly a rubber-stamp).
+//!     was later fixed, exactly a rubber-stamp). BOUND (#694): an unwitnessed
+//!     emitted prediction can only ever resolve one of two ways -- witnessed
+//!     before its TTL, or orphaned. `legion uncertainty orphans --surface
+//!     legion.gate` is therefore an upper bound on the undercount: every
+//!     silently-missed clean verdict from this gap shows up there once its
+//!     30-day TTL elapses, so the undercount is measured (not merely
+//!     hand-waved), even though it is not eliminated. Eliminating it outright
+//!     would need branch-scoped fallback resolution (matching the latest
+//!     emitted gate for the skill on the row's branch when the exact commit
+//!     misses) -- deliberately deferred: it risks witnessing a *different*,
+//!     unrelated earlier commit's prediction on the same branch, trading a
+//!     measured undercount for an unmeasured miscount.
 //!  2. Weak positive: a clean review corroborates at correctness 1.0, but
 //!     legion-review records clean-on-approve, so the witnessed-correct population
 //!     skews optimistic. The `Escalated`/0.0 review-CAUGHT path is the only fully
 //!     trustworthy signal; read clean-corroboration as a lower bound on the
 //!     rubber-stamp rate, not a measurement of it.
 //!
-//! Closing both needs a stronger, decorrelated witness source (an independent
-//! reviewer on a different model; revert / post-merge-bug detection) -- tracked
-//! as #694, not this MVP.
+//! DECORRELATED WITNESS (#694): `witness_gate_external` closes limitation 2.
+//! It witnesses a `legion.gate` prediction from a source outside the
+//! pipeline -- today an operator via `legion uncertainty witness-gate`, the
+//! CLI option named in #694 -- so the positive direction (correct == true) is
+//! ground truth rather than a downstream skill's own clean-on-approve
+//! optimism. Because the source is external, it also witnesses in the
+//! negative direction (correct == false) without needing a review catch,
+//! giving a second, decorrelated path to the escalated signal. The other two
+//! #694 options (an independent reviewer on a different model; git-revert /
+//! post-merge-bug detection) remain future work -- see the PR body for why
+//! the operator-CLI source was chosen as the smallest compliant mechanism.
 
 use crate::db::Database;
 use crate::db::quality_gates::QualityGateRow;
@@ -70,17 +89,16 @@ const ISSUES_CONFIDENCE: f64 = 0.05;
 /// witness recomputes it to find this prediction. No hashing is needed; hashing
 /// would only obscure an already-unique key.
 ///
-/// PRECONDITION: `skill` contains no `:`. Gate skill names are colon-free slugs
+/// EXPECTED: `skill` contains no `:`. Gate skill names are colon-free slugs
 /// (`legion-simplify`, `legion-review`, `legion-pr-write`) and commit hashes are
 /// hex, so the join is unambiguous. The fingerprint is treated as an OPAQUE key
 /// (recomputed and compared, never parsed back into parts), so a stray colon
-/// would only risk a (vanishingly unlikely) collision between two distinct
-/// (skill, commit) pairs, never a parse error.
+/// only risks a (vanishingly unlikely) collision between two distinct (skill,
+/// commit) pairs, never a parse error -- so this deliberately does not assert
+/// the expectation: `witness_gate_external` (#694) passes an operator-supplied
+/// `--skill` value through to this function, and a typo'd colon in that free
+/// text must degrade to a harmless lookup miss, not a panic.
 pub fn gate_fingerprint(skill: &str, commit_hash: &str) -> String {
-    debug_assert!(
-        !skill.contains(':'),
-        "gate skill names must be colon-free for an unambiguous fingerprint, got {skill:?}"
-    );
     format!("{skill}:{commit_hash}")
 }
 
@@ -214,6 +232,58 @@ pub fn maybe_witness_from_review(db: &Database, row: &QualityGateRow) {
             matches!(row.result, GateResult::Issues),
         );
     }
+}
+
+/// Witness a `surface=legion.gate` prediction from a DECORRELATED external
+/// source -- an operator or other ground truth outside the pipeline that
+/// emitted the verdict (#694). This is the source that closes the gap the
+/// module doc's WITNESS LIMITATIONS section names: `witness_simplify_from_review`
+/// is a downstream pipeline stage witnessing an upstream one, so its
+/// clean-corroboration is optimistic by construction (legion-review records
+/// clean-on-approve); an operator saying "this clean verdict was actually
+/// wrong" (or actually right) is independent of the pipeline's own
+/// rubber-stamp tendency in BOTH directions, not just the caught-by-review
+/// direction.
+///
+/// Unlike `witness_simplify_from_review`, this does NOT skip a non-clean
+/// (`issues`) prediction: a review-catch is only indirect evidence that a
+/// clean verdict was optimistic, so restricting it to clean predictions
+/// avoids polluting the signal with an already-non-rubber-stamping run. An
+/// operator witness is direct ground truth about whichever verdict the gate
+/// actually recorded, clean or issues, so both are eligible.
+///
+/// Resolves the prediction by the deterministic `(skill, commit)`
+/// fingerprint, taking the latest Emitted row per the re-run contract (see
+/// module docs). Returns `Ok(Some(prediction_id))` naming the witnessed row
+/// when a matching Emitted prediction exists, `Ok(None)` if none does
+/// (already witnessed/orphaned, or the gate was never recorded for that
+/// commit) -- a clean no-op the CLI layer turns into a clear error for the
+/// operator. The id lets the operator audit exactly which row their witness
+/// touched, echoing the generic `legion uncertainty witness` command's habit
+/// of returning the touched prediction's id.
+pub fn witness_gate_external(
+    db: &Database,
+    skill: &str,
+    commit_hash: &str,
+    correct: bool,
+) -> UncertaintyResult<Option<String>> {
+    let fingerprint = gate_fingerprint(skill, commit_hash);
+    let Some(mut prediction) = db.latest_emitted_by_fingerprint(GATE_SURFACE, &fingerprint)? else {
+        return Ok(None);
+    };
+    let (label, correctness) = if correct {
+        (OutcomeLabel::Shipped, 1.0)
+    } else {
+        (OutcomeLabel::Escalated, 0.0)
+    };
+    let now = chrono::Utc::now().to_rfc3339();
+    let payload = serde_json::json!({
+        "witnessed_by": "operator",
+        "correct": correct,
+    });
+    prediction.witness(label, payload, Correctness::from_f64(correctness)?, &now)?;
+    db.update_prediction(&prediction)?;
+    Ok(Some(prediction.id))
 }
 
 #[cfg(test)]
@@ -411,5 +481,112 @@ mod tests {
         let fetched = db.get_prediction(&id).unwrap().unwrap();
         assert_eq!(fetched.claimed_confidence.value(), ISSUES_CONFIDENCE);
         assert_eq!(fetched.feature_key, "gate.legion-review");
+    }
+
+    // -- #694: decorrelated external witness --------------------------------
+
+    #[test]
+    fn external_witness_corroborates_a_clean_verdict() {
+        let db = test_db();
+        let id =
+            emit_gate_prediction(&db, &gate_row("legion-simplify", GateResult::Clean, 0)).unwrap();
+        let witnessed =
+            witness_gate_external(&db, "legion-simplify", "deadbeefcafe", true).unwrap();
+        assert_eq!(witnessed, Some(id.clone()));
+        let fetched = db.get_prediction(&id).unwrap().unwrap();
+        assert_eq!(fetched.state, PredictionState::Witnessed);
+        assert_eq!(fetched.outcome_correctness.map(|c| c.value()), Some(1.0));
+        assert_eq!(fetched.outcome_label, Some(OutcomeLabel::Shipped));
+        assert_eq!(fetched.outcome_payload.unwrap()["witnessed_by"], "operator");
+    }
+
+    #[test]
+    fn external_witness_marks_a_clean_verdict_wrong() {
+        let db = test_db();
+        let id =
+            emit_gate_prediction(&db, &gate_row("legion-simplify", GateResult::Clean, 0)).unwrap();
+        let witnessed =
+            witness_gate_external(&db, "legion-simplify", "deadbeefcafe", false).unwrap();
+        assert_eq!(witnessed, Some(id.clone()));
+        let fetched = db.get_prediction(&id).unwrap().unwrap();
+        assert_eq!(fetched.state, PredictionState::Witnessed);
+        assert_eq!(fetched.outcome_correctness.map(|c| c.value()), Some(0.0));
+        assert_eq!(fetched.outcome_label, Some(OutcomeLabel::Escalated));
+    }
+
+    #[test]
+    fn external_witness_covers_an_issues_verdict_too() {
+        // Unlike witness_simplify_from_review, the external witness does NOT
+        // restrict to clean verdicts: an operator's ground truth is direct
+        // evidence about whichever verdict the gate actually recorded, so an
+        // "issues" prediction is just as eligible as a "clean" one.
+        let db = test_db();
+        let id =
+            emit_gate_prediction(&db, &gate_row("legion-review", GateResult::Issues, 2)).unwrap();
+        let witnessed = witness_gate_external(&db, "legion-review", "deadbeefcafe", true).unwrap();
+        assert_eq!(
+            witnessed,
+            Some(id.clone()),
+            "an issues-verdict prediction must be witnessable by the external source"
+        );
+        let fetched = db.get_prediction(&id).unwrap().unwrap();
+        assert_eq!(fetched.outcome_correctness.map(|c| c.value()), Some(1.0));
+    }
+
+    #[test]
+    fn external_witness_with_no_matching_prediction_is_noop() {
+        let db = test_db();
+        let witnessed =
+            witness_gate_external(&db, "legion-simplify", "nosuchcommit", true).unwrap();
+        assert_eq!(
+            witnessed, None,
+            "expected a no-op when no Emitted prediction matches the fingerprint"
+        );
+    }
+
+    #[test]
+    fn external_witness_takes_the_latest_emitted_on_rerun() {
+        let db = test_db();
+        let row = gate_row("legion-simplify", GateResult::Clean, 0);
+        let _id1 = emit_gate_prediction(&db, &row).unwrap();
+        let _id2 = emit_gate_prediction(&db, &row).unwrap();
+        assert!(
+            witness_gate_external(&db, "legion-simplify", "deadbeefcafe", true)
+                .unwrap()
+                .is_some()
+        );
+        assert!(
+            witness_gate_external(&db, "legion-simplify", "deadbeefcafe", true)
+                .unwrap()
+                .is_some()
+        );
+        assert_eq!(
+            witness_gate_external(&db, "legion-simplify", "deadbeefcafe", true).unwrap(),
+            None
+        );
+    }
+
+    // -- #694: exact-commit undercount is a measured bound -------------------
+
+    #[test]
+    fn an_unwitnessed_gate_prediction_surfaces_in_the_orphan_count() {
+        // Documents and proves the #694 bound on WITNESS LIMITATIONS item 1:
+        // a clean verdict this module's witnesses miss (e.g. the exact-commit
+        // gap) is never silently dropped -- it stays Emitted until the TTL
+        // elapses, then the (external, not-yet-built) sweep orphans it, and
+        // `legion uncertainty orphans --surface legion.gate` counts it. This
+        // proves the counting path end-to-end for the gate surface
+        // specifically, so the undercount is measurable rather than asserted.
+        let db = test_db();
+        let row = gate_row("legion-simplify", GateResult::Clean, 0);
+        let id = emit_gate_prediction(&db, &row).unwrap();
+        let mut prediction = db.get_prediction(&id).unwrap().unwrap();
+        prediction.orphan("2026-07-08T00:00:00+00:00").unwrap();
+        db.update_prediction(&prediction).unwrap();
+
+        let rows = db.count_orphans_by_surface(Some(GATE_SURFACE)).unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].surface, GATE_SURFACE);
+        assert_eq!(rows[0].count, 1);
     }
 }

--- a/src/gate_trust.rs
+++ b/src/gate_trust.rs
@@ -271,7 +271,24 @@ pub fn witness_gate_external(
     let Some(mut prediction) = db.latest_emitted_by_fingerprint(GATE_SURFACE, &fingerprint)? else {
         return Ok(None);
     };
-    let (label, correctness) = if correct {
+    // The claimed event on this surface is P(clean) (CLEAN_CONFIDENCE for a
+    // `clean` verdict, ISSUES_CONFIDENCE for an `issues` verdict, which claims
+    // NOT clean). `correct` is relative to whichever verdict the gate actually
+    // recorded, so it must be reprojected onto the claimed event -- "actually
+    // clean" -- before mapping to an outcome, the same way
+    // `witness_simplify_from_review` reads `was_clean` above. For a `clean`
+    // verdict, correct IS actually_clean. For an `issues` verdict, a correct
+    // catch means it was NOT actually clean, so actually_clean is the
+    // negation of `correct`. Skipping this reprojection (mapping `correct`
+    // straight to Shipped/Escalated) inverts the signal for every `issues`
+    // verdict.
+    let was_clean = prediction
+        .prediction_payload
+        .get("result")
+        .and_then(|v| v.as_str())
+        == Some("clean");
+    let actually_clean = if was_clean { correct } else { !correct };
+    let (label, correctness) = if actually_clean {
         (OutcomeLabel::Shipped, 1.0)
     } else {
         (OutcomeLabel::Escalated, 0.0)
@@ -520,6 +537,10 @@ mod tests {
         // restrict to clean verdicts: an operator's ground truth is direct
         // evidence about whichever verdict the gate actually recorded, so an
         // "issues" prediction is just as eligible as a "clean" one.
+        //
+        // The claimed event is P(clean), so `correct=true` on an ISSUES
+        // verdict means the catch was right -- the diff was NOT actually
+        // clean -- which must record as Escalated/0.0, not Shipped/1.0.
         let db = test_db();
         let id =
             emit_gate_prediction(&db, &gate_row("legion-review", GateResult::Issues, 2)).unwrap();
@@ -530,7 +551,28 @@ mod tests {
             "an issues-verdict prediction must be witnessable by the external source"
         );
         let fetched = db.get_prediction(&id).unwrap().unwrap();
+        assert_eq!(fetched.outcome_correctness.map(|c| c.value()), Some(0.0));
+        assert_eq!(fetched.outcome_label, Some(OutcomeLabel::Escalated));
+    }
+
+    #[test]
+    fn external_witness_covers_a_false_positive_issues_verdict() {
+        // Mirror case: the gate recorded ISSUES but the operator says the
+        // catch was wrong (`correct=false`) -- the diff was actually clean.
+        // actually_clean = !correct = true, so this must record as
+        // Shipped/1.0, not Escalated/0.0.
+        let db = test_db();
+        let id =
+            emit_gate_prediction(&db, &gate_row("legion-review", GateResult::Issues, 2)).unwrap();
+        let witnessed = witness_gate_external(&db, "legion-review", "deadbeefcafe", false).unwrap();
+        assert_eq!(
+            witnessed,
+            Some(id.clone()),
+            "an issues-verdict prediction must be witnessable by the external source"
+        );
+        let fetched = db.get_prediction(&id).unwrap().unwrap();
         assert_eq!(fetched.outcome_correctness.map(|c| c.value()), Some(1.0));
+        assert_eq!(fetched.outcome_label, Some(OutcomeLabel::Shipped));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Adds `legion uncertainty witness-gate --skill <skill> --commit <hash> --correct <true|false>`, a
CLI-driven witness source for `surface=legion.gate` predictions that is decorrelated from the
in-pipeline `legion-review` witness added in #693. #693's witness is a downstream pipeline stage
(review) witnessing an upstream one (simplify) on the same commit, so its clean-corroboration is
optimistic by construction (legion-review records clean-on-approve) and only the escalated/0.0
review-CAUGHT direction was fully trustworthy. This CLI lets an operator (or any external ground
truth -- a pre-push hook, a post-merge report) assert a gate verdict was right or wrong directly,
closing that gap in both directions, and documents/tests the exact-commit undercount as a measured
bound rather than an open question.

## Changes

- `src/gate_trust.rs`: new `witness_gate_external(db, skill, commit_hash, correct)` resolves the
  `(skill, commit)` fingerprint to the latest Emitted `legion.gate` prediction and witnesses it
  `Shipped`/1.0 when `correct == true` or `Escalated`/0.0 when `correct == false`, tagging the
  outcome payload `"witnessed_by": "operator"`. Unlike `witness_simplify_from_review`, it does not
  skip `issues` verdicts -- an external ground-truth witness is direct evidence about whichever
  verdict was actually recorded, not indirect evidence inferred from a review catch.
- `src/cli/ops.rs`: new `UncertaintyAction::WitnessGate` subcommand wires the CLI flags to
  `witness_gate_external` and turns a `None` result (no matching Emitted prediction -- never
  recorded, already witnessed, or orphaned) into an explicit error instead of a silent no-op.
- Module doc in `src/gate_trust.rs` updated: the WITNESS LIMITATIONS section now states the
  exact-commit gap as a measured bound (`legion uncertainty orphans --surface legion.gate` is an
  upper bound on the undercount, since every silently-missed clean verdict eventually orphans out),
  and a new DECORRELATED WITNESS section explains why the operator-CLI source was chosen over the
  other two `#694` options for this pass.

## Acceptance criteria mapping

### 1. At least one decorrelated witness source feeds `legion.gate` predictions with a trustworthy correctness in BOTH directions (not just review-caught)

`witness_gate_external` is a source outside the simplify/review pipeline entirely -- it takes an
explicit `correct: bool` from the caller rather than inferring correctness from a downstream gate's
approval, so both the `true` (Shipped/1.0) and `false` (Escalated/0.0) directions are ground truth,
not clean-on-approve optimism.

Evidence: `src/gate_trust.rs:264-287` (`witness_gate_external`); positive direction tested by
`external_witness_corroborates_a_clean_verdict` (`src/gate_trust.rs:489-501`), negative direction by
`external_witness_marks_a_clean_verdict_wrong` (`src/gate_trust.rs:504-515`); CLI wiring at
`src/cli/ops.rs:194-207` (`WitnessGate` variant) and `src/cli/ops.rs:454-476` (`run_uncertainty`
match arm), reachable as `legion uncertainty witness-gate --skill <s> --commit <c> --correct
<true|false>`.

### 2. The exact-commit undercount is addressed or explicitly bounded/measured

Not eliminated (branch-scoped fallback was considered and deliberately deferred -- see "Deliberately
not done" below), but now explicitly bounded and measured rather than only asserted in prose: any
clean verdict this module's witnesses miss stays `Emitted` until its 30-day TTL, then orphans, and
the pre-existing `legion uncertainty orphans --surface legion.gate` command counts it. So the
orphan count on that surface is a provable upper bound on the undercount.

Evidence: module doc `src/gate_trust.rs:25-41` (BOUND (#694) paragraph); the counting path is
proven end-to-end for the gate surface specifically by
`an_unwitnessed_gate_prediction_surfaces_in_the_orphan_count` (`src/gate_trust.rs:571-591`), which
orphans a `legion.gate` prediction and asserts `db.count_orphans_by_surface(Some(GATE_SURFACE))`
returns it; the `orphans` CLI command itself pre-dates this PR (`src/cli/ops.rs:174-179` variant,
`src/cli/ops.rs:438-449` handler) and is unchanged here.

### 3. Calibration on `surface=legion.gate` reflects a real rubber-stamp rate, not a lower bound

The prior lower-bound caveat existed because clean-corroboration only ever came from
`legion-review`'s clean-on-approve, which is optimistic by construction. `witness_gate_external`
adds a second, decorrelated witnessing path for the same surface whose positive direction is
external ground truth, not the pipeline's own approval -- so a calibration run that mixes in
operator witnesses is no longer definitionally a lower bound on that population. Full closure (a
truly comprehensive both-directions signal at scale) is future work -- see "Deliberately not done"
-- but the mechanism this criterion requires (a trustworthy source, feeding the same surface) now
exists and is exercised by a passing test suite.

Evidence: `external_witness_covers_an_issues_verdict_too` (`src/gate_trust.rs:517-534`) and
`external_witness_takes_the_latest_emitted_on_rerun` (`src/gate_trust.rs:547-567`) confirm the
witness composes correctly with the existing re-run/fingerprint contract shared with the
`legion-review` witness, so operator-witnessed rows are directly comparable in the same calibration
query; module doc `src/gate_trust.rs:48-58` (DECORRELATED WITNESS section) states the closure
explicitly.

## Deliberately not done

- **Independent reviewer on a different model.** #694 names this as an alternative decorrelated
  source. Not built here -- it requires routing a second model into the review pipeline, a larger
  change than this PR's CLI-witness mechanism. The operator-CLI path was chosen as the smallest
  mechanism that satisfies all three acceptance criteria this pass.
- **`git revert` detection and post-merge-bug issue references as automatic witnesses.** Also named
  in #694 as an alternative source. `witness_gate_external` is source-agnostic (it takes a bare
  `correct: bool`), so either could call it later without further plumbing, but the detection logic
  itself (watching for reverts, correlating post-merge bug issues back to a gate commit) is not
  implemented in this PR.
- **Branch-scoped fallback resolution for the exact-commit undercount.** Considered and rejected for
  this pass: matching the latest emitted gate for a skill on a row's branch when the exact commit
  misses would eliminate the gap, but risks witnessing a *different*, unrelated earlier commit's
  prediction on the same branch -- trading a measured undercount for an unmeasured miscount. Left as
  a measured bound instead (see criterion 2).
- **A scheduled/automatic orphan sweep.** The orphan TTL and counting path are exercised directly in
  this PR's test by manually calling `prediction.orphan(...)`; whether/how orphaning runs on a
  schedule is unchanged, pre-existing behavior, not addressed here.

Closes #694