### PR TITLE
fix(#761): pr merge gates on failing check-runs, not just absence

### DIFF
--- a/src/cli/pr.rs
+++ b/src/cli/pr.rs
@@ -211,6 +211,14 @@ pub(crate) enum PrAction {
         /// Kanban card ID to transition to done
         #[arg(long)]
         task: Option<String>,
+
+        /// Operator override: merge despite failing check-runs on the head
+        /// SHA. Writes an audit entry naming the failing checks (mirrors
+        /// `pr create --skip-gates`). Does not affect the #736 zero-runs
+        /// refusal, which still fires first -- this only overrides the
+        /// present-and-failing case.
+        #[arg(long)]
+        merge_despite_failures: bool,
     },
 
     /// Close a pull request without merging
@@ -241,6 +249,19 @@ fn no_runs_for_head_error(head_sha: &str, number: u64, source_repo: &str) -> err
     error::LegionError::WorkSource(format!(
         "no runs for head {head_sha}: PR #{number} on {source_repo} has zero check runs \
          for its head commit (not the branch's last suite)"
+    ))
+}
+
+/// Shared refusal for a PR head with one or more check-runs in a failing
+/// state (see `ExternalPRCheck::is_failing`). `legion pr checks` and `legion
+/// pr merge` both classify with the same predicate and must name the same
+/// failing checks the same way.
+fn failing_checks_error(failed: &[&str], number: u64) -> error::LegionError {
+    error::LegionError::WorkSource(format!(
+        "{} check(s) failed on PR #{}: {}",
+        failed.len(),
+        number,
+        failed.join(", ")
     ))
 }
 
@@ -521,12 +542,7 @@ pub(crate) fn handle(action: PrAction) -> error::Result<()> {
                 .map(|c| c.name.as_str())
                 .collect();
             if !failed.is_empty() {
-                return Err(error::LegionError::WorkSource(format!(
-                    "{} check(s) failed on PR #{}: {}",
-                    failed.len(),
-                    number,
-                    failed.join(", ")
-                )));
+                return Err(failing_checks_error(&failed, number));
             }
         }
         PrAction::View { repo, number, json } => {
@@ -715,6 +731,7 @@ pub(crate) fn handle(action: PrAction) -> error::Result<()> {
             strategy,
             keep_branch,
             task,
+            merge_despite_failures,
         } => {
             let (plugin_name, source_repo, _workdir) = worksource::require_worksource(&repo)?;
             let database = open_db()?;
@@ -725,13 +742,6 @@ pub(crate) fn handle(action: PrAction) -> error::Result<()> {
             // here (not left to branch protection) because a repo without a
             // required-status-checks rule would otherwise let an untested
             // head merge silently.
-            //
-            // Deliberately narrow: this refuses only the zero-runs state,
-            // not a head with checks that are actively failing. Merge never
-            // gated on failing checks before this change either (the plugin's
-            // own merge case only inspects reviewDecision) -- expanding that
-            // is a separate concern from #736's zero-runs false-green bug and
-            // left to the repo's own branch protection / required checks.
             let checks_result = worksource::pr_checks(&plugin_name, &source_repo, number)?;
             if checks_result.checks.is_empty() {
                 return Err(no_runs_for_head_error(
@@ -739,6 +749,48 @@ pub(crate) fn handle(action: PrAction) -> error::Result<()> {
                     number,
                     &source_repo,
                 ));
+            }
+
+            // #761: gate on PRESENT-AND-FAILING check-runs too, not just
+            // absence. Same classification `legion pr checks` uses
+            // (`ExternalPRCheck::is_failing`) so a red required check-run
+            // cannot be merged through legion without branch protection
+            // noticing -- this matters on repos with admin-bypass merge
+            // rules, where branch protection alone would not stop it.
+            // `--merge-despite-failures` is the operator's audited escape
+            // hatch (mirrors `pr create --skip-gates`): it does not touch
+            // the zero-runs refusal above, which still fires first.
+            let failed: Vec<&str> = checks_result
+                .checks
+                .iter()
+                .filter(|c| c.is_failing())
+                .map(|c| c.name.as_str())
+                .collect();
+            if !failed.is_empty() {
+                if !merge_despite_failures {
+                    return Err(failing_checks_error(&failed, number));
+                }
+                let details = serde_json::json!({ "failing_checks": failed }).to_string();
+                audit(
+                    &database,
+                    &db::AuditInput {
+                        agent: &repo,
+                        action: "merge-despite-failures",
+                        target_type: "pr",
+                        target_ref: &number.to_string(),
+                        task_id: task.as_deref(),
+                        source_type: &plugin_name,
+                        details: Some(&details),
+                        outcome: "overridden",
+                    },
+                );
+                eprintln!(
+                    "[legion] warning: merging PR #{} despite {} failing check(s): {} \
+                     (--merge-despite-failures override, audit-logged)",
+                    number,
+                    failed.len(),
+                    failed.join(", ")
+                );
             }
 
             let merge_outcome =

--- a/tests/integration/worksource_pr.rs
+++ b/tests/integration/worksource_pr.rs
@@ -558,6 +558,146 @@ fn pr_merge_refuses_when_head_has_zero_runs() {
 }
 
 // ---------------------------------------------------------------------------
+// #761: `legion pr merge` gates on PRESENT-AND-FAILING check-runs too, not
+// just absence -- #736 only covered the zero-runs case. Same `is_failing()`
+// classification `legion pr checks` uses.
+// ---------------------------------------------------------------------------
+
+/// `legion pr merge` refuses when the head SHA has a check-run in a failing
+/// state, naming the failing check -- and never invokes the plugin's `merge`
+/// subcommand (this stub does not implement it; a call would fail the test
+/// with "unknown subcommand" instead of the expected refusal, proving merge
+/// is gated before the plugin call).
+#[cfg(unix)]
+#[test]
+fn pr_merge_refuses_when_head_has_failing_checks() {
+    let data_dir = tempfile::tempdir().unwrap();
+    let plugin_root = tempfile::tempdir().unwrap();
+    let body = pr_checks_only_stub(
+        r#"{"headSha":"cafef00d","checks":[{"name":"Clippy","state":"FAILURE","workflow":"CI","link":"https://github.com/ex/ex/actions/runs/1/job/1","description":""}]}"#,
+    );
+    setup_pr_read_stub(data_dir.path(), plugin_root.path(), &body);
+
+    let (_stdout, stderr) = run_fail(
+        pr_read_cmd(data_dir.path(), plugin_root.path())
+            .args(["pr", "merge", "--repo", "stub", "--number", "42"]),
+    );
+    assert!(
+        stderr.contains("1 check(s) failed on PR #42"),
+        "expected the failing-checks refusal, got: {stderr}"
+    );
+    assert!(
+        stderr.contains("Clippy"),
+        "expected the failing check name in the refusal, got: {stderr}"
+    );
+}
+
+/// Stub worksource plugin for the failing-checks override test: `pr-checks`
+/// reports one FAILURE check on the pinned head SHA, `merge` succeeds
+/// (direct, non-queued), `close` exits 0 for the linked-issue path.
+#[cfg(unix)]
+fn pr_merge_failing_check_stub_plugin() -> String {
+    r#"#!/bin/bash
+set -e
+case "${1:-}" in
+  pr-checks)
+    cat <<'BODY'
+{"headSha":"cafef00d","checks":[{"name":"Clippy","state":"FAILURE","workflow":"CI","link":"https://github.com/ex/ex/actions/runs/1/job/1","description":""}]}
+BODY
+    ;;
+  merge)
+    echo '{"queued":false}'
+    ;;
+  close)
+    exit 0
+    ;;
+  *)
+    echo "stub: unknown subcommand $1" >&2
+    exit 2
+    ;;
+esac
+"#
+    .to_string()
+}
+
+/// `--merge-despite-failures` overrides the failing-checks refusal, actually
+/// merges, and writes an audit row naming the failing check -- the operator
+/// escape hatch mirroring `pr create --skip-gates`.
+#[cfg(unix)]
+#[test]
+fn pr_merge_despite_failures_overrides_and_audit_logs() {
+    let data_dir = tempfile::tempdir().unwrap();
+    let plugin_root = tempfile::tempdir().unwrap();
+    setup_pr_read_stub(
+        data_dir.path(),
+        plugin_root.path(),
+        &pr_merge_failing_check_stub_plugin(),
+    );
+
+    let out = run_ok_output(pr_read_cmd(data_dir.path(), plugin_root.path()).args([
+        "pr",
+        "merge",
+        "--repo",
+        "stub",
+        "--number",
+        "42",
+        "--merge-despite-failures",
+    ]));
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stdout.contains("PR #42 merged on owner/stub"),
+        "expected the override to still complete the merge, got: {stdout}"
+    );
+    assert!(
+        stderr.contains("Clippy"),
+        "expected the override warning to name the failing check, got: {stderr}"
+    );
+
+    let audit_out = run_ok(legion_cmd(data_dir.path()).args([
+        "audit",
+        "--action",
+        "merge-despite-failures",
+        "--json",
+    ]));
+    assert!(
+        audit_out.contains("Clippy"),
+        "expected the audit row to record the failing check name, got: {audit_out}"
+    );
+    assert!(
+        audit_out.contains("overridden"),
+        "expected the audit row outcome to mark this as an override, got: {audit_out}"
+    );
+}
+
+/// The #736 zero-runs refusal still fires first: `--merge-despite-failures`
+/// does not also waive the "no runs for head" state -- zero runs is absence,
+/// not a failing check-run, and is a different failure mode this flag does
+/// not cover.
+#[cfg(unix)]
+#[test]
+fn pr_merge_despite_failures_does_not_override_zero_runs_refusal() {
+    let data_dir = tempfile::tempdir().unwrap();
+    let plugin_root = tempfile::tempdir().unwrap();
+    let body = pr_checks_only_stub(r#"{"headSha":"ec3825b","checks":[]}"#);
+    setup_pr_read_stub(data_dir.path(), plugin_root.path(), &body);
+
+    let (_stdout, stderr) = run_fail(pr_read_cmd(data_dir.path(), plugin_root.path()).args([
+        "pr",
+        "merge",
+        "--repo",
+        "stub",
+        "--number",
+        "735",
+        "--merge-despite-failures",
+    ]));
+    assert!(
+        stderr.contains("no runs for head ec3825b"),
+        "expected the zero-runs refusal to still fire despite the override flag, got: {stderr}"
+    );
+}
+
+// ---------------------------------------------------------------------------
 // #630: merge-queue support. The plugin's `merge` subcommand now reports
 // whether it merged the PR directly or enqueued it onto the base branch's
 // merge queue via `{"queued": <bool>}`. These tests stub that boundary --


### PR DESCRIPTION
## Summary

`legion pr merge` fail-closed on a head SHA with zero check-runs (#736) but had no gate at
all on a head with check-runs that are PRESENT and FAILING -- a red required check could be
merged through legion without branch protection ever noticing, which matters on this repo
because it runs squash-merge with admin-bypass rules. This change reuses the exact
`ExternalPRCheck::is_failing()` classification `legion pr checks` already uses, refuses the
merge naming the failing checks, and adds an audited operator override
(`--merge-despite-failures`) that mirrors the existing `pr create --skip-gates` escape hatch.

## Acceptance criteria mapping

### 1. `legion pr merge` refuses when any check-run/status for the head SHA is in a failing state, with an error naming the failing checks

The `Merge` arm in `src/cli/pr.rs` (the "Merge" case, ~line 728 onward) now filters
`checks_result.checks` with `.filter(|c| c.is_failing())` -- the same predicate `is_failing()`
on `ExternalPRCheck` (`src/worksource/prs.rs:133`) that `pr checks` already uses -- and, when
that list is non-empty and the override flag is not set, returns
`failing_checks_error(&failed, number)`. I extracted `failing_checks_error` as a shared
helper (new function, `src/cli/pr.rs` ~line 255) instead of duplicating the format string,
and switched the existing `Checks` handler to call it too, so both commands emit byte-identical
wording: `"N check(s) failed on PR #<number>: <names>"`.

The issue's Build Notes correct the original text's `PR_CHECK_FAILING_STATES` reference --
that constant is `#[allow(dead_code)]`, referenced only by a partition test -- to
`is_failing()` / `PR_CHECK_PASSING_STATES`, which is what this change actually reuses.

Evidence: `pr_merge_refuses_when_head_has_failing_checks` (`tests/integration/worksource_pr.rs`)
stubs a FAILURE check and asserts stderr contains `"1 check(s) failed on PR #42"` and the
check name `"Clippy"`; the stub deliberately omits a `merge` subcommand implementation so a
call to it would fail the test with "unknown subcommand" instead of the expected refusal,
proving the gate fires before the plugin's merge is ever invoked.

### 2. An override flag exists, is audit-logged with the failing check names, and is not part of any agent-facing doctrine

`--merge-despite-failures` is a new bool flag on `PrAction::Merge` (`src/cli/pr.rs`, the
`Merge` variant). When failing checks are present and the flag is set, the Merge arm writes
an `audit()` row (`src/cli/util.rs:34`, the same best-effort audit helper every other action
in this file uses) with `action: "merge-despite-failures"`, `outcome: "overridden"`, and
`details` containing the JSON `{"failing_checks": [...]}` array of the failing check names --
mirroring the existing `skip-gate-bootstrap` audit call on `pr create --skip-gates`
(`src/cli/pr.rs` ~line 276) both in shape and in writing the audit entry before proceeding,
plus an `eprintln!` warning naming the checks so the operator sees it live, not just in the
log. This is a CLI flag documented only in `--help` text and this PR/issue -- it is not added
to any legion reflection, `whatami` doctrine, or agent-facing skill instructions, so an agent
following its normal workflow doctrine will not discover or reach for it.

Evidence: `pr_merge_despite_failures_overrides_and_audit_logs` asserts the merge completes
(`"PR #42 merged on owner/stub"`), the stderr warning names the failing check (`"Clippy"`),
and `legion audit --action merge-despite-failures --json` returns a row containing both
`"Clippy"` and `"overridden"`.

### 3. Tests: refuses on a failing run; override merges and audit-logs; passing and zero-run behavior unchanged (zero-run refusal from #736 still fires first)

Four new/verified tests in `tests/integration/worksource_pr.rs`:
- `pr_merge_refuses_when_head_has_failing_checks` -- refusal case (maps to criterion 1).
- `pr_merge_despite_failures_overrides_and_audit_logs` -- override + audit case (criterion 2).
- `pr_merge_despite_failures_does_not_override_zero_runs_refusal` -- passes
  `--merge-despite-failures` against a zero-runs stub and asserts the `"no runs for head
  ec3825b"` refusal still fires, proving the new flag does not waive the #736 gate, which
  the Build Notes' Merge-arm citation (~line 728-745 pre-change) confirmed still runs first
  in code order (the zero-runs check is unconditional and returns before the new
  failing-checks block is ever reached).
- Passing-checks and zero-run behavior unchanged: the pre-existing
  `pr_merge_direct_when_not_queued_behaves_as_before`, `pr_merge_enqueues_when_queued_...`,
  and `pr_merge_refuses_when_head_has_zero_runs` tests all still pass unmodified (full suite:
  `cargo test` -- 293 passed, 0 failed, 2 ignored).

Evidence: `cargo test` run at HEAD -- 293 passed; `cargo clippy --all-targets -- -D warnings`
clean; `cargo fmt -- --check` clean.

## Not done

- The sibling LOW from the same review (check-run `workflow` field falling back to
  `.app.name` so `pr checks --log-failed` degrades to "log unavailable" for per-workflow log
  fetch) is not touched. The issue marks it "fix only if touching the same code" -- this
  change touches `src/cli/pr.rs`'s error-handling and gating logic, not the plugin's check-run
  normalization in `plugin/worksources/github`, so it is out of scope here.
- The `pr merge --subject` idea from #776 is explicitly deferred per the Build Notes (it
  collides with this arm) and is not implemented.
- `--merge-despite-failures` is not added to the `Commands::Audit` CLI help's "Known verbs"
  list (`src/cli/mod.rs` ~line 735-740) -- that list already omits the existing
  `skip-gate-bootstrap` verb from `pr create --skip-gates`, so leaving the new override verb
  out too matches that established precedent (the doc comment itself says additional verbs
  work automatically without being listed).

Closes #761
