### PR TITLE
feat(#779): --base override for quality-gate check + R100 rename auto-clear

### DIFF
--- a/src/cli/pr.rs
+++ b/src/cli/pr.rs
@@ -349,6 +349,7 @@ fn validate_and_record_pr_write_gate(
         result: gate_result,
         findings_count: report.findings.len() as u64,
         details: Some(&details),
+        base: None,
     })?;
     crate::gate_trust::emit_gate_trust(database, &row);
 

--- a/src/cli/pr.rs
+++ b/src/cli/pr.rs
@@ -356,6 +356,7 @@ fn validate_and_record_pr_write_gate(
         findings_count: report.findings.len() as u64,
         details: Some(&details),
         provenance: GateProvenance::Validated,
+        base: None,
     })?;
     crate::gate_trust::emit_gate_trust(database, &row);
 

--- a/src/cli/util.rs
+++ b/src/cli/util.rs
@@ -177,7 +177,10 @@ pub(crate) fn git_changed_files(base: Option<&str>) -> Result<ChangedFiles, erro
         ));
     }
 
-    let resolved_base: Option<String> = if let Some(explicit) = base {
+    // Resolved directly to a `String` (not `Option<String>` + a later
+    // `.expect`) so the type system -- not a runtime assertion -- proves
+    // every path either yields a real base or returns early.
+    let base_ref: String = if let Some(explicit) = base {
         // An explicit --base must resolve to a real ref. No fallback, no
         // vacuous pass -- a typo'd or unmerged base ref is a hard error so
         // the gate never runs against an accidentally empty diff.
@@ -196,7 +199,7 @@ pub(crate) fn git_changed_files(base: Option<&str>) -> Result<ChangedFiles, erro
                  {stderr}"
             )));
         }
-        Some(explicit.to_owned())
+        explicit.to_owned()
     } else {
         // Probe each candidate base ref. Collect the first one that resolves.
         let candidates: [&str; 2] = ["main", "origin/main"];
@@ -216,7 +219,7 @@ pub(crate) fn git_changed_files(base: Option<&str>) -> Result<ChangedFiles, erro
             }
         }
 
-        let Some(base_ref) = found else {
+        let Some(found_ref) = found else {
             // Neither main nor origin/main exists. This is legitimate only
             // when HEAD itself has no parent (initial commit / orphan
             // branch). Probe for a parent commit; if there is one, the
@@ -256,12 +259,8 @@ pub(crate) fn git_changed_files(base: Option<&str>) -> Result<ChangedFiles, erro
                 base: None,
             });
         };
-        Some(base_ref.to_owned())
+        found_ref.to_owned()
     };
-
-    // resolved_base is always Some at this point -- both branches above
-    // either set it or return early.
-    let base_ref = resolved_base.expect("resolved_base set on every non-early-return path");
 
     // Run the three-dot diff with core.quotePath=false so non-ASCII paths
     // are returned as-is (no octal escaping) and match heading paths exactly.
@@ -298,36 +297,50 @@ pub(crate) fn git_changed_files(base: Option<&str>) -> Result<ChangedFiles, erro
         }
         let mut fields = line.split('\t');
         let status = fields.next().unwrap_or("");
-        if let Some(similarity) = status.strip_prefix('R') {
-            // Rename line: `R<nn>\t<old_path>\t<new_path>`.
+        // Rename (`R<nn>`) and copy (`C<nn>`) lines share the same
+        // three-field shape (`<status>\t<old>\t<new>`); RENAME_SIMILARITY
+        // never passes `-C` on the command line, so a `C` line should not
+        // occur in practice, but a future call site or an unusual git build
+        // must not silently misparse one as a plain `<status>\t<path>` line
+        // and grab the wrong (source, not destination) field. Only `R100`
+        // gets the zero-delta auto-clear -- this issue scopes that exclusion
+        // to true renames, not copies (a copy leaves the source in place, so
+        // even a byte-identical one is not risk-free the way a pure move is).
+        if let Some(similarity) = status
+            .strip_prefix('R')
+            .or_else(|| status.strip_prefix('C'))
+        {
+            let is_rename = status.starts_with('R');
             let old_path = fields.next();
             let new_path = fields.next();
             match (old_path, new_path) {
                 (Some(old_path), Some(new_path)) => {
-                    if similarity == "100" {
+                    if is_rename && similarity == "100" {
                         // Zero-delta move: excluded from the coverage set,
                         // recorded for the audit trail.
                         cleared_renames.push((old_path.to_owned(), new_path.to_owned()));
                     } else {
-                        // Content delta: the new path carries the diff that
-                        // needs review. (The old path no longer exists in
-                        // the tree -- there is nothing further to review
-                        // "at" it once the rename is detected as such.)
+                        // Content delta (rename) or any copy: the new path
+                        // carries the diff that needs review. (For a rename,
+                        // the old path no longer exists in the tree -- there
+                        // is nothing further to review "at" it once the
+                        // rename is detected as such.)
                         files.insert(new_path.to_owned());
                     }
                 }
                 _ => {
                     return Err(error::LegionError::WorkSource(format!(
-                        "git diff --name-status produced a malformed rename line \
-                         (expected 'R<nn>\\t<old>\\t<new>'): {line:?}"
+                        "git diff --name-status produced a malformed rename/copy line \
+                         (expected '{{R,C}}<nn>\\t<old>\\t<new>'): {line:?}"
                     )));
                 }
             }
         } else {
-            // Non-rename line (A/M/D/T/...): `<status>\t<path>`. An
-            // undetected rename below RENAME_SIMILARITY surfaces here as a
-            // separate D line and A line -- both paths land in the coverage
-            // set, exactly like any other unrelated delete + add pair.
+            // Non-rename, non-copy line (A/M/D/T/...): `<status>\t<path>`.
+            // An undetected rename below RENAME_SIMILARITY surfaces here as
+            // a separate D line and A line -- both paths land in the
+            // coverage set, exactly like any other unrelated delete + add
+            // pair.
             if let Some(path) = fields.next() {
                 files.insert(path.to_owned());
             }

--- a/src/cli/util.rs
+++ b/src/cli/util.rs
@@ -102,25 +102,68 @@ pub(crate) fn read_file_or_stdin(
     }
 }
 
-/// List files changed between main (or origin/main) and HEAD.
+/// Similarity threshold pinned on every `git diff -M` invocation in
+/// [`git_changed_files`] (#779). Passed explicitly on the command line so the
+/// coverage set never drifts with a repo's (or a contributor's global)
+/// `diff.renames` config -- an ambient config change must not silently widen
+/// or narrow what the simplify gate treats as a "pure" rename. 50% matches
+/// git's own long-standing default for `-M` with no argument.
+const RENAME_SIMILARITY: &str = "-M50%";
+
+/// The changed-file set resolved by [`git_changed_files`], plus the audit
+/// trail the R100 auto-clear (#779) requires.
+pub(crate) struct ChangedFiles {
+    /// Paths the simplify articulation must cover: every added/modified/
+    /// deleted/type-changed path, the new-path side of any rename with a
+    /// content delta (`R<100`), and both sides of an undetected rename
+    /// (below [`RENAME_SIMILARITY`], which git reports as a plain delete +
+    /// add pair rather than a single `R` line).
+    pub(crate) files: std::collections::HashSet<String>,
+    /// `(old_path, new_path)` pairs for every pure (`R100`, zero-delta)
+    /// rename excluded from `files`. Git's own rename detection guarantees
+    /// these carry no simplification risk -- content is byte-identical, only
+    /// the path moved -- but the pairs are surfaced here (rather than simply
+    /// dropped) so the exclusion is auditable, not silent (field case: a
+    /// 509-file strangler PR where 406 were verbatim moves).
+    pub(crate) cleared_renames: Vec<(String, String)>,
+    /// The base ref the diff actually ran against: the resolved `main` /
+    /// `origin/main` fallback, the caller's explicit `--base` override, or
+    /// `None` in the vacuous initial-commit case where no diff ran at all.
+    /// Recorded on the gate row so a too-narrow base stays visible in the
+    /// audit trail rather than disappearing once the coverage set looks
+    /// clean (#779).
+    pub(crate) base: Option<String>,
+}
+
+/// List files changed between `base` (or, when `None`, `main`/`origin/main`)
+/// and HEAD, auto-clearing pure renames from the coverage set.
 ///
-/// Uses `git diff -c core.quotePath=false --name-only main...HEAD` (three-dot
-/// merge-base range) so that files changed only on main since the branch point
-/// do not appear in the set. Falls back to `origin/main...HEAD` when `main` is
-/// absent locally.
+/// Uses `git diff -c core.quotePath=false --name-status -M50% <base>...HEAD`
+/// (three-dot merge-base range, explicit similarity pin -- see
+/// [`RENAME_SIMILARITY`]) so that files changed only on the base ref since the
+/// branch point do not appear in the set. When `base` is `None`, falls back
+/// to `origin/main...HEAD` when `main` is absent locally (the pre-#779
+/// default-resolution behavior, unchanged).
 ///
-/// Before trying the diff, each candidate base ref is probed with
-/// `git rev-parse --verify <ref>`. When a ref resolves but the diff command
-/// still fails, that is a hard error (the environment is broken, not a
-/// legitimate no-base situation). When neither ref resolves AND HEAD has no
-/// parent commit (initial commit), an empty set is returned so the gate passes
-/// vacuously. In any other failure mode this function returns `Err` so the
-/// caller can refuse to record a gate rather than silently accepting vacuous
-/// coverage.
+/// When `base` is `Some`, it is probed with `git rev-parse --verify <ref>`
+/// and any failure to resolve is a hard error -- an explicit `--base` that
+/// does not name a real ref must never silently fall back to the default
+/// resolution or vacuously pass, matching the existing no-base-ref behavior
+/// for the auto-detected case. When `base` is `None` and neither `main` nor
+/// `origin/main` resolves AND HEAD has no parent commit (initial commit), an
+/// empty set is returned so the gate passes vacuously. In any other failure
+/// mode this function returns `Err` so the caller can refuse to record a gate
+/// rather than silently accepting vacuous coverage.
+///
+/// `--name-status` (rather than `--name-only`) is what makes the R100
+/// auto-clear possible: it reports renames as `R<similarity>\t<old>\t<new>`
+/// instead of collapsing a detected rename down to just the new path, so a
+/// zero-delta (`R100`) move can be told apart from one that also touched
+/// content (`R<100`).
 ///
 /// Used by `legion quality-gate check` to build the coverage set the
 /// articulation must address.
-pub(crate) fn git_changed_files() -> Result<std::collections::HashSet<String>, error::LegionError> {
+pub(crate) fn git_changed_files(base: Option<&str>) -> Result<ChangedFiles, error::LegionError> {
     // Probe whether git is available at all first.
     let probe = std::process::Command::new("git")
         .args(["rev-parse", "--is-inside-work-tree"])
@@ -134,66 +177,105 @@ pub(crate) fn git_changed_files() -> Result<std::collections::HashSet<String>, e
         ));
     }
 
-    // Probe each candidate base ref. Collect the ones that resolve.
-    let candidates: [&str; 2] = ["main", "origin/main"];
-    let mut resolved_base: Option<&str> = None;
-    for candidate in candidates {
+    // Resolved directly to a `String` (not `Option<String>` + a later
+    // `.expect`) so the type system -- not a runtime assertion -- proves
+    // every path either yields a real base or returns early.
+    let base_ref: String = if let Some(explicit) = base {
+        // An explicit --base must resolve to a real ref. No fallback, no
+        // vacuous pass -- a typo'd or unmerged base ref is a hard error so
+        // the gate never runs against an accidentally empty diff.
         let verify = std::process::Command::new("git")
-            .args(["rev-parse", "--verify", candidate])
+            .args(["rev-parse", "--verify", explicit])
             .output()
             .map_err(|e| {
                 error::LegionError::WorkSource(format!(
-                    "failed to probe git ref '{candidate}': {e}"
+                    "failed to probe --base ref '{explicit}': {e}"
                 ))
             })?;
-        if verify.status.success() {
-            resolved_base = Some(candidate);
-            break;
+        if !verify.status.success() {
+            let stderr = String::from_utf8_lossy(&verify.stderr);
+            return Err(error::LegionError::WorkSource(format!(
+                "--base ref '{explicit}' does not resolve (git rev-parse --verify failed): \
+                 {stderr}"
+            )));
         }
-    }
+        explicit.to_owned()
+    } else {
+        // Probe each candidate base ref. Collect the first one that resolves.
+        let candidates: [&str; 2] = ["main", "origin/main"];
+        let mut found: Option<&str> = None;
+        for candidate in candidates {
+            let verify = std::process::Command::new("git")
+                .args(["rev-parse", "--verify", candidate])
+                .output()
+                .map_err(|e| {
+                    error::LegionError::WorkSource(format!(
+                        "failed to probe git ref '{candidate}': {e}"
+                    ))
+                })?;
+            if verify.status.success() {
+                found = Some(candidate);
+                break;
+            }
+        }
 
-    let Some(base_ref) = resolved_base else {
-        // Neither main nor origin/main exists. This is legitimate only when
-        // HEAD itself has no parent (initial commit / orphan branch). Probe
-        // for a parent commit; if there is one, the branch just has an unusual
-        // base-ref name, which is a hard error rather than vacuous-pass.
-        let parent = std::process::Command::new("git")
-            .args(["rev-parse", "--verify", "HEAD~1"])
-            .output()
-            .map_err(|e| error::LegionError::WorkSource(format!("failed to probe HEAD~1: {e}")))?;
-        if parent.status.success() {
-            // HEAD has a parent but no known base ref -- refuse rather than
-            // vacuously pass. An agent running on an unusual default branch
-            // (master, develop, etc.) must configure the base ref.
-            return Err(error::LegionError::WorkSource(
-                "could not find base ref 'main' or 'origin/main' and HEAD has a parent commit; \
-                 the simplify gate cannot determine the changed-file set. \
-                 Ensure 'main' or 'origin/main' exists in this repo."
-                    .to_owned(),
-            ));
-        }
-        // HEAD has no parent: genuine initial commit, vacuously valid. This is
-        // unreachable in the normal branch-off-main workflow (HEAD always has
-        // a parent once `main` exists), but note it on stderr rather than
-        // passing silently -- a vacuous pass should never be invisible to
-        // whoever is watching the gate run.
-        eprintln!(
-            "[legion] no base ref ('main' or 'origin/main') found and HEAD has no parent \
-             commit -- treating this as the initial commit. The changed-file set is empty \
-             and any articulation is accepted vacuously."
-        );
-        return Ok(std::collections::HashSet::new());
+        let Some(found_ref) = found else {
+            // Neither main nor origin/main exists. This is legitimate only
+            // when HEAD itself has no parent (initial commit / orphan
+            // branch). Probe for a parent commit; if there is one, the
+            // branch just has an unusual base-ref name, which is a hard
+            // error rather than vacuous-pass.
+            let parent = std::process::Command::new("git")
+                .args(["rev-parse", "--verify", "HEAD~1"])
+                .output()
+                .map_err(|e| {
+                    error::LegionError::WorkSource(format!("failed to probe HEAD~1: {e}"))
+                })?;
+            if parent.status.success() {
+                // HEAD has a parent but no known base ref -- refuse rather
+                // than vacuously pass. An agent running on an unusual
+                // default branch (master, develop, etc.) must configure the
+                // base ref (or pass --base explicitly).
+                return Err(error::LegionError::WorkSource(
+                    "could not find base ref 'main' or 'origin/main' and HEAD has a parent \
+                     commit; the simplify gate cannot determine the changed-file set. \
+                     Ensure 'main' or 'origin/main' exists in this repo, or pass --base."
+                        .to_owned(),
+                ));
+            }
+            // HEAD has no parent: genuine initial commit, vacuously valid.
+            // This is unreachable in the normal branch-off-main workflow
+            // (HEAD always has a parent once `main` exists), but note it on
+            // stderr rather than passing silently -- a vacuous pass should
+            // never be invisible to whoever is watching the gate run.
+            eprintln!(
+                "[legion] no base ref ('main' or 'origin/main') found and HEAD has no parent \
+                 commit -- treating this as the initial commit. The changed-file set is empty \
+                 and any articulation is accepted vacuously."
+            );
+            return Ok(ChangedFiles {
+                files: std::collections::HashSet::new(),
+                cleared_renames: Vec::new(),
+                base: None,
+            });
+        };
+        found_ref.to_owned()
     };
 
     // Run the three-dot diff with core.quotePath=false so non-ASCII paths
     // are returned as-is (no octal escaping) and match heading paths exactly.
+    // --name-status -M<pinned similarity> reports renames as their own
+    // `R<nn>\t<old>\t<new>` lines instead of collapsing them to the new path
+    // alone, which is what lets the parse below tell a pure move (R100) apart
+    // from a rename that also touched content (R<100).
     let refspec = format!("{base_ref}...HEAD");
     let out = std::process::Command::new("git")
         .args([
             "-c",
             "core.quotePath=false",
             "diff",
-            "--name-only",
+            "--name-status",
+            RENAME_SIMILARITY,
             &refspec,
         ])
         .output()
@@ -201,18 +283,75 @@ pub(crate) fn git_changed_files() -> Result<std::collections::HashSet<String>, e
     if !out.status.success() {
         let stderr = String::from_utf8_lossy(&out.stderr);
         return Err(error::LegionError::WorkSource(format!(
-            "git diff --name-only {refspec} failed (base ref '{base_ref}' resolved \
+            "git diff --name-status {refspec} failed (base ref '{base_ref}' resolved \
              but diff did not): {stderr}"
         )));
     }
 
-    let set: std::collections::HashSet<String> = String::from_utf8_lossy(&out.stdout)
-        .lines()
-        .map(str::trim)
-        .filter(|l| !l.is_empty())
-        .map(str::to_owned)
-        .collect();
-    Ok(set)
+    let mut files: std::collections::HashSet<String> = std::collections::HashSet::new();
+    let mut cleared_renames: Vec<(String, String)> = Vec::new();
+    for line in String::from_utf8_lossy(&out.stdout).lines() {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        let mut fields = line.split('\t');
+        let status = fields.next().unwrap_or("");
+        // Rename (`R<nn>`) and copy (`C<nn>`) lines share the same
+        // three-field shape (`<status>\t<old>\t<new>`); RENAME_SIMILARITY
+        // never passes `-C` on the command line, so a `C` line should not
+        // occur in practice, but a future call site or an unusual git build
+        // must not silently misparse one as a plain `<status>\t<path>` line
+        // and grab the wrong (source, not destination) field. Only `R100`
+        // gets the zero-delta auto-clear -- this issue scopes that exclusion
+        // to true renames, not copies (a copy leaves the source in place, so
+        // even a byte-identical one is not risk-free the way a pure move is).
+        if let Some(similarity) = status
+            .strip_prefix('R')
+            .or_else(|| status.strip_prefix('C'))
+        {
+            let is_rename = status.starts_with('R');
+            let old_path = fields.next();
+            let new_path = fields.next();
+            match (old_path, new_path) {
+                (Some(old_path), Some(new_path)) => {
+                    if is_rename && similarity == "100" {
+                        // Zero-delta move: excluded from the coverage set,
+                        // recorded for the audit trail.
+                        cleared_renames.push((old_path.to_owned(), new_path.to_owned()));
+                    } else {
+                        // Content delta (rename) or any copy: the new path
+                        // carries the diff that needs review. (For a rename,
+                        // the old path no longer exists in the tree -- there
+                        // is nothing further to review "at" it once the
+                        // rename is detected as such.)
+                        files.insert(new_path.to_owned());
+                    }
+                }
+                _ => {
+                    return Err(error::LegionError::WorkSource(format!(
+                        "git diff --name-status produced a malformed rename/copy line \
+                         (expected '{{R,C}}<nn>\\t<old>\\t<new>'): {line:?}"
+                    )));
+                }
+            }
+        } else {
+            // Non-rename, non-copy line (A/M/D/T/...): `<status>\t<path>`.
+            // An undetected rename below RENAME_SIMILARITY surfaces here as
+            // a separate D line and A line -- both paths land in the
+            // coverage set, exactly like any other unrelated delete + add
+            // pair.
+            if let Some(path) = fields.next() {
+                files.insert(path.to_owned());
+            }
+        }
+    }
+
+    Ok(ChangedFiles {
+        files,
+        cleared_renames,
+        base: Some(base_ref),
+    })
 }
 
 pub(crate) fn format_age(d: std::time::Duration) -> String {

--- a/src/cli/util.rs
+++ b/src/cli/util.rs
@@ -102,25 +102,68 @@ pub(crate) fn read_file_or_stdin(
     }
 }
 
-/// List files changed between main (or origin/main) and HEAD.
+/// Similarity threshold pinned on every `git diff -M` invocation in
+/// [`git_changed_files`] (#779). Passed explicitly on the command line so the
+/// coverage set never drifts with a repo's (or a contributor's global)
+/// `diff.renames` config -- an ambient config change must not silently widen
+/// or narrow what the simplify gate treats as a "pure" rename. 50% matches
+/// git's own long-standing default for `-M` with no argument.
+const RENAME_SIMILARITY: &str = "-M50%";
+
+/// The changed-file set resolved by [`git_changed_files`], plus the audit
+/// trail the R100 auto-clear (#779) requires.
+pub(crate) struct ChangedFiles {
+    /// Paths the simplify articulation must cover: every added/modified/
+    /// deleted/type-changed path, the new-path side of any rename with a
+    /// content delta (`R<100`), and both sides of an undetected rename
+    /// (below [`RENAME_SIMILARITY`], which git reports as a plain delete +
+    /// add pair rather than a single `R` line).
+    pub(crate) files: std::collections::HashSet<String>,
+    /// `(old_path, new_path)` pairs for every pure (`R100`, zero-delta)
+    /// rename excluded from `files`. Git's own rename detection guarantees
+    /// these carry no simplification risk -- content is byte-identical, only
+    /// the path moved -- but the pairs are surfaced here (rather than simply
+    /// dropped) so the exclusion is auditable, not silent (field case: a
+    /// 509-file strangler PR where 406 were verbatim moves).
+    pub(crate) cleared_renames: Vec<(String, String)>,
+    /// The base ref the diff actually ran against: the resolved `main` /
+    /// `origin/main` fallback, the caller's explicit `--base` override, or
+    /// `None` in the vacuous initial-commit case where no diff ran at all.
+    /// Recorded on the gate row so a too-narrow base stays visible in the
+    /// audit trail rather than disappearing once the coverage set looks
+    /// clean (#779).
+    pub(crate) base: Option<String>,
+}
+
+/// List files changed between `base` (or, when `None`, `main`/`origin/main`)
+/// and HEAD, auto-clearing pure renames from the coverage set.
 ///
-/// Uses `git diff -c core.quotePath=false --name-only main...HEAD` (three-dot
-/// merge-base range) so that files changed only on main since the branch point
-/// do not appear in the set. Falls back to `origin/main...HEAD` when `main` is
-/// absent locally.
+/// Uses `git diff -c core.quotePath=false --name-status -M50% <base>...HEAD`
+/// (three-dot merge-base range, explicit similarity pin -- see
+/// [`RENAME_SIMILARITY`]) so that files changed only on the base ref since the
+/// branch point do not appear in the set. When `base` is `None`, falls back
+/// to `origin/main...HEAD` when `main` is absent locally (the pre-#779
+/// default-resolution behavior, unchanged).
 ///
-/// Before trying the diff, each candidate base ref is probed with
-/// `git rev-parse --verify <ref>`. When a ref resolves but the diff command
-/// still fails, that is a hard error (the environment is broken, not a
-/// legitimate no-base situation). When neither ref resolves AND HEAD has no
-/// parent commit (initial commit), an empty set is returned so the gate passes
-/// vacuously. In any other failure mode this function returns `Err` so the
-/// caller can refuse to record a gate rather than silently accepting vacuous
-/// coverage.
+/// When `base` is `Some`, it is probed with `git rev-parse --verify <ref>`
+/// and any failure to resolve is a hard error -- an explicit `--base` that
+/// does not name a real ref must never silently fall back to the default
+/// resolution or vacuously pass, matching the existing no-base-ref behavior
+/// for the auto-detected case. When `base` is `None` and neither `main` nor
+/// `origin/main` resolves AND HEAD has no parent commit (initial commit), an
+/// empty set is returned so the gate passes vacuously. In any other failure
+/// mode this function returns `Err` so the caller can refuse to record a gate
+/// rather than silently accepting vacuous coverage.
+///
+/// `--name-status` (rather than `--name-only`) is what makes the R100
+/// auto-clear possible: it reports renames as `R<similarity>\t<old>\t<new>`
+/// instead of collapsing a detected rename down to just the new path, so a
+/// zero-delta (`R100`) move can be told apart from one that also touched
+/// content (`R<100`).
 ///
 /// Used by `legion quality-gate check` to build the coverage set the
 /// articulation must address.
-pub(crate) fn git_changed_files() -> Result<std::collections::HashSet<String>, error::LegionError> {
+pub(crate) fn git_changed_files(base: Option<&str>) -> Result<ChangedFiles, error::LegionError> {
     // Probe whether git is available at all first.
     let probe = std::process::Command::new("git")
         .args(["rev-parse", "--is-inside-work-tree"])
@@ -134,66 +177,106 @@ pub(crate) fn git_changed_files() -> Result<std::collections::HashSet<String>, e
         ));
     }
 
-    // Probe each candidate base ref. Collect the ones that resolve.
-    let candidates: [&str; 2] = ["main", "origin/main"];
-    let mut resolved_base: Option<&str> = None;
-    for candidate in candidates {
+    let resolved_base: Option<String> = if let Some(explicit) = base {
+        // An explicit --base must resolve to a real ref. No fallback, no
+        // vacuous pass -- a typo'd or unmerged base ref is a hard error so
+        // the gate never runs against an accidentally empty diff.
         let verify = std::process::Command::new("git")
-            .args(["rev-parse", "--verify", candidate])
+            .args(["rev-parse", "--verify", explicit])
             .output()
             .map_err(|e| {
                 error::LegionError::WorkSource(format!(
-                    "failed to probe git ref '{candidate}': {e}"
+                    "failed to probe --base ref '{explicit}': {e}"
                 ))
             })?;
-        if verify.status.success() {
-            resolved_base = Some(candidate);
-            break;
+        if !verify.status.success() {
+            let stderr = String::from_utf8_lossy(&verify.stderr);
+            return Err(error::LegionError::WorkSource(format!(
+                "--base ref '{explicit}' does not resolve (git rev-parse --verify failed): \
+                 {stderr}"
+            )));
         }
-    }
+        Some(explicit.to_owned())
+    } else {
+        // Probe each candidate base ref. Collect the first one that resolves.
+        let candidates: [&str; 2] = ["main", "origin/main"];
+        let mut found: Option<&str> = None;
+        for candidate in candidates {
+            let verify = std::process::Command::new("git")
+                .args(["rev-parse", "--verify", candidate])
+                .output()
+                .map_err(|e| {
+                    error::LegionError::WorkSource(format!(
+                        "failed to probe git ref '{candidate}': {e}"
+                    ))
+                })?;
+            if verify.status.success() {
+                found = Some(candidate);
+                break;
+            }
+        }
 
-    let Some(base_ref) = resolved_base else {
-        // Neither main nor origin/main exists. This is legitimate only when
-        // HEAD itself has no parent (initial commit / orphan branch). Probe
-        // for a parent commit; if there is one, the branch just has an unusual
-        // base-ref name, which is a hard error rather than vacuous-pass.
-        let parent = std::process::Command::new("git")
-            .args(["rev-parse", "--verify", "HEAD~1"])
-            .output()
-            .map_err(|e| error::LegionError::WorkSource(format!("failed to probe HEAD~1: {e}")))?;
-        if parent.status.success() {
-            // HEAD has a parent but no known base ref -- refuse rather than
-            // vacuously pass. An agent running on an unusual default branch
-            // (master, develop, etc.) must configure the base ref.
-            return Err(error::LegionError::WorkSource(
-                "could not find base ref 'main' or 'origin/main' and HEAD has a parent commit; \
-                 the simplify gate cannot determine the changed-file set. \
-                 Ensure 'main' or 'origin/main' exists in this repo."
-                    .to_owned(),
-            ));
-        }
-        // HEAD has no parent: genuine initial commit, vacuously valid. This is
-        // unreachable in the normal branch-off-main workflow (HEAD always has
-        // a parent once `main` exists), but note it on stderr rather than
-        // passing silently -- a vacuous pass should never be invisible to
-        // whoever is watching the gate run.
-        eprintln!(
-            "[legion] no base ref ('main' or 'origin/main') found and HEAD has no parent \
-             commit -- treating this as the initial commit. The changed-file set is empty \
-             and any articulation is accepted vacuously."
-        );
-        return Ok(std::collections::HashSet::new());
+        let Some(base_ref) = found else {
+            // Neither main nor origin/main exists. This is legitimate only
+            // when HEAD itself has no parent (initial commit / orphan
+            // branch). Probe for a parent commit; if there is one, the
+            // branch just has an unusual base-ref name, which is a hard
+            // error rather than vacuous-pass.
+            let parent = std::process::Command::new("git")
+                .args(["rev-parse", "--verify", "HEAD~1"])
+                .output()
+                .map_err(|e| {
+                    error::LegionError::WorkSource(format!("failed to probe HEAD~1: {e}"))
+                })?;
+            if parent.status.success() {
+                // HEAD has a parent but no known base ref -- refuse rather
+                // than vacuously pass. An agent running on an unusual
+                // default branch (master, develop, etc.) must configure the
+                // base ref (or pass --base explicitly).
+                return Err(error::LegionError::WorkSource(
+                    "could not find base ref 'main' or 'origin/main' and HEAD has a parent \
+                     commit; the simplify gate cannot determine the changed-file set. \
+                     Ensure 'main' or 'origin/main' exists in this repo, or pass --base."
+                        .to_owned(),
+                ));
+            }
+            // HEAD has no parent: genuine initial commit, vacuously valid.
+            // This is unreachable in the normal branch-off-main workflow
+            // (HEAD always has a parent once `main` exists), but note it on
+            // stderr rather than passing silently -- a vacuous pass should
+            // never be invisible to whoever is watching the gate run.
+            eprintln!(
+                "[legion] no base ref ('main' or 'origin/main') found and HEAD has no parent \
+                 commit -- treating this as the initial commit. The changed-file set is empty \
+                 and any articulation is accepted vacuously."
+            );
+            return Ok(ChangedFiles {
+                files: std::collections::HashSet::new(),
+                cleared_renames: Vec::new(),
+                base: None,
+            });
+        };
+        Some(base_ref.to_owned())
     };
+
+    // resolved_base is always Some at this point -- both branches above
+    // either set it or return early.
+    let base_ref = resolved_base.expect("resolved_base set on every non-early-return path");
 
     // Run the three-dot diff with core.quotePath=false so non-ASCII paths
     // are returned as-is (no octal escaping) and match heading paths exactly.
+    // --name-status -M<pinned similarity> reports renames as their own
+    // `R<nn>\t<old>\t<new>` lines instead of collapsing them to the new path
+    // alone, which is what lets the parse below tell a pure move (R100) apart
+    // from a rename that also touched content (R<100).
     let refspec = format!("{base_ref}...HEAD");
     let out = std::process::Command::new("git")
         .args([
             "-c",
             "core.quotePath=false",
             "diff",
-            "--name-only",
+            "--name-status",
+            RENAME_SIMILARITY,
             &refspec,
         ])
         .output()
@@ -201,18 +284,61 @@ pub(crate) fn git_changed_files() -> Result<std::collections::HashSet<String>, e
     if !out.status.success() {
         let stderr = String::from_utf8_lossy(&out.stderr);
         return Err(error::LegionError::WorkSource(format!(
-            "git diff --name-only {refspec} failed (base ref '{base_ref}' resolved \
+            "git diff --name-status {refspec} failed (base ref '{base_ref}' resolved \
              but diff did not): {stderr}"
         )));
     }
 
-    let set: std::collections::HashSet<String> = String::from_utf8_lossy(&out.stdout)
-        .lines()
-        .map(str::trim)
-        .filter(|l| !l.is_empty())
-        .map(str::to_owned)
-        .collect();
-    Ok(set)
+    let mut files: std::collections::HashSet<String> = std::collections::HashSet::new();
+    let mut cleared_renames: Vec<(String, String)> = Vec::new();
+    for line in String::from_utf8_lossy(&out.stdout).lines() {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        let mut fields = line.split('\t');
+        let status = fields.next().unwrap_or("");
+        if let Some(similarity) = status.strip_prefix('R') {
+            // Rename line: `R<nn>\t<old_path>\t<new_path>`.
+            let old_path = fields.next();
+            let new_path = fields.next();
+            match (old_path, new_path) {
+                (Some(old_path), Some(new_path)) => {
+                    if similarity == "100" {
+                        // Zero-delta move: excluded from the coverage set,
+                        // recorded for the audit trail.
+                        cleared_renames.push((old_path.to_owned(), new_path.to_owned()));
+                    } else {
+                        // Content delta: the new path carries the diff that
+                        // needs review. (The old path no longer exists in
+                        // the tree -- there is nothing further to review
+                        // "at" it once the rename is detected as such.)
+                        files.insert(new_path.to_owned());
+                    }
+                }
+                _ => {
+                    return Err(error::LegionError::WorkSource(format!(
+                        "git diff --name-status produced a malformed rename line \
+                         (expected 'R<nn>\\t<old>\\t<new>'): {line:?}"
+                    )));
+                }
+            }
+        } else {
+            // Non-rename line (A/M/D/T/...): `<status>\t<path>`. An
+            // undetected rename below RENAME_SIMILARITY surfaces here as a
+            // separate D line and A line -- both paths land in the coverage
+            // set, exactly like any other unrelated delete + add pair.
+            if let Some(path) = fields.next() {
+                files.insert(path.to_owned());
+            }
+        }
+    }
+
+    Ok(ChangedFiles {
+        files,
+        cleared_renames,
+        base: Some(base_ref),
+    })
 }
 
 pub(crate) fn format_age(d: std::time::Duration) -> String {

--- a/src/cli/verify.rs
+++ b/src/cli/verify.rs
@@ -98,19 +98,27 @@ pub(crate) enum QualityGateAction {
     /// Validate a simplify articulation file before recording the gate (#665).
     ///
     /// Resolves the changed-file set from
-    /// `git -c core.quotePath=false diff --name-only main...HEAD` (three-dot
-    /// merge-base range; falls back to origin/main...HEAD when main is absent).
+    /// `git -c core.quotePath=false diff --name-status -M50% <base>...HEAD`
+    /// (three-dot merge-base range; `<base>` is `--base` when given, else
+    /// `main`, falling back to `origin/main...HEAD` when `main` is absent).
     /// If no base ref resolves and HEAD has a parent commit, this hard-errors
-    /// rather than recording a gate against an empty set. Parses
-    /// the articulation file -- markdown with one `### <path>` heading per
-    /// changed file followed by prose -- and refuses when:
+    /// rather than recording a gate against an empty set; an explicit
+    /// `--base` that does not resolve is likewise a hard error (#779). Pure
+    /// (zero-delta, R100) renames are auto-cleared from the coverage set --
+    /// their old/new path pairs are recorded in the gate's `details` JSON
+    /// instead of requiring an articulation entry, since a byte-identical
+    /// move carries no simplification risk by construction. Renames with a
+    /// content delta (R<100) still require an entry under the new path.
+    /// Parses the articulation file -- markdown with one `### <path>`
+    /// heading per changed file followed by prose -- and refuses when:
     ///   - Coverage gap: a changed file has no `### <path>` entry (reports
     ///     which files are unaddressed).
     ///   - Boilerplate / thin: an entry's prose is below the substance threshold
     ///     (reuses the same word-count heuristic as `pr write-check`).
     ///
     /// On pass: records a quality gate for HEAD under `--skill` with
-    /// `--result` as the gate outcome. On failure: lists each gap and exits
+    /// `--result` as the gate outcome, and the resolved base ref on the
+    /// gate row's `base` column. On failure: lists each gap and exits
     /// non-zero without recording a gate.
     ///
     /// Mirror of `legion pr write-check` for the simplify gate. The
@@ -134,6 +142,19 @@ pub(crate) enum QualityGateAction {
         /// Number of skill findings (default 0; used when --result is "issues").
         #[arg(long, default_value = "0")]
         findings_count: u64,
+
+        /// Override the base ref the changed-file set is diffed against
+        /// (default: `main`, falling back to `origin/main`). For stacked
+        /// branches whose parent is an unmerged feature branch, pass that
+        /// branch so the coverage set is scoped to what this branch actually
+        /// changed rather than everything since `main` (#779). Must resolve
+        /// to a real ref -- an unresolvable `--base` is a hard error, same as
+        /// the no-base-ref case with no override. The resolved base is
+        /// recorded on the gate row regardless of whether it came from this
+        /// flag or the default resolution, so a too-narrow base stays
+        /// visible in the audit trail.
+        #[arg(long)]
+        base: Option<String>,
     },
 
     /// Void a gate row: retire a known-false verdict without deleting it
@@ -205,6 +226,7 @@ pub(crate) fn handle_quality_gate(action: QualityGateAction) -> error::Result<()
                 findings_count,
                 details: details_json.as_deref(),
                 provenance: GateProvenance::Asserted,
+                base: None,
             })?;
             emit_gate_trust(&database, &row);
             // Phase 2b: a downstream legion-review verdict witnesses the
@@ -260,19 +282,23 @@ pub(crate) fn handle_quality_gate(action: QualityGateAction) -> error::Result<()
             result,
             articulation_file,
             findings_count,
+            base,
         } => {
             // Parse and validate the result flag before touching the FS.
             let gate_result: GateResult = GateResult::from_str(&result)?;
 
-            // Resolve the changed-file set from git. Falls back gracefully
-            // when main is not present locally.
-            let changed_files = git_changed_files()?;
+            // Resolve the changed-file set from git. `--base` overrides the
+            // default main/origin-main resolution (#779); an unresolvable
+            // `--base` hard-errors rather than falling back silently. Pure
+            // (R100) renames are cleared from `files` and carried separately
+            // in `cleared_renames` for the audit trail.
+            let changed = git_changed_files(base.as_deref())?;
 
             // Read the articulation from --articulation-file or stdin.
             let articulation =
                 read_file_or_stdin(articulation_file.as_deref(), "--articulation-file")?;
 
-            let report = simplify_check::validate_articulation(&changed_files, &articulation);
+            let report = simplify_check::validate_articulation(&changed.files, &articulation);
 
             // The gate is only recorded when the articulation passes the
             // structural validator. A failed articulation exits non-zero
@@ -302,12 +328,23 @@ pub(crate) fn handle_quality_gate(action: QualityGateAction) -> error::Result<()
             // flag is informational, and the skill runner may not always surface
             // a count. The gate result is what matters for `legion pr create`.
             let (commit_hash, branch) = git_head_commit_and_branch()?;
+            // Cleared (R100) renames are excluded from `report`'s coverage
+            // requirement but still surfaced here -- count + pairs -- so the
+            // exclusion is auditable rather than silent (#779).
+            let cleared_renames_json: Vec<serde_json::Value> = changed
+                .cleared_renames
+                .iter()
+                .map(|(old, new)| serde_json::json!({"old": old, "new": new}))
+                .collect();
             let details = serde_json::json!({
                 "skill": skill,
                 "result": result,
                 "entry_count": report.entry_count,
                 "findings_count": findings_count,
                 "articulation": articulation,
+                "base": changed.base,
+                "cleared_renames_count": cleared_renames_json.len(),
+                "cleared_renames": cleared_renames_json,
             })
             .to_string();
 
@@ -320,14 +357,18 @@ pub(crate) fn handle_quality_gate(action: QualityGateAction) -> error::Result<()
                 findings_count,
                 details: Some(&details),
                 provenance: GateProvenance::Validated,
+                base: changed.base.as_deref(),
             })?;
             emit_gate_trust(&database, &row);
 
             println!(
                 "[legion] simplify-check articulation accepted for skill '{skill}' \
-                 (result '{result}', {} file entries, {findings_count} skill findings). \
-                 Gate id: {}",
-                report.entry_count, row.id,
+                 (result '{result}', {} file entries, {findings_count} skill findings, \
+                 base '{}', {} rename(s) auto-cleared). Gate id: {}",
+                report.entry_count,
+                changed.base.as_deref().unwrap_or("<none>"),
+                changed.cleared_renames.len(),
+                row.id,
             );
         }
 
@@ -532,6 +573,7 @@ pub(crate) fn handle_verify(
             // legion-verify has no check validator -- asserted by necessity
             // (#780), same as every other verify-recorded row below.
             provenance: GateProvenance::Asserted,
+            base: None,
         })?;
         eprintln!("[legion] verify BLOCKED for card {card}: {reason}");
         return Err(error::LegionError::ExitWith(1));
@@ -590,6 +632,7 @@ pub(crate) fn handle_verify(
         details: Some(&details),
         // legion-verify has no check validator -- asserted by necessity (#780).
         provenance: GateProvenance::Asserted,
+        base: None,
     })?;
 
     match decision {
@@ -872,6 +915,7 @@ mod tests {
                 findings_count: 0,
                 details: Some(&serde_json::json!({"articulation": articulation}).to_string()),
                 provenance: GateProvenance::Validated,
+                base: None,
             })
             .expect("record_quality_gate failed");
         assert!(!row.id.is_empty());

--- a/src/cli/verify.rs
+++ b/src/cli/verify.rs
@@ -89,19 +89,27 @@ pub(crate) enum QualityGateAction {
     /// Validate a simplify articulation file before recording the gate (#665).
     ///
     /// Resolves the changed-file set from
-    /// `git -c core.quotePath=false diff --name-only main...HEAD` (three-dot
-    /// merge-base range; falls back to origin/main...HEAD when main is absent).
+    /// `git -c core.quotePath=false diff --name-status -M50% <base>...HEAD`
+    /// (three-dot merge-base range; `<base>` is `--base` when given, else
+    /// `main`, falling back to `origin/main...HEAD` when `main` is absent).
     /// If no base ref resolves and HEAD has a parent commit, this hard-errors
-    /// rather than recording a gate against an empty set. Parses
-    /// the articulation file -- markdown with one `### <path>` heading per
-    /// changed file followed by prose -- and refuses when:
+    /// rather than recording a gate against an empty set; an explicit
+    /// `--base` that does not resolve is likewise a hard error (#779). Pure
+    /// (zero-delta, R100) renames are auto-cleared from the coverage set --
+    /// their old/new path pairs are recorded in the gate's `details` JSON
+    /// instead of requiring an articulation entry, since a byte-identical
+    /// move carries no simplification risk by construction. Renames with a
+    /// content delta (R<100) still require an entry under the new path.
+    /// Parses the articulation file -- markdown with one `### <path>`
+    /// heading per changed file followed by prose -- and refuses when:
     ///   - Coverage gap: a changed file has no `### <path>` entry (reports
     ///     which files are unaddressed).
     ///   - Boilerplate / thin: an entry's prose is below the substance threshold
     ///     (reuses the same word-count heuristic as `pr write-check`).
     ///
     /// On pass: records a quality gate for HEAD under `--skill` with
-    /// `--result` as the gate outcome. On failure: lists each gap and exits
+    /// `--result` as the gate outcome, and the resolved base ref on the
+    /// gate row's `base` column. On failure: lists each gap and exits
     /// non-zero without recording a gate.
     ///
     /// Mirror of `legion pr write-check` for the simplify gate. The
@@ -125,6 +133,19 @@ pub(crate) enum QualityGateAction {
         /// Number of skill findings (default 0; used when --result is "issues").
         #[arg(long, default_value = "0")]
         findings_count: u64,
+
+        /// Override the base ref the changed-file set is diffed against
+        /// (default: `main`, falling back to `origin/main`). For stacked
+        /// branches whose parent is an unmerged feature branch, pass that
+        /// branch so the coverage set is scoped to what this branch actually
+        /// changed rather than everything since `main` (#779). Must resolve
+        /// to a real ref -- an unresolvable `--base` is a hard error, same as
+        /// the no-base-ref case with no override. The resolved base is
+        /// recorded on the gate row regardless of whether it came from this
+        /// flag or the default resolution, so a too-narrow base stays
+        /// visible in the audit trail.
+        #[arg(long)]
+        base: Option<String>,
     },
 }
 
@@ -147,6 +168,7 @@ pub(crate) fn handle_quality_gate(action: QualityGateAction) -> error::Result<()
                 result: gate_result,
                 findings_count,
                 details: details_json.as_deref(),
+                base: None,
             })?;
             emit_gate_trust(&database, &row);
             // Phase 2b: a downstream legion-review verdict witnesses the
@@ -202,19 +224,23 @@ pub(crate) fn handle_quality_gate(action: QualityGateAction) -> error::Result<()
             result,
             articulation_file,
             findings_count,
+            base,
         } => {
             // Parse and validate the result flag before touching the FS.
             let gate_result: GateResult = GateResult::from_str(&result)?;
 
-            // Resolve the changed-file set from git. Falls back gracefully
-            // when main is not present locally.
-            let changed_files = git_changed_files()?;
+            // Resolve the changed-file set from git. `--base` overrides the
+            // default main/origin-main resolution (#779); an unresolvable
+            // `--base` hard-errors rather than falling back silently. Pure
+            // (R100) renames are cleared from `files` and carried separately
+            // in `cleared_renames` for the audit trail.
+            let changed = git_changed_files(base.as_deref())?;
 
             // Read the articulation from --articulation-file or stdin.
             let articulation =
                 read_file_or_stdin(articulation_file.as_deref(), "--articulation-file")?;
 
-            let report = simplify_check::validate_articulation(&changed_files, &articulation);
+            let report = simplify_check::validate_articulation(&changed.files, &articulation);
 
             // The gate is only recorded when the articulation passes the
             // structural validator. A failed articulation exits non-zero
@@ -244,12 +270,23 @@ pub(crate) fn handle_quality_gate(action: QualityGateAction) -> error::Result<()
             // flag is informational, and the skill runner may not always surface
             // a count. The gate result is what matters for `legion pr create`.
             let (commit_hash, branch) = git_head_commit_and_branch()?;
+            // Cleared (R100) renames are excluded from `report`'s coverage
+            // requirement but still surfaced here -- count + pairs -- so the
+            // exclusion is auditable rather than silent (#779).
+            let cleared_renames_json: Vec<serde_json::Value> = changed
+                .cleared_renames
+                .iter()
+                .map(|(old, new)| serde_json::json!({"old": old, "new": new}))
+                .collect();
             let details = serde_json::json!({
                 "skill": skill,
                 "result": result,
                 "entry_count": report.entry_count,
                 "findings_count": findings_count,
                 "articulation": articulation,
+                "base": changed.base,
+                "cleared_renames_count": cleared_renames_json.len(),
+                "cleared_renames": cleared_renames_json,
             })
             .to_string();
 
@@ -261,14 +298,18 @@ pub(crate) fn handle_quality_gate(action: QualityGateAction) -> error::Result<()
                 result: gate_result,
                 findings_count,
                 details: Some(&details),
+                base: changed.base.as_deref(),
             })?;
             emit_gate_trust(&database, &row);
 
             println!(
                 "[legion] simplify-check articulation accepted for skill '{skill}' \
-                 (result '{result}', {} file entries, {findings_count} skill findings). \
-                 Gate id: {}",
-                report.entry_count, row.id,
+                 (result '{result}', {} file entries, {findings_count} skill findings, \
+                 base '{}', {} rename(s) auto-cleared). Gate id: {}",
+                report.entry_count,
+                changed.base.as_deref().unwrap_or("<none>"),
+                changed.cleared_renames.len(),
+                row.id,
             );
         }
     }
@@ -441,6 +482,7 @@ pub(crate) fn handle_verify(
             result: GateResult::Issues,
             findings_count: 1,
             details: Some(&details),
+            base: None,
         })?;
         eprintln!("[legion] verify BLOCKED for card {card}: {reason}");
         return Err(error::LegionError::ExitWith(1));
@@ -497,6 +539,7 @@ pub(crate) fn handle_verify(
         result: gate_result,
         findings_count: findings,
         details: Some(&details),
+        base: None,
     })?;
 
     match decision {
@@ -778,6 +821,7 @@ mod tests {
                 result: GateResult::Clean,
                 findings_count: 0,
                 details: Some(&serde_json::json!({"articulation": articulation}).to_string()),
+                base: None,
             })
             .expect("record_quality_gate failed");
         assert!(!row.id.is_empty());

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -150,6 +150,7 @@ impl Database {
         kanban::migrate(conn)?;
         schedules::migrate(conn)?;
         wake::migrate(conn)?;
+        quality_gates::migrate(conn)?;
         Ok(())
     }
 

--- a/src/db/quality_gates.rs
+++ b/src/db/quality_gates.rs
@@ -34,6 +34,22 @@ pub(super) fn create_tables(conn: &Connection) -> Result<()> {
     Ok(())
 }
 
+/// Column migrations for `quality_gates`, in their original patch order.
+pub(super) fn migrate(conn: &Connection) -> Result<()> {
+    // Migration 17 (#779): `--base` override for `legion quality-gate check`.
+    // Nullable -- existing rows and gates recorded without an explicit
+    // `--base` (the default main/origin-main resolution, or non-`check`
+    // gate kinds like `record` and `legion-verify`) have no base to record.
+    // Recording the resolved base ref on the row (rather than only inside
+    // the `details` JSON blob) keeps a too-narrow `--base` visible to the
+    // same `quality-gate list`/`stats` surfaces that already query columns,
+    // consistent with the issue's auditability-over-trust stance.
+    if !Database::has_column(conn, "quality_gates", "base")? {
+        conn.execute_batch("ALTER TABLE quality_gates ADD COLUMN base TEXT;")?;
+    }
+    Ok(())
+}
+
 /// A recorded quality gate result tied to a git commit and skill.
 ///
 /// Written by skill runners so `legion pr create` can verify clean state
@@ -49,6 +65,11 @@ pub struct QualityGateRow {
     pub findings_count: u64,
     pub details: Option<String>,
     pub created_at: String,
+    /// The `--base` ref the changed-file set was computed against (#779),
+    /// when the caller supplied one. `None` for gates recorded without an
+    /// explicit base (default main/origin-main resolution, or gate kinds
+    /// that never compute a changed-file set, e.g. `legion-verify`).
+    pub base: Option<String>,
 }
 
 /// Parse a `GateResult` from a DB string, mapping unknown values to a
@@ -76,6 +97,11 @@ pub struct QualityGateInput<'a> {
     pub result: GateResult,
     pub findings_count: u64,
     pub details: Option<&'a str>,
+    /// The `--base` ref used to compute the changed-file set (#779), when
+    /// the caller resolved one. `None` for gate kinds that never compute a
+    /// changed-file set, or when the default main/origin-main resolution
+    /// was used (as opposed to an explicit `--base` override).
+    pub base: Option<&'a str>,
 }
 
 impl Database {
@@ -90,8 +116,8 @@ impl Database {
         let result_str: &str = input.result.as_str();
         self.conn.execute(
             "INSERT INTO quality_gates \
-             (id, branch, commit_hash, skill, result, findings_count, details, created_at) \
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+             (id, branch, commit_hash, skill, result, findings_count, details, created_at, base) \
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
             rusqlite::params![
                 &id,
                 input.branch,
@@ -101,6 +127,7 @@ impl Database {
                 input.findings_count as i64,
                 input.details,
                 &created_at,
+                input.base,
             ],
         )?;
         Ok(QualityGateRow {
@@ -112,6 +139,7 @@ impl Database {
             findings_count: input.findings_count,
             details: input.details.map(str::to_owned),
             created_at,
+            base: input.base.map(str::to_owned),
         })
     }
 
@@ -125,7 +153,7 @@ impl Database {
         skill: &str,
     ) -> Result<Option<QualityGateRow>> {
         let mut stmt = self.conn.prepare(
-            "SELECT id, branch, commit_hash, skill, result, findings_count, details, created_at \
+            "SELECT id, branch, commit_hash, skill, result, findings_count, details, created_at, base \
              FROM quality_gates \
              WHERE commit_hash = ?1 AND skill = ?2 \
              ORDER BY created_at DESC \
@@ -143,6 +171,7 @@ impl Database {
                 findings_count: findings_count_i64.unsigned_abs(),
                 details: row.get(6)?,
                 created_at: row.get(7)?,
+                base: row.get(8)?,
             })
         })?;
         match rows.next() {
@@ -162,7 +191,7 @@ impl Database {
     /// after material changes.
     pub fn get_latest_quality_gate_by_skill(&self, skill: &str) -> Result<Option<QualityGateRow>> {
         let mut stmt = self.conn.prepare(
-            "SELECT id, branch, commit_hash, skill, result, findings_count, details, created_at \
+            "SELECT id, branch, commit_hash, skill, result, findings_count, details, created_at, base \
              FROM quality_gates \
              WHERE skill = ?1 \
              ORDER BY created_at DESC \
@@ -180,6 +209,7 @@ impl Database {
                 findings_count: findings_count_i64.unsigned_abs(),
                 details: row.get(6)?,
                 created_at: row.get(7)?,
+                base: row.get(8)?,
             })
         })?;
         match rows.next() {
@@ -262,7 +292,7 @@ impl Database {
         let where_clause = where_and(&predicates);
 
         let sql = format!(
-            "SELECT id, branch, commit_hash, skill, result, findings_count, details, created_at \
+            "SELECT id, branch, commit_hash, skill, result, findings_count, details, created_at, base \
              FROM quality_gates \
              {where_clause} \
              ORDER BY created_at DESC"
@@ -283,6 +313,7 @@ impl Database {
                     findings_count: findings_count_i64.unsigned_abs(),
                     details: row.get(6)?,
                     created_at: row.get(7)?,
+                    base: row.get(8)?,
                 })
             },
         )?;
@@ -389,6 +420,7 @@ mod tests {
                 result: GateResult::Clean,
                 findings_count: 0,
                 details: None,
+                base: None,
             })
             .unwrap();
         assert!(!row.id.is_empty());
@@ -406,6 +438,70 @@ mod tests {
         let fetched = fetched.unwrap();
         assert_eq!(fetched.id, row.id);
         assert_eq!(fetched.result, GateResult::Clean);
+    }
+
+    /// The `base` column (#779) round-trips through insert, direct lookup,
+    /// and `list_quality_gates` -- the three read paths a gate row is
+    /// visible through.
+    #[test]
+    fn quality_gate_base_column_round_trips_through_insert_and_reads() {
+        use crate::db::quality_gates::QualityGateFilter;
+
+        let db = test_db();
+        let row = db
+            .record_quality_gate(&QualityGateInput {
+                branch: "feat/child",
+                commit_hash: "base1234",
+                skill: "legion-simplify",
+                result: GateResult::Clean,
+                findings_count: 0,
+                details: None,
+                base: Some("feat/base-branch"),
+            })
+            .unwrap();
+        assert_eq!(row.base.as_deref(), Some("feat/base-branch"));
+
+        let fetched = db
+            .get_quality_gate("base1234", "legion-simplify")
+            .unwrap()
+            .expect("gate row should exist");
+        assert_eq!(fetched.base.as_deref(), Some("feat/base-branch"));
+
+        let listed = db
+            .list_quality_gates(&QualityGateFilter {
+                skill: Some("legion-simplify".to_owned()),
+                ..Default::default()
+            })
+            .unwrap();
+        assert_eq!(listed.len(), 1);
+        assert_eq!(listed[0].base.as_deref(), Some("feat/base-branch"));
+    }
+
+    /// A gate recorded without an explicit base (the common case: `record`,
+    /// `legion-verify`, or a `check` run against the default main/origin-main
+    /// resolution's vacuous-initial-commit branch) stores `base` as `NULL`
+    /// and reads back as `None`, not an empty string.
+    #[test]
+    fn quality_gate_base_column_defaults_to_none() {
+        let db = test_db();
+        let row = db
+            .record_quality_gate(&QualityGateInput {
+                branch: "main",
+                commit_hash: "nobase123",
+                skill: "legion-verify:card-1",
+                result: GateResult::Clean,
+                findings_count: 0,
+                details: None,
+                base: None,
+            })
+            .unwrap();
+        assert!(row.base.is_none());
+
+        let fetched = db
+            .get_quality_gate("nobase123", "legion-verify:card-1")
+            .unwrap()
+            .expect("gate row should exist");
+        assert!(fetched.base.is_none());
     }
 
     #[test]
@@ -427,6 +523,7 @@ mod tests {
             result: GateResult::Clean,
             findings_count: 0,
             details: None,
+            base: None,
         })
         .unwrap();
         // Different skill on the same commit should not match.
@@ -445,6 +542,7 @@ mod tests {
             result: GateResult::Clean,
             findings_count: 0,
             details: None,
+            base: None,
         })
         .unwrap();
         db.record_quality_gate(&QualityGateInput {
@@ -454,6 +552,7 @@ mod tests {
             result: GateResult::Issues,
             findings_count: 2,
             details: Some("{}"),
+            base: None,
         })
         .unwrap();
 
@@ -483,6 +582,7 @@ mod tests {
             result: GateResult::Issues,
             findings_count: 3,
             details: None,
+            base: None,
         })
         .unwrap();
         // Second run after fixing: clean.
@@ -493,6 +593,7 @@ mod tests {
             result: GateResult::Clean,
             findings_count: 0,
             details: None,
+            base: None,
         })
         .unwrap();
 
@@ -519,6 +620,7 @@ mod tests {
                 result: GateResult::Issues,
                 findings_count: 1,
                 details: Some(details),
+                base: None,
             })
             .unwrap();
         assert_eq!(row.details.as_deref(), Some(details));
@@ -544,6 +646,7 @@ mod tests {
             result: GateResult::Issues,
             findings_count: 1,
             details: None,
+            base: None,
         })
         .unwrap();
         db.record_quality_gate(&QualityGateInput {
@@ -553,6 +656,7 @@ mod tests {
             result: GateResult::Clean,
             findings_count: 0,
             details: None,
+            base: None,
         })
         .unwrap();
 
@@ -598,6 +702,7 @@ mod tests {
             result: GateResult::Clean,
             findings_count: 0,
             details: None,
+            base: None,
         })
         .unwrap();
         // Force a strictly later timestamp so ORDER BY created_at DESC is
@@ -611,6 +716,7 @@ mod tests {
             result: GateResult::Issues,
             findings_count: 2,
             details: None,
+            base: None,
         })
         .unwrap();
 
@@ -634,6 +740,7 @@ mod tests {
             result: GateResult::Clean,
             findings_count: 0,
             details: None,
+            base: None,
         })
         .unwrap();
         db.record_quality_gate(&QualityGateInput {
@@ -643,6 +750,7 @@ mod tests {
             result: GateResult::Issues,
             findings_count: 1,
             details: None,
+            base: None,
         })
         .unwrap();
 
@@ -667,6 +775,7 @@ mod tests {
             result: GateResult::Clean,
             findings_count: 0,
             details: None,
+            base: None,
         })
         .unwrap();
         db.record_quality_gate(&QualityGateInput {
@@ -676,6 +785,7 @@ mod tests {
             result: GateResult::Issues,
             findings_count: 3,
             details: None,
+            base: None,
         })
         .unwrap();
         db.record_quality_gate(&QualityGateInput {
@@ -685,6 +795,7 @@ mod tests {
             result: GateResult::Clean,
             findings_count: 0,
             details: None,
+            base: None,
         })
         .unwrap();
 
@@ -710,6 +821,7 @@ mod tests {
             result: GateResult::Clean,
             findings_count: 0,
             details: None,
+            base: None,
         })
         .unwrap();
         db.record_quality_gate(&QualityGateInput {
@@ -719,6 +831,7 @@ mod tests {
             result: GateResult::Clean,
             findings_count: 0,
             details: None,
+            base: None,
         })
         .unwrap();
 
@@ -748,6 +861,7 @@ mod tests {
                 result: GateResult::Clean,
                 findings_count: 0,
                 details: None,
+                base: None,
             })
             .unwrap();
         // Sleep briefly so the second row has a strictly later timestamp.
@@ -760,6 +874,7 @@ mod tests {
                 result: GateResult::Issues,
                 findings_count: 1,
                 details: None,
+                base: None,
             })
             .unwrap();
 
@@ -796,6 +911,7 @@ mod tests {
             result: GateResult::Clean,
             findings_count: 0,
             details: None,
+            base: None,
         })
         .unwrap();
         db.record_quality_gate(&QualityGateInput {
@@ -805,6 +921,7 @@ mod tests {
             result: GateResult::Issues,
             findings_count: 5,
             details: None,
+            base: None,
         })
         .unwrap();
         db.record_quality_gate(&QualityGateInput {
@@ -814,6 +931,7 @@ mod tests {
             result: GateResult::Issues,
             findings_count: 3,
             details: None,
+            base: None,
         })
         .unwrap();
         // 1 run for legion-review: 1 clean, findings = 0.
@@ -824,6 +942,7 @@ mod tests {
             result: GateResult::Clean,
             findings_count: 0,
             details: None,
+            base: None,
         })
         .unwrap();
 
@@ -867,6 +986,7 @@ mod tests {
             result: GateResult::Issues,
             findings_count: 2,
             details: None,
+            base: None,
         })
         .unwrap();
         db.record_quality_gate(&QualityGateInput {
@@ -876,6 +996,7 @@ mod tests {
             result: GateResult::Clean,
             findings_count: 0,
             details: None,
+            base: None,
         })
         .unwrap();
 
@@ -897,6 +1018,7 @@ mod tests {
             result: GateResult::Clean,
             findings_count: 0,
             details: None,
+            base: None,
         })
         .unwrap();
         db.record_quality_gate(&QualityGateInput {
@@ -906,6 +1028,7 @@ mod tests {
             result: GateResult::Clean,
             findings_count: 0,
             details: None,
+            base: None,
         })
         .unwrap();
 
@@ -924,6 +1047,7 @@ mod tests {
             result: GateResult::Issues,
             findings_count: 1,
             details: None,
+            base: None,
         })
         .unwrap();
         db.record_quality_gate(&QualityGateInput {
@@ -933,11 +1057,53 @@ mod tests {
             result: GateResult::Issues,
             findings_count: 1,
             details: None,
+            base: None,
         })
         .unwrap();
 
         let stats = db.quality_gate_stats(None, None).unwrap();
         assert_eq!(stats.len(), 1);
         assert!((stats[0].catch_rate - 1.0).abs() < f64::EPSILON);
+    }
+
+    /// Migration 17's `base` column ALTER is idempotent on reopen (#779),
+    /// same shape as kanban.rs's `migration_document_id_column_is_idempotent_on_reopen`
+    /// (migration 16): a second `Database::open` over the same file-backed
+    /// path must not fail even though `has_column` now finds `base` already
+    /// present. Uses a real file path (not in-memory) so the guard actually
+    /// runs against a persisted schema.
+    #[test]
+    fn migration_base_column_is_idempotent_on_reopen() {
+        use crate::db::Database;
+
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("test_base_idempotent.db");
+
+        // First open: creates the schema including the base column.
+        let db1 = Database::open(&db_path).expect("first open");
+        let row = db1
+            .record_quality_gate(&QualityGateInput {
+                branch: "feat/x",
+                commit_hash: "reopen-hash",
+                skill: "legion-simplify",
+                result: GateResult::Clean,
+                findings_count: 0,
+                details: None,
+                base: Some("main"),
+            })
+            .expect("record on first open");
+        assert_eq!(row.base.as_deref(), Some("main"));
+        drop(db1);
+
+        // Second open over the same path: migration 17's has_column guard
+        // must prevent a duplicate ALTER TABLE from failing, and the row
+        // written under the first open must still read back correctly.
+        let db2 = Database::open(&db_path).expect("second open must not fail");
+        let fetched = db2
+            .get_quality_gate("reopen-hash", "legion-simplify")
+            .expect("get")
+            .expect("row from first open readable after second open");
+        assert_eq!(fetched.base.as_deref(), Some("main"));
+        // dir is dropped here, cleaning up the temp files.
     }
 }

--- a/src/db/quality_gates.rs
+++ b/src/db/quality_gates.rs
@@ -34,20 +34,29 @@ pub(super) fn create_tables(conn: &Connection) -> Result<()> {
     Ok(())
 }
 
-/// Column migrations for `quality_gates` (#780): provenance plus the
-/// void/supersede tombstone pattern, mirroring `tasks.deleted_at`
+/// Column migrations for `quality_gates`, in their original patch order.
+///
+/// The provenance/void/supersede block (#780) mirrors `tasks.deleted_at`
 /// (src/db/kanban.rs migration 13) -- a known-false row is retired without
 /// deleting history, and a re-laid genuine row can point back at what it
-/// replaces.
+/// replaces. `provenance` defaults to `'asserted'` for pre-existing rows:
+/// every row recorded before this migration went through the
+/// un-validated `record` path (the `check` validator predates this column
+/// but always calls `record_quality_gate` directly, so historical
+/// `check`-recorded rows are indistinguishable from `record`-recorded ones
+/// at the DB layer without a backfill this issue does not attempt) -- the
+/// conservative default, since treating an unknown row as VALIDATED would
+/// be exactly the ground-truth leak #780 closes.
 ///
-/// `provenance` defaults to `'asserted'` for pre-existing rows: every row
-/// recorded before this migration went through the un-validated `record`
-/// path (the `check` validator predates this column but always calls
-/// `record_quality_gate` directly, so historical `check`-recorded rows are
-/// indistinguishable from `record`-recorded ones at the DB layer without a
-/// backfill this issue does not attempt) -- the conservative default, since
-/// treating an unknown row as VALIDATED would be exactly the ground-truth
-/// leak #780 closes.
+/// The `base` column (#779) follows: `--base` override for `legion
+/// quality-gate check`. Nullable -- existing rows and gates recorded
+/// without an explicit `--base` (the default main/origin-main resolution,
+/// or non-`check` gate kinds like `record` and `legion-verify`) have no
+/// base to record. Recording the resolved base ref on the row (rather than
+/// only inside the `details` JSON blob) keeps a too-narrow `--base`
+/// visible to the same `quality-gate list`/`stats` surfaces that already
+/// query columns, consistent with the issue's auditability-over-trust
+/// stance.
 pub(super) fn migrate(conn: &Connection) -> Result<()> {
     if !Database::has_column(conn, "quality_gates", "provenance")? {
         conn.execute_batch(
@@ -62,6 +71,9 @@ pub(super) fn migrate(conn: &Connection) -> Result<()> {
     }
     if !Database::has_column(conn, "quality_gates", "superseded_by")? {
         conn.execute_batch("ALTER TABLE quality_gates ADD COLUMN superseded_by TEXT;")?;
+    }
+    if !Database::has_column(conn, "quality_gates", "base")? {
+        conn.execute_batch("ALTER TABLE quality_gates ADD COLUMN base TEXT;")?;
     }
     Ok(())
 }
@@ -91,6 +103,11 @@ pub struct QualityGateRow {
     /// The id of the row that supersedes this one, if a re-laid genuine row
     /// has replaced it (#780).
     pub superseded_by: Option<String>,
+    /// The `--base` ref the changed-file set was computed against (#779),
+    /// when the caller supplied one. `None` for gates recorded without an
+    /// explicit base (default main/origin-main resolution, or gate kinds
+    /// that never compute a changed-file set, e.g. `legion-verify`).
+    pub base: Option<String>,
 }
 
 /// Parse a `GateResult` from a DB string, mapping unknown values to a
@@ -137,6 +154,11 @@ pub struct QualityGateInput<'a> {
     /// knows which code path it is (the `Check` handler vs. the `Record`
     /// handler) is the single source of truth for it.
     pub provenance: GateProvenance,
+    /// The `--base` ref used to compute the changed-file set (#779), when
+    /// the caller resolved one. `None` for gate kinds that never compute a
+    /// changed-file set, or when the default main/origin-main resolution
+    /// was used (as opposed to an explicit `--base` override).
+    pub base: Option<&'a str>,
 }
 
 impl Database {
@@ -153,8 +175,8 @@ impl Database {
         self.conn.execute(
             "INSERT INTO quality_gates \
              (id, branch, commit_hash, skill, result, findings_count, details, created_at, \
-              provenance) \
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
+              provenance, base) \
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)",
             rusqlite::params![
                 &id,
                 input.branch,
@@ -165,6 +187,7 @@ impl Database {
                 input.details,
                 &created_at,
                 provenance_str,
+                input.base,
             ],
         )?;
         Ok(QualityGateRow {
@@ -180,6 +203,7 @@ impl Database {
             voided_at: None,
             void_reason: None,
             superseded_by: None,
+            base: input.base.map(str::to_owned),
         })
     }
 
@@ -190,7 +214,7 @@ impl Database {
     pub fn get_quality_gate_by_id(&self, id: &str) -> Result<Option<QualityGateRow>> {
         let mut stmt = self.conn.prepare(
             "SELECT id, branch, commit_hash, skill, result, findings_count, details, \
-                    created_at, provenance, voided_at, void_reason, superseded_by \
+                    created_at, provenance, voided_at, void_reason, superseded_by, base \
              FROM quality_gates \
              WHERE id = ?1",
         )?;
@@ -235,7 +259,7 @@ impl Database {
             .ok_or_else(|| LegionError::QualityGateNotFound(id.to_owned()))
     }
 
-    /// Shared row-mapping closure for the 12-column `SELECT ... FROM
+    /// Shared row-mapping closure for the 13-column `SELECT ... FROM
     /// quality_gates` shape every read path here uses, so a future column
     /// addition only changes the column list and this function once.
     fn row_to_gate(
@@ -257,6 +281,7 @@ impl Database {
             voided_at: row.get(9)?,
             void_reason: row.get(10)?,
             superseded_by: row.get(11)?,
+            base: row.get(12)?,
         })
     }
 
@@ -274,7 +299,7 @@ impl Database {
         // retired row as a live clean verdict (#780).
         let mut stmt = self.conn.prepare(
             "SELECT id, branch, commit_hash, skill, result, findings_count, details, \
-                    created_at, provenance, voided_at, void_reason, superseded_by \
+                    created_at, provenance, voided_at, void_reason, superseded_by, base \
              FROM quality_gates \
              WHERE commit_hash = ?1 AND skill = ?2 AND voided_at IS NULL \
              ORDER BY created_at DESC \
@@ -301,7 +326,7 @@ impl Database {
         // card-keyed ->Done check must never resolve to a retired verdict.
         let mut stmt = self.conn.prepare(
             "SELECT id, branch, commit_hash, skill, result, findings_count, details, \
-                    created_at, provenance, voided_at, void_reason, superseded_by \
+                    created_at, provenance, voided_at, void_reason, superseded_by, base \
              FROM quality_gates \
              WHERE skill = ?1 AND voided_at IS NULL \
              ORDER BY created_at DESC \
@@ -395,7 +420,7 @@ impl Database {
 
         let sql = format!(
             "SELECT id, branch, commit_hash, skill, result, findings_count, details, \
-                    created_at, provenance, voided_at, void_reason, superseded_by \
+                    created_at, provenance, voided_at, void_reason, superseded_by, base \
              FROM quality_gates \
              {where_clause} \
              ORDER BY created_at DESC"
@@ -515,6 +540,7 @@ mod tests {
                 findings_count: 0,
                 details: None,
                 provenance: GateProvenance::Asserted,
+                base: None,
             })
             .unwrap();
         assert!(!row.id.is_empty());
@@ -539,6 +565,72 @@ mod tests {
         assert_eq!(fetched.provenance, GateProvenance::Asserted);
     }
 
+    /// The `base` column (#779) round-trips through insert, direct lookup,
+    /// and `list_quality_gates` -- the three read paths a gate row is
+    /// visible through.
+    #[test]
+    fn quality_gate_base_column_round_trips_through_insert_and_reads() {
+        use crate::db::quality_gates::QualityGateFilter;
+
+        let db = test_db();
+        let row = db
+            .record_quality_gate(&QualityGateInput {
+                branch: "feat/child",
+                commit_hash: "base1234",
+                skill: "legion-simplify",
+                result: GateResult::Clean,
+                findings_count: 0,
+                details: None,
+                provenance: GateProvenance::Asserted,
+                base: Some("feat/base-branch"),
+            })
+            .unwrap();
+        assert_eq!(row.base.as_deref(), Some("feat/base-branch"));
+
+        let fetched = db
+            .get_quality_gate("base1234", "legion-simplify")
+            .unwrap()
+            .expect("gate row should exist");
+        assert_eq!(fetched.base.as_deref(), Some("feat/base-branch"));
+
+        let listed = db
+            .list_quality_gates(&QualityGateFilter {
+                skill: Some("legion-simplify".to_owned()),
+                ..Default::default()
+            })
+            .unwrap();
+        assert_eq!(listed.len(), 1);
+        assert_eq!(listed[0].base.as_deref(), Some("feat/base-branch"));
+    }
+
+    /// A gate recorded without an explicit base (the common case: `record`,
+    /// `legion-verify`, or a `check` run against the default main/origin-main
+    /// resolution's vacuous-initial-commit branch) stores `base` as `NULL`
+    /// and reads back as `None`, not an empty string.
+    #[test]
+    fn quality_gate_base_column_defaults_to_none() {
+        let db = test_db();
+        let row = db
+            .record_quality_gate(&QualityGateInput {
+                branch: "main",
+                commit_hash: "nobase123",
+                skill: "legion-verify:card-1",
+                result: GateResult::Clean,
+                findings_count: 0,
+                details: None,
+                provenance: GateProvenance::Asserted,
+                base: None,
+            })
+            .unwrap();
+        assert!(row.base.is_none());
+
+        let fetched = db
+            .get_quality_gate("nobase123", "legion-verify:card-1")
+            .unwrap()
+            .expect("gate row should exist");
+        assert!(fetched.base.is_none());
+    }
+
     #[test]
     fn quality_gate_missing_commit_returns_none() {
         let db = test_db();
@@ -559,6 +651,7 @@ mod tests {
             findings_count: 0,
             details: None,
             provenance: GateProvenance::Asserted,
+            base: None,
         })
         .unwrap();
         // Different skill on the same commit should not match.
@@ -578,6 +671,7 @@ mod tests {
             findings_count: 0,
             details: None,
             provenance: GateProvenance::Asserted,
+            base: None,
         })
         .unwrap();
         db.record_quality_gate(&QualityGateInput {
@@ -588,6 +682,7 @@ mod tests {
             findings_count: 2,
             details: Some("{}"),
             provenance: GateProvenance::Asserted,
+            base: None,
         })
         .unwrap();
 
@@ -618,6 +713,7 @@ mod tests {
             findings_count: 3,
             details: None,
             provenance: GateProvenance::Asserted,
+            base: None,
         })
         .unwrap();
         // Second run after fixing: clean.
@@ -629,6 +725,7 @@ mod tests {
             findings_count: 0,
             details: None,
             provenance: GateProvenance::Asserted,
+            base: None,
         })
         .unwrap();
 
@@ -656,6 +753,7 @@ mod tests {
                 findings_count: 1,
                 details: Some(details),
                 provenance: GateProvenance::Asserted,
+                base: None,
             })
             .unwrap();
         assert_eq!(row.details.as_deref(), Some(details));
@@ -682,6 +780,7 @@ mod tests {
             findings_count: 1,
             details: None,
             provenance: GateProvenance::Asserted,
+            base: None,
         })
         .unwrap();
         db.record_quality_gate(&QualityGateInput {
@@ -692,6 +791,7 @@ mod tests {
             findings_count: 0,
             details: None,
             provenance: GateProvenance::Asserted,
+            base: None,
         })
         .unwrap();
 
@@ -738,6 +838,7 @@ mod tests {
             findings_count: 0,
             details: None,
             provenance: GateProvenance::Asserted,
+            base: None,
         })
         .unwrap();
         // Force a strictly later timestamp so ORDER BY created_at DESC is
@@ -752,6 +853,7 @@ mod tests {
             findings_count: 2,
             details: None,
             provenance: GateProvenance::Asserted,
+            base: None,
         })
         .unwrap();
 
@@ -776,6 +878,7 @@ mod tests {
             findings_count: 0,
             details: None,
             provenance: GateProvenance::Asserted,
+            base: None,
         })
         .unwrap();
         db.record_quality_gate(&QualityGateInput {
@@ -786,6 +889,7 @@ mod tests {
             findings_count: 1,
             details: None,
             provenance: GateProvenance::Asserted,
+            base: None,
         })
         .unwrap();
 
@@ -811,6 +915,7 @@ mod tests {
             findings_count: 0,
             details: None,
             provenance: GateProvenance::Asserted,
+            base: None,
         })
         .unwrap();
         db.record_quality_gate(&QualityGateInput {
@@ -821,6 +926,7 @@ mod tests {
             findings_count: 3,
             details: None,
             provenance: GateProvenance::Asserted,
+            base: None,
         })
         .unwrap();
         db.record_quality_gate(&QualityGateInput {
@@ -831,6 +937,7 @@ mod tests {
             findings_count: 0,
             details: None,
             provenance: GateProvenance::Asserted,
+            base: None,
         })
         .unwrap();
 
@@ -857,6 +964,7 @@ mod tests {
             findings_count: 0,
             details: None,
             provenance: GateProvenance::Asserted,
+            base: None,
         })
         .unwrap();
         db.record_quality_gate(&QualityGateInput {
@@ -867,6 +975,7 @@ mod tests {
             findings_count: 0,
             details: None,
             provenance: GateProvenance::Asserted,
+            base: None,
         })
         .unwrap();
 
@@ -897,6 +1006,7 @@ mod tests {
                 findings_count: 0,
                 details: None,
                 provenance: GateProvenance::Asserted,
+                base: None,
             })
             .unwrap();
         // Sleep briefly so the second row has a strictly later timestamp.
@@ -910,6 +1020,7 @@ mod tests {
                 findings_count: 1,
                 details: None,
                 provenance: GateProvenance::Asserted,
+                base: None,
             })
             .unwrap();
 
@@ -947,6 +1058,7 @@ mod tests {
             findings_count: 0,
             details: None,
             provenance: GateProvenance::Asserted,
+            base: None,
         })
         .unwrap();
         db.record_quality_gate(&QualityGateInput {
@@ -957,6 +1069,7 @@ mod tests {
             findings_count: 5,
             details: None,
             provenance: GateProvenance::Asserted,
+            base: None,
         })
         .unwrap();
         db.record_quality_gate(&QualityGateInput {
@@ -967,6 +1080,7 @@ mod tests {
             findings_count: 3,
             details: None,
             provenance: GateProvenance::Asserted,
+            base: None,
         })
         .unwrap();
         // 1 run for legion-review: 1 clean, findings = 0.
@@ -978,6 +1092,7 @@ mod tests {
             findings_count: 0,
             details: None,
             provenance: GateProvenance::Asserted,
+            base: None,
         })
         .unwrap();
 
@@ -1022,6 +1137,7 @@ mod tests {
             findings_count: 2,
             details: None,
             provenance: GateProvenance::Asserted,
+            base: None,
         })
         .unwrap();
         db.record_quality_gate(&QualityGateInput {
@@ -1032,6 +1148,7 @@ mod tests {
             findings_count: 0,
             details: None,
             provenance: GateProvenance::Asserted,
+            base: None,
         })
         .unwrap();
 
@@ -1054,6 +1171,7 @@ mod tests {
             findings_count: 0,
             details: None,
             provenance: GateProvenance::Asserted,
+            base: None,
         })
         .unwrap();
         db.record_quality_gate(&QualityGateInput {
@@ -1064,6 +1182,7 @@ mod tests {
             findings_count: 0,
             details: None,
             provenance: GateProvenance::Asserted,
+            base: None,
         })
         .unwrap();
 
@@ -1083,6 +1202,7 @@ mod tests {
             findings_count: 1,
             details: None,
             provenance: GateProvenance::Asserted,
+            base: None,
         })
         .unwrap();
         db.record_quality_gate(&QualityGateInput {
@@ -1093,6 +1213,7 @@ mod tests {
             findings_count: 1,
             details: None,
             provenance: GateProvenance::Asserted,
+            base: None,
         })
         .unwrap();
 
@@ -1114,6 +1235,7 @@ mod tests {
             findings_count: 0,
             details: None,
             provenance: GateProvenance::Validated,
+            base: None,
         })
         .unwrap();
 
@@ -1136,6 +1258,7 @@ mod tests {
                 findings_count: 0,
                 details: None,
                 provenance: GateProvenance::Asserted,
+                base: None,
             })
             .unwrap();
 
@@ -1167,6 +1290,7 @@ mod tests {
                 findings_count: 0,
                 details: None,
                 provenance: GateProvenance::Asserted,
+                base: None,
             })
             .unwrap();
         let new = db
@@ -1178,6 +1302,7 @@ mod tests {
                 findings_count: 0,
                 details: None,
                 provenance: GateProvenance::Validated,
+                base: None,
             })
             .unwrap();
 
@@ -1212,6 +1337,7 @@ mod tests {
                 findings_count: 0,
                 details: None,
                 provenance: GateProvenance::Asserted,
+                base: None,
             })
             .unwrap();
         db.void_quality_gate(&row.id, "known false", None).unwrap();
@@ -1237,6 +1363,7 @@ mod tests {
                 findings_count: 0,
                 details: None,
                 provenance: GateProvenance::Asserted,
+                base: None,
             })
             .unwrap();
         db.void_quality_gate(&row.id, "known false", None).unwrap();
@@ -1262,6 +1389,7 @@ mod tests {
                 findings_count: 0,
                 details: None,
                 provenance: GateProvenance::Asserted,
+                base: None,
             })
             .unwrap();
         db.void_quality_gate(&row.id, "known false", None).unwrap();
@@ -1290,6 +1418,7 @@ mod tests {
                 findings_count: 0,
                 details: None,
                 provenance: GateProvenance::Asserted,
+                base: None,
             })
             .unwrap();
         db.void_quality_gate(&row.id, "known false", None).unwrap();
@@ -1301,6 +1430,7 @@ mod tests {
             findings_count: 2,
             details: None,
             provenance: GateProvenance::Validated,
+            base: None,
         })
         .unwrap();
 
@@ -1329,6 +1459,7 @@ mod tests {
                 findings_count: 0,
                 details: None,
                 provenance: GateProvenance::Asserted,
+                base: None,
             })
             .unwrap();
         db.void_quality_gate(&row.id, "known false", None).unwrap();
@@ -1348,10 +1479,13 @@ mod tests {
 
     /// Migration is idempotent: opening the same file-backed database a
     /// second time must not fail even though the provenance/void columns
-    /// already exist. Mirrors kanban.rs's
-    /// `migration_document_id_column_is_idempotent_on_reopen` (#780).
+    /// (#780) AND the `base` column (#779) already exist. Mirrors
+    /// kanban.rs's `migration_document_id_column_is_idempotent_on_reopen`.
+    /// Both migrations share the same `migrate()` function and the same
+    /// has_column guard mechanism, so one test recording both fields and
+    /// reopening covers both double-apply paths.
     #[test]
-    fn migration_provenance_and_void_columns_are_idempotent_on_reopen() {
+    fn migration_provenance_void_and_base_columns_are_idempotent_on_reopen() {
         let dir = tempfile::tempdir().unwrap();
         let db_path = dir.path().join("test_gate_migration.db");
 
@@ -1365,12 +1499,15 @@ mod tests {
                 findings_count: 0,
                 details: None,
                 provenance: GateProvenance::Validated,
+                base: Some("main"),
             })
             .expect("record on first open");
+        assert_eq!(row.base.as_deref(), Some("main"));
         drop(db1);
 
-        // Second open over the same path: the has_column guards must
-        // prevent a duplicate ALTER TABLE from failing.
+        // Second open over the same path: both migrations' has_column
+        // guards must prevent a duplicate ALTER TABLE from failing, and the
+        // row written under the first open must still read back correctly.
         let db2 = Database::open(&db_path).expect("second open must not fail");
         let fetched = db2
             .get_quality_gate("reopen-hash", "legion-simplify")
@@ -1378,6 +1515,7 @@ mod tests {
             .expect("row from first open readable after second open");
         assert_eq!(fetched.id, row.id);
         assert_eq!(fetched.provenance, GateProvenance::Validated);
+        assert_eq!(fetched.base.as_deref(), Some("main"));
         // dir is dropped here, cleaning up the temp files.
     }
 }

--- a/src/gate_trust.rs
+++ b/src/gate_trust.rs
@@ -319,6 +319,7 @@ mod tests {
             findings_count: findings,
             details: None,
             created_at: "2026-06-27T00:00:00+00:00".to_string(),
+            base: None,
         }
     }
 

--- a/src/gate_trust.rs
+++ b/src/gate_trust.rs
@@ -372,6 +372,7 @@ mod tests {
             voided_at: None,
             void_reason: None,
             superseded_by: None,
+            base: None,
         }
     }
 

--- a/src/identity_generate.rs
+++ b/src/identity_generate.rs
@@ -374,7 +374,12 @@ pub fn apply(
 ) -> Result<ApplyResult> {
     validate_manifest(manifest)?;
 
-    let old_rows = db.get_reflections_by_domain(repo, "identity", IDENTITY_BACKUP_LIMIT)?;
+    let old_rows = db.get_reflections_by_domain(
+        repo,
+        "identity",
+        IDENTITY_BACKUP_LIMIT,
+        crate::recall::ArchiveMode::Both,
+    )?;
     if old_rows.len() == IDENTITY_BACKUP_LIMIT {
         // A corpus at exactly the cap almost certainly means rows beyond
         // it were cut off by the SQL LIMIT -- and both the backup and the
@@ -850,7 +855,7 @@ mod tests {
         )
         .unwrap();
         let before = db
-            .get_reflections_by_domain("legion", "identity", 500)
+            .get_reflections_by_domain("legion", "identity", 500, crate::recall::ArchiveMode::Both)
             .unwrap();
 
         let backup_dir = dir.path().join("backups");
@@ -863,7 +868,7 @@ mod tests {
 
         assert!(!backup_dir.exists());
         let after = db
-            .get_reflections_by_domain("legion", "identity", 500)
+            .get_reflections_by_domain("legion", "identity", 500, crate::recall::ArchiveMode::Both)
             .unwrap();
         assert_eq!(before.len(), after.len());
     }
@@ -1129,7 +1134,7 @@ mod tests {
         )
         .unwrap();
         let before = db
-            .get_reflections_by_domain("legion", "identity", 500)
+            .get_reflections_by_domain("legion", "identity", 500, crate::recall::ArchiveMode::Both)
             .unwrap();
 
         let backup_dir = dir.path().join("backups");
@@ -1148,7 +1153,7 @@ mod tests {
         assert!(!plan.backup_path.exists());
 
         let after = db
-            .get_reflections_by_domain("legion", "identity", 500)
+            .get_reflections_by_domain("legion", "identity", 500, crate::recall::ArchiveMode::Both)
             .unwrap();
         assert_eq!(before.len(), after.len());
     }

--- a/src/simplify_check.rs
+++ b/src/simplify_check.rs
@@ -356,13 +356,23 @@ mod tests {
 
     #[test]
     fn refuses_rename_when_old_path_entry_missing() {
-        // Renames below git's similarity threshold are reported by
-        // `git diff --name-only` as a delete of the old path plus an add of
-        // the new path (two separate entries), not a single rename line.
-        // Coverage must be exact-path: an articulation addressing only the
-        // new path still leaves the old path uncovered, and the gate refuses
-        // by name -- an agent cannot clear this by adding more prose about
-        // the new path, since the old path simply will not match.
+        // `git_changed_files` now runs `git diff --name-status -M50%`
+        // (#779), not `--name-only`: a rename detected at or above the
+        // pinned 50% similarity surfaces as a single `R<nn>\t<old>\t<new>`
+        // line, and `git_changed_files` puts the R100 (zero-delta) case
+        // through R100 auto-clear or, for R<100 (content delta), just the
+        // new path into the coverage set. A rename that falls BELOW the
+        // pinned similarity is still undetected as a rename at the git
+        // level and is reported as two independent lines -- a delete of the
+        // old path and an add of the new path -- exactly as it was under
+        // `--name-only`. This test constructs that latter (still-relevant)
+        // case directly against `validate_articulation`, which is agnostic
+        // to where the changed-file set came from: it only sees two
+        // unrelated paths in the set. Coverage must be exact-path: an
+        // articulation addressing only the new path still leaves the old
+        // path uncovered, and the gate refuses by name -- an agent cannot
+        // clear this by adding more prose about the new path, since the old
+        // path simply will not match.
         let files = changed(&["src/old_name.rs", "src/new_name.rs"]);
         let only_new_path = "### src/new_name.rs\n\
              Renamed from old_name.rs and reviewed for duplicate logic, stringly-typed \

--- a/tests/integration/worksource_pr.rs
+++ b/tests/integration/worksource_pr.rs
@@ -2616,6 +2616,15 @@ fn quality_gate_check_passing_articulation_records_gate_row() {
         "expected exactly one gate row, got: {list_out}"
     );
     assert_eq!(arr[0]["result"].as_str().unwrap(), "clean");
+    // #779: the resolved base is recorded even on the default (no --base)
+    // path, not only on an explicit override -- "which base the
+    // articulation covered" must be visible for every gate, not just the
+    // unusual ones.
+    assert_eq!(
+        arr[0]["base"].as_str(),
+        Some("main"),
+        "expected the default-resolved base 'main' recorded on the gate row, got: {list_out}"
+    );
 }
 
 /// quality-gate check: a failing articulation (missing coverage) exits non-zero
@@ -2894,5 +2903,332 @@ fn quality_gate_check_non_ascii_path_roundtrips_correctly() {
     assert!(
         stdout.contains("accepted"),
         "expected acceptance for non-ASCII path, got: {stdout}"
+    );
+}
+
+// --- quality-gate check --base override + R100 auto-clear tests (#779) ---
+
+/// Build a substantive articulation covering an arbitrary `path` with enough
+/// prose and a located-evidence line to clear both structural bars.
+fn good_articulation_for(path: &str) -> String {
+    format!(
+        "### {path}\n\
+         Checked for duplicate logic, unnecessary abstraction, stringly-typed state, \
+         hand-rolled standard library dupes, copy-paste variation, and error swallowing. \
+         No issues found: the single declaration in this file has one responsibility.\n\
+         Evidence: {path}:1 the lone declaration.\n"
+    )
+}
+
+/// `--base` overrides the default main/origin-main resolution: a stacked
+/// branch (`feat/child`, based on the still-unmerged `feat/base-branch`, not
+/// `main`) diffed with `--base feat/base-branch` sees only the child's own
+/// changes, and the resolved base is recorded on the gate row.
+#[cfg(unix)]
+#[test]
+fn quality_gate_check_base_override_scopes_to_stacked_branch_and_is_recorded() {
+    let _config_guard = RealRepoConfigGuard::new();
+    let repo = tempfile::tempdir().unwrap();
+    let rp = repo.path();
+
+    run_git_fixture(rp, &["init", "-b", "main"]);
+    std::fs::write(rp.join("README.md"), "seed\n").unwrap();
+    run_git_fixture(rp, &["add", "README.md"]);
+    run_git_fixture(rp, &["commit", "-m", "seed"]);
+
+    // Intermediate, still-unmerged base branch.
+    run_git_fixture(rp, &["checkout", "-b", "feat/base-branch"]);
+    std::fs::write(rp.join("base_only.rs"), "// base branch content\n").unwrap();
+    run_git_fixture(rp, &["add", "base_only.rs"]);
+    run_git_fixture(rp, &["commit", "-m", "base branch work"]);
+
+    // Child branch stacked on top of the (unmerged) base branch.
+    run_git_fixture(rp, &["checkout", "-b", "feat/child"]);
+    std::fs::write(rp.join("child_only.rs"), "// child branch content\n").unwrap();
+    run_git_fixture(rp, &["add", "child_only.rs"]);
+    run_git_fixture(rp, &["commit", "-m", "child branch work"]);
+
+    let data_dir = tempfile::tempdir().unwrap();
+    // Articulation covers ONLY child_only.rs -- correct when scoped to
+    // feat/base-branch...HEAD, but would leave base_only.rs (and README.md)
+    // uncovered against the default main...HEAD range.
+    let artic_file = tempfile::NamedTempFile::new().unwrap();
+    std::fs::write(artic_file.path(), good_articulation_for("child_only.rs")).unwrap();
+
+    let stdout = run_ok(legion_cmd(data_dir.path()).current_dir(rp).args([
+        "quality-gate",
+        "check",
+        "--skill",
+        "legion-simplify",
+        "--result",
+        "clean",
+        "--articulation-file",
+        artic_file.path().to_str().unwrap(),
+        "--base",
+        "feat/base-branch",
+    ]));
+    assert!(
+        stdout.contains("accepted"),
+        "expected acceptance scoped to the stacked base, got: {stdout}"
+    );
+
+    // The resolved base is recorded on the gate row.
+    let list_out = run_ok(legion_cmd(data_dir.path()).args([
+        "quality-gate",
+        "list",
+        "--skill",
+        "legion-simplify",
+        "--json",
+    ]));
+    let rows: serde_json::Value = serde_json::from_str(&list_out).expect("expected JSON");
+    let arr = rows.as_array().expect("expected array");
+    assert_eq!(
+        arr.len(),
+        1,
+        "expected exactly one gate row, got: {list_out}"
+    );
+    assert_eq!(
+        arr[0]["base"].as_str(),
+        Some("feat/base-branch"),
+        "expected the --base override recorded on the gate row, got: {list_out}"
+    );
+}
+
+/// `--base` naming a ref that does not resolve is a hard error: no fallback
+/// to the default main/origin-main resolution, no gate recorded.
+#[cfg(unix)]
+#[test]
+fn quality_gate_check_base_unresolvable_ref_hard_errors() {
+    let _config_guard = RealRepoConfigGuard::new();
+    let repo = setup_git_repo_with_feature_branch();
+    let data_dir = tempfile::tempdir().unwrap();
+    let artic_file = tempfile::NamedTempFile::new().unwrap();
+    std::fs::write(artic_file.path(), good_articulation_for_foo()).unwrap();
+
+    let (_stdout, stderr) = run_fail(legion_cmd(data_dir.path()).current_dir(repo.path()).args([
+        "quality-gate",
+        "check",
+        "--skill",
+        "legion-simplify",
+        "--result",
+        "clean",
+        "--articulation-file",
+        artic_file.path().to_str().unwrap(),
+        "--base",
+        "no-such-ref-at-all",
+    ]));
+    assert!(
+        stderr.contains("no-such-ref-at-all") && stderr.contains("does not resolve"),
+        "expected an unresolvable --base error naming the ref, got: {stderr}"
+    );
+
+    let list_out = run_ok(legion_cmd(data_dir.path()).args([
+        "quality-gate",
+        "list",
+        "--skill",
+        "legion-simplify",
+        "--json",
+    ]));
+    let rows: serde_json::Value = serde_json::from_str(&list_out).expect("expected JSON");
+    assert_eq!(
+        rows.as_array().unwrap().len(),
+        0,
+        "expected zero gate rows after an unresolvable --base, got: {list_out}"
+    );
+}
+
+/// A pure (R100, zero-delta) rename is auto-cleared from the coverage set: an
+/// articulation with no entry for the renamed file still passes, and the
+/// rename pair is recorded in the gate's `details` JSON for audit.
+#[cfg(unix)]
+#[test]
+fn quality_gate_check_pure_rename_auto_cleared_and_recorded() {
+    let _config_guard = RealRepoConfigGuard::new();
+    let repo = tempfile::tempdir().unwrap();
+    let rp = repo.path();
+
+    run_git_fixture(rp, &["init", "-b", "main"]);
+    std::fs::write(
+        rp.join("mod.rs"),
+        "line1\nline2\nline3\nline4\nline5\nline6\nline7\nline8\nline9\nline10\n",
+    )
+    .unwrap();
+    run_git_fixture(rp, &["add", "mod.rs"]);
+    run_git_fixture(rp, &["commit", "-m", "seed"]);
+
+    run_git_fixture(rp, &["checkout", "-b", "feat/pure-rename"]);
+    run_git_fixture(rp, &["mv", "mod.rs", "renamed.rs"]);
+    run_git_fixture(rp, &["commit", "-m", "pure rename, no content change"]);
+
+    let data_dir = tempfile::tempdir().unwrap();
+    // No entries at all -- a zero-delta rename requires none.
+    let artic_file = tempfile::NamedTempFile::new().unwrap();
+    std::fs::write(artic_file.path(), "# No entries needed\n").unwrap();
+
+    let stdout = run_ok(legion_cmd(data_dir.path()).current_dir(rp).args([
+        "quality-gate",
+        "check",
+        "--skill",
+        "legion-simplify",
+        "--result",
+        "clean",
+        "--articulation-file",
+        artic_file.path().to_str().unwrap(),
+    ]));
+    assert!(
+        stdout.contains("accepted") && stdout.contains("1 rename(s) auto-cleared"),
+        "expected acceptance noting one auto-cleared rename, got: {stdout}"
+    );
+
+    let list_out = run_ok(legion_cmd(data_dir.path()).args([
+        "quality-gate",
+        "list",
+        "--skill",
+        "legion-simplify",
+        "--json",
+    ]));
+    let rows: serde_json::Value = serde_json::from_str(&list_out).expect("expected JSON");
+    let arr = rows.as_array().expect("expected array");
+    assert_eq!(
+        arr.len(),
+        1,
+        "expected exactly one gate row, got: {list_out}"
+    );
+    let details: serde_json::Value =
+        serde_json::from_str(arr[0]["details"].as_str().expect("details string"))
+            .expect("details JSON");
+    assert_eq!(details["cleared_renames_count"].as_u64(), Some(1));
+    let cleared = details["cleared_renames"]
+        .as_array()
+        .expect("cleared_renames array");
+    assert_eq!(cleared.len(), 1);
+    assert_eq!(cleared[0]["old"].as_str(), Some("mod.rs"));
+    assert_eq!(cleared[0]["new"].as_str(), Some("renamed.rs"));
+}
+
+/// The R100 auto-clear must not depend on the repo's ambient `diff.renames`
+/// config: with `diff.renames=false` set LOCALLY on the fixture repo (a
+/// config a contributor or CI image could plausibly carry), a pure rename is
+/// still detected and cleared because `--name-status -M50%` is pinned
+/// explicitly on the command line (#779 Build Notes: "do not inherit
+/// ambient diff.renames config"). Without the explicit pin, this same rename
+/// would surface as an untracked `D`/`A` pair and never clear.
+#[cfg(unix)]
+#[test]
+fn quality_gate_check_pure_rename_cleared_despite_diff_renames_false_config() {
+    let _config_guard = RealRepoConfigGuard::new();
+    let repo = tempfile::tempdir().unwrap();
+    let rp = repo.path();
+
+    run_git_fixture(rp, &["init", "-b", "main"]);
+    std::fs::write(
+        rp.join("mod.rs"),
+        "line1\nline2\nline3\nline4\nline5\nline6\nline7\nline8\nline9\nline10\n",
+    )
+    .unwrap();
+    run_git_fixture(rp, &["add", "mod.rs"]);
+    run_git_fixture(rp, &["commit", "-m", "seed"]);
+
+    // Local config override -- writes to this fixture repo's own
+    // .git/config only (GIT_DIR is scoped to `rp` by fixture_git_command).
+    run_git_fixture(rp, &["config", "diff.renames", "false"]);
+
+    run_git_fixture(rp, &["checkout", "-b", "feat/pure-rename-vs-config"]);
+    run_git_fixture(rp, &["mv", "mod.rs", "renamed.rs"]);
+    run_git_fixture(
+        rp,
+        &["commit", "-m", "pure rename under diff.renames=false"],
+    );
+
+    let data_dir = tempfile::tempdir().unwrap();
+    let artic_file = tempfile::NamedTempFile::new().unwrap();
+    std::fs::write(artic_file.path(), "# No entries needed\n").unwrap();
+
+    let stdout = run_ok(legion_cmd(data_dir.path()).current_dir(rp).args([
+        "quality-gate",
+        "check",
+        "--skill",
+        "legion-simplify",
+        "--result",
+        "clean",
+        "--articulation-file",
+        artic_file.path().to_str().unwrap(),
+    ]));
+    assert!(
+        stdout.contains("accepted") && stdout.contains("1 rename(s) auto-cleared"),
+        "expected the rename to still auto-clear despite diff.renames=false, got: {stdout}"
+    );
+}
+
+/// A rename with a content delta (R<100) is NOT cleared: the new path still
+/// requires an articulation entry, but the old path (which no longer exists
+/// in the tree) does not.
+#[cfg(unix)]
+#[test]
+fn quality_gate_check_rename_with_delta_requires_new_path_not_old_path() {
+    let _config_guard = RealRepoConfigGuard::new();
+    let repo = tempfile::tempdir().unwrap();
+    let rp = repo.path();
+
+    run_git_fixture(rp, &["init", "-b", "main"]);
+    std::fs::write(
+        rp.join("mod.rs"),
+        "line1\nline2\nline3\nline4\nline5\nline6\nline7\nline8\nline9\nline10\n",
+    )
+    .unwrap();
+    run_git_fixture(rp, &["add", "mod.rs"]);
+    run_git_fixture(rp, &["commit", "-m", "seed"]);
+
+    run_git_fixture(rp, &["checkout", "-b", "feat/rename-with-delta"]);
+    run_git_fixture(rp, &["mv", "mod.rs", "renamed.rs"]);
+    std::fs::write(
+        rp.join("renamed.rs"),
+        "line1\nCHANGED\nline3\nline4\nline5\nline6\nline7\nline8\nline9\nline10\nnewline\n",
+    )
+    .unwrap();
+    run_git_fixture(rp, &["add", "renamed.rs"]);
+    run_git_fixture(rp, &["commit", "-m", "rename with content delta"]);
+
+    let data_dir = tempfile::tempdir().unwrap();
+
+    // First: an empty articulation refuses, naming renamed.rs (not mod.rs).
+    let empty_artic = tempfile::NamedTempFile::new().unwrap();
+    std::fs::write(empty_artic.path(), "# No entries\n").unwrap();
+    let (_stdout, stderr) = run_fail(legion_cmd(data_dir.path()).current_dir(rp).args([
+        "quality-gate",
+        "check",
+        "--skill",
+        "legion-simplify",
+        "--result",
+        "clean",
+        "--articulation-file",
+        empty_artic.path().to_str().unwrap(),
+    ]));
+    assert!(
+        stderr.contains("renamed.rs"),
+        "expected missing-coverage naming renamed.rs, got: {stderr}"
+    );
+    assert!(
+        !stderr.contains("mod.rs"),
+        "the old path must not be required once the rename is detected, got: {stderr}"
+    );
+
+    // Then: an articulation covering only the new path passes.
+    let good_artic = tempfile::NamedTempFile::new().unwrap();
+    std::fs::write(good_artic.path(), good_articulation_for("renamed.rs")).unwrap();
+    let stdout = run_ok(legion_cmd(data_dir.path()).current_dir(rp).args([
+        "quality-gate",
+        "check",
+        "--skill",
+        "legion-simplify",
+        "--result",
+        "clean",
+        "--articulation-file",
+        good_artic.path().to_str().unwrap(),
+    ]));
+    assert!(
+        stdout.contains("accepted") && stdout.contains("0 rename(s) auto-cleared"),
+        "expected acceptance with zero auto-cleared renames (delta rename stays in scope), \
+         got: {stdout}"
     );
 }

--- a/tests/integration/worksource_pr.rs
+++ b/tests/integration/worksource_pr.rs
@@ -2417,6 +2417,15 @@ fn quality_gate_check_passing_articulation_records_gate_row() {
         "expected exactly one gate row, got: {list_out}"
     );
     assert_eq!(arr[0]["result"].as_str().unwrap(), "clean");
+    // #779: the resolved base is recorded even on the default (no --base)
+    // path, not only on an explicit override -- "which base the
+    // articulation covered" must be visible for every gate, not just the
+    // unusual ones.
+    assert_eq!(
+        arr[0]["base"].as_str(),
+        Some("main"),
+        "expected the default-resolved base 'main' recorded on the gate row, got: {list_out}"
+    );
 }
 
 /// quality-gate check: a failing articulation (missing coverage) exits non-zero
@@ -2695,5 +2704,332 @@ fn quality_gate_check_non_ascii_path_roundtrips_correctly() {
     assert!(
         stdout.contains("accepted"),
         "expected acceptance for non-ASCII path, got: {stdout}"
+    );
+}
+
+// --- quality-gate check --base override + R100 auto-clear tests (#779) ---
+
+/// Build a substantive articulation covering an arbitrary `path` with enough
+/// prose and a located-evidence line to clear both structural bars.
+fn good_articulation_for(path: &str) -> String {
+    format!(
+        "### {path}\n\
+         Checked for duplicate logic, unnecessary abstraction, stringly-typed state, \
+         hand-rolled standard library dupes, copy-paste variation, and error swallowing. \
+         No issues found: the single declaration in this file has one responsibility.\n\
+         Evidence: {path}:1 the lone declaration.\n"
+    )
+}
+
+/// `--base` overrides the default main/origin-main resolution: a stacked
+/// branch (`feat/child`, based on the still-unmerged `feat/base-branch`, not
+/// `main`) diffed with `--base feat/base-branch` sees only the child's own
+/// changes, and the resolved base is recorded on the gate row.
+#[cfg(unix)]
+#[test]
+fn quality_gate_check_base_override_scopes_to_stacked_branch_and_is_recorded() {
+    let _config_guard = RealRepoConfigGuard::new();
+    let repo = tempfile::tempdir().unwrap();
+    let rp = repo.path();
+
+    run_git_fixture(rp, &["init", "-b", "main"]);
+    std::fs::write(rp.join("README.md"), "seed\n").unwrap();
+    run_git_fixture(rp, &["add", "README.md"]);
+    run_git_fixture(rp, &["commit", "-m", "seed"]);
+
+    // Intermediate, still-unmerged base branch.
+    run_git_fixture(rp, &["checkout", "-b", "feat/base-branch"]);
+    std::fs::write(rp.join("base_only.rs"), "// base branch content\n").unwrap();
+    run_git_fixture(rp, &["add", "base_only.rs"]);
+    run_git_fixture(rp, &["commit", "-m", "base branch work"]);
+
+    // Child branch stacked on top of the (unmerged) base branch.
+    run_git_fixture(rp, &["checkout", "-b", "feat/child"]);
+    std::fs::write(rp.join("child_only.rs"), "// child branch content\n").unwrap();
+    run_git_fixture(rp, &["add", "child_only.rs"]);
+    run_git_fixture(rp, &["commit", "-m", "child branch work"]);
+
+    let data_dir = tempfile::tempdir().unwrap();
+    // Articulation covers ONLY child_only.rs -- correct when scoped to
+    // feat/base-branch...HEAD, but would leave base_only.rs (and README.md)
+    // uncovered against the default main...HEAD range.
+    let artic_file = tempfile::NamedTempFile::new().unwrap();
+    std::fs::write(artic_file.path(), good_articulation_for("child_only.rs")).unwrap();
+
+    let stdout = run_ok(legion_cmd(data_dir.path()).current_dir(rp).args([
+        "quality-gate",
+        "check",
+        "--skill",
+        "legion-simplify",
+        "--result",
+        "clean",
+        "--articulation-file",
+        artic_file.path().to_str().unwrap(),
+        "--base",
+        "feat/base-branch",
+    ]));
+    assert!(
+        stdout.contains("accepted"),
+        "expected acceptance scoped to the stacked base, got: {stdout}"
+    );
+
+    // The resolved base is recorded on the gate row.
+    let list_out = run_ok(legion_cmd(data_dir.path()).args([
+        "quality-gate",
+        "list",
+        "--skill",
+        "legion-simplify",
+        "--json",
+    ]));
+    let rows: serde_json::Value = serde_json::from_str(&list_out).expect("expected JSON");
+    let arr = rows.as_array().expect("expected array");
+    assert_eq!(
+        arr.len(),
+        1,
+        "expected exactly one gate row, got: {list_out}"
+    );
+    assert_eq!(
+        arr[0]["base"].as_str(),
+        Some("feat/base-branch"),
+        "expected the --base override recorded on the gate row, got: {list_out}"
+    );
+}
+
+/// `--base` naming a ref that does not resolve is a hard error: no fallback
+/// to the default main/origin-main resolution, no gate recorded.
+#[cfg(unix)]
+#[test]
+fn quality_gate_check_base_unresolvable_ref_hard_errors() {
+    let _config_guard = RealRepoConfigGuard::new();
+    let repo = setup_git_repo_with_feature_branch();
+    let data_dir = tempfile::tempdir().unwrap();
+    let artic_file = tempfile::NamedTempFile::new().unwrap();
+    std::fs::write(artic_file.path(), good_articulation_for_foo()).unwrap();
+
+    let (_stdout, stderr) = run_fail(legion_cmd(data_dir.path()).current_dir(repo.path()).args([
+        "quality-gate",
+        "check",
+        "--skill",
+        "legion-simplify",
+        "--result",
+        "clean",
+        "--articulation-file",
+        artic_file.path().to_str().unwrap(),
+        "--base",
+        "no-such-ref-at-all",
+    ]));
+    assert!(
+        stderr.contains("no-such-ref-at-all") && stderr.contains("does not resolve"),
+        "expected an unresolvable --base error naming the ref, got: {stderr}"
+    );
+
+    let list_out = run_ok(legion_cmd(data_dir.path()).args([
+        "quality-gate",
+        "list",
+        "--skill",
+        "legion-simplify",
+        "--json",
+    ]));
+    let rows: serde_json::Value = serde_json::from_str(&list_out).expect("expected JSON");
+    assert_eq!(
+        rows.as_array().unwrap().len(),
+        0,
+        "expected zero gate rows after an unresolvable --base, got: {list_out}"
+    );
+}
+
+/// A pure (R100, zero-delta) rename is auto-cleared from the coverage set: an
+/// articulation with no entry for the renamed file still passes, and the
+/// rename pair is recorded in the gate's `details` JSON for audit.
+#[cfg(unix)]
+#[test]
+fn quality_gate_check_pure_rename_auto_cleared_and_recorded() {
+    let _config_guard = RealRepoConfigGuard::new();
+    let repo = tempfile::tempdir().unwrap();
+    let rp = repo.path();
+
+    run_git_fixture(rp, &["init", "-b", "main"]);
+    std::fs::write(
+        rp.join("mod.rs"),
+        "line1\nline2\nline3\nline4\nline5\nline6\nline7\nline8\nline9\nline10\n",
+    )
+    .unwrap();
+    run_git_fixture(rp, &["add", "mod.rs"]);
+    run_git_fixture(rp, &["commit", "-m", "seed"]);
+
+    run_git_fixture(rp, &["checkout", "-b", "feat/pure-rename"]);
+    run_git_fixture(rp, &["mv", "mod.rs", "renamed.rs"]);
+    run_git_fixture(rp, &["commit", "-m", "pure rename, no content change"]);
+
+    let data_dir = tempfile::tempdir().unwrap();
+    // No entries at all -- a zero-delta rename requires none.
+    let artic_file = tempfile::NamedTempFile::new().unwrap();
+    std::fs::write(artic_file.path(), "# No entries needed\n").unwrap();
+
+    let stdout = run_ok(legion_cmd(data_dir.path()).current_dir(rp).args([
+        "quality-gate",
+        "check",
+        "--skill",
+        "legion-simplify",
+        "--result",
+        "clean",
+        "--articulation-file",
+        artic_file.path().to_str().unwrap(),
+    ]));
+    assert!(
+        stdout.contains("accepted") && stdout.contains("1 rename(s) auto-cleared"),
+        "expected acceptance noting one auto-cleared rename, got: {stdout}"
+    );
+
+    let list_out = run_ok(legion_cmd(data_dir.path()).args([
+        "quality-gate",
+        "list",
+        "--skill",
+        "legion-simplify",
+        "--json",
+    ]));
+    let rows: serde_json::Value = serde_json::from_str(&list_out).expect("expected JSON");
+    let arr = rows.as_array().expect("expected array");
+    assert_eq!(
+        arr.len(),
+        1,
+        "expected exactly one gate row, got: {list_out}"
+    );
+    let details: serde_json::Value =
+        serde_json::from_str(arr[0]["details"].as_str().expect("details string"))
+            .expect("details JSON");
+    assert_eq!(details["cleared_renames_count"].as_u64(), Some(1));
+    let cleared = details["cleared_renames"]
+        .as_array()
+        .expect("cleared_renames array");
+    assert_eq!(cleared.len(), 1);
+    assert_eq!(cleared[0]["old"].as_str(), Some("mod.rs"));
+    assert_eq!(cleared[0]["new"].as_str(), Some("renamed.rs"));
+}
+
+/// The R100 auto-clear must not depend on the repo's ambient `diff.renames`
+/// config: with `diff.renames=false` set LOCALLY on the fixture repo (a
+/// config a contributor or CI image could plausibly carry), a pure rename is
+/// still detected and cleared because `--name-status -M50%` is pinned
+/// explicitly on the command line (#779 Build Notes: "do not inherit
+/// ambient diff.renames config"). Without the explicit pin, this same rename
+/// would surface as an untracked `D`/`A` pair and never clear.
+#[cfg(unix)]
+#[test]
+fn quality_gate_check_pure_rename_cleared_despite_diff_renames_false_config() {
+    let _config_guard = RealRepoConfigGuard::new();
+    let repo = tempfile::tempdir().unwrap();
+    let rp = repo.path();
+
+    run_git_fixture(rp, &["init", "-b", "main"]);
+    std::fs::write(
+        rp.join("mod.rs"),
+        "line1\nline2\nline3\nline4\nline5\nline6\nline7\nline8\nline9\nline10\n",
+    )
+    .unwrap();
+    run_git_fixture(rp, &["add", "mod.rs"]);
+    run_git_fixture(rp, &["commit", "-m", "seed"]);
+
+    // Local config override -- writes to this fixture repo's own
+    // .git/config only (GIT_DIR is scoped to `rp` by fixture_git_command).
+    run_git_fixture(rp, &["config", "diff.renames", "false"]);
+
+    run_git_fixture(rp, &["checkout", "-b", "feat/pure-rename-vs-config"]);
+    run_git_fixture(rp, &["mv", "mod.rs", "renamed.rs"]);
+    run_git_fixture(
+        rp,
+        &["commit", "-m", "pure rename under diff.renames=false"],
+    );
+
+    let data_dir = tempfile::tempdir().unwrap();
+    let artic_file = tempfile::NamedTempFile::new().unwrap();
+    std::fs::write(artic_file.path(), "# No entries needed\n").unwrap();
+
+    let stdout = run_ok(legion_cmd(data_dir.path()).current_dir(rp).args([
+        "quality-gate",
+        "check",
+        "--skill",
+        "legion-simplify",
+        "--result",
+        "clean",
+        "--articulation-file",
+        artic_file.path().to_str().unwrap(),
+    ]));
+    assert!(
+        stdout.contains("accepted") && stdout.contains("1 rename(s) auto-cleared"),
+        "expected the rename to still auto-clear despite diff.renames=false, got: {stdout}"
+    );
+}
+
+/// A rename with a content delta (R<100) is NOT cleared: the new path still
+/// requires an articulation entry, but the old path (which no longer exists
+/// in the tree) does not.
+#[cfg(unix)]
+#[test]
+fn quality_gate_check_rename_with_delta_requires_new_path_not_old_path() {
+    let _config_guard = RealRepoConfigGuard::new();
+    let repo = tempfile::tempdir().unwrap();
+    let rp = repo.path();
+
+    run_git_fixture(rp, &["init", "-b", "main"]);
+    std::fs::write(
+        rp.join("mod.rs"),
+        "line1\nline2\nline3\nline4\nline5\nline6\nline7\nline8\nline9\nline10\n",
+    )
+    .unwrap();
+    run_git_fixture(rp, &["add", "mod.rs"]);
+    run_git_fixture(rp, &["commit", "-m", "seed"]);
+
+    run_git_fixture(rp, &["checkout", "-b", "feat/rename-with-delta"]);
+    run_git_fixture(rp, &["mv", "mod.rs", "renamed.rs"]);
+    std::fs::write(
+        rp.join("renamed.rs"),
+        "line1\nCHANGED\nline3\nline4\nline5\nline6\nline7\nline8\nline9\nline10\nnewline\n",
+    )
+    .unwrap();
+    run_git_fixture(rp, &["add", "renamed.rs"]);
+    run_git_fixture(rp, &["commit", "-m", "rename with content delta"]);
+
+    let data_dir = tempfile::tempdir().unwrap();
+
+    // First: an empty articulation refuses, naming renamed.rs (not mod.rs).
+    let empty_artic = tempfile::NamedTempFile::new().unwrap();
+    std::fs::write(empty_artic.path(), "# No entries\n").unwrap();
+    let (_stdout, stderr) = run_fail(legion_cmd(data_dir.path()).current_dir(rp).args([
+        "quality-gate",
+        "check",
+        "--skill",
+        "legion-simplify",
+        "--result",
+        "clean",
+        "--articulation-file",
+        empty_artic.path().to_str().unwrap(),
+    ]));
+    assert!(
+        stderr.contains("renamed.rs"),
+        "expected missing-coverage naming renamed.rs, got: {stderr}"
+    );
+    assert!(
+        !stderr.contains("mod.rs"),
+        "the old path must not be required once the rename is detected, got: {stderr}"
+    );
+
+    // Then: an articulation covering only the new path passes.
+    let good_artic = tempfile::NamedTempFile::new().unwrap();
+    std::fs::write(good_artic.path(), good_articulation_for("renamed.rs")).unwrap();
+    let stdout = run_ok(legion_cmd(data_dir.path()).current_dir(rp).args([
+        "quality-gate",
+        "check",
+        "--skill",
+        "legion-simplify",
+        "--result",
+        "clean",
+        "--articulation-file",
+        good_artic.path().to_str().unwrap(),
+    ]));
+    assert!(
+        stdout.contains("accepted") && stdout.contains("0 rename(s) auto-cleared"),
+        "expected acceptance with zero auto-cleared renames (delta rename stays in scope), \
+         got: {stdout}"
     );
 }


### PR DESCRIPTION
## Summary

`git_changed_files` (the sole runtime source for `legion quality-gate check`'s coverage
set) gains an explicit `--base <ref>` override, and switches its underlying git
invocation from `--name-only` to `--name-status -M50%` so pure (zero-delta) renames
auto-clear from the coverage set while renames with real content changes stay in scope.
Both the resolved base and the cleared-rename pairs are recorded on the gate row so a
too-narrow base or a silently-excluded rename stay auditable rather than disappearing.

Closes #779.

## Acceptance criteria mapping

### `legion quality-gate check` gains `--base <ref>`; the changed-file set is computed as `<base>...HEAD`. Default behavior (main/origin/main fallback) is unchanged when `--base` is omitted.
Done. `QualityGateAction::Check` gained `#[arg(long)] base: Option<String>`
(src/cli/verify.rs:129-158), threaded into `git_changed_files(base.as_deref())?`
(src/cli/verify.rs:280-295). `git_changed_files` (src/cli/util.rs:163-341) branches on
`Option<&str>`: `Some(explicit)` probes and diffs against that ref directly; `None` runs
the exact same main/origin-main candidate loop as before, byte-for-byte behavior
preserved. Evidence:
`quality_gate_check_base_override_scopes_to_stacked_branch_and_is_recorded`
(tests/integration/worksource_pr.rs) builds a `main` -> `feat/base-branch` ->
`feat/child` stack and shows `--base feat/base-branch` accepts an articulation covering
only the child's own file, which would fail under the default `main...HEAD` range.
`quality_gate_check_passing_articulation_records_gate_row` (existing test, extended)
confirms the untouched default-path behavior still passes.

### `legion verify` shares the same base resolution (same `git_changed_files` path) so the simplify and verify gates agree on scope.
Not implemented as originally written -- corrected per the issue's own Build Notes
(file:line-verified at HEAD f45e7e5): `git_changed_files` has exactly one runtime call
site, `quality-gate check` (src/cli/verify.rs:211 pre-#779); `legion verify`
(`handle_verify`, src/cli/verify.rs) never computes a changed-file set at all -- the
`verify.rs:90` citation in the original AC was a stale doc comment, not live code. The
Build Notes' replacement AC is implemented instead (see next item).

### Replacement AC: "the `--base` used is recorded on the gate row (new `base` column, has_column-guarded ALTER per the src/db/kanban.rs:1195-1216 precedent)."
Done. The `base` ALTER in src/db/quality_gates.rs:75-77 (`if !Database::has_column(conn,
"quality_gates", "base")? { ALTER TABLE quality_gates ADD COLUMN base TEXT; }`), wired
into `Database::init_schema` (src/db/mod.rs). It now lives inside the same combined
`migrate()` (src/db/quality_gates.rs:37-79) that also carries #780's
`provenance`/`voided_at`/`void_reason`/`superseded_by` columns -- #780 merged to main
first, so this branch's originally-solo "Migration 17" ALTER was merged alongside #780's
block rather than claiming that label on its own; see the last "Not done" item.
`QualityGateInput`/`QualityGateRow` both
gained a `base: Option<&'a str>` / `Option<String>` field, threaded through the one
INSERT and all three SELECT paths (`get_quality_gate`, `get_latest_quality_gate_by_skill`,
`list_quality_gates`). `git_changed_files` returns the *resolved* base (default or
override) on every non-vacuous run, and `handle_quality_gate`'s `Check` arm passes it into
`QualityGateInput.base` unconditionally -- not just when `--base` was passed -- so every
`legion-simplify` gate row from `quality-gate check` records which base its coverage set
was diffed against. Evidence:
`quality_gate_base_column_round_trips_through_insert_and_reads` and
`migration_provenance_void_and_base_columns_are_idempotent_on_reopen` (src/db/quality_gates.rs,
unit tests -- the latter was merged with #780's own idempotency test into one that
double-opens with both provenance and base set, rather than keeping two near-duplicate
tests over the same `has_column` guard mechanism);
`quality_gate_check_passing_articulation_records_gate_row`'s new assertion
(`arr[0]["base"] == "main"`) and
`quality_gate_check_base_override_scopes_to_stacked_branch_and_is_recorded`'s
(`arr[0]["base"] == "feat/base-branch"`) confirm both the default and override paths write
the column end-to-end through the CLI.

### `--base` must resolve to a real ref (hard-error otherwise, matching the existing no-base-ref behavior).
Done. src/cli/util.rs:180-198: an explicit `--base` is probed with `git rev-parse
--verify`; a failed probe returns `LegionError::WorkSource` naming the ref, with no
fallback to the default main/origin-main resolution and no vacuous pass. Evidence:
`quality_gate_check_base_unresolvable_ref_hard_errors` asserts the error names the bad ref
and that zero gate rows are recorded.

### Auditability over trust: `--base` is an honest-diff tool for stacked branches, not a gate-narrowing bypass. Recording the base keeps a too-narrow base visible to the same `quality-gate list`/`stats` surfaces that already query columns.
Done via the always-recorded `base` column above (both default and override cases) plus
the `cleared_renames` audit trail below -- a caller cannot narrow the diff (via `--base`)
or exclude files (via a pure rename) without both facts being visible in the same
`quality-gate list --json` row a reviewer already checks.
Evidence: `quality_gate_check_base_override_scopes_to_stacked_branch_and_is_recorded`
and `quality_gate_check_pure_rename_auto_cleared_and_recorded` both assert against the
`--json` row directly rather than trusting the CLI's own accept message.

### Field-case AC: "the coverage set auto-clears pure R100 renames (zero-delta moves); renames with any content delta (R<100) stay in the set; the cleared renames are LISTED in the gate record (count + paths or a digest)."
Done. `git_changed_files` switched from `--name-only` to `--name-status -M50%` (explicit
similarity pin -- see next item) and now returns a `ChangedFiles { files, cleared_renames,
base }` struct (src/cli/util.rs:113-136) instead of a bare `HashSet<String>`. The parser
(src/cli/util.rs:291-341) reads `R<nn>\t<old>\t<new>` lines: `R100` pairs go to
`cleared_renames` and are excluded from `files`; `R<100` pairs put only the new path into
`files` (the old path no longer exists in the tree once a rename is detected as such). An
undetected rename (below the 50% pin) still surfaces as an independent `D`/`A` pair,
requiring both paths, unchanged from before. `handle_quality_gate`'s `Check` arm
(src/cli/verify.rs:331-361) writes `cleared_renames_count` and a `cleared_renames: [{old,
new}, ...]` array into the gate's `details` JSON, and the CLI's accept message states the
count (`"N rename(s) auto-cleared"`). Evidence: `quality_gate_check_pure_rename_auto_cleared_and_recorded`
(empty articulation still passes; `details.cleared_renames == [{"old":"mod.rs","new":"renamed.rs"}]`)
and `quality_gate_check_rename_with_delta_requires_new_path_not_old_path` (empty
articulation refuses naming only the new path; an articulation covering the new path
passes with `0 rename(s) auto-cleared`).

### Build Notes: "EXPLICIT similarity pin (do not inherit ambient diff.renames config)."
Done and specifically regression-tested, not just implemented: `RENAME_SIMILARITY =
"-M50%"` is passed literally on the command line (src/cli/util.rs:105-111) rather than
relying on git's default `-M` behavior or the repo's `diff.renames` config. Verified
manually that `git -c diff.renames=false diff --name-status -M50% ...` still emits `R100`
(the ambient config would otherwise suppress rename detection entirely, turning a pure
rename into an undetected `D`+`A` pair that never clears). Evidence:
`quality_gate_check_pure_rename_cleared_despite_diff_renames_false_config` sets
`diff.renames false` LOCALLY on the fixture repo and asserts the rename still clears.

### Build Notes: "Expect to update the existing test `refuses_rename_when_old_path_entry_missing` (src/simplify_check.rs:357-384) -- `-M` changes how renames surface. That is intended, not a regression."
Done. `validate_articulation` (src/simplify_check.rs) is agnostic to how its
`HashSet<String>` input was built -- the R100 clearing happens entirely inside
`git_changed_files`, upstream of this function -- so the test's assertions are unchanged;
only its doc comment (src/simplify_check.rs:357-374) was updated to describe the new
`--name-status -M50%` mechanism (single `R<nn>` line for a detected rename vs. the
still-existing `D`+`A` fallback for an undetected one) instead of the retired
`--name-only` framing. `cargo test refuses_rename_when_old_path_entry_missing` passes
unmodified in logic.

## Not done

- The original "`legion verify` shares the same base resolution" AC is not implemented --
  see the mapping above; it was corrected by the issue's own Build Notes because `legion
  verify` never computes a changed-file set to share a base with.
- `--base` is not surfaced in `print_gate_table`'s human-readable `quality-gate list`
  output -- only via `--json` (`row.base`) and inside `details.base`/`details.cleared_renames`
  for `check` rows. Not requested by any AC; flagging in case a follow-on wants it
  visible in the plain-table view too.
- `C<nn>` (copy) line handling in the `--name-status` parser is defensive, not a live
  path: `RENAME_SIMILARITY` never passes `-C`, so git never emits a `C` line for this
  invocation. Added it because a pre-commit review round caught that the *old* code would
  have silently grabbed the wrong (source) path had a `C` line ever appeared; verified
  manually with an explicit `-C50% --find-copies-harder` probe outside the binary, but
  there is no integration test exercising it through `legion` itself since the code path
  it defends is currently unreachable via this binary's own invocation.
- Per Build Notes this issue "merges AFTER #780 (same DDL block, trivial rebase)". That
  happened: #780 merged to main first (PR #801), and this branch was built off released
  v0.21.0 (`5446fbe`), predating it. The anticipated rebase/renumber turned out to be a
  merge conflict (both PRs' branches had already been pushed, so per the no-force-push
  doctrine the resolution was `git merge origin/main` rather than a rebase) touching
  `src/db/quality_gates.rs`, `src/cli/verify.rs`, `src/cli/pr.rs`, and `src/gate_trust.rs`
  -- exactly the predicted DDL block plus every `QualityGateInput`/`QualityGateRow`
  construction site, since both PRs added a field to the same structs. Confirmed a logic
  conflict, not just a label collision: `migrate()` now runs both ALTER blocks in sequence
  (#780's provenance/void columns, then this issue's `base`), and every read path
  (`row_to_gate` et al.) selects all 13 columns together. The merge also picked up an
  unrelated pre-existing compile break on main tip (`src/identity_generate.rs` calling
  `get_reflections_by_domain` with a stale 3-arg signature after a 4th `ArchiveMode`
  parameter landed from a different already-merged PR) -- fixed as part of getting the
  merge commit to build, out of scope for this issue's own acceptance criteria.