### PR TITLE
feat(#780): provenance + void columns, validator registry, gate-trust exclusion for check-gated asserted-clean

### DIFF
--- a/src/cli/pr.rs
+++ b/src/cli/pr.rs
@@ -5,7 +5,7 @@ use clap::Subcommand;
 use crate::cli::datadir::data_dir;
 use crate::cli::util::{audit, git_head_commit_and_branch, open_db, read_file_or_stdin};
 use crate::db::quality_gates::QualityGateInput;
-use crate::verify::GateResult;
+use crate::verify::{GateProvenance, GateResult};
 use crate::{board, card_parse, db, error, kanban, pr_view, pr_write, search, worksource};
 
 #[derive(Subcommand, Debug)]
@@ -314,6 +314,12 @@ fn failing_checks_error(failed: &[&str], number: u64) -> error::LegionError {
 /// cross-checks the PR's head SHA first and phrases its own advice; the
 /// closing-keyword warning stays with each caller since the fix differs --
 /// `--closes` exists for `pr create`, not for editing a live PR).
+///
+/// This IS `legion-pr-write`'s check validator (#780): `pr_write::validate_pr_body`
+/// plays the same role `simplify_check::validate_articulation` plays for
+/// `legion-simplify` -- a structural gate the result must pass before the
+/// row is written -- so the row it records always carries VALIDATED
+/// provenance, mirroring `cli::verify`'s `Check` action.
 #[allow(clippy::too_many_arguments)]
 fn validate_and_record_pr_write_gate(
     plugin_name: &str,
@@ -349,6 +355,7 @@ fn validate_and_record_pr_write_gate(
         result: gate_result,
         findings_count: report.findings.len() as u64,
         details: Some(&details),
+        provenance: GateProvenance::Validated,
     })?;
     crate::gate_trust::emit_gate_trust(database, &row);
 

--- a/src/cli/verify.rs
+++ b/src/cli/verify.rs
@@ -11,8 +11,8 @@ use crate::db::quality_gates::{
     QualityGateFilter, QualityGateInput, QualityGateRow, QualityGateStats,
 };
 use crate::gate_trust::emit_gate_trust;
-use crate::verify::GateResult;
-use crate::{error, kanban, simplify_check, verify};
+use crate::verify::{GateProvenance, GateResult};
+use crate::{error, gate_registry, kanban, simplify_check, verify};
 
 #[derive(Subcommand, Debug)]
 pub(crate) enum QualityGateAction {
@@ -21,6 +21,15 @@ pub(crate) enum QualityGateAction {
     /// Reads git HEAD and branch automatically. The skill runner calls this
     /// after inspecting the diff. `legion pr create` checks the gate before
     /// calling the work source so the result cannot be faked via a file flag.
+    ///
+    /// The row is recorded with ASSERTED provenance (#780): no validator
+    /// backs it. For a skill with a check validator
+    /// (`gate_registry::has_check_validator` -- `legion-simplify`,
+    /// `legion-pr-write`), `--result clean` is REFUSED here -- a clean
+    /// verdict for those skills can only be earned via `quality-gate check`,
+    /// which validates a substantive articulation before recording. Skills
+    /// with no check validator (`legion-review`, a `legion-verify:<card_id>`
+    /// verdict) are unaffected: `record` is their only, legitimate path.
     Record {
         /// Skill name (e.g., "legion-simplify")
         #[arg(long)]
@@ -126,6 +135,36 @@ pub(crate) enum QualityGateAction {
         #[arg(long, default_value = "0")]
         findings_count: u64,
     },
+
+    /// Void a gate row: retire a known-false verdict without deleting it
+    /// from history (#780 tombstone pattern, mirroring `deleted_at` on
+    /// tasks/reflections/schedules).
+    ///
+    /// A voided row drops out of `get_quality_gate` /
+    /// `get_latest_quality_gate_by_skill` (so `pr create`'s gate check and
+    /// the ->Done gate can never resolve to it again) and out of
+    /// `quality-gate stats`, but stays visible in `quality-gate list` --
+    /// voiding annotates the ledger, it never erases it.
+    ///
+    /// Use `--superseded-by` once the genuine replacement row exists (e.g.
+    /// after re-running `quality-gate check` on the same commit) to link the
+    /// voided row to what replaced it.
+    Void {
+        /// Id of the gate row to void (from `quality-gate list` or the id
+        /// printed by `record`/`check`).
+        #[arg(long)]
+        id: String,
+
+        /// Why this row is known-false (required -- a void with no reason
+        /// is not an audit trail).
+        #[arg(long)]
+        reason: String,
+
+        /// Id of the row that supersedes this one, if a re-laid genuine row
+        /// already exists.
+        #[arg(long)]
+        superseded_by: Option<String>,
+    },
 }
 
 pub(crate) fn handle_quality_gate(action: QualityGateAction) -> error::Result<()> {
@@ -137,6 +176,24 @@ pub(crate) fn handle_quality_gate(action: QualityGateAction) -> error::Result<()
             details_json,
         } => {
             let gate_result = GateResult::from_str(&result)?;
+
+            // #780: a "clean" verdict for a skill with a check validator can
+            // only be earned by passing that validator. Refusing here closes
+            // the exact loophole a manufactured-clean row exploits -- self-
+            // reporting "clean" via `record` for a skill whose real gate is
+            // `check`. Skills with no validator (legion-review, a
+            // legion-verify:<card_id> verdict) are asserted by necessity and
+            // unaffected.
+            if gate_result == GateResult::Clean && gate_registry::has_check_validator(&skill) {
+                eprintln!(
+                    "[legion] error: '{skill}' has a check validator -- a clean gate cannot be \
+                     recorded via 'quality-gate record'. Run 'quality-gate check --skill {skill} \
+                     --result clean ...' instead, which validates a substantive per-changed-file \
+                     articulation before recording."
+                );
+                return Err(error::LegionError::ExitWith(1));
+            }
+
             let (commit_hash, branch) = git_head_commit_and_branch()?;
 
             let database = open_db()?;
@@ -147,6 +204,7 @@ pub(crate) fn handle_quality_gate(action: QualityGateAction) -> error::Result<()
                 result: gate_result,
                 findings_count,
                 details: details_json.as_deref(),
+                provenance: GateProvenance::Asserted,
             })?;
             emit_gate_trust(&database, &row);
             // Phase 2b: a downstream legion-review verdict witnesses the
@@ -261,6 +319,7 @@ pub(crate) fn handle_quality_gate(action: QualityGateAction) -> error::Result<()
                 result: gate_result,
                 findings_count,
                 details: Some(&details),
+                provenance: GateProvenance::Validated,
             })?;
             emit_gate_trust(&database, &row);
 
@@ -271,6 +330,22 @@ pub(crate) fn handle_quality_gate(action: QualityGateAction) -> error::Result<()
                 report.entry_count, row.id,
             );
         }
+
+        QualityGateAction::Void {
+            id,
+            reason,
+            superseded_by,
+        } => {
+            let database = open_db()?;
+            let row = database.void_quality_gate(&id, &reason, superseded_by.as_deref())?;
+            println!(
+                "[legion] voided gate {} (skill '{}', commit {}): {}",
+                row.id, row.skill, row.commit_hash, reason
+            );
+            if let Some(sup) = &row.superseded_by {
+                println!("  superseded by: {sup}");
+            }
+        }
     }
     Ok(())
 }
@@ -278,29 +353,42 @@ pub(crate) fn handle_quality_gate(action: QualityGateAction) -> error::Result<()
 /// Print gate rows as a human-readable table to stdout.
 ///
 /// Columns: id (first 8 chars), branch, commit (first 8 chars), skill,
-/// result, findings, created_at. An empty slice prints nothing.
+/// result, findings, provenance, void, created_at. An empty slice prints
+/// nothing.
+///
+/// PROVENANCE and VOID surface #780's audit distinction on the table a human
+/// actually reads by default: PROVENANCE separates a structurally VALIDATED
+/// clean from a merely ASSERTED one, and VOID marks a row retired as
+/// known-false ("-" for a live row, "VOID" for a voided one) so a retired
+/// row never visually blends in with a live one. `--json` (see
+/// `QualityGateRow`'s `Serialize`) already carries the full
+/// `voided_at`/`void_reason`/`superseded_by` detail for tooling; this table
+/// is the quick-glance surface.
 fn print_gate_table(rows: &[QualityGateRow]) {
     if rows.is_empty() {
         return;
     }
     println!(
-        "{:<8}  {:<20}  {:<8}  {:<22}  {:<6}  {:>8}  CREATED",
-        "ID", "BRANCH", "COMMIT", "SKILL", "RESULT", "FINDINGS"
+        "{:<8}  {:<20}  {:<8}  {:<22}  {:<6}  {:>8}  {:<9}  {:<4}  CREATED",
+        "ID", "BRANCH", "COMMIT", "SKILL", "RESULT", "FINDINGS", "PROVENANCE", "VOID"
     );
-    println!("{}", "-".repeat(100));
+    println!("{}", "-".repeat(130));
     for row in rows {
         let id_short: String = row.id.chars().take(8).collect();
         let branch_trunc: String = row.branch.chars().take(20).collect();
         let commit_short: String = row.commit_hash.chars().take(8).collect();
         let skill_trunc: String = row.skill.chars().take(22).collect();
+        let void_marker = if row.voided_at.is_some() { "VOID" } else { "-" };
         println!(
-            "{:<8}  {:<20}  {:<8}  {:<22}  {:<6}  {:>8}  {}",
+            "{:<8}  {:<20}  {:<8}  {:<22}  {:<6}  {:>8}  {:<9}  {:<4}  {}",
             id_short,
             branch_trunc,
             commit_short,
             skill_trunc,
             row.result.as_str(),
             row.findings_count,
+            row.provenance.as_str(),
+            void_marker,
             row.created_at,
         );
     }
@@ -441,6 +529,9 @@ pub(crate) fn handle_verify(
             result: GateResult::Issues,
             findings_count: 1,
             details: Some(&details),
+            // legion-verify has no check validator -- asserted by necessity
+            // (#780), same as every other verify-recorded row below.
+            provenance: GateProvenance::Asserted,
         })?;
         eprintln!("[legion] verify BLOCKED for card {card}: {reason}");
         return Err(error::LegionError::ExitWith(1));
@@ -497,6 +588,8 @@ pub(crate) fn handle_verify(
         result: gate_result,
         findings_count: findings,
         details: Some(&details),
+        // legion-verify has no check validator -- asserted by necessity (#780).
+        provenance: GateProvenance::Asserted,
     })?;
 
     match decision {
@@ -778,6 +871,7 @@ mod tests {
                 result: GateResult::Clean,
                 findings_count: 0,
                 details: Some(&serde_json::json!({"articulation": articulation}).to_string()),
+                provenance: GateProvenance::Validated,
             })
             .expect("record_quality_gate failed");
         assert!(!row.id.is_empty());

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -150,6 +150,7 @@ impl Database {
         kanban::migrate(conn)?;
         schedules::migrate(conn)?;
         wake::migrate(conn)?;
+        quality_gates::migrate(conn)?;
         Ok(())
     }
 

--- a/src/db/quality_gates.rs
+++ b/src/db/quality_gates.rs
@@ -10,7 +10,7 @@ use uuid::Uuid;
 
 use super::Database;
 use crate::error::{LegionError, Result};
-use crate::verify::GateResult;
+use crate::verify::{GateProvenance, GateResult};
 
 /// `quality_gates` table (#200).
 pub(super) fn create_tables(conn: &Connection) -> Result<()> {
@@ -34,6 +34,38 @@ pub(super) fn create_tables(conn: &Connection) -> Result<()> {
     Ok(())
 }
 
+/// Column migrations for `quality_gates` (#780): provenance plus the
+/// void/supersede tombstone pattern, mirroring `tasks.deleted_at`
+/// (src/db/kanban.rs migration 13) -- a known-false row is retired without
+/// deleting history, and a re-laid genuine row can point back at what it
+/// replaces.
+///
+/// `provenance` defaults to `'asserted'` for pre-existing rows: every row
+/// recorded before this migration went through the un-validated `record`
+/// path (the `check` validator predates this column but always calls
+/// `record_quality_gate` directly, so historical `check`-recorded rows are
+/// indistinguishable from `record`-recorded ones at the DB layer without a
+/// backfill this issue does not attempt) -- the conservative default, since
+/// treating an unknown row as VALIDATED would be exactly the ground-truth
+/// leak #780 closes.
+pub(super) fn migrate(conn: &Connection) -> Result<()> {
+    if !Database::has_column(conn, "quality_gates", "provenance")? {
+        conn.execute_batch(
+            "ALTER TABLE quality_gates ADD COLUMN provenance TEXT NOT NULL DEFAULT 'asserted';",
+        )?;
+    }
+    if !Database::has_column(conn, "quality_gates", "voided_at")? {
+        conn.execute_batch("ALTER TABLE quality_gates ADD COLUMN voided_at TEXT;")?;
+    }
+    if !Database::has_column(conn, "quality_gates", "void_reason")? {
+        conn.execute_batch("ALTER TABLE quality_gates ADD COLUMN void_reason TEXT;")?;
+    }
+    if !Database::has_column(conn, "quality_gates", "superseded_by")? {
+        conn.execute_batch("ALTER TABLE quality_gates ADD COLUMN superseded_by TEXT;")?;
+    }
+    Ok(())
+}
+
 /// A recorded quality gate result tied to a git commit and skill.
 ///
 /// Written by skill runners so `legion pr create` can verify clean state
@@ -49,6 +81,16 @@ pub struct QualityGateRow {
     pub findings_count: u64,
     pub details: Option<String>,
     pub created_at: String,
+    /// Whether this verdict was structurally VALIDATED (`quality-gate
+    /// check`) or merely ASSERTED (`quality-gate record`, #780).
+    pub provenance: GateProvenance,
+    /// RFC3339 timestamp this row was voided, if any. `None` means live.
+    pub voided_at: Option<String>,
+    /// Why the row was voided (required alongside `voided_at`; #780).
+    pub void_reason: Option<String>,
+    /// The id of the row that supersedes this one, if a re-laid genuine row
+    /// has replaced it (#780).
+    pub superseded_by: Option<String>,
 }
 
 /// Parse a `GateResult` from a DB string, mapping unknown values to a
@@ -63,12 +105,25 @@ fn parse_result_from_db(s: String) -> std::result::Result<GateResult, rusqlite::
     })
 }
 
+/// Parse a `GateProvenance` from a DB string, mapping unknown values to a
+/// `LegionError::Database` so the error stays in the rusqlite query path.
+/// Column index 8 (`provenance`) in every SELECT below.
+fn parse_provenance_from_db(s: String) -> std::result::Result<GateProvenance, rusqlite::Error> {
+    GateProvenance::from_str(&s).map_err(|e| {
+        rusqlite::Error::FromSqlConversionFailure(
+            8,
+            rusqlite::types::Type::Text,
+            Box::new(std::io::Error::other(e.to_string())),
+        )
+    })
+}
+
 /// Input for recording a quality gate result (#787).
 ///
 /// Groups the positional argument list of `record_quality_gate` into a
 /// single struct, following the `db::AuditInput` precedent, so future
-/// additions (e.g. provenance/void columns, findings linkage) add a field
-/// instead of extending a positional signature.
+/// additions (e.g. findings linkage) add a field instead of extending a
+/// positional signature.
 pub struct QualityGateInput<'a> {
     pub branch: &'a str,
     pub commit_hash: &'a str,
@@ -76,6 +131,12 @@ pub struct QualityGateInput<'a> {
     pub result: GateResult,
     pub findings_count: u64,
     pub details: Option<&'a str>,
+    /// Whether this verdict was VALIDATED (via `quality-gate check`) or
+    /// merely ASSERTED (via `quality-gate record`, #780). The caller states
+    /// this explicitly rather than it being inferred, so the write site that
+    /// knows which code path it is (the `Check` handler vs. the `Record`
+    /// handler) is the single source of truth for it.
+    pub provenance: GateProvenance,
 }
 
 impl Database {
@@ -88,10 +149,12 @@ impl Database {
         let id = Uuid::now_v7().to_string();
         let created_at = Utc::now().to_rfc3339();
         let result_str: &str = input.result.as_str();
+        let provenance_str: &str = input.provenance.as_str();
         self.conn.execute(
             "INSERT INTO quality_gates \
-             (id, branch, commit_hash, skill, result, findings_count, details, created_at) \
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+             (id, branch, commit_hash, skill, result, findings_count, details, created_at, \
+              provenance) \
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
             rusqlite::params![
                 &id,
                 input.branch,
@@ -101,6 +164,7 @@ impl Database {
                 input.findings_count as i64,
                 input.details,
                 &created_at,
+                provenance_str,
             ],
         )?;
         Ok(QualityGateRow {
@@ -112,6 +176,87 @@ impl Database {
             findings_count: input.findings_count,
             details: input.details.map(str::to_owned),
             created_at,
+            provenance: input.provenance,
+            voided_at: None,
+            void_reason: None,
+            superseded_by: None,
+        })
+    }
+
+    /// Return a gate row by its id regardless of live/voided state, or
+    /// `None` if no row has that id. Used by `void_quality_gate` to return
+    /// the post-update row, and available generally for id-keyed lookups
+    /// (e.g. an operator auditing a `superseded_by` chain).
+    pub fn get_quality_gate_by_id(&self, id: &str) -> Result<Option<QualityGateRow>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT id, branch, commit_hash, skill, result, findings_count, details, \
+                    created_at, provenance, voided_at, void_reason, superseded_by \
+             FROM quality_gates \
+             WHERE id = ?1",
+        )?;
+        let mut rows = stmt.query_map(rusqlite::params![id], Self::row_to_gate)?;
+        match rows.next() {
+            Some(Ok(row)) => Ok(Some(row)),
+            Some(Err(e)) => Err(LegionError::Database(e)),
+            None => Ok(None),
+        }
+    }
+
+    /// Void a gate row: mark it `voided_at`/`void_reason` so a known-false
+    /// verdict is retired without deleting history (#780). Optionally names
+    /// the row that supersedes it -- typically a re-laid genuine row from a
+    /// fresh `quality-gate check` run, recorded separately and linked back
+    /// here once its id is known.
+    ///
+    /// A voided row drops out of the "live" lookups (`get_quality_gate`,
+    /// `get_latest_quality_gate_by_skill`) and out of `quality_gate_stats`,
+    /// but stays visible in `list_quality_gates` and by direct id lookup, so
+    /// the audit trail is never destroyed.
+    ///
+    /// Errors with `LegionError::QualityGateNotFound` when `id` does not
+    /// match any row -- voiding a typo'd id must fail loudly, not silently
+    /// no-op.
+    pub fn void_quality_gate(
+        &self,
+        id: &str,
+        reason: &str,
+        superseded_by: Option<&str>,
+    ) -> Result<QualityGateRow> {
+        let now = Utc::now().to_rfc3339();
+        let affected = self.conn.execute(
+            "UPDATE quality_gates SET voided_at = ?1, void_reason = ?2, superseded_by = ?3 \
+             WHERE id = ?4",
+            rusqlite::params![&now, reason, superseded_by, id],
+        )?;
+        if affected == 0 {
+            return Err(LegionError::QualityGateNotFound(id.to_owned()));
+        }
+        self.get_quality_gate_by_id(id)?
+            .ok_or_else(|| LegionError::QualityGateNotFound(id.to_owned()))
+    }
+
+    /// Shared row-mapping closure for the 12-column `SELECT ... FROM
+    /// quality_gates` shape every read path here uses, so a future column
+    /// addition only changes the column list and this function once.
+    fn row_to_gate(
+        row: &rusqlite::Row<'_>,
+    ) -> std::result::Result<QualityGateRow, rusqlite::Error> {
+        let result_str: String = row.get(4)?;
+        let findings_count_i64: i64 = row.get(5)?;
+        let provenance_str: String = row.get(8)?;
+        Ok(QualityGateRow {
+            id: row.get(0)?,
+            branch: row.get(1)?,
+            commit_hash: row.get(2)?,
+            skill: row.get(3)?,
+            result: parse_result_from_db(result_str)?,
+            findings_count: findings_count_i64.unsigned_abs(),
+            details: row.get(6)?,
+            created_at: row.get(7)?,
+            provenance: parse_provenance_from_db(provenance_str)?,
+            voided_at: row.get(9)?,
+            void_reason: row.get(10)?,
+            superseded_by: row.get(11)?,
         })
     }
 
@@ -124,27 +269,18 @@ impl Database {
         commit_hash: &str,
         skill: &str,
     ) -> Result<Option<QualityGateRow>> {
+        // Voided rows are excluded: a gate lookup this function feeds
+        // (`pr create`'s pre-create check) must never treat a known-false
+        // retired row as a live clean verdict (#780).
         let mut stmt = self.conn.prepare(
-            "SELECT id, branch, commit_hash, skill, result, findings_count, details, created_at \
+            "SELECT id, branch, commit_hash, skill, result, findings_count, details, \
+                    created_at, provenance, voided_at, void_reason, superseded_by \
              FROM quality_gates \
-             WHERE commit_hash = ?1 AND skill = ?2 \
+             WHERE commit_hash = ?1 AND skill = ?2 AND voided_at IS NULL \
              ORDER BY created_at DESC \
              LIMIT 1",
         )?;
-        let mut rows = stmt.query_map(rusqlite::params![commit_hash, skill], |row| {
-            let result_str: String = row.get(4)?;
-            let findings_count_i64: i64 = row.get(5)?;
-            Ok(QualityGateRow {
-                id: row.get(0)?,
-                branch: row.get(1)?,
-                commit_hash: row.get(2)?,
-                skill: row.get(3)?,
-                result: parse_result_from_db(result_str)?,
-                findings_count: findings_count_i64.unsigned_abs(),
-                details: row.get(6)?,
-                created_at: row.get(7)?,
-            })
-        })?;
+        let mut rows = stmt.query_map(rusqlite::params![commit_hash, skill], Self::row_to_gate)?;
         match rows.next() {
             Some(Ok(row)) => Ok(Some(row)),
             Some(Err(e)) => Err(LegionError::Database(e)),
@@ -161,27 +297,17 @@ impl Database {
     /// after the branch merged). Staleness is the caller's concern -- re-verify
     /// after material changes.
     pub fn get_latest_quality_gate_by_skill(&self, skill: &str) -> Result<Option<QualityGateRow>> {
+        // Voided rows are excluded, same as `get_quality_gate` (#780): the
+        // card-keyed ->Done check must never resolve to a retired verdict.
         let mut stmt = self.conn.prepare(
-            "SELECT id, branch, commit_hash, skill, result, findings_count, details, created_at \
+            "SELECT id, branch, commit_hash, skill, result, findings_count, details, \
+                    created_at, provenance, voided_at, void_reason, superseded_by \
              FROM quality_gates \
-             WHERE skill = ?1 \
+             WHERE skill = ?1 AND voided_at IS NULL \
              ORDER BY created_at DESC \
              LIMIT 1",
         )?;
-        let mut rows = stmt.query_map(rusqlite::params![skill], |row| {
-            let result_str: String = row.get(4)?;
-            let findings_count_i64: i64 = row.get(5)?;
-            Ok(QualityGateRow {
-                id: row.get(0)?,
-                branch: row.get(1)?,
-                commit_hash: row.get(2)?,
-                skill: row.get(3)?,
-                result: parse_result_from_db(result_str)?,
-                findings_count: findings_count_i64.unsigned_abs(),
-                details: row.get(6)?,
-                created_at: row.get(7)?,
-            })
-        })?;
+        let mut rows = stmt.query_map(rusqlite::params![skill], Self::row_to_gate)?;
         match rows.next() {
             Some(Ok(row)) => Ok(Some(row)),
             Some(Err(e)) => Err(LegionError::Database(e)),
@@ -241,6 +367,12 @@ impl Database {
     ///
     /// An empty result set is not an error; the caller decides how to
     /// present it. All filter fields are applied with AND semantics.
+    ///
+    /// Unlike `get_quality_gate` / `get_latest_quality_gate_by_skill`, this
+    /// does NOT exclude voided rows -- it is the audit surface, and a voided
+    /// row (its `voided_at`/`void_reason`/`superseded_by` fields are part of
+    /// `QualityGateRow`) must stay visible here so retiring a known-false
+    /// row never reads as deleting history (#780).
     pub fn list_quality_gates(&self, filter: &QualityGateFilter) -> Result<Vec<QualityGateRow>> {
         // Build (predicate, param) pairs together so a SQL fragment and its
         // bound value can never drift out of order.
@@ -262,7 +394,8 @@ impl Database {
         let where_clause = where_and(&predicates);
 
         let sql = format!(
-            "SELECT id, branch, commit_hash, skill, result, findings_count, details, created_at \
+            "SELECT id, branch, commit_hash, skill, result, findings_count, details, \
+                    created_at, provenance, voided_at, void_reason, superseded_by \
              FROM quality_gates \
              {where_clause} \
              ORDER BY created_at DESC"
@@ -271,20 +404,7 @@ impl Database {
         let mut stmt = self.conn.prepare(&sql)?;
         let rows = stmt.query_map(
             rusqlite::params_from_iter(clauses.iter().map(|(_, v)| v.as_ref())),
-            |row| {
-                let result_str: String = row.get(4)?;
-                let findings_count_i64: i64 = row.get(5)?;
-                Ok(QualityGateRow {
-                    id: row.get(0)?,
-                    branch: row.get(1)?,
-                    commit_hash: row.get(2)?,
-                    skill: row.get(3)?,
-                    result: parse_result_from_db(result_str)?,
-                    findings_count: findings_count_i64.unsigned_abs(),
-                    details: row.get(6)?,
-                    created_at: row.get(7)?,
-                })
-            },
+            Self::row_to_gate,
         )?;
 
         let mut out: Vec<QualityGateRow> = Vec::new();
@@ -296,6 +416,9 @@ impl Database {
 
     /// Return per-skill aggregate statistics, optionally filtered by `skill`
     /// and/or `since`.
+    ///
+    /// Voided rows are excluded (#780): a known-false verdict must not
+    /// inflate `clean`/`catch_rate` for the very skill it was retired for.
     ///
     /// The aggregation runs in SQLite (SUM/COUNT/MAX), then `catch_rate` is
     /// computed in Rust from the returned counts so no floating-point SQL
@@ -313,7 +436,8 @@ impl Database {
             clauses.push(("created_at >= ?", Box::new(ts.to_owned())));
         }
 
-        let predicates: Vec<&str> = clauses.iter().map(|(p, _)| *p).collect();
+        let mut predicates: Vec<&str> = vec!["voided_at IS NULL"];
+        predicates.extend(clauses.iter().map(|(p, _)| *p));
         let where_clause = where_and(&predicates);
 
         let sql = format!(
@@ -374,9 +498,10 @@ impl Database {
 
 #[cfg(test)]
 mod tests {
+    use crate::db::Database;
     use crate::db::quality_gates::QualityGateInput;
     use crate::db::testutil::test_db;
-    use crate::verify::GateResult;
+    use crate::verify::{GateProvenance, GateResult};
 
     #[test]
     fn quality_gate_insert_and_lookup() {
@@ -389,6 +514,7 @@ mod tests {
                 result: GateResult::Clean,
                 findings_count: 0,
                 details: None,
+                provenance: GateProvenance::Asserted,
             })
             .unwrap();
         assert!(!row.id.is_empty());
@@ -398,6 +524,10 @@ mod tests {
         assert_eq!(row.result, GateResult::Clean);
         assert_eq!(row.findings_count, 0);
         assert!(row.details.is_none());
+        assert_eq!(row.provenance, GateProvenance::Asserted);
+        assert!(row.voided_at.is_none());
+        assert!(row.void_reason.is_none());
+        assert!(row.superseded_by.is_none());
 
         let fetched = db
             .get_quality_gate("abc1234def5678", "legion-simplify")
@@ -406,6 +536,7 @@ mod tests {
         let fetched = fetched.unwrap();
         assert_eq!(fetched.id, row.id);
         assert_eq!(fetched.result, GateResult::Clean);
+        assert_eq!(fetched.provenance, GateProvenance::Asserted);
     }
 
     #[test]
@@ -427,6 +558,7 @@ mod tests {
             result: GateResult::Clean,
             findings_count: 0,
             details: None,
+            provenance: GateProvenance::Asserted,
         })
         .unwrap();
         // Different skill on the same commit should not match.
@@ -445,6 +577,7 @@ mod tests {
             result: GateResult::Clean,
             findings_count: 0,
             details: None,
+            provenance: GateProvenance::Asserted,
         })
         .unwrap();
         db.record_quality_gate(&QualityGateInput {
@@ -454,6 +587,7 @@ mod tests {
             result: GateResult::Issues,
             findings_count: 2,
             details: Some("{}"),
+            provenance: GateProvenance::Asserted,
         })
         .unwrap();
 
@@ -483,6 +617,7 @@ mod tests {
             result: GateResult::Issues,
             findings_count: 3,
             details: None,
+            provenance: GateProvenance::Asserted,
         })
         .unwrap();
         // Second run after fixing: clean.
@@ -493,6 +628,7 @@ mod tests {
             result: GateResult::Clean,
             findings_count: 0,
             details: None,
+            provenance: GateProvenance::Asserted,
         })
         .unwrap();
 
@@ -519,6 +655,7 @@ mod tests {
                 result: GateResult::Issues,
                 findings_count: 1,
                 details: Some(details),
+                provenance: GateProvenance::Asserted,
             })
             .unwrap();
         assert_eq!(row.details.as_deref(), Some(details));
@@ -544,6 +681,7 @@ mod tests {
             result: GateResult::Issues,
             findings_count: 1,
             details: None,
+            provenance: GateProvenance::Asserted,
         })
         .unwrap();
         db.record_quality_gate(&QualityGateInput {
@@ -553,6 +691,7 @@ mod tests {
             result: GateResult::Clean,
             findings_count: 0,
             details: None,
+            provenance: GateProvenance::Asserted,
         })
         .unwrap();
 
@@ -598,6 +737,7 @@ mod tests {
             result: GateResult::Clean,
             findings_count: 0,
             details: None,
+            provenance: GateProvenance::Asserted,
         })
         .unwrap();
         // Force a strictly later timestamp so ORDER BY created_at DESC is
@@ -611,6 +751,7 @@ mod tests {
             result: GateResult::Issues,
             findings_count: 2,
             details: None,
+            provenance: GateProvenance::Asserted,
         })
         .unwrap();
 
@@ -634,6 +775,7 @@ mod tests {
             result: GateResult::Clean,
             findings_count: 0,
             details: None,
+            provenance: GateProvenance::Asserted,
         })
         .unwrap();
         db.record_quality_gate(&QualityGateInput {
@@ -643,6 +785,7 @@ mod tests {
             result: GateResult::Issues,
             findings_count: 1,
             details: None,
+            provenance: GateProvenance::Asserted,
         })
         .unwrap();
 
@@ -667,6 +810,7 @@ mod tests {
             result: GateResult::Clean,
             findings_count: 0,
             details: None,
+            provenance: GateProvenance::Asserted,
         })
         .unwrap();
         db.record_quality_gate(&QualityGateInput {
@@ -676,6 +820,7 @@ mod tests {
             result: GateResult::Issues,
             findings_count: 3,
             details: None,
+            provenance: GateProvenance::Asserted,
         })
         .unwrap();
         db.record_quality_gate(&QualityGateInput {
@@ -685,6 +830,7 @@ mod tests {
             result: GateResult::Clean,
             findings_count: 0,
             details: None,
+            provenance: GateProvenance::Asserted,
         })
         .unwrap();
 
@@ -710,6 +856,7 @@ mod tests {
             result: GateResult::Clean,
             findings_count: 0,
             details: None,
+            provenance: GateProvenance::Asserted,
         })
         .unwrap();
         db.record_quality_gate(&QualityGateInput {
@@ -719,6 +866,7 @@ mod tests {
             result: GateResult::Clean,
             findings_count: 0,
             details: None,
+            provenance: GateProvenance::Asserted,
         })
         .unwrap();
 
@@ -748,6 +896,7 @@ mod tests {
                 result: GateResult::Clean,
                 findings_count: 0,
                 details: None,
+                provenance: GateProvenance::Asserted,
             })
             .unwrap();
         // Sleep briefly so the second row has a strictly later timestamp.
@@ -760,6 +909,7 @@ mod tests {
                 result: GateResult::Issues,
                 findings_count: 1,
                 details: None,
+                provenance: GateProvenance::Asserted,
             })
             .unwrap();
 
@@ -796,6 +946,7 @@ mod tests {
             result: GateResult::Clean,
             findings_count: 0,
             details: None,
+            provenance: GateProvenance::Asserted,
         })
         .unwrap();
         db.record_quality_gate(&QualityGateInput {
@@ -805,6 +956,7 @@ mod tests {
             result: GateResult::Issues,
             findings_count: 5,
             details: None,
+            provenance: GateProvenance::Asserted,
         })
         .unwrap();
         db.record_quality_gate(&QualityGateInput {
@@ -814,6 +966,7 @@ mod tests {
             result: GateResult::Issues,
             findings_count: 3,
             details: None,
+            provenance: GateProvenance::Asserted,
         })
         .unwrap();
         // 1 run for legion-review: 1 clean, findings = 0.
@@ -824,6 +977,7 @@ mod tests {
             result: GateResult::Clean,
             findings_count: 0,
             details: None,
+            provenance: GateProvenance::Asserted,
         })
         .unwrap();
 
@@ -867,6 +1021,7 @@ mod tests {
             result: GateResult::Issues,
             findings_count: 2,
             details: None,
+            provenance: GateProvenance::Asserted,
         })
         .unwrap();
         db.record_quality_gate(&QualityGateInput {
@@ -876,6 +1031,7 @@ mod tests {
             result: GateResult::Clean,
             findings_count: 0,
             details: None,
+            provenance: GateProvenance::Asserted,
         })
         .unwrap();
 
@@ -897,6 +1053,7 @@ mod tests {
             result: GateResult::Clean,
             findings_count: 0,
             details: None,
+            provenance: GateProvenance::Asserted,
         })
         .unwrap();
         db.record_quality_gate(&QualityGateInput {
@@ -906,6 +1063,7 @@ mod tests {
             result: GateResult::Clean,
             findings_count: 0,
             details: None,
+            provenance: GateProvenance::Asserted,
         })
         .unwrap();
 
@@ -924,6 +1082,7 @@ mod tests {
             result: GateResult::Issues,
             findings_count: 1,
             details: None,
+            provenance: GateProvenance::Asserted,
         })
         .unwrap();
         db.record_quality_gate(&QualityGateInput {
@@ -933,11 +1092,292 @@ mod tests {
             result: GateResult::Issues,
             findings_count: 1,
             details: None,
+            provenance: GateProvenance::Asserted,
         })
         .unwrap();
 
         let stats = db.quality_gate_stats(None, None).unwrap();
         assert_eq!(stats.len(), 1);
         assert!((stats[0].catch_rate - 1.0).abs() < f64::EPSILON);
+    }
+
+    // --- provenance + void/supersede tests (#780) ---
+
+    #[test]
+    fn provenance_validated_round_trips_through_lookup() {
+        let db = test_db();
+        db.record_quality_gate(&QualityGateInput {
+            branch: "feat/x",
+            commit_hash: "hash-validated",
+            skill: "legion-simplify",
+            result: GateResult::Clean,
+            findings_count: 0,
+            details: None,
+            provenance: GateProvenance::Validated,
+        })
+        .unwrap();
+
+        let fetched = db
+            .get_quality_gate("hash-validated", "legion-simplify")
+            .unwrap()
+            .expect("row should exist");
+        assert_eq!(fetched.provenance, GateProvenance::Validated);
+    }
+
+    #[test]
+    fn void_quality_gate_sets_voided_fields_and_reason() {
+        let db = test_db();
+        let row = db
+            .record_quality_gate(&QualityGateInput {
+                branch: "feat/1754-alert-port",
+                commit_hash: "e74a06d6",
+                skill: "legion-simplify",
+                result: GateResult::Clean,
+                findings_count: 0,
+                details: None,
+                provenance: GateProvenance::Asserted,
+            })
+            .unwrap();
+
+        let voided = db
+            .void_quality_gate(
+                &row.id,
+                "manufactured clean, no articulation ever ran",
+                None,
+            )
+            .unwrap();
+        assert_eq!(voided.id, row.id);
+        assert!(voided.voided_at.is_some());
+        assert_eq!(
+            voided.void_reason.as_deref(),
+            Some("manufactured clean, no articulation ever ran")
+        );
+        assert!(voided.superseded_by.is_none());
+    }
+
+    #[test]
+    fn void_quality_gate_can_link_a_superseding_row() {
+        let db = test_db();
+        let old = db
+            .record_quality_gate(&QualityGateInput {
+                branch: "feat/x",
+                commit_hash: "hash-old",
+                skill: "legion-simplify",
+                result: GateResult::Clean,
+                findings_count: 0,
+                details: None,
+                provenance: GateProvenance::Asserted,
+            })
+            .unwrap();
+        let new = db
+            .record_quality_gate(&QualityGateInput {
+                branch: "feat/x",
+                commit_hash: "hash-old",
+                skill: "legion-simplify",
+                result: GateResult::Clean,
+                findings_count: 0,
+                details: None,
+                provenance: GateProvenance::Validated,
+            })
+            .unwrap();
+
+        let voided = db
+            .void_quality_gate(&old.id, "superseded by a validated re-run", Some(&new.id))
+            .unwrap();
+        assert_eq!(voided.superseded_by.as_deref(), Some(new.id.as_str()));
+    }
+
+    #[test]
+    fn void_quality_gate_missing_id_errors() {
+        let db = test_db();
+        let err = db
+            .void_quality_gate("no-such-id", "reason", None)
+            .unwrap_err();
+        assert!(err.to_string().contains("no-such-id"));
+    }
+
+    #[test]
+    fn voided_row_excluded_from_get_quality_gate() {
+        // A voided clean row must not satisfy a live lookup -- this is the
+        // behavior that makes voiding actually retract the manufactured
+        // clean (e.g. the disposed feat/1754-alert-port row) from `pr
+        // create`'s gate check, not just annotate it.
+        let db = test_db();
+        let row = db
+            .record_quality_gate(&QualityGateInput {
+                branch: "feat/x",
+                commit_hash: "hash-voided",
+                skill: "legion-simplify",
+                result: GateResult::Clean,
+                findings_count: 0,
+                details: None,
+                provenance: GateProvenance::Asserted,
+            })
+            .unwrap();
+        db.void_quality_gate(&row.id, "known false", None).unwrap();
+
+        assert!(
+            db.get_quality_gate("hash-voided", "legion-simplify")
+                .unwrap()
+                .is_none(),
+            "a voided row must not be returned as the live gate"
+        );
+    }
+
+    #[test]
+    fn voided_row_excluded_from_latest_by_skill() {
+        let db = test_db();
+        let skill = "legion-verify:card-void";
+        let row = db
+            .record_quality_gate(&QualityGateInput {
+                branch: "feat/x",
+                commit_hash: "hash-a",
+                skill,
+                result: GateResult::Clean,
+                findings_count: 0,
+                details: None,
+                provenance: GateProvenance::Asserted,
+            })
+            .unwrap();
+        db.void_quality_gate(&row.id, "known false", None).unwrap();
+
+        assert!(
+            db.get_latest_quality_gate_by_skill(skill)
+                .unwrap()
+                .is_none(),
+            "a voided row must not resolve as the latest live gate for the skill"
+        );
+    }
+
+    #[test]
+    fn voided_row_still_visible_in_list_quality_gates() {
+        use crate::db::quality_gates::QualityGateFilter;
+        let db = test_db();
+        let row = db
+            .record_quality_gate(&QualityGateInput {
+                branch: "feat/x",
+                commit_hash: "hash-listed",
+                skill: "legion-simplify",
+                result: GateResult::Clean,
+                findings_count: 0,
+                details: None,
+                provenance: GateProvenance::Asserted,
+            })
+            .unwrap();
+        db.void_quality_gate(&row.id, "known false", None).unwrap();
+
+        let rows = db
+            .list_quality_gates(&QualityGateFilter::default())
+            .unwrap();
+        assert_eq!(
+            rows.len(),
+            1,
+            "voiding must not delete the row from history"
+        );
+        assert!(rows[0].voided_at.is_some());
+        assert_eq!(rows[0].void_reason.as_deref(), Some("known false"));
+    }
+
+    #[test]
+    fn voided_row_excluded_from_stats() {
+        let db = test_db();
+        let row = db
+            .record_quality_gate(&QualityGateInput {
+                branch: "main",
+                commit_hash: "hash-stats-voided",
+                skill: "legion-simplify",
+                result: GateResult::Clean,
+                findings_count: 0,
+                details: None,
+                provenance: GateProvenance::Asserted,
+            })
+            .unwrap();
+        db.void_quality_gate(&row.id, "known false", None).unwrap();
+        db.record_quality_gate(&QualityGateInput {
+            branch: "main",
+            commit_hash: "hash-stats-live",
+            skill: "legion-simplify",
+            result: GateResult::Issues,
+            findings_count: 2,
+            details: None,
+            provenance: GateProvenance::Validated,
+        })
+        .unwrap();
+
+        let stats = db.quality_gate_stats(None, None).unwrap();
+        assert_eq!(stats.len(), 1);
+        // Only the live row counts: 1 run, 0 clean, 1 issues -- the voided
+        // clean row must not inflate `clean` or dilute `catch_rate`.
+        assert_eq!(stats[0].runs, 1);
+        assert_eq!(stats[0].clean, 0);
+        assert_eq!(stats[0].issues, 1);
+        assert!((stats[0].catch_rate - 1.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn get_quality_gate_by_id_finds_a_voided_row_too() {
+        // Unlike the live lookups, id-keyed lookup must still resolve a
+        // voided row -- an operator auditing a supersede chain needs to walk
+        // from the new row back to the one it replaced.
+        let db = test_db();
+        let row = db
+            .record_quality_gate(&QualityGateInput {
+                branch: "feat/x",
+                commit_hash: "hash-by-id",
+                skill: "legion-simplify",
+                result: GateResult::Clean,
+                findings_count: 0,
+                details: None,
+                provenance: GateProvenance::Asserted,
+            })
+            .unwrap();
+        db.void_quality_gate(&row.id, "known false", None).unwrap();
+
+        let fetched = db
+            .get_quality_gate_by_id(&row.id)
+            .unwrap()
+            .expect("voided row must still be reachable by id");
+        assert!(fetched.voided_at.is_some());
+    }
+
+    #[test]
+    fn get_quality_gate_by_id_missing_returns_none() {
+        let db = test_db();
+        assert!(db.get_quality_gate_by_id("no-such-id").unwrap().is_none());
+    }
+
+    /// Migration is idempotent: opening the same file-backed database a
+    /// second time must not fail even though the provenance/void columns
+    /// already exist. Mirrors kanban.rs's
+    /// `migration_document_id_column_is_idempotent_on_reopen` (#780).
+    #[test]
+    fn migration_provenance_and_void_columns_are_idempotent_on_reopen() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("test_gate_migration.db");
+
+        let db1 = Database::open(&db_path).expect("first open");
+        let row = db1
+            .record_quality_gate(&QualityGateInput {
+                branch: "main",
+                commit_hash: "reopen-hash",
+                skill: "legion-simplify",
+                result: GateResult::Clean,
+                findings_count: 0,
+                details: None,
+                provenance: GateProvenance::Validated,
+            })
+            .expect("record on first open");
+        drop(db1);
+
+        // Second open over the same path: the has_column guards must
+        // prevent a duplicate ALTER TABLE from failing.
+        let db2 = Database::open(&db_path).expect("second open must not fail");
+        let fetched = db2
+            .get_quality_gate("reopen-hash", "legion-simplify")
+            .expect("get")
+            .expect("row from first open readable after second open");
+        assert_eq!(fetched.id, row.id);
+        assert_eq!(fetched.provenance, GateProvenance::Validated);
+        // dir is dropped here, cleaning up the temp files.
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -192,6 +192,12 @@ pub enum LegionError {
     #[error("invalid gate result: '{0}' (expected 'clean' or 'issues')")]
     InvalidGateResult(String),
 
+    #[error("invalid gate provenance: '{0}' (expected 'validated' or 'asserted')")]
+    InvalidGateProvenance(String),
+
+    #[error("quality gate row not found: {0}")]
+    QualityGateNotFound(String),
+
     #[error("delegation refused: {0}")]
     DelegationRefused(String),
 
@@ -309,6 +315,20 @@ mod tests {
         assert!(err.to_string().contains("bad"));
         assert!(err.to_string().contains("clean"));
         assert!(err.to_string().contains("issues"));
+    }
+
+    #[test]
+    fn invalid_gate_provenance_display() {
+        let err = LegionError::InvalidGateProvenance("bad".to_string());
+        assert!(err.to_string().contains("bad"));
+        assert!(err.to_string().contains("validated"));
+        assert!(err.to_string().contains("asserted"));
+    }
+
+    #[test]
+    fn quality_gate_not_found_display() {
+        let err = LegionError::QualityGateNotFound("gate-id-1".to_string());
+        assert!(err.to_string().contains("gate-id-1"));
     }
 
     #[test]

--- a/src/gate_registry.rs
+++ b/src/gate_registry.rs
@@ -1,0 +1,64 @@
+//! Validator registry (#780): the single source of truth for which
+//! quality-gate skills have a CHECK validator (a structural
+//! coverage-plus-substance gate the skill's articulation must pass before a
+//! row is recorded) versus which are asserted-by-necessity (no validator
+//! exists, so `quality-gate record` is the only way to write their verdict --
+//! `legion-review`, and a card-keyed `legion-verify:<card_id>` verdict).
+//!
+//! Before this module, "which skills have a check validator" was implicit:
+//! `legion-simplify` and `legion-pr-write` were hardcoded, separately, in
+//! `cli/pr.rs`'s pre-create gate loop and `cli/verify.rs`'s `Check` action,
+//! with nothing tying them together. Two independent call sites now need the
+//! same list to stay in lockstep -- `quality-gate record`'s clean-refusal
+//! (cli/verify.rs) and gate-trust's ingestion guard (gate_trust.rs) -- so a
+//! third hardcoded copy would only grow the drift risk this module closes.
+
+/// Skills that have a `legion quality-gate check` validator. A skill named
+/// here can never earn a "clean" verdict on the ledger via `quality-gate
+/// record` -- it must go through `check`, which validates a substantive,
+/// per-changed-file articulation before recording (see
+/// `crate::simplify_check::validate_articulation` for `legion-simplify`, and
+/// `crate::pr_write::validate_pr_body` via
+/// `cli::pr::validate_and_record_pr_write_gate` for `legion-pr-write`).
+const CHECK_GATED_SKILLS: &[&str] = &["legion-simplify", "legion-pr-write"];
+
+/// True when `skill` has a check validator (see `CHECK_GATED_SKILLS`).
+///
+/// Matches the bare skill name exactly. The verify gate's key format
+/// (`legion-verify:<card_id>`, built by `crate::verify::verify_gate_key`)
+/// never appears in `CHECK_GATED_SKILLS`, so a card-keyed verify skill
+/// correctly reads as "no check validator" without needing to strip the
+/// `:<card_id>` suffix first.
+pub fn has_check_validator(skill: &str) -> bool {
+    CHECK_GATED_SKILLS.contains(&skill)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn simplify_and_pr_write_are_check_gated() {
+        assert!(has_check_validator("legion-simplify"));
+        assert!(has_check_validator("legion-pr-write"));
+    }
+
+    #[test]
+    fn review_and_verify_are_not_check_gated() {
+        assert!(!has_check_validator("legion-review"));
+        assert!(!has_check_validator("legion-verify"));
+    }
+
+    #[test]
+    fn card_keyed_verify_skill_is_not_check_gated() {
+        // legion-verify:<card_id> must not accidentally match a check-gated
+        // entry -- it has no validator and never will.
+        assert!(!has_check_validator("legion-verify:card-abc-123"));
+    }
+
+    #[test]
+    fn unknown_skill_is_not_check_gated() {
+        assert!(!has_check_validator("some-future-skill"));
+        assert!(!has_check_validator(""));
+    }
+}

--- a/src/gate_trust.rs
+++ b/src/gate_trust.rs
@@ -59,12 +59,13 @@
 
 use crate::db::Database;
 use crate::db::quality_gates::QualityGateRow;
+use crate::gate_registry;
 use crate::uncertainty::error::Result as UncertaintyResult;
 use crate::uncertainty::storage::orphan_after_from_ttl;
 use crate::uncertainty::types::{
     Confidence, Correctness, OutcomeLabel, Prediction, PredictionInput,
 };
-use crate::verify::GateResult;
+use crate::verify::{GateProvenance, GateResult};
 
 /// The uncertainty surface all gate verdicts emit under.
 pub const GATE_SURFACE: &str = "legion.gate";
@@ -151,10 +152,44 @@ pub fn emit_gate_prediction(db: &Database, row: &QualityGateRow) -> UncertaintyR
     Ok(prediction.id)
 }
 
+/// True when `row` must NOT be ingested as gate-trust ground truth (#780): an
+/// ASSERTED "clean" verdict for a skill that has a check validator
+/// (`gate_registry::has_check_validator`). Recording such a row is already
+/// refused at the CLI layer (`cli::verify::handle_quality_gate`'s `Record`
+/// arm), but this is the defense-in-depth boundary for the ingestion path
+/// itself -- a pre-#780 historical row, or any future caller that reaches
+/// `record_quality_gate` without going through that CLI refusal, must still
+/// never let a manufactured clean count as a passed gate. Admitting it would
+/// let exactly the rubber-stamp this module measures poison its own
+/// denominator.
+///
+/// A VALIDATED clean (the `check` path) and an ASSERTED `issues` (a real
+/// finding, self-reported or not, is not a ground-truth risk in the same
+/// direction) are both eligible for ingestion as before.
+fn is_ungrounded_assertion(row: &QualityGateRow) -> bool {
+    row.result == GateResult::Clean
+        && row.provenance == GateProvenance::Asserted
+        && gate_registry::has_check_validator(&row.skill)
+}
+
 /// Non-blocking gate-trust emit for the gate-record handlers: log on failure,
 /// never propagate. A gate-trust problem must never break gate recording or the
 /// agent's workflow -- the measurement is best-effort, the gate is not.
+///
+/// Skips ingestion entirely (no prediction emitted) for an ungrounded
+/// assertion (#780, see `is_ungrounded_assertion`) -- this is the boundary
+/// acceptance criterion #3 names: gate-trust must not consume an
+/// asserted-clean row for a check-gated skill as positive ground truth.
 pub fn emit_gate_trust(db: &Database, row: &QualityGateRow) {
+    if is_ungrounded_assertion(row) {
+        eprintln!(
+            "[legion] gate-trust: skipping ingestion of an ASSERTED clean verdict for \
+             check-gated skill '{}' on commit {} -- a manufactured clean cannot count as \
+             ground truth (#780). Re-run via 'quality-gate check' to validate and ingest it.",
+            row.skill, row.commit_hash
+        );
+        return;
+    }
     if let Err(e) = emit_gate_prediction(db, row) {
         eprintln!("[legion] gate-trust emit failed (non-fatal): {e}");
     }
@@ -309,7 +344,21 @@ mod tests {
     use crate::db::testutil::test_db;
     use crate::uncertainty::types::PredictionState;
 
+    /// Builds a row with VALIDATED provenance -- the common case every
+    /// pre-#780 test in this module exercises (emission/witness mechanics
+    /// unrelated to provenance), so defaulting here keeps their behavior
+    /// unchanged. The #780 ingestion-guard tests build their own row with
+    /// ASSERTED provenance via `gate_row_with_provenance` instead.
     fn gate_row(skill: &str, result: GateResult, findings: u64) -> QualityGateRow {
+        gate_row_with_provenance(skill, result, findings, GateProvenance::Validated)
+    }
+
+    fn gate_row_with_provenance(
+        skill: &str,
+        result: GateResult,
+        findings: u64,
+        provenance: GateProvenance,
+    ) -> QualityGateRow {
         QualityGateRow {
             id: "gate-id".to_string(),
             branch: "feat/x".to_string(),
@@ -319,6 +368,10 @@ mod tests {
             findings_count: findings,
             details: None,
             created_at: "2026-06-27T00:00:00+00:00".to_string(),
+            provenance,
+            voided_at: None,
+            void_reason: None,
+            superseded_by: None,
         }
     }
 
@@ -388,6 +441,106 @@ mod tests {
             .count_predictions_by_surface_state("legion.gate", PredictionState::Emitted)
             .unwrap();
         assert_eq!(emitted, 1, "the wrapper must emit exactly one Emitted row");
+    }
+
+    // -- #780: gate-trust must not ingest asserted-clean for a check-gated
+    // skill --------------------------------------------------------------
+
+    #[test]
+    fn ungrounded_assertion_detects_asserted_clean_check_gated() {
+        let row = gate_row_with_provenance(
+            "legion-simplify",
+            GateResult::Clean,
+            0,
+            GateProvenance::Asserted,
+        );
+        assert!(is_ungrounded_assertion(&row));
+
+        let row = gate_row_with_provenance(
+            "legion-pr-write",
+            GateResult::Clean,
+            0,
+            GateProvenance::Asserted,
+        );
+        assert!(is_ungrounded_assertion(&row));
+    }
+
+    #[test]
+    fn validated_clean_is_not_an_ungrounded_assertion() {
+        let row = gate_row_with_provenance(
+            "legion-simplify",
+            GateResult::Clean,
+            0,
+            GateProvenance::Validated,
+        );
+        assert!(!is_ungrounded_assertion(&row));
+    }
+
+    #[test]
+    fn asserted_issues_is_not_an_ungrounded_assertion() {
+        // Only a CLEAN claim is a ground-truth risk in this direction -- an
+        // asserted "issues" result is a self-reported finding, not a
+        // manufactured pass.
+        let row = gate_row_with_provenance(
+            "legion-simplify",
+            GateResult::Issues,
+            1,
+            GateProvenance::Asserted,
+        );
+        assert!(!is_ungrounded_assertion(&row));
+    }
+
+    #[test]
+    fn asserted_clean_for_a_skill_without_a_validator_is_not_ungrounded() {
+        // legion-review and a legion-verify:<card_id> verdict have no check
+        // validator -- asserted is their only, legitimate provenance, so a
+        // clean verdict from them must still be ingested.
+        let row = gate_row_with_provenance(
+            "legion-review",
+            GateResult::Clean,
+            0,
+            GateProvenance::Asserted,
+        );
+        assert!(!is_ungrounded_assertion(&row));
+
+        let row = gate_row_with_provenance(
+            "legion-verify:card-1",
+            GateResult::Clean,
+            0,
+            GateProvenance::Asserted,
+        );
+        assert!(!is_ungrounded_assertion(&row));
+    }
+
+    #[test]
+    fn emit_gate_trust_skips_ingestion_of_an_ungrounded_assertion() {
+        use crate::uncertainty::types::PredictionState;
+        let db = test_db();
+        let row = gate_row_with_provenance(
+            "legion-simplify",
+            GateResult::Clean,
+            0,
+            GateProvenance::Asserted,
+        );
+        emit_gate_trust(&db, &row);
+        let emitted = db
+            .count_predictions_by_surface_state("legion.gate", PredictionState::Emitted)
+            .unwrap();
+        assert_eq!(
+            emitted, 0,
+            "an asserted-clean row for a check-gated skill must not be ingested"
+        );
+    }
+
+    #[test]
+    fn emit_gate_trust_still_ingests_a_validated_clean_row() {
+        use crate::uncertainty::types::PredictionState;
+        let db = test_db();
+        emit_gate_trust(&db, &gate_row("legion-simplify", GateResult::Clean, 0));
+        let emitted = db
+            .count_predictions_by_surface_state("legion.gate", PredictionState::Emitted)
+            .unwrap();
+        assert_eq!(emitted, 1, "a validated clean row must still be ingested");
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,7 @@ mod documents;
 mod embed;
 mod error;
 mod etc;
+mod gate_registry;
 mod gate_trust;
 mod graph;
 mod health;

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -66,6 +66,68 @@ impl FromStr for GateResult {
     }
 }
 
+/// Provenance of a recorded quality-gate row (#780): whether the verdict was
+/// structurally VALIDATED (a coverage-and-substance articulation passed
+/// `quality-gate check`) or merely ASSERTED (written via `quality-gate
+/// record`, with no validator backing the claim).
+///
+/// This is the distinction gate-trust and audits need to tell a proven clean
+/// gate apart from a self-reported one: the cross-repo ledger the
+/// uncertainty engine (#694) treats as calibration ground truth cannot
+/// afford to let an unvalidated "clean" claim count the same as a validated
+/// one, or a manufactured row silently poisons the very rubber-stamp
+/// measurement it exists to produce.
+///
+/// Stored as lowercase string in `quality_gates.provenance`, mirroring
+/// `GateResult`'s Display/FromStr/serde symmetry.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum GateProvenance {
+    /// Recorded via `quality-gate check`: the structural validator (coverage
+    /// of every changed file + non-boilerplate substance) passed before this
+    /// row was written.
+    Validated,
+    /// Recorded via `quality-gate record`: no validator ran. Legitimate --
+    /// and the only option -- for skills with no check validator
+    /// (`legion-review`, a `legion-verify:<card_id>` verdict: asserted by
+    /// necessity, since no validator exists for either). For a skill that
+    /// DOES have a check validator (`gate_registry::has_check_validator`),
+    /// a `clean` result under this provenance is refused at the CLI layer
+    /// and, as defense in depth, never ingested by gate-trust even if a row
+    /// reaches the ledger some other way (a pre-#780 historical row, or a
+    /// future caller that bypasses the CLI).
+    Asserted,
+}
+
+impl GateProvenance {
+    /// The serialized column value. Display and the SQL write path both
+    /// delegate here so the wire form has exactly one source.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Validated => "validated",
+            Self::Asserted => "asserted",
+        }
+    }
+}
+
+impl fmt::Display for GateProvenance {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl FromStr for GateProvenance {
+    type Err = LegionError;
+
+    fn from_str(s: &str) -> Result<Self> {
+        match s {
+            "validated" => Ok(Self::Validated),
+            "asserted" => Ok(Self::Asserted),
+            other => Err(LegionError::InvalidGateProvenance(other.to_string())),
+        }
+    }
+}
+
 /// Build the quality-gate skill key for a verify verdict on `card_id`.
 ///
 /// The key is single-sourced here so that the handler that writes the gate
@@ -612,6 +674,30 @@ mod tests {
         assert!("Clean".parse::<GateResult>().is_err());
         assert!("CLEAN".parse::<GateResult>().is_err());
         assert!("".parse::<GateResult>().is_err());
+    }
+
+    // --- GateProvenance tests (#780) ---
+
+    #[test]
+    fn gate_provenance_display_roundtrip() {
+        for p in [GateProvenance::Validated, GateProvenance::Asserted] {
+            let s = p.to_string();
+            let parsed = s.parse::<GateProvenance>().expect("parse should succeed");
+            assert_eq!(p, parsed, "display/parse roundtrip failed for {p}");
+        }
+    }
+
+    #[test]
+    fn gate_provenance_display_values() {
+        assert_eq!(GateProvenance::Validated.to_string(), "validated");
+        assert_eq!(GateProvenance::Asserted.to_string(), "asserted");
+    }
+
+    #[test]
+    fn gate_provenance_parse_invalid_returns_err() {
+        assert!("unknown".parse::<GateProvenance>().is_err());
+        assert!("Validated".parse::<GateProvenance>().is_err());
+        assert!("".parse::<GateProvenance>().is_err());
     }
 
     // --- verify_gate_key tests ---

--- a/tests/integration/worksource_pr.rs
+++ b/tests/integration/worksource_pr.rs
@@ -960,6 +960,12 @@ fn pr_view_surfaces_malformed_plugin_json_as_worksource_error() {
 // ---------------------------------------------------------------------------
 
 /// `legion quality-gate record` writes a row and prints a UUIDv7 on stdout.
+///
+/// Uses "legion-review" -- a skill with no check validator -- rather than
+/// "legion-simplify": since #780, `record --result clean` is refused for a
+/// check-gated skill (see `quality_gate_record_refuses_clean_for_check_gated_skill`
+/// below), and this test exercises the generic record mechanics, not that
+/// distinction.
 #[test]
 fn quality_gate_record_prints_id() {
     let dir = tempfile::tempdir().unwrap();
@@ -968,9 +974,59 @@ fn quality_gate_record_prints_id() {
         "quality-gate",
         "record",
         "--skill",
+        "legion-review",
+        "--result",
+        "clean",
+    ]))
+    .trim()
+    .to_string();
+    assert_uuid_format(&id);
+}
+
+/// #780: `quality-gate record --result clean` is refused for a skill with a
+/// check validator (legion-simplify, legion-pr-write) -- a clean gate for
+/// those can only be earned via `quality-gate check`.
+#[test]
+fn quality_gate_record_refuses_clean_for_check_gated_skill() {
+    let dir = tempfile::tempdir().unwrap();
+
+    let (_stdout, stderr) = run_fail(legion_cmd(dir.path()).args([
+        "quality-gate",
+        "record",
+        "--skill",
         "legion-simplify",
         "--result",
         "clean",
+    ]));
+    assert!(
+        stderr.contains("check validator"),
+        "expected a check-validator refusal message, got: {stderr}"
+    );
+
+    // No row was written -- the refusal happens before the DB touch.
+    let stdout = run_ok(legion_cmd(dir.path()).args(["quality-gate", "list", "--json"]));
+    let arr: Vec<serde_json::Value> = serde_json::from_str(&stdout).expect("expected JSON array");
+    assert!(
+        arr.is_empty(),
+        "a refused record must not write a row, got: {arr:?}"
+    );
+}
+
+/// #780: `record --result issues` is still allowed for a check-gated skill --
+/// only a manufactured "clean" is the ground-truth risk.
+#[test]
+fn quality_gate_record_allows_issues_for_check_gated_skill() {
+    let dir = tempfile::tempdir().unwrap();
+
+    let id = run_ok(legion_cmd(dir.path()).args([
+        "quality-gate",
+        "record",
+        "--skill",
+        "legion-simplify",
+        "--result",
+        "issues",
+        "--findings-count",
+        "1",
     ]))
     .trim()
     .to_string();
@@ -2017,6 +2073,12 @@ fn quality_gate_list_empty_json_prints_empty_array() {
 }
 
 /// `legion quality-gate list` shows recorded rows in the human table.
+///
+/// legion-simplify records "issues" and legion-review records "clean": since
+/// #780, `record --result clean` is refused for a check-gated skill
+/// (legion-simplify has one), so the mix is swapped from a legion-simplify
+/// row's usual verdict -- this test only cares that both result strings
+/// render, not which skill carries which.
 #[test]
 fn quality_gate_list_shows_recorded_rows() {
     let dir = tempfile::tempdir().unwrap();
@@ -2028,7 +2090,9 @@ fn quality_gate_list_shows_recorded_rows() {
         "--skill",
         "legion-simplify",
         "--result",
-        "clean",
+        "issues",
+        "--findings-count",
+        "3",
     ]));
     run_ok(legion_cmd(dir.path()).args([
         "quality-gate",
@@ -2036,9 +2100,7 @@ fn quality_gate_list_shows_recorded_rows() {
         "--skill",
         "legion-review",
         "--result",
-        "issues",
-        "--findings-count",
-        "3",
+        "clean",
     ]));
 
     let stdout = run_ok(legion_cmd(dir.path()).args(["quality-gate", "list"]));
@@ -2065,13 +2127,16 @@ fn quality_gate_list_shows_recorded_rows() {
 fn quality_gate_list_filter_by_skill() {
     let dir = tempfile::tempdir().unwrap();
 
+    // legion-simplify records "issues" (#780: "clean" is refused for a
+    // check-gated skill via `record`) -- irrelevant to this test, which
+    // filters on skill name, not result.
     run_ok(legion_cmd(dir.path()).args([
         "quality-gate",
         "record",
         "--skill",
         "legion-simplify",
         "--result",
-        "clean",
+        "issues",
     ]));
     run_ok(legion_cmd(dir.path()).args([
         "quality-gate",
@@ -2148,6 +2213,132 @@ fn quality_gate_list_invalid_result_value_exits_nonzero() {
     );
 }
 
+// --- quality-gate void tests (#780) ---
+
+/// `legion quality-gate void` marks a row voided with a reason, and the
+/// voided row is still visible (with `voided_at`/`void_reason` populated) in
+/// `quality-gate list --json` -- voiding annotates the ledger, it never
+/// deletes from it.
+#[test]
+fn quality_gate_void_marks_row_and_stays_visible_in_list() {
+    let dir = tempfile::tempdir().unwrap();
+
+    let id = run_ok(legion_cmd(dir.path()).args([
+        "quality-gate",
+        "record",
+        "--skill",
+        "legion-review",
+        "--result",
+        "clean",
+    ]))
+    .trim()
+    .to_string();
+
+    let stdout = run_ok(legion_cmd(dir.path()).args([
+        "quality-gate",
+        "void",
+        "--id",
+        &id,
+        "--reason",
+        "manufactured clean, no articulation ever ran",
+    ]));
+    assert!(
+        stdout.contains(&id),
+        "expected the void confirmation to name the row id, got: {stdout}"
+    );
+
+    let list_stdout = run_ok(legion_cmd(dir.path()).args(["quality-gate", "list", "--json"]));
+    let arr: Vec<serde_json::Value> =
+        serde_json::from_str(&list_stdout).expect("expected JSON array");
+    assert_eq!(arr.len(), 1, "voiding must not delete the row from history");
+    assert!(
+        !arr[0]["voided_at"].is_null(),
+        "expected voided_at to be set, got: {arr:?}"
+    );
+    assert_eq!(
+        arr[0]["void_reason"].as_str().unwrap(),
+        "manufactured clean, no articulation ever ran"
+    );
+
+    // The human table marks it too.
+    let table_stdout = run_ok(legion_cmd(dir.path()).args(["quality-gate", "list"]));
+    assert!(
+        table_stdout.contains("VOID"),
+        "expected the human table to mark the voided row, got: {table_stdout}"
+    );
+}
+
+/// `legion quality-gate void --superseded-by` links a voided row to its
+/// replacement.
+#[test]
+fn quality_gate_void_links_superseding_row() {
+    let dir = tempfile::tempdir().unwrap();
+
+    let old_id = run_ok(legion_cmd(dir.path()).args([
+        "quality-gate",
+        "record",
+        "--skill",
+        "legion-review",
+        "--result",
+        "clean",
+    ]))
+    .trim()
+    .to_string();
+    let new_id = run_ok(legion_cmd(dir.path()).args([
+        "quality-gate",
+        "record",
+        "--skill",
+        "legion-review",
+        "--result",
+        "clean",
+    ]))
+    .trim()
+    .to_string();
+
+    let stdout = run_ok(legion_cmd(dir.path()).args([
+        "quality-gate",
+        "void",
+        "--id",
+        &old_id,
+        "--reason",
+        "superseded by a re-run",
+        "--superseded-by",
+        &new_id,
+    ]));
+    assert!(
+        stdout.contains(&new_id),
+        "expected the void output to name the superseding row, got: {stdout}"
+    );
+
+    let list_stdout = run_ok(legion_cmd(dir.path()).args(["quality-gate", "list", "--json"]));
+    let arr: Vec<serde_json::Value> =
+        serde_json::from_str(&list_stdout).expect("expected JSON array");
+    let voided = arr
+        .iter()
+        .find(|r| r["id"].as_str() == Some(old_id.as_str()))
+        .expect("voided row should still be listed");
+    assert_eq!(voided["superseded_by"].as_str().unwrap(), new_id);
+}
+
+/// `legion quality-gate void` with an unknown id exits non-zero.
+#[test]
+fn quality_gate_void_missing_id_exits_nonzero() {
+    let dir = tempfile::tempdir().unwrap();
+
+    let (_stdout, stderr) = run_fail(legion_cmd(dir.path()).args([
+        "quality-gate",
+        "void",
+        "--id",
+        "no-such-id",
+        "--reason",
+        "test",
+    ]));
+    assert!(
+        stderr.contains("no-such-id"),
+        "expected the error to name the missing id, got: {stderr}"
+    );
+}
+
 /// `legion quality-gate list --json` emits a JSON array with all fields including details.
 #[test]
 fn quality_gate_list_json_emits_array_with_details() {
@@ -2208,16 +2399,21 @@ fn quality_gate_stats_empty_json_prints_empty_array() {
 }
 
 /// `legion quality-gate stats` shows per-skill aggregates in the human table.
+///
+/// Uses "legion-review" -- a mixed clean/issues run pair recorded via
+/// `record` -- rather than "legion-simplify": #780 refuses `record --result
+/// clean` for a check-gated skill, and legion-review has no check validator,
+/// so it is the real skill this recording pattern is legitimate for.
 #[test]
 fn quality_gate_stats_shows_per_skill_aggregates() {
     let dir = tempfile::tempdir().unwrap();
 
-    // 2 runs for legion-simplify: 1 clean, 1 issues (1 finding).
+    // 2 runs for legion-review: 1 clean, 1 issues (1 finding).
     run_ok(legion_cmd(dir.path()).args([
         "quality-gate",
         "record",
         "--skill",
-        "legion-simplify",
+        "legion-review",
         "--result",
         "clean",
     ]));
@@ -2225,7 +2421,7 @@ fn quality_gate_stats_shows_per_skill_aggregates() {
         "quality-gate",
         "record",
         "--skill",
-        "legion-simplify",
+        "legion-review",
         "--result",
         "issues",
         "--findings-count",
@@ -2234,7 +2430,7 @@ fn quality_gate_stats_shows_per_skill_aggregates() {
 
     let stdout = run_ok(legion_cmd(dir.path()).args(["quality-gate", "stats"]));
     assert!(
-        stdout.contains("legion-simplify"),
+        stdout.contains("legion-review"),
         "expected skill row in stats output, got: {stdout}"
     );
     // 2 runs total.
@@ -2297,13 +2493,16 @@ fn quality_gate_stats_json_shape() {
 fn quality_gate_stats_filter_by_skill() {
     let dir = tempfile::tempdir().unwrap();
 
+    // legion-simplify records "issues" (#780: "clean" is refused for a
+    // check-gated skill via `record`) -- irrelevant to this test, which
+    // filters on skill name, not result.
     run_ok(legion_cmd(dir.path()).args([
         "quality-gate",
         "record",
         "--skill",
         "legion-simplify",
         "--result",
-        "clean",
+        "issues",
     ]));
     run_ok(legion_cmd(dir.path()).args([
         "quality-gate",


### PR DESCRIPTION
## Summary

Closes #780. Adds provenance + void/supersede columns to `quality_gates` (tombstone
pattern), a small validator registry naming which skills have a `quality-gate check`
validator, a CLI refusal that stops `quality-gate record --result clean` from manufacturing
a clean verdict for a check-gated skill, and a gate-trust ingestion guard so an
asserted-clean row for a check-gated skill can never count as ground truth.

## Acceptance criteria mapping

### Row provenance: every gate row records whether it was VALIDATED (via check) or ASSERTED (via record). gate-trust and audits can distinguish.

New `GateProvenance` enum (`Validated`/`Asserted`) with the same Display/FromStr/serde shape
as the existing `GateResult`, in `src/verify.rs`. New `provenance TEXT NOT NULL DEFAULT
'asserted'` column on `quality_gates`, added via a `has_column`-guarded ALTER in the new
`quality_gates::migrate` (mirrors `kanban.rs`'s `deleted_at` migration), in
`src/db/quality_gates.rs`. `QualityGateInput` gained a required `provenance` field; every
write site states it explicitly: `Check` (both `cli/verify.rs`'s simplify-check action and
`cli/pr.rs`'s `validate_and_record_pr_write_gate`, which is `legion-pr-write`'s own check
validator) records `Validated`; `Record` and both `handle_verify` writes record `Asserted`.
`list_quality_gates --json` and the human table both surface `provenance` via
`print_gate_table` in `src/cli/verify.rs`. Evidence:
`provenance_validated_round_trips_through_lookup` in src/db/quality_gates.rs.

### `quality-gate record --result clean` is REFUSED for a skill that has a check validator (legion-simplify, legion-pr-write) -- those must go through check.

Implemented as the hard refusal, not the "mark asserted + warn" alternative: in
`cli::verify::handle_quality_gate`'s `Record` arm, `gate_result == GateResult::Clean &&
gate_registry::has_check_validator(&skill)` exits 1 with a message pointing at `quality-gate
check`, before any DB or git call. `record --result issues` for a check-gated skill is still
allowed, since a self-reported finding is not the ground-truth risk this closes. Verified the
two real skills are unaffected by reading both skill files directly:
`plugin/skills/legion-simplify/SKILL.md` calls `quality-gate check`, never `record`;
`plugin/skills/legion-pr-write/SKILL.md` calls `pr write-check` (the
`validate_and_record_pr_write_gate` path, `Validated` provenance). Five pre-existing
integration tests used `record --skill legion-simplify --result clean` as a generic example
and were fixed to use the skill/result combination each test actually needs. Evidence:
`quality_gate_record_refuses_clean_for_check_gated_skill` and
`quality_gate_record_allows_issues_for_check_gated_skill` in
tests/integration/worksource_pr.rs.

### gate-trust must not consume an asserted-clean row for a check-gated skill as positive ground truth.

New `gate_trust::is_ungrounded_assertion(row)` predicate: `Clean && Asserted &&
has_check_validator(skill)`. `emit_gate_trust` -- the sole production entry; both
`cli/verify.rs` write paths and `cli/pr.rs`'s write-gate recorder call it, and only tests call
the inner `emit_gate_prediction` directly -- checks this first and skips ingestion entirely
when true, logging why, in `src/gate_trust.rs`. This sits at `emit_gate_trust` rather than at
`prediction_input` as the Build Notes named: `emit_gate_trust`'s `-> ()` signature is the only
one where "skip" doesn't require turning `emit_gate_prediction`'s `Result<String>` into an
`Option`-wrapping shape across its existing call sites, and `prediction_input` is only ever
reached via `emit_gate_prediction`, which in production is only ever reached via
`emit_gate_trust` -- functionally the same integration point. This is defense in depth on top
of the CLI refusal above: the refusal stops a new ungrounded row from being recorded in the
normal pipeline, and this guard additionally stops gate-trust from ingesting one if a row
reaches the ledger some other way (a pre-#780 historical row, or a future caller bypassing the
CLI). Evidence: `emit_gate_trust_skips_ingestion_of_an_ungrounded_assertion` and
`emit_gate_trust_still_ingests_a_validated_clean_row` in src/gate_trust.rs.

### A void/supersede mechanism: mark a gate row void (with reason) so a known-false row can be retired without deleting history; a re-laid genuine row supersedes it.

New `voided_at TEXT` / `void_reason TEXT` / `superseded_by TEXT` columns via the same
`has_column`-guarded migration as provenance, in `src/db/quality_gates.rs`.
`Database::void_quality_gate(id, reason, superseded_by: Option<&str>)` sets all three and
errors with `LegionError::QualityGateNotFound` on an unknown id rather than silently no-op'ing.
Voided rows are excluded from the live lookups `get_quality_gate` and
`get_latest_quality_gate_by_skill` (`AND voided_at IS NULL`) and from `quality_gate_stats`, but
stay fully visible in `list_quality_gates` and the new `get_quality_gate_by_id` -- voiding
annotates the ledger, it never deletes from it. New `legion quality-gate void --id <id>
--reason <reason> [--superseded-by <id>]` CLI command in `src/cli/verify.rs`; `print_gate_table`
grew a VOID column so a voided row is visibly distinct on the default human-readable list, not
just in `--json`. Evidence: `voided_row_excluded_from_get_quality_gate`,
`voided_row_excluded_from_stats`, and `void_quality_gate_can_link_a_superseding_row` in
src/db/quality_gates.rs, plus `quality_gate_void_marks_row_and_stays_visible_in_list` in
tests/integration/worksource_pr.rs.

### Hidden work named in scope: a validator registry centralizing which skills have a check validator.

New `src/gate_registry.rs`: `CHECK_GATED_SKILLS` + `has_check_validator`, the single source of
truth both the Record-refusal (`cli/verify.rs`) and the gate-trust guard (`gate_trust.rs`)
read, replacing two previously-independent hardcoded copies of the same list (`cli/pr.rs`'s
pre-create gate loop, `cli/verify.rs`'s `Check` action). Evidence:
`card_keyed_verify_skill_is_not_check_gated` in src/gate_registry.rs.

## Not done

- **The live false row is NOT voided.** The issue's disposition note names
  `feat/1754-alert-port @ e74a06d6` (legion-simplify clean/0) as a row to treat as VOID. This
  PR builds the mechanism (`quality-gate void`); it does not execute that data operation --
  the issue itself says the genuine re-run needs #779's `--base` support first, which has not
  shipped. Voiding the historical row without re-laying a genuine one first would leave that
  commit with no gate at all, which is a separate operator call.
- **Voiding does not retract an already-emitted gate-trust prediction.** The
  `emit_gate_trust` guard is forward-looking: it stops a *new* ungrounded row from becoming a
  prediction. A prediction already emitted for a row voided after the fact (including
  e74a06d6's, once it exists) is not retroactively purged from the uncertainty engine. This
  is the honest boundary where AC3 and AC4 meet -- closing it needs the uncertainty engine to
  support retracting/orphaning a prediction by its source row's void, which is out of scope
  here.
- **`provenance` defaults to `'asserted'` for every pre-#780 row, including ones that went
  through `check`.** This is a conservative default, not a backfill: a `check`-recorded row
  from before this column existed is indistinguishable from a `record`-recorded one at the DB
  layer without re-deriving it from `details` JSON, which this issue does not attempt.
- **`quality-gate record --result issues` is not restricted for a check-gated skill.** Only a
  manufactured "clean" is the ground-truth risk this issue names; a self-reported "issues" is
  not, so `record` remains available for it.

## Verification

- `cargo test`: 1497 unit + 329 integration tests pass, 0 failed.
- `cargo clippy --all-targets -- -D warnings`: clean.
- `cargo fmt -- --check`: clean.
- `legion quality-gate check --skill legion-simplify --result clean`: accepted, 10/10 file
  entries, gate id `019f6824-0d02-7890-a498-1f0b869d6866`.