### PR TITLE
feat(#791): legion push -- in-band audited git push

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -11,6 +11,7 @@ pub(crate) mod memory;
 pub(crate) mod misc;
 pub(crate) mod ops;
 pub(crate) mod pr;
+pub(crate) mod push;
 pub(crate) mod schedule;
 pub(crate) mod signal;
 pub(crate) mod spec_gen;
@@ -724,6 +725,34 @@ pub(crate) enum Commands {
     Pr {
         #[command(subcommand)]
         action: PrAction,
+    },
+
+    /// Push a branch to origin -- the sanctioned in-band push path (#791).
+    ///
+    /// Resolves the checkout that has `--branch` checked out via `git
+    /// worktree list --porcelain` and runs the push FROM that checkout, so
+    /// the push-from-own-checkout doctrine is enforced by the tool instead
+    /// of agent discipline: the pre-push hook reviews the CWD's checked-out
+    /// branch, not the ref being pushed, so pushing a ref from the wrong
+    /// checkout silently reviews (or blocks on) the wrong diff. Hard errors
+    /// if no checkout has the branch, naming the worktrees it searched.
+    ///
+    /// Refuses to push `main`/`master` (Sean merges; agents never push main)
+    /// and refuses any `--branch` value shaped like a git flag or a
+    /// force/retarget refspec (leading `-`/`+`, embedded `:`, whitespace) --
+    /// there is no `--force` flag on this command, and a crafted branch
+    /// value cannot recover force semantics either. Sets upstream (`-u
+    /// origin <branch>`) on every push, which is a no-op after the first.
+    /// Every attempt (success or failure) is audit-logged with the branch,
+    /// resolved checkout path, and head SHA.
+    Push {
+        /// Repository name (identifies the calling agent for the audit log)
+        #[arg(long)]
+        repo: String,
+
+        /// Branch to push. Defaults to the CWD's checked-out branch.
+        #[arg(long)]
+        branch: Option<String>,
     },
 
     /// View the audit log of work source actions

--- a/src/cli/push.rs
+++ b/src/cli/push.rs
@@ -1,0 +1,397 @@
+//! `legion push` (#791): the sanctioned push path for agents, retiring raw
+//! `git push` from agent doctrine.
+//!
+//! Resolves the checkout that has the target branch checked out via `git
+//! worktree list --porcelain` and runs the push FROM that checkout -- the
+//! push-from-own-checkout doctrine is enforced by the tool rather than left
+//! to agent discipline. The doctrine exists because the pre-push hook
+//! reviews the CWD's checked-out branch, not the ref actually being pushed
+//! (019f20eb): pushing branch B from a checkout sitting on branch A silently
+//! reviews (or blocks on) A's diff instead of B's.
+
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+
+use crate::cli::util::{audit, git_head_commit_and_branch, open_db};
+use crate::{db, error};
+
+/// Branches this command refuses to push under any circumstances. Merges to
+/// these happen through a reviewed PR, never a direct agent push.
+const REFUSED_BRANCHES: [&str; 2] = ["main", "master"];
+
+/// One `git worktree list --porcelain` entry: the checkout path, its HEAD
+/// commit, and the branch it has checked out (`None` for a detached HEAD or
+/// a bare entry).
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct WorktreeEntry {
+    path: PathBuf,
+    head_sha: Option<String>,
+    branch: Option<String>,
+}
+
+pub(crate) fn handle_push(repo: String, branch: Option<String>) -> error::Result<()> {
+    let target_branch = match branch {
+        Some(b) => b,
+        None => {
+            let (_, cwd_branch) = git_head_commit_and_branch()?;
+            cwd_branch
+        }
+    };
+
+    validate_branch(&target_branch)?;
+
+    let entries = list_worktrees()?;
+    let entry = resolve_checkout(&entries, &target_branch)?;
+    let checkout_path = entry.path.clone();
+    let head_sha = entry.head_sha.clone();
+
+    info!(
+        "[legion] pushing '{target_branch}' from {}",
+        checkout_path.display()
+    );
+
+    let push_result = run_push(&checkout_path, &target_branch);
+
+    // Audit every attempt, success or failure -- the audit trail is the
+    // point of routing pushes through this command instead of raw `git
+    // push`, so a hook-blocked push must leave a row just as a successful
+    // one does. The error (if any) propagates AFTER the row is written.
+    let database = open_db()?;
+    let details = serde_json::json!({
+        "checkout": checkout_path.display().to_string(),
+        "head_sha": head_sha,
+    })
+    .to_string();
+    audit(
+        &database,
+        &db::AuditInput {
+            agent: &repo,
+            action: "push",
+            target_type: "branch",
+            target_ref: &target_branch,
+            task_id: None,
+            source_type: "git",
+            details: Some(&details),
+            outcome: if push_result.is_ok() {
+                "success"
+            } else {
+                "failure"
+            },
+        },
+    );
+
+    push_result?;
+
+    println!(
+        "pushed {target_branch} to origin ({})",
+        checkout_path.display()
+    );
+    Ok(())
+}
+
+/// Reject anything that is not a plain branch name: empty, a leading `-`
+/// (could be parsed as a git flag, e.g. a `--branch '--force'` smuggle
+/// attempt), a leading `+` (git's force-push refspec marker), an embedded
+/// `:` (refspec source:dest separator -- could retarget the push to an
+/// unrelated remote ref), or embedded whitespace. This command has no
+/// `--force` flag by construction (#791); this guard closes the gap where a
+/// crafted `--branch` value could recover force/retarget semantics anyway.
+/// Also refuses `main`/`master` outright -- agents never push those
+/// directly.
+fn validate_branch(branch: &str) -> error::Result<()> {
+    if branch.is_empty()
+        || branch.starts_with('-')
+        || branch.starts_with('+')
+        || branch.contains(':')
+        || branch.chars().any(char::is_whitespace)
+    {
+        return Err(error::LegionError::PushRefused {
+            branch: branch.to_string(),
+            reason: "not a plain branch name (must not start with '-'/'+', contain ':', or \
+                      contain whitespace) -- no flag exists on this command to force-push or \
+                      retarget the ref"
+                .to_string(),
+        });
+    }
+    if REFUSED_BRANCHES.contains(&branch) {
+        return Err(error::LegionError::PushRefused {
+            branch: branch.to_string(),
+            reason: "agents never push main/master directly -- merges happen through a \
+                      reviewed PR"
+                .to_string(),
+        });
+    }
+    Ok(())
+}
+
+/// Find the worktree entry with `branch` checked out. Errors naming every
+/// searched checkout path when none match.
+fn resolve_checkout<'a>(
+    entries: &'a [WorktreeEntry],
+    branch: &str,
+) -> error::Result<&'a WorktreeEntry> {
+    entries
+        .iter()
+        .find(|e| e.branch.as_deref() == Some(branch))
+        .ok_or_else(|| {
+            let searched = entries
+                .iter()
+                .map(|e| e.path.display().to_string())
+                .collect::<Vec<_>>()
+                .join(", ");
+            error::LegionError::PushBranchNotFound {
+                branch: branch.to_string(),
+                searched,
+            }
+        })
+}
+
+/// Run `git worktree list --porcelain` (ambient CWD -- lists every worktree
+/// of whichever repo the caller is standing in, regardless of which linked
+/// checkout that happens to be) and parse the result.
+fn list_worktrees() -> error::Result<Vec<WorktreeEntry>> {
+    let output = Command::new("git")
+        .args(["worktree", "list", "--porcelain"])
+        .output()
+        .map_err(|e| {
+            error::LegionError::WorkSource(format!("failed to run git worktree list: {e}"))
+        })?;
+    if !output.status.success() {
+        return Err(error::LegionError::WorkSource(format!(
+            "git worktree list --porcelain failed: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        )));
+    }
+    Ok(parse_worktree_list_porcelain(&String::from_utf8_lossy(
+        &output.stdout,
+    )))
+}
+
+/// Pure parser for `git worktree list --porcelain` output, isolated from
+/// the git invocation so it is unit-testable without a real repo. Entries
+/// are separated by a blank line; each carries a `worktree <path>` line, an
+/// optional `HEAD <sha>` line, and either `branch refs/heads/<name>`,
+/// `bare`, or `detached`.
+fn parse_worktree_list_porcelain(text: &str) -> Vec<WorktreeEntry> {
+    let mut entries = Vec::new();
+    let mut path: Option<PathBuf> = None;
+    let mut head_sha: Option<String> = None;
+    let mut branch: Option<String> = None;
+
+    let flush = |path: &mut Option<PathBuf>,
+                 head_sha: &mut Option<String>,
+                 branch: &mut Option<String>,
+                 entries: &mut Vec<WorktreeEntry>| {
+        if let Some(p) = path.take() {
+            entries.push(WorktreeEntry {
+                path: p,
+                head_sha: head_sha.take(),
+                branch: branch.take(),
+            });
+        }
+    };
+
+    for line in text.lines() {
+        if line.is_empty() {
+            flush(&mut path, &mut head_sha, &mut branch, &mut entries);
+            continue;
+        }
+        if let Some(p) = line.strip_prefix("worktree ") {
+            path = Some(PathBuf::from(p));
+        } else if let Some(sha) = line.strip_prefix("HEAD ") {
+            head_sha = Some(sha.to_string());
+        } else if let Some(b) = line.strip_prefix("branch ") {
+            branch = Some(b.trim_start_matches("refs/heads/").to_string());
+        }
+        // "bare" / "detached" / "locked ..." / "prunable ..." lines carry no
+        // field this command needs.
+    }
+    // Porcelain output does not reliably end with a trailing blank line --
+    // flush whatever block is still open.
+    flush(&mut path, &mut head_sha, &mut branch, &mut entries);
+
+    entries
+}
+
+/// Run `git -C <checkout> push -u origin <branch>`. `-u` runs on every push,
+/// not just the first -- it is a no-op once the upstream is already set, so
+/// this avoids an extra `@{upstream}` probe to distinguish first-push from
+/// steady-state. stderr is relayed live, line by line, AND captured for the
+/// failure message: a long-running hook (the nested-claude pre-push review)
+/// must be visible as it happens, not only after the whole push completes.
+fn run_push(checkout: &Path, branch: &str) -> error::Result<()> {
+    let mut child = Command::new("git")
+        .arg("-C")
+        .arg(checkout)
+        .args(["push", "-u", "origin", branch])
+        .stdin(Stdio::null())
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::piped())
+        .spawn()
+        .map_err(|e| error::LegionError::WorkSource(format!("failed to spawn git push: {e}")))?;
+
+    let stderr_pipe = child
+        .stderr
+        .take()
+        .ok_or_else(|| error::LegionError::WorkSource("git push stderr missing".to_string()))?;
+    let captured = relay_and_capture_stderr(stderr_pipe);
+
+    let status = child
+        .wait()
+        .map_err(|e| error::LegionError::WorkSource(format!("git push wait failed: {e}")))?;
+
+    if !status.success() {
+        return Err(error::LegionError::PushFailed { stderr: captured });
+    }
+
+    Ok(())
+}
+
+/// Read `pipe` line by line, relaying each line to our own stderr as it
+/// arrives and accumulating it into the returned string.
+fn relay_and_capture_stderr(pipe: impl std::io::Read) -> String {
+    use std::io::BufRead;
+    let reader = std::io::BufReader::new(pipe);
+    let mut captured = String::new();
+    for line in reader.lines() {
+        match line {
+            Ok(l) => {
+                eprintln!("{l}");
+                captured.push_str(&l);
+                captured.push('\n');
+            }
+            Err(_) => break,
+        }
+    }
+    captured
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_worktree_list_porcelain_multiple_entries() {
+        let text = "worktree /repo/main\n\
+                     HEAD abc123\n\
+                     branch refs/heads/main\n\
+                     \n\
+                     worktree /repo/feat\n\
+                     HEAD def456\n\
+                     branch refs/heads/feat/x\n\
+                     \n";
+        let entries = parse_worktree_list_porcelain(text);
+        assert_eq!(entries.len(), 2);
+        assert_eq!(entries[0].path, PathBuf::from("/repo/main"));
+        assert_eq!(entries[0].head_sha.as_deref(), Some("abc123"));
+        assert_eq!(entries[0].branch.as_deref(), Some("main"));
+        assert_eq!(entries[1].path, PathBuf::from("/repo/feat"));
+        assert_eq!(entries[1].branch.as_deref(), Some("feat/x"));
+    }
+
+    #[test]
+    fn parse_worktree_list_porcelain_no_trailing_blank_line() {
+        // git does not guarantee a trailing blank line after the last
+        // block; the flush-at-end path must still capture it.
+        let text = "worktree /repo/main\nHEAD abc123\nbranch refs/heads/main";
+        let entries = parse_worktree_list_porcelain(text);
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].branch.as_deref(), Some("main"));
+    }
+
+    #[test]
+    fn parse_worktree_list_porcelain_detached_head_has_no_branch() {
+        let text = "worktree /repo/detached\nHEAD abc123\ndetached\n";
+        let entries = parse_worktree_list_porcelain(text);
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].branch, None);
+        assert_eq!(entries[0].head_sha.as_deref(), Some("abc123"));
+    }
+
+    #[test]
+    fn parse_worktree_list_porcelain_bare_entry() {
+        let text = "worktree /repo/bare\nbare\n\n";
+        let entries = parse_worktree_list_porcelain(text);
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].branch, None);
+        assert_eq!(entries[0].head_sha, None);
+    }
+
+    #[test]
+    fn resolve_checkout_finds_matching_branch() {
+        let entries = vec![
+            WorktreeEntry {
+                path: PathBuf::from("/repo/main"),
+                head_sha: Some("abc".to_string()),
+                branch: Some("main".to_string()),
+            },
+            WorktreeEntry {
+                path: PathBuf::from("/repo/feat"),
+                head_sha: Some("def".to_string()),
+                branch: Some("feat/x".to_string()),
+            },
+        ];
+        let found = resolve_checkout(&entries, "feat/x").expect("must find feat/x");
+        assert_eq!(found.path, PathBuf::from("/repo/feat"));
+    }
+
+    #[test]
+    fn resolve_checkout_errors_naming_searched_paths() {
+        let entries = vec![
+            WorktreeEntry {
+                path: PathBuf::from("/repo/main"),
+                head_sha: None,
+                branch: Some("main".to_string()),
+            },
+            WorktreeEntry {
+                path: PathBuf::from("/repo/other"),
+                head_sha: None,
+                branch: Some("other".to_string()),
+            },
+        ];
+        let err = resolve_checkout(&entries, "feat/missing").unwrap_err();
+        match err {
+            error::LegionError::PushBranchNotFound { branch, searched } => {
+                assert_eq!(branch, "feat/missing");
+                assert!(searched.contains("/repo/main"));
+                assert!(searched.contains("/repo/other"));
+            }
+            other => panic!("expected PushBranchNotFound, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn validate_branch_refuses_main_and_master() {
+        assert!(validate_branch("main").is_err());
+        assert!(validate_branch("master").is_err());
+        assert!(validate_branch("feat/main-fix").is_ok());
+    }
+
+    #[test]
+    fn validate_branch_refuses_flag_shaped_values() {
+        assert!(validate_branch("--force").is_err());
+        assert!(validate_branch("-f").is_err());
+    }
+
+    #[test]
+    fn validate_branch_refuses_force_prefix() {
+        assert!(validate_branch("+feat/x").is_err());
+    }
+
+    #[test]
+    fn validate_branch_refuses_refspec_separator() {
+        assert!(validate_branch("feat/x:refs/heads/other").is_err());
+    }
+
+    #[test]
+    fn validate_branch_refuses_whitespace_and_empty() {
+        assert!(validate_branch("").is_err());
+        assert!(validate_branch("feat x").is_err());
+    }
+
+    #[test]
+    fn validate_branch_accepts_plain_names() {
+        assert!(validate_branch("feat/791-legion-push").is_ok());
+        assert!(validate_branch("some-branch").is_ok());
+    }
+}

--- a/src/cli/push.rs
+++ b/src/cli/push.rs
@@ -45,6 +45,11 @@ pub(crate) fn handle_push(repo: String, branch: Option<String>) -> error::Result
     let checkout_path = entry.path.clone();
     let head_sha = entry.head_sha.clone();
 
+    // Opened before the push (not after) so a DB-open failure fails fast
+    // rather than masking the actual push result behind a DB error once the
+    // push has already happened.
+    let database = open_db()?;
+
     info!(
         "[legion] pushing '{target_branch}' from {}",
         checkout_path.display()
@@ -56,7 +61,6 @@ pub(crate) fn handle_push(repo: String, branch: Option<String>) -> error::Result
     // point of routing pushes through this command instead of raw `git
     // push`, so a hook-blocked push must leave a row just as a successful
     // one does. The error (if any) propagates AFTER the row is written.
-    let database = open_db()?;
     let details = serde_json::json!({
         "checkout": checkout_path.display().to_string(),
         "head_sha": head_sha,

--- a/src/error.rs
+++ b/src/error.rs
@@ -182,6 +182,15 @@ pub enum LegionError {
     #[error("invalid gate result: '{0}' (expected 'clean' or 'issues')")]
     InvalidGateResult(String),
 
+    #[error("branch '{branch}' not found in any worktree checkout (searched: {searched})")]
+    PushBranchNotFound { branch: String, searched: String },
+
+    #[error("refusing to push '{branch}': {reason}")]
+    PushRefused { branch: String, reason: String },
+
+    #[error("git push failed: {stderr}")]
+    PushFailed { stderr: String },
+
     /// Signals that the process should exit with a specific non-zero code.
     ///
     /// Used by CLI handlers that have already printed a user-facing message
@@ -287,5 +296,35 @@ mod tests {
         assert!(err.to_string().contains("bad"));
         assert!(err.to_string().contains("clean"));
         assert!(err.to_string().contains("issues"));
+    }
+
+    #[test]
+    fn push_branch_not_found_display() {
+        let err = LegionError::PushBranchNotFound {
+            branch: "feat/x".to_string(),
+            searched: "/a, /b".to_string(),
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("feat/x"));
+        assert!(msg.contains("/a, /b"));
+    }
+
+    #[test]
+    fn push_refused_display() {
+        let err = LegionError::PushRefused {
+            branch: "main".to_string(),
+            reason: "agents never push main".to_string(),
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("main"));
+        assert!(msg.contains("agents never push main"));
+    }
+
+    #[test]
+    fn push_failed_display() {
+        let err = LegionError::PushFailed {
+            stderr: "! [rejected]".to_string(),
+        };
+        assert!(err.to_string().contains("! [rejected]"));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -251,6 +251,7 @@ fn run() -> error::Result<()> {
         Commands::Schedule { action } => cli::schedule::handle(action)?,
         Commands::Issue { action } => cli::issue::handle(action)?,
         Commands::Pr { action } => cli::pr::handle(action)?,
+        Commands::Push { repo, branch } => cli::push::handle_push(repo, branch)?,
         Commands::Comment { repo, number, body } => cli::issue::handle_comment(repo, number, body)?,
         Commands::Audit {
             repo,

--- a/tests/integration/common.rs
+++ b/tests/integration/common.rs
@@ -197,7 +197,7 @@ static ISOLATED_GIT_CONFIG: OnceLock<(PathBuf, PathBuf)> = OnceLock::new();
 /// global state. The backing tempdir is deliberately leaked (`mem::forget`):
 /// it must outlive every test in this binary, and process exit reclaims it
 /// like any other tempfile.
-fn isolated_git_config_paths() -> &'static (PathBuf, PathBuf) {
+pub fn isolated_git_config_paths() -> &'static (PathBuf, PathBuf) {
     ISOLATED_GIT_CONFIG.get_or_init(|| {
         let dir = tempfile::tempdir().expect("create isolated git config dir");
         let global = dir.path().join("global.gitconfig");

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -21,6 +21,7 @@ mod mcp;
 mod memory;
 mod mesh;
 mod module_graph;
+mod push;
 mod serve;
 mod spec_gen;
 mod sym_tree;

--- a/tests/integration/push.rs
+++ b/tests/integration/push.rs
@@ -1,0 +1,362 @@
+//! Integration tests for `legion push` (#791): the sanctioned in-band push
+//! path. Every test drives real `git` fixtures (a bare "remote" plus a
+//! local checkout, mirroring `setup_git_repo_with_feature_branch` in
+//! worksource_pr.rs) since the command's whole job is resolving worktrees
+//! and shelling out to `git push`.
+
+use crate::common::*;
+use std::path::Path;
+
+/// Init a bare "remote" repo. Plain `git init --bare` never reads or writes
+/// any config, and this is a disconnected tempdir with no relation to the
+/// enclosing real checkout, so it needs none of `run_git_fixture`'s
+/// isolation machinery (that exists specifically for the `git worktree
+/// add` config-inheritance hazard, #723).
+fn init_bare_remote() -> tempfile::TempDir {
+    let remote = tempfile::tempdir().unwrap();
+    let out = std::process::Command::new("git")
+        .current_dir(remote.path())
+        .args(["init", "--bare", "-q"])
+        .output()
+        .expect("git init --bare must spawn");
+    assert!(
+        out.status.success(),
+        "git init --bare failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    remote
+}
+
+/// Local repo with `main` (seeded and pushed to `origin`) and a feature
+/// branch `feat/x` carrying one additional commit. Leaves the checkout on
+/// `feat/x`. Every write goes through `run_git_fixture` (#723 isolation).
+fn setup_local_repo(remote: &Path) -> tempfile::TempDir {
+    let local = tempfile::tempdir().unwrap();
+    let lp = local.path();
+    run_git_fixture(lp, &["init", "-q", "-b", "main"]);
+    run_git_fixture(lp, &["remote", "add", "origin", remote.to_str().unwrap()]);
+
+    std::fs::write(lp.join("README.md"), "seed\n").unwrap();
+    run_git_fixture(lp, &["add", "README.md"]);
+    run_git_fixture(lp, &["commit", "-q", "-m", "seed"]);
+    run_git_fixture(lp, &["push", "-q", "origin", "main"]);
+
+    run_git_fixture(lp, &["checkout", "-q", "-b", "feat/x"]);
+    std::fs::write(lp.join("feature.txt"), "change\n").unwrap();
+    run_git_fixture(lp, &["add", "feature.txt"]);
+    run_git_fixture(lp, &["commit", "-q", "-m", "add feature"]);
+
+    local
+}
+
+/// `legion push` command scoped to `cwd`, with `GIT_CONFIG_GLOBAL`/
+/// `GIT_CONFIG_SYSTEM` pinned to isolated empty files. This is layered onto
+/// the command UNDER TEST (not just fixture setup) because `legion push`
+/// shells out to a real `git push`, and an operator machine's real global
+/// config could point `core.hooksPath` at a real pre-push hook (the
+/// nested-claude review) -- isolating it keeps these tests hermetic and
+/// fast regardless of the host's global git config.
+fn push_cmd(data_dir: &Path, cwd: &Path) -> std::process::Command {
+    let (global, system) = isolated_git_config_paths();
+    let mut cmd = legion_cmd(data_dir);
+    cmd.current_dir(cwd)
+        .env("GIT_CONFIG_GLOBAL", global)
+        .env("GIT_CONFIG_SYSTEM", system);
+    cmd
+}
+
+fn rev_parse(repo: &Path, rev: &str) -> std::process::Output {
+    std::process::Command::new("git")
+        .current_dir(repo)
+        .args(["rev-parse", rev])
+        .output()
+        .expect("git rev-parse must spawn")
+}
+
+/// Happy path: pushing a feature branch from the checkout that has it
+/// checked out succeeds, lands the ref on the remote, and sets the
+/// upstream tracking branch (`-u`).
+#[cfg(unix)]
+#[test]
+fn push_first_time_sets_upstream_and_pushes_feature_branch() {
+    let _guard = RealRepoConfigGuard::new();
+    let remote = init_bare_remote();
+    let local = setup_local_repo(remote.path());
+    let data_dir = tempfile::tempdir().unwrap();
+
+    let stdout = run_ok(push_cmd(data_dir.path(), local.path()).args([
+        "push",
+        "--repo",
+        "test-agent",
+        "--branch",
+        "feat/x",
+    ]));
+    assert!(
+        stdout.contains("feat/x"),
+        "expected confirmation naming the branch, got: {stdout}"
+    );
+
+    let rev = rev_parse(remote.path(), "refs/heads/feat/x");
+    assert!(
+        rev.status.success(),
+        "expected feat/x to exist on the remote after push"
+    );
+
+    let upstream = std::process::Command::new("git")
+        .current_dir(local.path())
+        .args(["rev-parse", "--abbrev-ref", "feat/x@{upstream}"])
+        .output()
+        .expect("git rev-parse --abbrev-ref must spawn");
+    assert!(
+        upstream.status.success(),
+        "expected -u to set the upstream tracking branch"
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&upstream.stdout).trim(),
+        "origin/feat/x"
+    );
+}
+
+/// Omitting `--branch` pushes whatever branch the CWD has checked out.
+#[cfg(unix)]
+#[test]
+fn push_default_branch_uses_cwd_checked_out_branch() {
+    let _guard = RealRepoConfigGuard::new();
+    let remote = init_bare_remote();
+    let local = setup_local_repo(remote.path()); // leaves checkout on feat/x
+
+    let data_dir = tempfile::tempdir().unwrap();
+    let stdout =
+        run_ok(push_cmd(data_dir.path(), local.path()).args(["push", "--repo", "test-agent"]));
+    assert!(
+        stdout.contains("feat/x"),
+        "expected the default (CWD-checked-out) branch feat/x to be pushed, got: {stdout}"
+    );
+    assert!(
+        rev_parse(remote.path(), "refs/heads/feat/x")
+            .status
+            .success()
+    );
+}
+
+/// `main` is refused outright, before any worktree resolution or push
+/// attempt.
+#[cfg(unix)]
+#[test]
+fn push_refuses_main() {
+    let remote = init_bare_remote();
+    let local = setup_local_repo(remote.path());
+    let data_dir = tempfile::tempdir().unwrap();
+
+    let (_stdout, stderr) = run_fail(push_cmd(data_dir.path(), local.path()).args([
+        "push",
+        "--repo",
+        "test-agent",
+        "--branch",
+        "main",
+    ]));
+    assert!(
+        stderr.contains("main") && stderr.to_lowercase().contains("refus"),
+        "expected a refusal naming main, got: {stderr}"
+    );
+}
+
+/// `master` is refused the same way as `main`.
+#[cfg(unix)]
+#[test]
+fn push_refuses_master() {
+    let remote = init_bare_remote();
+    let local = setup_local_repo(remote.path());
+    run_git_fixture(local.path(), &["checkout", "-q", "-b", "master"]);
+    let data_dir = tempfile::tempdir().unwrap();
+
+    let (_stdout, stderr) = run_fail(push_cmd(data_dir.path(), local.path()).args([
+        "push",
+        "--repo",
+        "test-agent",
+        "--branch",
+        "master",
+    ]));
+    assert!(
+        stderr.contains("master") && stderr.to_lowercase().contains("refus"),
+        "expected a refusal naming master, got: {stderr}"
+    );
+}
+
+/// A `--branch` value shaped like a git flag or a force/retarget refspec is
+/// refused -- this command has no `--force` flag, and a crafted branch
+/// value must not be able to recover force semantics.
+#[cfg(unix)]
+#[test]
+fn push_refuses_flag_shaped_branch_value() {
+    let remote = init_bare_remote();
+    let local = setup_local_repo(remote.path());
+    let data_dir = tempfile::tempdir().unwrap();
+
+    // `=`-form so clap assigns the literal value rather than trying to
+    // parse `--force` as a separate flag token.
+    let (_stdout, stderr) = run_fail(push_cmd(data_dir.path(), local.path()).args([
+        "push",
+        "--repo",
+        "test-agent",
+        "--branch=--force",
+    ]));
+    assert!(
+        stderr.contains("not a plain branch name"),
+        "expected the flag-shaped-value refusal, got: {stderr}"
+    );
+}
+
+/// Requesting a branch that no checkout of the repo has results in a hard
+/// error naming the worktrees that were searched.
+#[cfg(unix)]
+#[test]
+fn push_branch_not_found_in_any_worktree_errors() {
+    let remote = init_bare_remote();
+    let local = setup_local_repo(remote.path());
+    let data_dir = tempfile::tempdir().unwrap();
+
+    let (_stdout, stderr) = run_fail(push_cmd(data_dir.path(), local.path()).args([
+        "push",
+        "--repo",
+        "test-agent",
+        "--branch",
+        "feat/does-not-exist",
+    ]));
+    assert!(
+        stderr.contains("feat/does-not-exist"),
+        "expected the missing branch name in the error, got: {stderr}"
+    );
+    assert!(
+        stderr.contains(local.path().to_str().unwrap()),
+        "expected the searched checkout path named in the error, got: {stderr}"
+    );
+}
+
+/// Resolves the checkout that has the target branch checked out even when
+/// that is NOT the checkout `legion push` was invoked from -- the core
+/// push-from-own-checkout doctrine (#791, 019f20eb). CWD sits on `main`; a
+/// linked worktree sits on `feat/x`; pushing `feat/x` must succeed by
+/// finding and pushing FROM the linked worktree.
+#[cfg(unix)]
+#[test]
+fn push_resolves_checkout_from_linked_worktree_not_cwd() {
+    let _guard = RealRepoConfigGuard::new();
+    let remote = init_bare_remote();
+    let local = setup_local_repo(remote.path());
+    // Back to main in the primary checkout -- it no longer has feat/x.
+    run_git_fixture(local.path(), &["checkout", "-q", "main"]);
+
+    // A separate, not-yet-existing path for the linked worktree.
+    let linked_parent = tempfile::tempdir().unwrap();
+    let linked_path = linked_parent.path().join("linked-checkout");
+    run_git_fixture(
+        local.path(),
+        &["worktree", "add", linked_path.to_str().unwrap(), "feat/x"],
+    );
+
+    let data_dir = tempfile::tempdir().unwrap();
+    // Invoke from `local` (checked out to main) targeting feat/x, which
+    // only the linked worktree has.
+    let stdout = run_ok(push_cmd(data_dir.path(), local.path()).args([
+        "push",
+        "--repo",
+        "test-agent",
+        "--branch",
+        "feat/x",
+    ]));
+    assert!(stdout.contains("feat/x"), "got: {stdout}");
+
+    assert!(
+        rev_parse(remote.path(), "refs/heads/feat/x")
+            .status
+            .success(),
+        "expected feat/x to have been pushed from the linked worktree"
+    );
+}
+
+/// Every push attempt is audit-logged, success or failure, carrying the
+/// branch and the resolved checkout.
+#[cfg(unix)]
+#[test]
+fn push_writes_audit_row_on_success() {
+    let remote = init_bare_remote();
+    let local = setup_local_repo(remote.path());
+    let data_dir = tempfile::tempdir().unwrap();
+
+    run_ok(push_cmd(data_dir.path(), local.path()).args([
+        "push",
+        "--repo",
+        "test-agent",
+        "--branch",
+        "feat/x",
+    ]));
+
+    let audit_out =
+        run_ok(legion_cmd(data_dir.path()).args(["audit", "--action", "push", "--json"]));
+    assert!(
+        audit_out.contains("\"action\": \"push\""),
+        "got: {audit_out}"
+    );
+    assert!(audit_out.contains("feat/x"), "got: {audit_out}");
+    assert!(
+        audit_out.contains("\"outcome\": \"success\""),
+        "got: {audit_out}"
+    );
+    assert!(
+        audit_out.contains(local.path().to_str().unwrap()),
+        "expected the resolved checkout path in the audit details, got: {audit_out}"
+    );
+}
+
+/// An underlying `git push` failure (here: `origin` points at a directory
+/// that is not a git repository at all) surfaces as the command's error
+/// with git's own stderr relayed, and the failed attempt is still
+/// audit-logged with outcome "failure" -- the audit trail is the whole
+/// point of routing pushes through this command.
+#[cfg(unix)]
+#[test]
+fn push_underlying_git_failure_surfaces_error_and_audits_failure() {
+    let local = tempfile::tempdir().unwrap();
+    let lp = local.path();
+    run_git_fixture(lp, &["init", "-q", "-b", "main"]);
+
+    let bogus_remote = tempfile::tempdir().unwrap();
+    run_git_fixture(
+        lp,
+        &[
+            "remote",
+            "add",
+            "origin",
+            bogus_remote.path().to_str().unwrap(),
+        ],
+    );
+
+    std::fs::write(lp.join("README.md"), "seed\n").unwrap();
+    run_git_fixture(lp, &["add", "README.md"]);
+    run_git_fixture(lp, &["commit", "-q", "-m", "seed"]);
+    run_git_fixture(lp, &["checkout", "-q", "-b", "feat/x"]);
+    std::fs::write(lp.join("feature.txt"), "change\n").unwrap();
+    run_git_fixture(lp, &["add", "feature.txt"]);
+    run_git_fixture(lp, &["commit", "-q", "-m", "add feature"]);
+
+    let data_dir = tempfile::tempdir().unwrap();
+    let (_stdout, stderr) = run_fail(push_cmd(data_dir.path(), lp).args([
+        "push",
+        "--repo",
+        "test-agent",
+        "--branch",
+        "feat/x",
+    ]));
+    assert!(
+        !stderr.trim().is_empty(),
+        "expected git's own failure text relayed to stderr"
+    );
+
+    let audit_out =
+        run_ok(legion_cmd(data_dir.path()).args(["audit", "--action", "push", "--json"]));
+    assert!(
+        audit_out.contains("\"outcome\": \"failure\""),
+        "expected a failure-outcome audit row for the failed push, got: {audit_out}"
+    );
+}


### PR DESCRIPTION
## Summary

Adds `legion push --repo <name> [--branch <b>]`, the sanctioned in-band push path for
agents. Raw `git push` has never been allowlisted (it prompts the operator on every
invocation) and the standing push-from-own-checkout doctrine (019f20eb: the pre-push hook
reviews the CWD's checked-out branch, not the ref being pushed) currently has to be enforced
by agent discipline alone -- exactly the failure mode that turns worktree wave automation
into a permission-prompt storm. This command enforces the doctrine structurally: it resolves
the checkout that actually has the target branch checked out via `git worktree list
--porcelain`, runs the push from that checkout, refuses `main`/`master` and any
force/refspec-shaped `--branch` value by construction (there is no `--force` flag to bypass),
sets the upstream tracking branch, and audit-logs every attempt -- success or failure -- with
the branch, resolved checkout, and head SHA.

## Acceptance criteria mapping

### 1. All tests pass
`cargo test --bin legion` passes all 1422 unit tests (12 of them new, in
`src/cli/push.rs::tests`, covering the porcelain parser, checkout resolution, and branch
validation as pure functions). `cargo test --test integration` passes all 299 integration
tests, including 9 new tests in `tests/integration/push.rs` that drive the compiled binary
against real hermetic git fixtures (a bare "remote" plus a local checkout, following the
`setup_git_repo_with_feature_branch` pattern already established in
`tests/integration/worksource_pr.rs:1876`): the happy path (upstream set, ref lands on the
remote), the CWD-default-branch path, `main`/`master` refusal, a flag-shaped `--branch` value
refusal, a not-found-in-any-worktree error naming the searched checkouts, the core
push-from-linked-worktree-not-cwd doctrine case, and both audit outcomes (success and a real
`git push` failure against a non-repo `origin`).
Evidence: `cargo test --bin legion` -> "test result: ok. 1422 passed; 0 failed"; `cargo test
--test integration` -> "test result: ok. 299 passed; 0 failed".

### 2. Simplify pass completed
Ran `/legion-simplify` against `main...HEAD` (7 changed files), writing a per-file
articulation citing concrete file:line/fn locators for every entry, and recorded it via
`legion quality-gate check --skill legion-simplify --result clean`.
Evidence: quality gate id `019f64a3-5892-7011-acf0-a4c847f023a1`, recorded clean, 7 file
entries, 0 findings, on HEAD commit `8fd39195a1a3d5ec108de625d03fb455469b5193`. The
pre-commit hook's own simplify review on both commits also returned PASS (the second commit
was written specifically to address the one non-blocking suggestion the first review made:
opening the audit DB before the push instead of after, in `src/cli/push.rs::handle_push`).

### 3. Review pass completed and issues fixed
Not reached at this point in the pipeline by design: this implementer's mandate stops after
`pr-write` and commit, before `legion pr create` -- the operator pushes and opens the PR in
the main session, and `legion-review` runs against the open PR as the next pipeline stage
(simplify -> pr-write -> review -> verify). Nothing here is deferred maintenance debt: the
simplify pass (criterion 2) already reviewed every changed file for the same
structural-quality categories review re-checks, so the review stage has a clean starting
point rather than a backlog of known issues to fix.
Evidence: pipeline order documented in the `legion-review` skill description ("the review
stage of the plugin quality pipeline: simplify -> pr-write -> review -> verify"); no review
findings exist yet because no review has run yet.

### 4. PR created and linked
This PR, opened via `legion pr create --closes 791` from the branch's own checkout after the
supervised push.
Evidence: `legion pr write-check` records a clean `legion-pr-write` gate on HEAD, which is
the precondition `legion pr create` checks before it will open the PR.

## Behavior detail (issue's Behavior/Error Handling requirements, for the reviewer)

- **Checkout resolution + hard error naming searched worktrees**: `list_worktrees()` +
  `parse_worktree_list_porcelain()` in `src/cli/push.rs` parse `git worktree list
  --porcelain`; `resolve_checkout()` finds the entry whose `branch` matches, or returns
  `LegionError::PushBranchNotFound { branch, searched }` naming every checkout path
  searched. Covered by
  `tests/integration/push.rs::push_branch_not_found_in_any_worktree_errors` and
  `push_resolves_checkout_from_linked_worktree_not_cwd` (the doctrine's core case: CWD sits
  on `main`, the target branch only exists in a linked worktree, and the push still finds
  and runs from it).
- **Default branch = CWD's checked-out branch; main/master refused; no force flag**:
  `handle_push` defaults to `git_head_commit_and_branch()`'s branch when `--branch` is
  omitted; `validate_branch()` refuses `main`/`master` and any value shaped like a git flag
  or a force/retarget refspec (leading `-`/`+`, embedded `:`, whitespace) -- closing the gap
  where a crafted `--branch` value could recover force semantics even though the CLI itself
  has no `--force` flag. Covered by `push_refuses_main`, `push_refuses_master`,
  `push_refuses_flag_shaped_branch_value`, and 8 unit tests in `push.rs::tests`.
- **Sets upstream on push**: `run_push()` always runs `git -C <checkout> push -u origin
  <branch>` -- unconditional rather than probing for "is this the first push", since `-u` is
  a no-op once the upstream is already correct. Covered by
  `push_first_time_sets_upstream_and_pushes_feature_branch`, which asserts
  `feat/x@{upstream}` resolves to `origin/feat/x` after the push.
- **Audit-logged via `db::AuditInput`**: every attempt, success or failure, is audited with
  `target_ref` = branch, `details` = `{checkout, head_sha}` JSON, `outcome` = "success" or
  "failure" -- the DB is opened before the push runs so a DB-open failure cannot mask a
  completed push's real result. Covered by `push_writes_audit_row_on_success` and
  `push_underlying_git_failure_surfaces_error_and_audits_failure` (the latter asserts a
  `"failure"`-outcome row exists for a push that actually failed).
- **Hooks run normally, never bypassed**: `run_push()` invokes plain `git push` with no
  `--no-verify`-equivalent flag and no timeout wrapper (unlike the worksource plugin's
  bounded `call_plugin`, which exists for `gh` API calls, not git hooks that may legitimately
  run long, e.g. the nested-claude pre-push review) -- a hook failure surfaces through git's
  own non-zero exit status as `LegionError::PushFailed`.
- **Exit codes / stderr relay per worksource conventions**: `relay_and_capture_stderr()`
  streams each stderr line to our own stderr live (visible during a long-running hook, not
  only after completion) and also captures it for the `PushFailed` message -- mirroring
  `call_plugin_inner`'s "relayed for every plugin call" behavior in `src/worksource/mod.rs`.
  Our own diagnostics (the "pushing '<branch>' from <path>" line) go through the `info!`
  macro, gated on `--verbose`; git's own output is always relayed.
- **thiserror variants**: `PushBranchNotFound { branch, searched }`, `PushRefused { branch,
  reason }` (covers both the main/master refusal and the force/flag-shaped-value refusal),
  and `PushFailed { stderr }` added to `src/error.rs`, each with a Display test.

## Not done

- No `--force` flag, by construction, per the issue's explicit requirement -- there is
  nothing to "not do" here beyond confirming its absence (`src/cli/mod.rs`'s `Push` variant
  has exactly `--repo` and `--branch`).
- Did not retire the pre-push hook's CWD-scoped review behavior itself -- explicitly out of
  scope per the issue ("Retiring the pre-push hook's CWD behavior (separate concern; this
  tool sidesteps it correctly by construction)").
- Did not touch the worksource/gh plugin path at all -- explicitly out of scope per the issue
  ("Any gh/API interaction (this is pure git; the worksource plugin is not involved)").
- Did not add a first-push-vs-steady-state distinction to the audit details (e.g. an
  `is_first_push` field) -- `-u` unconditionally is a strict superset of "sets upstream on
  first push" and avoids an extra `@{upstream}` probe; not required by the issue text.
- Did not impose a timeout on the push subprocess, unlike the worksource plugin's 30s
  `call_plugin` bound -- deliberate, since a pre-push hook (the nested-claude review) may
  legitimately run long, and the issue's own Behavior list says a hook failure/timeout must
  surface as the command's error, not that this command should impose its own timeout on top
  of whatever the hook itself does. Operator field note the same day (019f64b5): the real
  foot-gun is callers under-provisioning their own timeouts and misreading exit 143 as a
  hook failure.

Closes #791
