### PR TITLE
feat(#772): wire sym imports/importers over module_edges

### DIFF
--- a/src/cli/index_cmd.rs
+++ b/src/cli/index_cmd.rs
@@ -743,6 +743,15 @@ fn run_sym_edges(
 ) -> error::Result<()> {
     use std::io::Write;
 
+    // An empty `file` argument is a suffix of every path (`"".ends_with("")`
+    // and `s.ends_with("")` are both always true), so without this guard the
+    // suffix match in `list_module_edges_from`/`_to` would silently return
+    // every edge in scope instead of erroring on a clearly-wrong query.
+    if file.trim().is_empty() {
+        eprintln!("[legion] file argument must not be empty");
+        return Err(error::LegionError::ExitWith(2));
+    }
+
     if !module_edges_indexed(database, repo.as_deref())? {
         eprintln!("{}", module_edges_no_index_message(repo.as_deref()));
         return Err(error::LegionError::ExitWith(1));

--- a/src/cli/index_cmd.rs
+++ b/src/cli/index_cmd.rs
@@ -131,6 +131,34 @@ pub(crate) enum SymAction {
         #[arg(long)]
         json: bool,
     },
+
+    /// What this file imports -- one row per static/dynamic import in a
+    /// js/ts/jsx/tsx file, resolved (to = Some) or unresolved/external
+    /// (to = None). Direct edges only; no transitive/re-export resolution.
+    Imports {
+        /// Importer file: exact repo-relative path or a path-suffix
+        /// (mirrors `sym list --file` matching).
+        file: String,
+        /// Restrict to a single repo (default: every indexed repo)
+        #[arg(long)]
+        repo: Option<String>,
+        /// Emit results as the #746 freshness envelope
+        #[arg(long)]
+        json: bool,
+    },
+
+    /// What imports this file -- every edge that resolved to it. Answers
+    /// the "who consumes X" question SCIP symbol-refs cannot.
+    Importers {
+        /// Importee file: exact repo-relative path or a path-suffix.
+        file: String,
+        /// Restrict to a single repo (default: every indexed repo)
+        #[arg(long)]
+        repo: Option<String>,
+        /// Emit results as the #746 freshness envelope
+        #[arg(long)]
+        json: bool,
+    },
 }
 
 #[derive(Subcommand)]
@@ -277,6 +305,8 @@ fn run_sym_action(database: &db::Database, action: SymAction) -> error::Result<(
             file,
             json,
         } => run_sym_list(database, repo, lang, kind, file, json),
+        SymAction::Imports { file, repo, json } => run_sym_imports(database, file, repo, json),
+        SymAction::Importers { file, repo, json } => run_sym_importers(database, file, repo, json),
         SymAction::Tree {
             repo,
             ext,
@@ -588,6 +618,207 @@ fn run_sym_list(
         }
     }
     Ok(())
+}
+
+/// One row in `sym imports`/`sym importers`' output: a `graph::ImportEdge`
+/// decoupled into its own JSON-facing shape (mirrors `CssSymbolHit`, #744)
+/// so a future change to the internal graph-edge type does not silently
+/// reshape the CLI's `--json` contract.
+#[derive(Debug, serde::Serialize)]
+struct ImportEdgeHit {
+    repo: String,
+    from: String,
+    specifier: String,
+    to: Option<String>,
+}
+
+impl From<graph::ImportEdge> for ImportEdgeHit {
+    fn from(e: graph::ImportEdge) -> Self {
+        Self {
+            repo: e.repo,
+            from: e.from,
+            specifier: e.specifier,
+            to: e.to,
+        }
+    }
+}
+
+/// Every repo `sym imports`/`sym importers` should query: just `repo` itself
+/// when given, else every repo with at least one `file_inventory` row.
+///
+/// Deliberately NOT narrowed by extension the way `css_repo_scope` narrows
+/// to `ext = "css"`: `module_edges` is populated only for js/ts/jsx/tsx
+/// files (`build_module_graph`), so a cleanly indexed pure-Rust (or
+/// mixed-language) repo has zero edges forever but is still indexed --
+/// narrowing this scope by extension would make such a repo invisible to a
+/// cross-repo query instead of correctly contributing an empty result
+/// (Build Notes, #772).
+fn module_edges_repo_scope(
+    database: &db::Database,
+    repo: Option<&str>,
+) -> error::Result<Vec<String>> {
+    if let Some(r) = repo {
+        return Ok(vec![r.to_string()]);
+    }
+    let entries = database.list_file_inventory(&db::inventory::InventoryFilter {
+        repo: None,
+        ext: None,
+        lang: None,
+    })?;
+    let mut repos: Vec<String> = entries.into_iter().map(|e| e.repo).collect();
+    repos.sort();
+    repos.dedup();
+    Ok(repos)
+}
+
+/// True when `repo` (or, when `None`, any repo at all) has at least one
+/// `file_inventory` row -- "has `legion index` ever run here", not "does
+/// this repo have js/ts files" and not "does this file have edges".
+///
+/// Keying off `file_inventory` rather than `module_edges` rowcount matters:
+/// `module_edges` is js/ts/jsx/tsx-only, so a cleanly indexed pure-Rust repo
+/// has zero `module_edges` rows forever and would otherwise false-error as
+/// "never indexed" on every `sym imports`/`sym importers` call -- the same
+/// misroute class `css_symbol_no_index_message` prevents for `--lang css`,
+/// but mirrored without the ext filter since the js/ts narrowing that is
+/// correct for css is exactly what would break here (Build Notes, #772).
+fn module_edges_indexed(database: &db::Database, repo: Option<&str>) -> error::Result<bool> {
+    let entries = database.list_file_inventory(&db::inventory::InventoryFilter {
+        repo,
+        ext: None,
+        lang: None,
+    })?;
+    Ok(!entries.is_empty())
+}
+
+/// `sym imports`/`sym importers`'s "never indexed" error message, mirroring
+/// `css_symbol_no_index_message`'s shape and fix-hint wording.
+fn module_edges_no_index_message(repo: Option<&str>) -> String {
+    let scope = repo.unwrap_or("(any repo)");
+    format!("[legion] no index found for {scope}; run `legion index {scope}` first")
+}
+
+/// Print one line per edge in the `sym list` house style: specifier, the
+/// from -> to arrow (an unresolved/external edge prints `unresolved`
+/// instead of a path -- it is shown, not dropped), then the owning repo.
+/// Shared by `run_sym_imports`/`run_sym_importers`; the two commands differ
+/// only in which DB method produced `hits` and which "matched nothing"
+/// hint to print.
+fn print_import_edge_hits(
+    out: &mut impl std::io::Write,
+    hits: &[ImportEdgeHit],
+) -> error::Result<()> {
+    for h in hits {
+        let to_col = h.to.as_deref().unwrap_or("unresolved");
+        writeln!(
+            out,
+            "{}\t{} -> {}\t[{}]",
+            h.specifier, h.from, to_col, h.repo
+        )?;
+    }
+    Ok(())
+}
+
+/// Shared implementation for `sym imports`/`sym importers` (#772):
+/// never-indexed check, the `module_edges_repo_scope` loop, freshness
+/// computation, and the human/`--json` output shapes. The two commands
+/// differ only in which DB method produces edges (`list_module_edges_from`
+/// vs `list_module_edges_to`, passed as `query_edges`) and which "matched
+/// nothing" hint to print (`empty_message`).
+///
+/// Unresolved/external edges (`to: None`) are included, not dropped -- an
+/// agent needs to see the dangling `lodash` / broken-relative import.
+///
+/// `--json` wraps results in the #746 `FreshJsonEnvelope` (mirroring
+/// `run_sym_tree`), never a bare array -- `run_css_sym_list`'s bare-array
+/// `--json` is the anti-pattern this issue deliberately does not copy,
+/// since a graph answer is only as good as the last index.
+fn run_sym_edges(
+    database: &db::Database,
+    file: String,
+    repo: Option<String>,
+    json: bool,
+    empty_message: &str,
+    query_edges: impl Fn(&db::Database, &str, &str) -> error::Result<Vec<graph::ImportEdge>>,
+) -> error::Result<()> {
+    use std::io::Write;
+
+    if !module_edges_indexed(database, repo.as_deref())? {
+        eprintln!("{}", module_edges_no_index_message(repo.as_deref()));
+        return Err(error::LegionError::ExitWith(1));
+    }
+
+    let repos = module_edges_repo_scope(database, repo.as_deref())?;
+    let mut hits = Vec::new();
+    for r in &repos {
+        let edges = query_edges(database, r, &file)?;
+        hits.extend(edges.into_iter().map(ImportEdgeHit::from));
+    }
+
+    let snapshots = compute_freshness(
+        database,
+        repo.as_deref(),
+        hits.iter().map(|h| h.repo.as_str()),
+    )?;
+
+    let stdout = std::io::stdout();
+    let mut out = stdout.lock();
+    if json {
+        let envelope = FreshJsonEnvelope {
+            snapshots,
+            entries: hits,
+        };
+        serde_json::to_writer(&mut out, &envelope)?;
+        writeln!(out)?;
+    } else {
+        let now = chrono::Utc::now();
+        for s in &snapshots {
+            eprintln!("[legion] {}", format_freshness_line(s, now));
+        }
+        print_import_edge_hits(&mut out, &hits)?;
+        if hits.is_empty() {
+            eprintln!("[legion] {empty_message}");
+        }
+    }
+    Ok(())
+}
+
+/// `sym imports <file>` (#772): every edge whose importer matches `file`
+/// (exact path or suffix, `Database::list_module_edges_from`). See
+/// `run_sym_edges` for the shared implementation.
+fn run_sym_imports(
+    database: &db::Database,
+    file: String,
+    repo: Option<String>,
+    json: bool,
+) -> error::Result<()> {
+    run_sym_edges(
+        database,
+        file,
+        repo,
+        json,
+        "no imports found",
+        db::Database::list_module_edges_from,
+    )
+}
+
+/// `sym importers <file>` (#772): every edge that resolved to `file` (exact
+/// path or suffix, `Database::list_module_edges_to`). See `run_sym_edges`
+/// for the shared implementation.
+fn run_sym_importers(
+    database: &db::Database,
+    file: String,
+    repo: Option<String>,
+    json: bool,
+) -> error::Result<()> {
+    run_sym_edges(
+        database,
+        file,
+        repo,
+        json,
+        "no importers found",
+        db::Database::list_module_edges_to,
+    )
 }
 
 /// One row in `sym tree`'s structured output: the file-inventory columns

--- a/src/db/module_edges.rs
+++ b/src/db/module_edges.rs
@@ -92,46 +92,56 @@ impl Database {
         Ok(())
     }
 
-    /// Return every edge whose importer is `from_path` -- "what does this
-    /// file import" -- ordered by specifier for stable output.
+    /// Return every edge whose importer matches `from_path` -- "what does
+    /// this file import" -- ordered by specifier for stable output.
     ///
-    /// Not yet wired to a CLI surface -- #710 only populates the table via
-    /// `legion index` (see `handle_index` in `src/cli/index_cmd.rs`). No
-    /// issue is filed yet for the query commands (`sym imports` /
-    /// `sym importers`, or similar) that would call this; this is the query
-    /// API they will use once one is. Exercised directly by this module's
-    /// tests in the meantime.
-    #[allow(dead_code)]
+    /// `from_path` matches exactly OR as a path suffix, mirroring `sym list
+    /// --file`'s semantics (`sym::query_symbols`, `src/sym.rs:303-306`): the
+    /// SQL filter narrows to `repo` only, and the exact/suffix match runs
+    /// Rust-side via `retain` (same shape as `list_css_symbols`,
+    /// `src/db/css_symbols.rs:193-195`) so a bare `Button.tsx` resolves
+    /// instead of silent-empty. This bypasses the `module_edges` indexes --
+    /// accepted at per-repo sizes (#772).
+    ///
+    /// Backs `sym imports` (`src/cli/index_cmd.rs`).
     pub fn list_module_edges_from(&self, repo: &str, from_path: &str) -> Result<Vec<ImportEdge>> {
         let mut stmt = self.conn.prepare(
             "SELECT repo, from_path, specifier, to_path
              FROM module_edges
-             WHERE repo = ?1 AND from_path = ?2
+             WHERE repo = ?1
              ORDER BY specifier",
         )?;
-        let rows = stmt
-            .query_map(rusqlite::params![repo, from_path], row_to_edge)?
+        let mut rows = stmt
+            .query_map(rusqlite::params![repo], row_to_edge)?
             .collect::<std::result::Result<Vec<_>, _>>()?;
+        rows.retain(|e| e.from == from_path || e.from.ends_with(from_path));
         Ok(rows)
     }
 
-    /// Return every edge that resolved to `to_path` -- "what imports this
-    /// file" -- ordered by importer path for stable output. Edges with
-    /// `to_path IS NULL` (unresolved/external) never match; there is
-    /// nothing to look up an importee for.
+    /// Return every edge that resolved to a `to_path` matching `to_path` --
+    /// "what imports this file" -- ordered by importer path for stable
+    /// output. Edges with `to_path IS NULL` (unresolved/external) never
+    /// match; there is nothing to look up an importee for.
     ///
-    /// Not yet wired to a CLI surface; see `list_module_edges_from`.
-    #[allow(dead_code)]
+    /// `to_path` matches exactly OR as a path suffix; see
+    /// `list_module_edges_from`'s doc comment for the matching rationale
+    /// and the SQL/Rust split it uses.
+    ///
+    /// Backs `sym importers` (`src/cli/index_cmd.rs`).
     pub fn list_module_edges_to(&self, repo: &str, to_path: &str) -> Result<Vec<ImportEdge>> {
         let mut stmt = self.conn.prepare(
             "SELECT repo, from_path, specifier, to_path
              FROM module_edges
-             WHERE repo = ?1 AND to_path = ?2
+             WHERE repo = ?1
              ORDER BY from_path",
         )?;
-        let rows = stmt
-            .query_map(rusqlite::params![repo, to_path], row_to_edge)?
+        let mut rows = stmt
+            .query_map(rusqlite::params![repo], row_to_edge)?
             .collect::<std::result::Result<Vec<_>, _>>()?;
+        rows.retain(|e| {
+            e.to.as_deref()
+                .is_some_and(|t| t == to_path || t.ends_with(to_path))
+        });
         Ok(rows)
     }
 
@@ -380,5 +390,97 @@ mod tests {
         let got = db.list_module_edges_from("alpha", "src/a.ts").unwrap();
         assert_eq!(got.len(), 1);
         assert_eq!(got[0].repo, "alpha");
+    }
+
+    #[test]
+    fn list_from_matches_a_path_suffix() {
+        let db = test_db();
+        db.upsert_module_edges(
+            "r",
+            &["src/components/Button.tsx"],
+            &[edge(
+                "r",
+                "src/components/Button.tsx",
+                "./icon",
+                Some("src/components/Icon.tsx"),
+            )],
+        )
+        .unwrap();
+
+        let got = db.list_module_edges_from("r", "Button.tsx").unwrap();
+        assert_eq!(
+            got.len(),
+            1,
+            "a bare basename suffix must resolve, not silent-empty, got {got:?}"
+        );
+        assert_eq!(got[0].from, "src/components/Button.tsx");
+    }
+
+    #[test]
+    fn list_to_matches_a_path_suffix() {
+        let db = test_db();
+        db.upsert_module_edges(
+            "r",
+            &["src/a.ts"],
+            &[edge(
+                "r",
+                "src/a.ts",
+                "./components/Icon",
+                Some("src/components/Icon.tsx"),
+            )],
+        )
+        .unwrap();
+
+        let got = db.list_module_edges_to("r", "Icon.tsx").unwrap();
+        assert_eq!(
+            got.len(),
+            1,
+            "a bare basename suffix must resolve, not silent-empty, got {got:?}"
+        );
+        assert_eq!(got[0].from, "src/a.ts");
+    }
+
+    #[test]
+    fn suffix_match_returns_every_ambiguous_hit() {
+        let db = test_db();
+        db.upsert_module_edges(
+            "r",
+            &["src/a.ts", "src/b.ts", "src/c.ts"],
+            &[
+                edge(
+                    "r",
+                    "src/a.ts",
+                    "../shared/Button",
+                    Some("src/shared/Button.tsx"),
+                ),
+                edge(
+                    "r",
+                    "src/b.ts",
+                    "../widgets/Button",
+                    Some("src/widgets/Button.tsx"),
+                ),
+                edge("r", "src/c.ts", "./unrelated", Some("src/unrelated.ts")),
+            ],
+        )
+        .unwrap();
+
+        // A suffix ambiguous between two distinct files must return both,
+        // each row still tagged with its own resolved path (#772).
+        let got = db.list_module_edges_to("r", "Button.tsx").unwrap();
+        assert_eq!(got.len(), 2, "expected both ambiguous matches, got {got:?}");
+        let tos: Vec<&str> = got.iter().filter_map(|e| e.to.as_deref()).collect();
+        assert!(tos.contains(&"src/shared/Button.tsx"));
+        assert!(tos.contains(&"src/widgets/Button.tsx"));
+    }
+
+    #[test]
+    fn list_to_never_matches_an_unresolved_edge() {
+        let db = test_db();
+        db.upsert_module_edges("r", &["src/a.ts"], &[edge("r", "src/a.ts", "lodash", None)])
+            .unwrap();
+
+        // An unresolved/external edge has no `to_path` at all -- no suffix
+        // (however short) may accidentally match a NULL column.
+        assert!(db.list_module_edges_to("r", "lodash").unwrap().is_empty());
     }
 }

--- a/tests/integration/module_graph.rs
+++ b/tests/integration/module_graph.rs
@@ -1,17 +1,20 @@
-//! CLI end-to-end tests for the module-graph wiring in `legion index` (#710).
+//! CLI end-to-end tests for the module-graph wiring in `legion index` (#710)
+//! and the `sym imports`/`sym importers` query surface (#772).
 //!
 //! `src/graph.rs` and `src/db/module_edges.rs` carry their own unit tests for
-//! the parse/resolve logic and the persistence API in isolation; these tests
-//! exercise the actual binary surface -- a real `legion index <repo>` run
-//! over a small TS fixture must populate `module_edges`, honoring tsconfig
-//! `paths` and recording unresolved specifiers as `to_path = NULL` rather
-//! than dropping them. No CLI query surface exists yet (see
-//! `Database::list_module_edges_from`'s doc comment), so assertions read the
-//! `module_edges` table directly out of the data dir's `legion.db`.
+//! the parse/resolve logic and the persistence API in isolation; the first
+//! group of tests below exercises the actual binary surface -- a real
+//! `legion index <repo>` run over a small TS fixture must populate
+//! `module_edges`, honoring tsconfig `paths` and recording unresolved
+//! specifiers as `to_path = NULL` rather than dropping them -- and reads the
+//! `module_edges` table directly out of the data dir's `legion.db`. The
+//! second group drives `sym imports`/`sym importers` through the compiled
+//! binary against that same indexed data (mirrors `css_symbols.rs`'s shape
+//! for #744).
 
 use rusqlite::Connection;
 
-use crate::common::{legion_cmd, run_ok};
+use crate::common::{legion_cmd, run_fail, run_ok, run_ok_stderr};
 
 /// Seed a watch.toml in the data dir pointing at `repos` (name, workdir).
 /// Mirrors `sym_tree::seed_watch_toml` -- forward-slash normalized so a
@@ -169,4 +172,223 @@ fn index_with_no_ts_files_leaves_module_edges_empty() {
 
     let edges = edges_for_repo(data_dir.path(), "docsonly");
     assert!(edges.is_empty(), "expected no module edges, got {edges:?}");
+}
+
+/// Seed a small TS fixture (a resolved edge, an unresolved/external edge,
+/// and an ambiguous basename shared by two files under different
+/// directories), index it, and return the data dir. Shared setup for the
+/// `sym imports`/`sym importers` CLI tests below (#772).
+fn seed_and_index_import_graph(repo: &str) -> tempfile::TempDir {
+    let data_dir = tempfile::tempdir().expect("data dir");
+    let repo_dir = tempfile::tempdir().expect("repo dir");
+    std::fs::create_dir_all(repo_dir.path().join("src/components")).expect("mkdir components");
+    std::fs::create_dir_all(repo_dir.path().join("src/widgets")).expect("mkdir widgets");
+    std::fs::create_dir_all(repo_dir.path().join("src/pages")).expect("mkdir pages");
+    std::fs::write(
+        repo_dir.path().join("src/index.ts"),
+        "import { widget } from './widgets/widget';\n\
+         import unresolved from 'some-external-package-that-does-not-exist';\n\
+         export { widget, unresolved };\n",
+    )
+    .expect("write index.ts");
+    std::fs::write(
+        repo_dir.path().join("src/widgets/widget.ts"),
+        "export const widget = 1;\n",
+    )
+    .expect("write widget.ts");
+    // Two distinct Button files under different directories, both importing
+    // the same widget and both themselves imported by a page -- so a bare
+    // "Button.tsx" suffix query is ambiguous whether asked as an importer
+    // (`sym imports`) or as an importee (`sym importers`).
+    std::fs::write(
+        repo_dir.path().join("src/components/Button.tsx"),
+        "import { widget } from '../widgets/widget';\nexport const Button = () => widget;\n",
+    )
+    .expect("write components/Button.tsx");
+    std::fs::write(
+        repo_dir.path().join("src/widgets/Button.tsx"),
+        "import { widget } from './widget';\nexport const Button2 = () => widget;\n",
+    )
+    .expect("write widgets/Button.tsx");
+    std::fs::write(
+        repo_dir.path().join("src/pages/Home.tsx"),
+        "import { Button } from '../components/Button';\nexport const Home = () => Button;\n",
+    )
+    .expect("write pages/Home.tsx");
+    std::fs::write(
+        repo_dir.path().join("src/pages/Other.tsx"),
+        "import { Button2 } from '../widgets/Button';\nexport const Other = () => Button2;\n",
+    )
+    .expect("write pages/Other.tsx");
+    seed_watch_toml(data_dir.path(), &[(repo, repo_dir.path())]);
+    run_ok(legion_cmd(data_dir.path()).args(["index", repo]));
+    drop(repo_dir);
+    data_dir
+}
+
+#[test]
+fn sym_imports_prints_resolved_and_unresolved_edges_in_text_format() {
+    let data_dir = seed_and_index_import_graph("importsq");
+
+    let out = run_ok(legion_cmd(data_dir.path()).args(["sym", "imports", "src/index.ts"]));
+    assert!(
+        out.lines()
+            .any(|l| l.starts_with("./widgets/widget\tsrc/index.ts -> src/widgets/widget.ts\t")),
+        "expected the resolved widget edge, got:\n{out}"
+    );
+    assert!(
+        out.lines().any(|l| {
+            l.starts_with("some-external-package-that-does-not-exist\tsrc/index.ts -> unresolved\t")
+        }),
+        "the unresolved/external edge must be shown as 'unresolved', not dropped, got:\n{out}"
+    );
+}
+
+#[test]
+fn sym_imports_json_wraps_entries_with_snapshot_freshness() {
+    let data_dir = seed_and_index_import_graph("importsqjson");
+
+    let out = run_ok(legion_cmd(data_dir.path()).args([
+        "sym",
+        "imports",
+        "src/index.ts",
+        "--repo",
+        "importsqjson",
+        "--json",
+    ]));
+    let envelope: serde_json::Value =
+        serde_json::from_str(out.trim()).expect("stdout is a JSON envelope object");
+    let entries = envelope["entries"].as_array().expect("entries array");
+    assert_eq!(entries.len(), 2, "expected both edges, got {entries:?}");
+    assert!(
+        entries.iter().any(
+            |e| e["specifier"] == "some-external-package-that-does-not-exist" && e["to"].is_null()
+        ),
+        "unresolved edge must serialize to as JSON null, got {entries:?}"
+    );
+
+    let snapshots = envelope["snapshots"].as_array().expect("snapshots array");
+    assert_eq!(
+        snapshots.len(),
+        1,
+        "explicit --repo yields exactly one snapshot: {snapshots:?}"
+    );
+    assert_eq!(snapshots[0]["repo"], "importsqjson");
+}
+
+#[test]
+fn sym_importers_finds_every_file_importing_a_shared_module() {
+    let data_dir = seed_and_index_import_graph("importersq");
+
+    let out = run_ok(legion_cmd(data_dir.path()).args(["sym", "importers", "widget.ts"]));
+    assert!(
+        out.lines()
+            .any(|l| l.contains("src/index.ts -> src/widgets/widget.ts")),
+        "expected src/index.ts as an importer, got:\n{out}"
+    );
+    assert!(
+        out.lines()
+            .any(|l| l.contains("src/components/Button.tsx -> src/widgets/widget.ts")),
+        "expected src/components/Button.tsx as an importer, got:\n{out}"
+    );
+    assert!(
+        out.lines()
+            .any(|l| l.contains("src/widgets/Button.tsx -> src/widgets/widget.ts")),
+        "expected src/widgets/Button.tsx as an importer, got:\n{out}"
+    );
+}
+
+#[test]
+fn sym_importers_ambiguous_suffix_returns_every_match() {
+    let data_dir = seed_and_index_import_graph("importersqambig");
+
+    // "Button.tsx" is a bare basename shared by two distinct importee files
+    // under different directories (src/components/Button.tsx and
+    // src/widgets/Button.tsx), each imported by its own page -- both edges
+    // must be returned, not just one (#772).
+    let out = run_ok(legion_cmd(data_dir.path()).args(["sym", "importers", "Button.tsx"]));
+    let lines: Vec<&str> = out.lines().collect();
+    assert_eq!(
+        lines.len(),
+        2,
+        "expected one importer edge per ambiguous Button.tsx file, got:\n{out}"
+    );
+    assert!(
+        lines
+            .iter()
+            .any(|l| l.contains("-> src/components/Button.tsx"))
+    );
+    assert!(
+        lines
+            .iter()
+            .any(|l| l.contains("-> src/widgets/Button.tsx"))
+    );
+}
+
+#[test]
+fn sym_imports_indexed_but_no_matching_edges_is_a_clean_empty_exit() {
+    let data_dir = seed_and_index_import_graph("importsqempty");
+
+    // widget.ts has no imports of its own -- indexed, genuinely empty.
+    let stdout =
+        run_ok(legion_cmd(data_dir.path()).args(["sym", "imports", "src/widgets/widget.ts"]));
+    assert_eq!(stdout, "", "empty result must not print any rows");
+
+    let stderr = run_ok_stderr(legion_cmd(data_dir.path()).args([
+        "sym",
+        "imports",
+        "src/widgets/widget.ts",
+    ]));
+    assert!(
+        stderr.contains("[legion] no imports found"),
+        "expected the no-imports-found line, got: {stderr}"
+    );
+}
+
+#[test]
+fn sym_imports_never_indexed_repo_fails_loudly_not_silently_empty() {
+    let data_dir = tempfile::tempdir().expect("data dir");
+    let repo_dir = tempfile::tempdir().expect("repo dir");
+    std::fs::write(repo_dir.path().join("README.md"), "# hi\n").expect("write fixture");
+    seed_watch_toml(data_dir.path(), &[("importsqnever", repo_dir.path())]);
+    // Deliberately never run `legion index` -- no file_inventory rows exist.
+
+    let (_, stderr) = run_fail(legion_cmd(data_dir.path()).args([
+        "sym",
+        "imports",
+        "anything.ts",
+        "--repo",
+        "importsqnever",
+    ]));
+    assert!(
+        stderr.contains("legion index importsqnever"),
+        "expected the message to name the fixing command, got: {stderr}"
+    );
+}
+
+/// A repo indexed cleanly but with zero js/ts/jsx/tsx files (pure docs, or
+/// pure Rust) must NOT be reported as never-indexed just because
+/// `module_edges` is empty for it -- that would be the exact misroute
+/// `css_symbol_no_index_message` exists to prevent for `--lang css`, mirrored
+/// here without the extension narrowing (Build Notes, #772).
+#[test]
+fn sym_imports_indexed_repo_with_no_ts_files_is_empty_not_never_indexed() {
+    let data_dir = tempfile::tempdir().expect("data dir");
+    let repo_dir = tempfile::tempdir().expect("repo dir");
+    std::fs::write(repo_dir.path().join("README.md"), "# hi\n").expect("write fixture");
+    seed_watch_toml(data_dir.path(), &[("importsqdocsonly", repo_dir.path())]);
+    run_ok(legion_cmd(data_dir.path()).args(["index", "importsqdocsonly"]));
+
+    let stderr = run_ok_stderr(legion_cmd(data_dir.path()).args([
+        "sym",
+        "imports",
+        "anything.ts",
+        "--repo",
+        "importsqdocsonly",
+    ]));
+    assert!(
+        stderr.contains("[legion] no imports found"),
+        "an indexed repo with no ts files must be a clean empty result, not a \
+         never-indexed error, got: {stderr}"
+    );
 }

--- a/tests/integration/module_graph.rs
+++ b/tests/integration/module_graph.rs
@@ -226,6 +226,72 @@ fn seed_and_index_import_graph(repo: &str) -> tempfile::TempDir {
     data_dir
 }
 
+/// Cross-repo (`--repo` omitted): two separately-indexed repos, each with
+/// its own `widget.ts` importer, share one data dir. `sym imports`/`sym
+/// importers` with no `--repo` must aggregate across both -- the least
+/// exercised path, since every other test above pins `--repo` explicitly
+/// (#772 review finding).
+#[test]
+fn sym_imports_cross_repo_aggregates_across_every_indexed_repo() {
+    let data_dir = tempfile::tempdir().expect("data dir");
+
+    let repo_a_dir = tempfile::tempdir().expect("repo a dir");
+    std::fs::write(
+        repo_a_dir.path().join("index.ts"),
+        "import { w } from './widget';\nexport { w };\n",
+    )
+    .expect("write repo a index.ts");
+    std::fs::write(repo_a_dir.path().join("widget.ts"), "export const w = 1;\n")
+        .expect("write repo a widget.ts");
+
+    let repo_b_dir = tempfile::tempdir().expect("repo b dir");
+    std::fs::write(
+        repo_b_dir.path().join("index.ts"),
+        "import { w } from './widget';\nexport { w };\n",
+    )
+    .expect("write repo b index.ts");
+    std::fs::write(repo_b_dir.path().join("widget.ts"), "export const w = 1;\n")
+        .expect("write repo b widget.ts");
+
+    seed_watch_toml(
+        data_dir.path(),
+        &[
+            ("crossrepo_a", repo_a_dir.path()),
+            ("crossrepo_b", repo_b_dir.path()),
+        ],
+    );
+    run_ok(legion_cmd(data_dir.path()).args(["index", "crossrepo_a"]));
+    run_ok(legion_cmd(data_dir.path()).args(["index", "crossrepo_b"]));
+
+    // `sym importers widget.ts` with no --repo must find the importer in
+    // both repos, each row tagged with its own repo.
+    let out = run_ok(legion_cmd(data_dir.path()).args(["sym", "importers", "widget.ts"]));
+    let lines: Vec<&str> = out.lines().collect();
+    assert_eq!(
+        lines.len(),
+        2,
+        "expected one importer edge per repo, got:\n{out}"
+    );
+    assert!(lines.iter().any(|l| l.ends_with("[crossrepo_a]")));
+    assert!(lines.iter().any(|l| l.ends_with("[crossrepo_b]")));
+
+    // The --json envelope's freshness snapshots must cover both repos too,
+    // not just the first one encountered.
+    let json_out =
+        run_ok(legion_cmd(data_dir.path()).args(["sym", "importers", "widget.ts", "--json"]));
+    let envelope: serde_json::Value =
+        serde_json::from_str(json_out.trim()).expect("stdout is a JSON envelope object");
+    let snapshots = envelope["snapshots"].as_array().expect("snapshots array");
+    let snapshot_repos: std::collections::HashSet<&str> = snapshots
+        .iter()
+        .filter_map(|s| s["repo"].as_str())
+        .collect();
+    assert!(
+        snapshot_repos.contains("crossrepo_a") && snapshot_repos.contains("crossrepo_b"),
+        "cross-repo snapshots must cover both indexed repos, got {snapshots:?}"
+    );
+}
+
 #[test]
 fn sym_imports_prints_resolved_and_unresolved_edges_in_text_format() {
     let data_dir = seed_and_index_import_graph("importsq");
@@ -342,6 +408,26 @@ fn sym_imports_indexed_but_no_matching_edges_is_a_clean_empty_exit() {
     assert!(
         stderr.contains("[legion] no imports found"),
         "expected the no-imports-found line, got: {stderr}"
+    );
+}
+
+/// An empty `file` argument is a suffix of every path -- without an explicit
+/// guard, `""` would silently match and dump every edge in scope instead of
+/// erroring on a clearly-wrong query (#772 review finding).
+#[test]
+fn sym_imports_empty_file_argument_errors_instead_of_dumping_everything() {
+    let data_dir = seed_and_index_import_graph("importsqemptyarg");
+
+    let (_, stderr) = run_fail(legion_cmd(data_dir.path()).args(["sym", "imports", ""]));
+    assert!(
+        stderr.contains("file argument must not be empty"),
+        "expected the empty-argument guard to fire, got: {stderr}"
+    );
+
+    let (_, stderr) = run_fail(legion_cmd(data_dir.path()).args(["sym", "importers", ""]));
+    assert!(
+        stderr.contains("file argument must not be empty"),
+        "expected the empty-argument guard to fire for importers too, got: {stderr}"
     );
 }
 


### PR DESCRIPTION
## Summary

Wires the #710 module-graph reader to a CLI surface: `sym imports <file>` (what a file
imports) and `sym importers <file>` (what imports a file), backed by
`Database::list_module_edges_from`/`list_module_edges_to`. Both commands share one
`run_sym_edges` implementation in `src/cli/index_cmd.rs` -- never-indexed check, repo-scope
loop, freshness computation, and human/`--json` output -- parametrized by which DB method
to call and which "matched nothing" hint to print. `--json` wraps results in the #746
`FreshJsonEnvelope`, mirroring `run_sym_tree` rather than `run_css_sym_list`'s bare-array
shape. The two DB read methods now suffix-match (SQL narrows to `repo` only, a Rust-side
`retain` does exact-or-suffix), and their `#[allow(dead_code)]` is removed now that a CLI
surface calls them.

## Acceptance criteria mapping

### 1. `sym imports <file>` and `sym importers <file>` return correct direct edges, exact-path and suffix tokens both resolve

`run_sym_imports`/`run_sym_importers` (`src/cli/index_cmd.rs`) call
`Database::list_module_edges_from`/`list_module_edges_to`, which I changed to relax their
SQL `WHERE` clause to `repo = ?1` only and do the exact-or-suffix match Rust-side via
`rows.retain(|e| e.from == from_path || e.from.ends_with(from_path))` (and the `Option`-aware
equivalent for `to_path`), mirroring `sym list --file`'s existing suffix semantics
(`src/sym.rs:303-306`) and `list_css_symbols`'s `retain` shape (`src/db/css_symbols.rs:193-195`).
An ambiguous suffix (matching more than one file) returns every match, each row still tagged
with its own `repo`/`from`/`to`.
Evidence: `src/db/module_edges.rs` unit tests `list_from_matches_a_path_suffix`,
`list_to_matches_a_path_suffix`, and `suffix_match_returns_every_ambiguous_hit`; CLI-level
`tests/integration/module_graph.rs::sym_importers_ambiguous_suffix_returns_every_match`
(seeds two distinct `Button.tsx` files under different directories, asserts both edges come
back for a bare `Button.tsx` query).

### 2. `--json` emits the #746 freshness envelope, not a bare array

`run_sym_edges` computes `compute_freshness` over the entries actually returned (the same
call shape `run_sym_tree` uses) and wraps `{ snapshots, entries }` in the existing
`FreshJsonEnvelope<T>` struct -- I did not invent a second envelope type, I reused the one
`sym tree` already defined. This deliberately does not copy `run_css_sym_list`'s bare-array
`--json`, which the issue's Build Notes name as the anti-pattern.
Evidence: `tests/integration/module_graph.rs::sym_imports_json_wraps_entries_with_snapshot_freshness`
parses stdout as a JSON object, asserts `entries` and `snapshots` are both present, and
asserts the unresolved edge serializes `to` as JSON `null` rather than being dropped.

### 3. Never-indexed = loud error + non-zero exit; indexed-but-empty = clean exit 0

`module_edges_indexed` checks `list_file_inventory` for at least one row for the repo (or
any repo, when `--repo` is omitted) -- not `module_edges` rowcount and not narrowed by
extension, per the issue's Build Notes: `module_edges` only has rows for js/ts/jsx/tsx
files, so a cleanly indexed pure-Rust repo would otherwise false-error as never-indexed on
every call, the same misroute class `css_symbol_no_index_message` exists to prevent for
`--lang css`. On a real miss, `run_sym_edges` prints `module_edges_no_index_message` and
returns `LegionError::ExitWith(1)`. An indexed repo with zero matching edges instead prints
nothing to stdout, an informational `"[legion] no imports/importers found"` to stderr, and
returns `Ok(())` (exit 0).
Evidence: `tests/integration/module_graph.rs::sym_imports_never_indexed_repo_fails_loudly_not_silently_empty`
(never-indexed -> `run_fail`, stderr names the fix command);
`sym_imports_indexed_repo_with_no_ts_files_is_empty_not_never_indexed` (indexed, zero js/ts
files -> clean exit, "no imports found", not an error -- the exact false-positive class the
Build Notes call out); `sym_imports_indexed_but_no_matching_edges_is_a_clean_empty_exit`
(indexed, file with no imports of its own -> `run_ok` with empty stdout).

### 4. `#[allow(dead_code)]` removed from both read methods

Removed from `list_module_edges_from` and `list_module_edges_to` in
`src/db/module_edges.rs`; both are now called from `run_sym_edges`, so `cargo clippy
--all-targets -- -D warnings` would fail if either went unused again.
Evidence: `git diff main...HEAD -- src/db/module_edges.rs` shows both attributes removed;
`cargo clippy --all-targets -- -D warnings` passes clean (no dead-code warning reintroduced).

### 5. All tests pass; simplify + review passes completed and fixed

`cargo test` (1411 unit + 297 integration, 0 failed, 2 pre-existing ignores unrelated to
this change), `cargo clippy --all-targets -- -D warnings` (clean), and `cargo fmt -- --check`
(clean) all pass on HEAD. Simplify pass caught that my first draft had
`run_sym_imports`/`run_sym_importers` as two nearly-identical ~50-line functions; I
extracted the shared body into `run_sym_edges`, parametrized by a `query_edges: impl Fn(&Database,
&str, &str) -> Result<Vec<ImportEdge>>` (passed as the `Database::list_module_edges_from`/
`_to` method pointers) and an `empty_message: &str`. The `legion quality-gate check --skill
legion-simplify` articulation is recorded on this HEAD.
Evidence: full `cargo test` run finishing `1411 passed; 0 failed` and `297 passed; 0 failed`;
`src/cli/index_cmd.rs::run_sym_edges` (the extracted shared function) called from both
`run_sym_imports` and `run_sym_importers`, each now four lines.

### 6. PR created and linked

This PR, opened via `legion pr create --repo legion` referencing issue #772.
Evidence: PR body/title reference `#772`; `legion issue view --repo legion --number 772`
shows the issue this closes.

## Review response

`git push` triggers a pre-push PR review hook; it passed (PASS, no CRITICAL findings) but
raised three HIGH/quality notes on the first commit. Addressed two, disclosed the third:

- **Empty `file` argument silently dumped every edge** -- `"".ends_with(x)` and
  `x.ends_with("")` are both always true, so `sym imports ""` matched everything instead of
  erroring. Fixed: `run_sym_edges` now rejects an empty/whitespace-only `file` with
  `ExitWith(2)` before querying.
  Evidence: `tests/integration/module_graph.rs::sym_imports_empty_file_argument_errors_instead_of_dumping_everything`.
- **Cross-repo (`--repo` omitted) aggregation was untested** -- every prior test pinned
  `--repo` explicitly. Fixed: added a two-repo fixture test asserting both the aggregated
  text output and the `--json` envelope's per-repo freshness snapshots.
  Evidence: `tests/integration/module_graph.rs::sym_imports_cross_repo_aggregates_across_every_indexed_repo`.
- **Suffix match has no path-separator boundary** (`Button.tsx` also matches
  `FooButton.tsx`) -- left as-is; see "Not done" below for why.
- **Cross-repo freshness only covers repos with a matching hit** -- `compute_freshness` is
  called with `hits.iter().map(|h| h.repo)`, so in cross-repo mode (`--repo` omitted) a
  stale-but-indexed repo that happens to have zero matching edges contributes no
  `SnapshotFreshness` row, i.e. no drift warning for that repo. This is inherited unchanged
  from `run_sym_tree`'s identical `compute_freshness(database, repo.as_deref(),
  result.entries.iter().map(...))` call shape and `freshness_repo_scope`'s documented
  "empty cross-repo result yields an empty list" behavior (#746) -- not a new defect this
  issue introduces, and the Build Notes explicitly direct copying `run_sym_tree`'s envelope
  shape. Left unchanged for consistency with that existing convention; a fix (if wanted)
  would be a `sym tree`-wide follow-up, not scoped to this issue.

## Not done

- **Transitive/re-export resolution** (explicitly out of scope in the issue): a barrel
  `index.ts` that re-exports a primitive shows the barrel as the importer, not the ultimate
  consumer. The reader surfaces the direct edge only; a separate issue tracks collapsing the
  chain.
- **`--lang` flag**: not added, per the issue -- there is one module graph, not per-language
  graphs.
- **CSS/Astro/other formats**: `module_edges` is js/ts/jsx/tsx-only; out of scope here.
- **Telemetry** (`EtcUsageRecord`, as `run_sym_tree` records): not added. The issue models
  this command on the #744 css reader (`run_css_sym_list`), which does not record telemetry
  either -- I followed that precedent rather than `sym tree`'s, since the issue's explicit
  comparison point for wiring shape is css, not tree. Flagging this explicitly since the
  `--json` envelope is borrowed from `sym tree` while the telemetry omission is borrowed from
  css, so the two source commands diverge on this one point.
- **Path-segment-anchored suffix matching**: the suffix match (`ends_with`) is
  final-path-component permissive, not separator-anchored -- a query for `Button.tsx` would
  also match a hypothetical `MyButton.tsx`. This is intentional and matches the existing
  `sym list --file` / `list_css_symbols` suffix semantics exactly (not a new behavior this
  issue introduces); flagged by the pre-commit simplify review as a minor, non-blocking note
  and left as-is for consistency with the sibling readers.

Closes #772
