### PR TITLE
feat(#782): forget --persist archives reflections; close #457 domain/latest coverage gap

### DIFF
--- a/src/cli/memory.rs
+++ b/src/cli/memory.rs
@@ -384,6 +384,17 @@ pub(crate) fn handle_recall(
     // corpus is a different feature than this issue's DB-join filter, not
     // a caller-side wiring gap. Warn loudly there so an operator does not
     // silently get hot-only results from --cosine-only --archives.
+    //
+    // This condition does not need to also check `domain.is_none() &&
+    // !latest`: clap's `conflicts_with` on the `domain`/`latest`/
+    // `cosine_only` args (src/cli/mod.rs) is enforced bidirectionally, so
+    // `cosine_only` can never be `true` here while `domain` is `Some` or
+    // `latest` is `true` -- confirmed empirically (`recall --domain x
+    // --cosine-only` and `recall --latest --cosine-only` both refuse to
+    // parse). If `cosine_only` reaches this point, the `if let`/`else if`
+    // chain below is guaranteed to fall through to the `cosine_only`
+    // branch, so the warning is never a false alarm for a run that
+    // actually takes the --domain or --latest path.
     if (archives || include_archives) && cosine_only {
         eprintln!(
             "[legion] warning: --archives / --include-archives do not apply to --cosine-only, which ranks purely by embedding similarity with no archive-mode filter. This run uses hot-only results."

--- a/src/cli/memory.rs
+++ b/src/cli/memory.rs
@@ -235,27 +235,34 @@ pub(crate) fn handle_reflect(
     Ok(())
 }
 
-pub(crate) fn handle_forget(id: String, repo: Option<String>) -> error::Result<()> {
+pub(crate) fn handle_forget(id: String, repo: Option<String>, persist: bool) -> error::Result<()> {
     let (database, index) = open_db_and_index()?;
 
     // Peek at the reflection first so we can run the optional
     // --repo safety check AND print a summary of what is about
-    // to be deleted. The actual delete goes through
-    // `delete_reflection` which re-verifies the id exists.
+    // to be forgotten. The actual write goes through
+    // `delete_reflection` / `archive_reflection`, which re-verify the
+    // id exists.
     let existing = database
         .get_reflection_by_id(&id)?
         .ok_or_else(|| error::LegionError::ReflectionNotFound(id.clone()))?;
 
-    // Every audit row for this command shares action/target_type/
-    // target_ref/task_id/source_type. Build them through one closure
-    // so the three call sites (rejected / success / partial) only
-    // name the three things that actually differ.
+    // Every audit row for this command shares target_type/target_ref/
+    // task_id/source_type; only the action differs by disposition
+    // (permanent delete vs. #782's archive). Build audit rows through
+    // one closure so the three call sites (rejected / success / partial)
+    // only name the three things that actually differ.
+    let action = if persist {
+        "archive-reflection"
+    } else {
+        "delete-reflection"
+    };
     let write_audit = |agent: &str, outcome: &str, details: Option<&str>| {
         audit(
             &database,
             &db::AuditInput {
                 agent,
-                action: "delete-reflection",
+                action,
                 target_type: "reflection",
                 target_ref: &id,
                 task_id: None,
@@ -279,6 +286,29 @@ pub(crate) fn handle_forget(id: String, repo: Option<String>) -> error::Result<(
             actual: existing.repo.clone(),
             expected: expected_repo.clone(),
         });
+    }
+
+    if persist {
+        // Archive: the row and its tantivy index entry both survive
+        // (#782). No index write here -- unlike the permanent-delete
+        // path below, there is no index-side counterpart to reconcile;
+        // the search index returns ids regardless of archive state, and
+        // the DB join step is what applies the archive-mode filter.
+        let archived = database.archive_reflection(&id)?;
+        write_audit(&archived.repo, "success", None);
+
+        let preview: String = archived.text.chars().take(80).collect();
+        let ellipsis = if archived.text.chars().count() > 80 {
+            "..."
+        } else {
+            ""
+        };
+        println!(
+            "persisted reflection {} ({}): {}{} -- archived, out of hot recall/whoami/whatami, \
+             still reachable via `recall --archives` / `--include-archives`.",
+            id, archived.repo, preview, ellipsis
+        );
+        return Ok(());
     }
 
     // Delete from SQLite first. The audit entry is written AFTER
@@ -346,20 +376,24 @@ pub(crate) fn handle_recall(
         recall::ArchiveMode::Hot
     };
 
-    // v1 scope: --archives / --include-archives only affect
-    // the BM25/hybrid path. Warn loudly when combined with the
-    // other variants so an operator does not silently get
-    // hot-only results from --latest --archives.
-    if (archives || include_archives) && (latest || cosine_only || domain.is_some()) {
+    // #782 closed the --domain / --latest half of the #457 coverage gap:
+    // both now thread the resolved archive mode through to their DB
+    // backers. --cosine-only remains out of scope -- it ranks purely by
+    // embedding similarity against `get_embeddings`, which has no
+    // archive-mode parameter, and cosine ranking over a mixed hot+cold
+    // corpus is a different feature than this issue's DB-join filter, not
+    // a caller-side wiring gap. Warn loudly there so an operator does not
+    // silently get hot-only results from --cosine-only --archives.
+    if (archives || include_archives) && cosine_only {
         eprintln!(
-            "[legion] warning: --archives / --include-archives currently apply only to the BM25/hybrid recall path. Combined with --latest / --domain / --cosine-only, this run uses hot-only results. Extending coverage is tracked as a #457 follow-up."
+            "[legion] warning: --archives / --include-archives do not apply to --cosine-only, which ranks purely by embedding similarity with no archive-mode filter. This run uses hot-only results."
         );
     }
 
     let mut result = if let Some(ref dom) = domain {
-        recall::recall_by_domain(&database, &repo, dom, limit)?
+        recall::recall_by_domain(&database, &repo, dom, limit, mode)?
     } else if latest {
-        recall::recall_latest(&database, &repo, limit)?
+        recall::recall_latest(&database, &repo, limit, mode)?
     } else if cosine_only {
         // --cosine-only requires the embed model; error if unavailable.
         let model = embed::EmbedModel::load().map_err(|e| {

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -105,27 +105,38 @@ pub(crate) enum Commands {
         dedupe_mode: DedupeMode,
     },
 
-    /// Permanently delete a reflection by id.
+    /// Permanently delete a reflection by id, or (with --persist) archive
+    /// it instead.
     ///
-    /// Destructive. No soft-delete, no undo. Removes the row from both
-    /// the SQLite reflections table and the tantivy search index. Used
-    /// to retire stale workaround reflections, demonstrably-wrong
-    /// reflections, or personal data that should not persist in the
-    /// corpus.
+    /// Default (no --persist): destructive. No soft-delete, no undo.
+    /// Removes the row from both the SQLite reflections table and the
+    /// tantivy search index. Used to retire stale workaround reflections,
+    /// demonstrably-wrong reflections, or personal data that should not
+    /// persist in the corpus.
     ///
     /// The optional `--repo` flag is a safety check: when provided,
-    /// the delete is refused unless the reflection's actual repo
-    /// matches. Prevents accidentally nuking the wrong reflection when
-    /// working with a similarly-shaped id.
+    /// the delete (or archive) is refused unless the reflection's actual
+    /// repo matches. Prevents accidentally nuking the wrong reflection
+    /// when working with a similarly-shaped id.
     Forget {
-        /// Reflection id to delete.
+        /// Reflection id to forget.
         #[arg(long)]
         id: String,
 
-        /// Optional safety check: refuse the delete unless the
+        /// Optional safety check: refuse the operation unless the
         /// reflection's repo matches this value.
         #[arg(long)]
         repo: Option<String>,
+
+        /// Archive instead of delete (#782): moves the reflection to
+        /// #457's cold tier. The row and search index entry survive --
+        /// it drops out of hot `recall` / `whoami` / `whatami` but stays
+        /// reachable via `recall --archives` / `--include-archives`
+        /// (including the `--domain` and `--latest` paths). One-way
+        /// today: legion ships no un-persist verb yet, matching
+        /// `document`'s archive (also writer-only).
+        #[arg(long)]
+        persist: bool,
     },
 
     /// Recall relevant reflections for the current context
@@ -165,14 +176,15 @@ pub(crate) enum Commands {
 
         /// Search ONLY archived reflections (the deep-dive). Default mode
         /// is hot-only; this flag inverts. Mutually exclusive with
-        /// --include-archives. v1 only affects the BM25/hybrid path;
-        /// --latest, --domain, --cosine-only stay hot-mode regardless.
+        /// --include-archives. Applies to the BM25/hybrid, --domain, and
+        /// --latest paths (#782); --cosine-only stays hot-mode regardless
+        /// (it ranks by embedding similarity with no archive-mode join).
         /// See #457.
         #[arg(long)]
         archives: bool,
 
         /// Search BOTH hot and archived reflections. Mutually exclusive
-        /// with --archives. Same v1 scope caveat as --archives.
+        /// with --archives. Same --cosine-only scope caveat as --archives.
         #[arg(long, conflicts_with = "archives")]
         include_archives: bool,
     },

--- a/src/db/reflections.rs
+++ b/src/db/reflections.rs
@@ -165,6 +165,20 @@ pub(super) fn migrate(conn: &Connection) -> Result<()> {
     Ok(())
 }
 
+/// SQL fragment applying an archive-mode filter (#457/#782), shared by
+/// every reflections read that takes an [`ArchiveMode`](crate::recall::ArchiveMode)
+/// parameter -- [`Database::get_reflection_by_id_in_mode`],
+/// [`Database::get_reflections_by_domain`], and
+/// [`Database::get_latest_self_reflections`]. One definition means the
+/// three modes (Hot/Cold/Both) cannot drift out of sync across callers.
+fn archive_mode_where_clause(mode: crate::recall::ArchiveMode) -> &'static str {
+    match mode {
+        crate::recall::ArchiveMode::Hot => "AND archived_at IS NULL",
+        crate::recall::ArchiveMode::Cold => "AND archived_at IS NOT NULL",
+        crate::recall::ArchiveMode::Both => "",
+    }
+}
+
 impl Database {
     /// Insert a new reflection for the given repository.
     ///
@@ -289,23 +303,15 @@ impl Database {
     /// "Live" here means `domain = 'identity' AND parent_id IS NULL AND
     /// deleted_at IS NULL AND archived_at IS NULL` -- a standalone query,
     /// not a call to [`get_identity_roots`](Self::get_identity_roots),
-    /// because the guard's liveness definition must include the
-    /// `archived_at` filter now (an archived root must not block a new
-    /// bootstrap or replacement) while the shared banner reader behind
-    /// `get_identity_roots` does not filter `archived_at` yet (tracked
-    /// separately as #782). This function does not wait for that fix.
-    ///
-    /// The asymmetry this creates -- an archived root plus a fresh root
-    /// both satisfying `get_identity_roots`'s current predicate -- is not
-    /// reachable through any production write path today: `legion
-    /// reflect` always stores identity reflections with `audience =
-    /// "self"` (hardcoded; there is no `--audience` flag), and the only
-    /// writer of `archived_at` on the `reflections` table
-    /// (`Database::archive_read_posts`, `src/db/board.rs`) is scoped to
-    /// `audience = 'team'`. Verified in
-    /// `insert_reflection_with_meta_ignores_archived_root_for_guard`,
-    /// which asserts the two-root state directly rather than leaving it
-    /// implicit.
+    /// kept as its own predicate (rather than reused) because the guard
+    /// fires on every `insert_reflection_with_meta` call and does not need
+    /// `get_identity_roots`'s ordering guarantees or full row projection.
+    /// Both predicates now agree on `archived_at IS NULL` (#782 added the
+    /// same filter to [`get_domain_roots`](Self::get_domain_roots), which
+    /// `get_identity_roots` wraps), so there is no longer an asymmetry
+    /// between what blocks a new bootstrap and what the banner shows.
+    /// `insert_reflection_with_meta_ignores_archived_root_for_guard`
+    /// exercises the guard's own archived-root bypass directly.
     fn live_identity_root_id(&self, repo: &str) -> Result<Option<String>> {
         // ORDER BY pins which id surfaces in the IdentityRootExists error
         // message when more than one live root already exists (reachable
@@ -344,15 +350,16 @@ impl Database {
     /// Deletes every row matching `domain = 'identity' AND parent_id IS
     /// NULL AND deleted_at IS NULL` for `repo` -- deliberately not
     /// filtering `archived_at` the way the insert guard's
-    /// [`live_identity_root_id`](Self::live_identity_root_id) does. An
-    /// archived orphan left behind by a swap would still satisfy "a
-    /// second domain=identity, parent_id IS NULL row" for any reader that
-    /// does not yet filter `archived_at` (the banner reader, until #782),
-    /// which is exactly the two-roots bug this issue closes. Swap is the
-    /// explicit "replace everything" path, so it clears every *root* row,
-    /// including any pre-existing leaked duplicates from before this fix
-    /// landed -- the plain insert guard only ever sees (and blocks
-    /// against) one at a time.
+    /// [`live_identity_root_id`](Self::live_identity_root_id) does. Since
+    /// #782, `get_domain_roots` (which `get_identity_roots` wraps, and
+    /// which backs the whoami/whatami banners) also filters
+    /// `archived_at IS NULL`, so an archived orphan left behind by a swap
+    /// no longer resurfaces in the banner either way -- but swap still
+    /// clears it here rather than leaving a dangling archived duplicate
+    /// row around. Swap is the explicit "replace everything" path, so it
+    /// clears every *root* row, including any pre-existing leaked
+    /// duplicates from before the #785 guard landed -- the plain insert
+    /// guard only ever sees (and blocks against) one at a time.
     ///
     /// Deliberately NOT cascading: only the root row(s) are deleted, not
     /// their `--follows` chain children. A replaced root's old chain
@@ -627,11 +634,7 @@ impl Database {
         id: &str,
         mode: crate::recall::ArchiveMode,
     ) -> Result<Option<Reflection>> {
-        let where_clause = match mode {
-            crate::recall::ArchiveMode::Hot => "AND archived_at IS NULL",
-            crate::recall::ArchiveMode::Cold => "AND archived_at IS NOT NULL",
-            crate::recall::ArchiveMode::Both => "",
-        };
+        let where_clause = archive_mode_where_clause(mode);
         let sql = format!(
             "SELECT {REFLECTION_COLUMNS} \
              FROM reflections WHERE id = ?1 AND deleted_at IS NULL {where_clause}"
@@ -677,6 +680,55 @@ impl Database {
             return Err(LegionError::ReflectionNotFound(id.to_string()));
         }
         Ok(reflection)
+    }
+
+    /// Archive a reflection: `legion forget --id X --persist`'s writer.
+    ///
+    /// Sets `archived_at` (and refreshes `updated_at`), moving the row into
+    /// #457's cold tier without deleting it -- the opposite disposition
+    /// from [`delete_reflection`](Self::delete_reflection), which is
+    /// permanent. An archived reflection drops out of hot `recall` /
+    /// `whoami` / `whatami` (both now filter `archived_at IS NULL`, the
+    /// latter two unconditionally via [`get_domain_roots`](Self::get_domain_roots))
+    /// but stays reachable through `recall --archives` / `--include-archives`,
+    /// across every recall path after #782 (BM25/hybrid via
+    /// [`get_reflection_by_id_in_mode`](Self::get_reflection_by_id_in_mode),
+    /// `--domain` via [`get_reflections_by_domain`](Self::get_reflections_by_domain),
+    /// `--latest` via [`get_latest_self_reflections`](Self::get_latest_self_reflections)).
+    /// The row also stays in the tantivy search index untouched -- unlike
+    /// `delete_reflection`, there is no index-side counterpart to call.
+    ///
+    /// Idempotent: `COALESCE(archived_at, ?1)` preserves the original
+    /// archive timestamp on a repeat call, matching
+    /// `Database::archive_document`'s contract for the documents table.
+    ///
+    /// One-way today: legion ships no un-persist verb, the same shape as
+    /// `document`'s archive (also writer-only, no unarchive command). The
+    /// row and its `archived_at` timestamp are ordinary column state, not
+    /// a destructive rewrite, so restoring visibility is a future `legion
+    /// forget --id X --unpersist` (or equivalent) away whenever that need
+    /// materializes -- nothing here forecloses it structurally, it is
+    /// simply not built yet.
+    ///
+    /// Returns `LegionError::ReflectionNotFound` if the id does not match
+    /// any live (non-soft-deleted) row, mirroring `delete_reflection`.
+    pub fn archive_reflection(&self, id: &str) -> Result<Reflection> {
+        // Fetch first so a missing id produces a clear error rather than a
+        // silent zero-row UPDATE, matching delete_reflection's shape.
+        self.get_reflection_by_id(id)?
+            .ok_or_else(|| LegionError::ReflectionNotFound(id.to_string()))?;
+
+        let now = Utc::now().to_rfc3339();
+        self.conn.execute(
+            "UPDATE reflections SET archived_at = COALESCE(archived_at, ?1), updated_at = ?1 \
+             WHERE id = ?2 AND deleted_at IS NULL",
+            rusqlite::params![now, id],
+        )?;
+
+        // Re-fetch: get_reflection_by_id does not filter archived_at, so
+        // the now-archived row is still visible to it.
+        self.get_reflection_by_id(id)?
+            .ok_or_else(|| LegionError::ReflectionNotFound(id.to_string()))
     }
 
     /// Soft-delete a reflection by setting its deleted_at timestamp.
@@ -732,9 +784,22 @@ impl Database {
     ///
     /// More efficient than `get_reflections_by_repo` when only a small
     /// number of results are needed, since the database handles the LIMIT.
-    pub fn get_latest_self_reflections(&self, repo: &str, limit: usize) -> Result<Vec<Reflection>> {
+    ///
+    /// `mode` applies the same archive-mode filter as
+    /// [`get_reflections_by_domain`](Self::get_reflections_by_domain) (#782)
+    /// -- the DB backer for `recall::recall_latest`, which is how `recall
+    /// --latest --archives` reaches persisted (`forget --persist`)
+    /// reflections.
+    pub fn get_latest_self_reflections(
+        &self,
+        repo: &str,
+        limit: usize,
+        mode: crate::recall::ArchiveMode,
+    ) -> Result<Vec<Reflection>> {
+        let where_clause = archive_mode_where_clause(mode);
         let sql = format!(
-            "SELECT {REFLECTION_COLUMNS} FROM reflections WHERE repo = ?1 AND audience = 'self' AND deleted_at IS NULL ORDER BY created_at DESC LIMIT ?2"
+            "SELECT {REFLECTION_COLUMNS} FROM reflections WHERE repo = ?1 AND audience = 'self' \
+             AND deleted_at IS NULL {where_clause} ORDER BY created_at DESC LIMIT ?2"
         );
         let mut stmt = self.conn.prepare(&sql)?;
 
@@ -748,15 +813,28 @@ impl Database {
     /// Bypasses search entirely -- pure SQL lookup by domain. Used for
     /// reserved domains like `identity` and `snooze` that get injected
     /// on every session start without needing a search query.
+    ///
+    /// `mode` applies the same archive-mode filter as [`get_reflection_by_id_in_mode`]
+    /// (#457/#782): Hot excludes archived rows (the default), Cold returns
+    /// only archived rows, Both applies no archive filter. This is the DB
+    /// backer for `recall::recall_by_domain`, which is how `recall --domain
+    /// <d> --archives` reaches persisted (`forget --persist`) reflections --
+    /// before #782 this function had no mode parameter at all, so
+    /// `--archives` combined with `--domain` silently fell back to hot-only.
+    ///
+    /// [`get_reflection_by_id_in_mode`]: Self::get_reflection_by_id_in_mode
     pub fn get_reflections_by_domain(
         &self,
         repo: &str,
         domain: &str,
         limit: usize,
+        mode: crate::recall::ArchiveMode,
     ) -> Result<Vec<Reflection>> {
+        let where_clause = archive_mode_where_clause(mode);
         let sql = format!(
             "SELECT {REFLECTION_COLUMNS} \
-             FROM reflections WHERE repo = ?1 AND domain = ?2 AND deleted_at IS NULL ORDER BY created_at DESC LIMIT ?3"
+             FROM reflections WHERE repo = ?1 AND domain = ?2 AND deleted_at IS NULL {where_clause} \
+             ORDER BY created_at DESC LIMIT ?3"
         );
         let mut stmt = self.conn.prepare(&sql)?;
 
@@ -773,6 +851,13 @@ impl Database {
     /// Fetch the root reflections (no parent) for a repo in a given domain,
     /// newest first. Backs the SessionStart boot banners: `whoami`
     /// (domain=identity, who I am) and `whatami` (domain=workflow, how I operate).
+    ///
+    /// Unconditionally filters `archived_at IS NULL` (#782): a `forget
+    /// --persist`-ed root must not surface in either banner. This is
+    /// deliberately NOT parameterized by archive mode the way
+    /// [`get_reflections_by_domain`](Self::get_reflections_by_domain) is --
+    /// the boot banners have no "show archived roots too" use case, so
+    /// there is no caller that would ever pass anything but hot-only here.
     pub fn get_domain_roots(
         &self,
         repo: &str,
@@ -781,7 +866,8 @@ impl Database {
     ) -> Result<Vec<Reflection>> {
         let sql = format!(
             "SELECT {REFLECTION_COLUMNS} \
-             FROM reflections WHERE repo = ?1 AND domain = ?2 AND parent_id IS NULL AND deleted_at IS NULL ORDER BY created_at DESC LIMIT ?3"
+             FROM reflections WHERE repo = ?1 AND domain = ?2 AND parent_id IS NULL \
+             AND deleted_at IS NULL AND archived_at IS NULL ORDER BY created_at DESC LIMIT ?3"
         );
         let mut stmt = self.conn.prepare(&sql)?;
 
@@ -1282,22 +1368,10 @@ mod tests {
     #[test]
     fn insert_reflection_with_meta_ignores_archived_root_for_guard() {
         // The guard's own liveness read filters archived_at IS NULL (#785
-        // build note), independently of get_identity_roots (which does
-        // not filter archived_at yet -- #782). An archived root must not
-        // block a fresh bootstrap insert.
-        //
-        // Documenting the consequence, not just the guard's own behavior:
-        // once this insert succeeds, get_identity_roots("legion", ..) DOES
-        // return both rows (asserted below) -- the pre-#782 banner reader
-        // would show two roots again if an identity reflection were ever
-        // archived. No current write path can do that: `legion reflect`
-        // always stores identity reflections with audience="self"
-        // (hardcoded, no --audience flag exists), and the only production
-        // writer of `archived_at` on the reflections table
-        // (`Database::archive_read_posts`, src/db/board.rs) is scoped to
-        // `audience = 'team'`. This test's archive step is a raw UPDATE
-        // simulating a future/hypothetical writer, not a reachable path
-        // today.
+        // build note). An archived root must not block a fresh bootstrap
+        // insert -- exercised here through the real writer, `forget
+        // --persist`'s `archive_reflection` (#782), rather than a raw
+        // UPDATE simulating a hypothetical one.
         let db = test_db();
         let root = db
             .insert_reflection_with_meta(
@@ -1310,13 +1384,7 @@ mod tests {
                 },
             )
             .unwrap();
-        let now = Utc::now().to_rfc3339();
-        db.conn
-            .execute(
-                "UPDATE reflections SET archived_at = ?1 WHERE id = ?2",
-                rusqlite::params![&now, &root.id],
-            )
-            .unwrap();
+        db.archive_reflection(&root.id).unwrap();
 
         let fresh = db
             .insert_reflection_with_meta(
@@ -1332,18 +1400,17 @@ mod tests {
         assert!(fresh.parent_id.is_none());
         assert_ne!(fresh.id, root.id);
 
-        // The archived root and the fresh root now BOTH satisfy
-        // get_identity_roots's current (pre-#782) predicate -- this is
-        // the documented, accepted asymmetry, made visible here rather
-        // than left implicit.
+        // Since #782, get_domain_roots (which get_identity_roots wraps)
+        // also filters archived_at IS NULL, so the archived root no
+        // longer resurfaces alongside the fresh one -- the two-roots
+        // asymmetry this test used to document is closed.
         let roots = db.get_identity_roots("legion", 10).unwrap();
         assert_eq!(
             roots.len(),
-            2,
-            "pre-#782, get_identity_roots does not filter archived_at, so \
-             an archived root and a fresh root both surface -- tracked, not \
-             regressed, by this guard"
+            1,
+            "archived root must not surface in get_identity_roots post-#782"
         );
+        assert_eq!(roots[0].id, fresh.id);
     }
 
     #[test]
@@ -1674,6 +1741,212 @@ mod tests {
             "expected ReflectionNotFound, got {:?}",
             result
         );
+    }
+
+    #[test]
+    fn archive_reflection_sets_archived_at_and_survives_the_row() {
+        let db = test_db();
+        let r = db
+            .insert_reflection("legion", "spent-but-historic lesson", "self")
+            .unwrap();
+
+        // Hidden nowhere yet: plain get and Hot mode both see it.
+        assert!(db.get_reflection_by_id(&r.id).unwrap().is_some());
+        assert!(
+            db.get_reflection_by_id_in_mode(&r.id, crate::recall::ArchiveMode::Hot)
+                .unwrap()
+                .is_some()
+        );
+
+        let archived = db.archive_reflection(&r.id).expect("archive");
+        assert_eq!(archived.id, r.id);
+        assert_eq!(archived.text, "spent-but-historic lesson");
+
+        // Row survives (unlike delete_reflection) -- plain get still finds it.
+        assert!(db.get_reflection_by_id(&r.id).unwrap().is_some());
+
+        // Hot mode (hot recall / whoami / whatami) no longer sees it;
+        // Cold mode (--archives) does.
+        assert!(
+            db.get_reflection_by_id_in_mode(&r.id, crate::recall::ArchiveMode::Hot)
+                .unwrap()
+                .is_none(),
+            "archived reflection must drop out of hot mode"
+        );
+        assert!(
+            db.get_reflection_by_id_in_mode(&r.id, crate::recall::ArchiveMode::Cold)
+                .unwrap()
+                .is_some(),
+            "archived reflection must be reachable in cold mode"
+        );
+        assert!(
+            db.get_reflection_by_id_in_mode(&r.id, crate::recall::ArchiveMode::Both)
+                .unwrap()
+                .is_some(),
+            "archived reflection must be reachable in both mode"
+        );
+    }
+
+    #[test]
+    fn archive_reflection_is_idempotent() {
+        // Matches archive_document's idempotency contract: a repeat
+        // archive call preserves the original archived_at rather than
+        // bumping it, exercised via the actual DB timestamp so a
+        // regression to plain `SET archived_at = ?1` (no COALESCE) is
+        // caught even though both calls trip the same public assertions.
+        let db = test_db();
+        let r = db
+            .insert_reflection("legion", "archive twice", "self")
+            .unwrap();
+
+        db.archive_reflection(&r.id).expect("first archive");
+        let first_ts: String = db
+            .conn
+            .query_row(
+                "SELECT archived_at FROM reflections WHERE id = ?1",
+                [&r.id],
+                |row| row.get(0),
+            )
+            .unwrap();
+
+        std::thread::sleep(std::time::Duration::from_millis(10));
+        db.archive_reflection(&r.id).expect("second archive");
+        let second_ts: String = db
+            .conn
+            .query_row(
+                "SELECT archived_at FROM reflections WHERE id = ?1",
+                [&r.id],
+                |row| row.get(0),
+            )
+            .unwrap();
+
+        assert_eq!(
+            first_ts, second_ts,
+            "repeat archive must not overwrite the original archived_at"
+        );
+    }
+
+    #[test]
+    fn archive_reflection_nonexistent_returns_not_found() {
+        let db = test_db();
+        let result = db.archive_reflection("no-such-id");
+        assert!(
+            matches!(result, Err(LegionError::ReflectionNotFound(_))),
+            "expected ReflectionNotFound, got {:?}",
+            result
+        );
+    }
+
+    #[test]
+    fn get_domain_roots_excludes_archived_roots() {
+        // Direct coverage of #782's shared liveness fix for the shape
+        // whoami/whatami actually inject: an archived root must not
+        // surface in get_domain_roots (get_identity_roots's, and
+        // whatami's domain=workflow read's, shared backer).
+        let db = test_db();
+        let live_root = db
+            .insert_reflection_with_meta(
+                "legion",
+                "live operating rule",
+                "self",
+                &ReflectionMeta {
+                    domain: Some("workflow".into()),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+        let archived_root = db
+            .insert_reflection_with_meta(
+                "legion",
+                "superseded operating rule",
+                "self",
+                &ReflectionMeta {
+                    domain: Some("workflow".into()),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+        db.archive_reflection(&archived_root.id).expect("archive");
+
+        let roots = db.get_domain_roots("legion", "workflow", 10).unwrap();
+        assert_eq!(roots.len(), 1);
+        assert_eq!(roots[0].id, live_root.id);
+    }
+
+    #[test]
+    fn get_reflections_by_domain_respects_archive_mode() {
+        let db = test_db();
+        let hot = db
+            .insert_reflection_with_meta(
+                "legion",
+                "hot domain reflection",
+                "self",
+                &ReflectionMeta {
+                    domain: Some("checkpoint".into()),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+        let cold = db
+            .insert_reflection_with_meta(
+                "legion",
+                "persisted domain reflection",
+                "self",
+                &ReflectionMeta {
+                    domain: Some("checkpoint".into()),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+        db.archive_reflection(&cold.id).expect("archive");
+
+        let hot_only = db
+            .get_reflections_by_domain("legion", "checkpoint", 10, crate::recall::ArchiveMode::Hot)
+            .unwrap();
+        assert_eq!(hot_only.len(), 1);
+        assert_eq!(hot_only[0].id, hot.id);
+
+        let cold_only = db
+            .get_reflections_by_domain("legion", "checkpoint", 10, crate::recall::ArchiveMode::Cold)
+            .unwrap();
+        assert_eq!(cold_only.len(), 1);
+        assert_eq!(cold_only[0].id, cold.id);
+
+        let both = db
+            .get_reflections_by_domain("legion", "checkpoint", 10, crate::recall::ArchiveMode::Both)
+            .unwrap();
+        assert_eq!(both.len(), 2);
+    }
+
+    #[test]
+    fn get_latest_self_reflections_respects_archive_mode() {
+        let db = test_db();
+        let hot = db
+            .insert_reflection("legion", "hot latest", "self")
+            .unwrap();
+        let cold = db
+            .insert_reflection("legion", "persisted latest", "self")
+            .unwrap();
+        db.archive_reflection(&cold.id).expect("archive");
+
+        let hot_only = db
+            .get_latest_self_reflections("legion", 10, crate::recall::ArchiveMode::Hot)
+            .unwrap();
+        let hot_ids: Vec<&str> = hot_only.iter().map(|r| r.id.as_str()).collect();
+        assert!(hot_ids.contains(&hot.id.as_str()));
+        assert!(!hot_ids.contains(&cold.id.as_str()));
+
+        let cold_only = db
+            .get_latest_self_reflections("legion", 10, crate::recall::ArchiveMode::Cold)
+            .unwrap();
+        let cold_ids: Vec<&str> = cold_only.iter().map(|r| r.id.as_str()).collect();
+        assert!(cold_ids.contains(&cold.id.as_str()));
+        assert!(!cold_ids.contains(&hot.id.as_str()));
+
+        let both = db
+            .get_latest_self_reflections("legion", 10, crate::recall::ArchiveMode::Both)
+            .unwrap();
+        assert_eq!(both.len(), 2);
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -131,7 +131,7 @@ fn run() -> error::Result<()> {
             force,
             dedupe_mode,
         )?,
-        Commands::Forget { id, repo } => cli::memory::handle_forget(id, repo)?,
+        Commands::Forget { id, repo, persist } => cli::memory::handle_forget(id, repo, persist)?,
         Commands::Recall {
             repo,
             context,

--- a/src/recall.rs
+++ b/src/recall.rs
@@ -521,8 +521,17 @@ pub fn consult(
 /// Useful for session-start hooks where no meaningful search context
 /// is available yet. Returns results ordered newest first. Uses SQL
 /// LIMIT for efficiency instead of fetching all and truncating.
-pub fn recall_latest(db: &Database, repo: &str, limit: usize) -> Result<RecallResult> {
-    let latest = db.get_latest_self_reflections(repo, limit)?;
+///
+/// `mode` closes the #457/#782 coverage gap: `legion recall --latest
+/// --archives` now reaches persisted (`forget --persist`) reflections
+/// instead of silently staying hot-only.
+pub fn recall_latest(
+    db: &Database,
+    repo: &str,
+    limit: usize,
+    mode: ArchiveMode,
+) -> Result<RecallResult> {
+    let latest = db.get_latest_self_reflections(repo, limit, mode)?;
 
     let reflections: Vec<RecalledReflection> = latest
         .into_iter()
@@ -546,13 +555,18 @@ pub fn recall_latest(db: &Database, repo: &str, limit: usize) -> Result<RecallRe
 ///
 /// Used for reserved domains like `identity` and `snooze` that are injected
 /// on every session start. Pure SQL lookup, no BM25 or cosine involved.
+///
+/// `mode` closes the #457/#782 coverage gap: `legion recall --domain <d>
+/// --archives` now reaches persisted (`forget --persist`) reflections
+/// instead of silently staying hot-only.
 pub fn recall_by_domain(
     db: &Database,
     repo: &str,
     domain: &str,
     limit: usize,
+    mode: ArchiveMode,
 ) -> Result<RecallResult> {
-    let matched = db.get_reflections_by_domain(repo, domain, limit)?;
+    let matched = db.get_reflections_by_domain(repo, domain, limit, mode)?;
 
     let reflections: Vec<RecalledReflection> = matched
         .into_iter()

--- a/tests/integration/memory.rs
+++ b/tests/integration/memory.rs
@@ -811,6 +811,21 @@ fn forget_persist_rejects_wrong_repo_safety_check() {
         stdout.contains("doomed persist attempt"),
         "reflection should still be hot after rejected persist, got: {stdout}"
     );
+
+    // The rejected --persist is audited under archive-reflection (not
+    // delete-reflection) with outcome=rejected -- destructive-command
+    // rejections are forensically relevant for persist exactly as they
+    // are for a permanent forget.
+    let audit_stdout =
+        run_ok(legion_cmd(dir.path()).args(["audit", "--action", "archive-reflection", "--json"]));
+    assert!(
+        audit_stdout.contains("\"outcome\": \"rejected\""),
+        "rejected persist should be audited, got: {audit_stdout}"
+    );
+    assert!(
+        audit_stdout.contains("expected=rafters") && audit_stdout.contains("actual=kelex"),
+        "audit details should name expected/actual repos, got: {audit_stdout}"
+    );
 }
 
 #[test]

--- a/tests/integration/memory.rs
+++ b/tests/integration/memory.rs
@@ -708,6 +708,253 @@ fn forget_rejects_wrong_repo_safety_check() {
 }
 
 #[test]
+fn forget_persist_archives_out_of_hot_recall_but_reachable_via_archives() {
+    // #782: `forget --id X --persist` moves the row to the #457 cold tier
+    // instead of deleting it -- absent from hot recall, present via
+    // `--archives`.
+    let dir = tempfile::tempdir().unwrap();
+
+    let id = run_ok(legion_cmd(dir.path()).args([
+        "reflect",
+        "--repo",
+        "kelex",
+        "--text",
+        "spent-but-historic mapping rule",
+    ]))
+    .trim()
+    .to_string();
+    assert_uuid_format(&id);
+
+    let stdout = run_ok(legion_cmd(dir.path()).args(["forget", "--id", &id, "--persist"]));
+    assert!(
+        stdout.contains("persisted reflection"),
+        "expected persist confirmation, got: {stdout}"
+    );
+
+    // Hot (default) recall must no longer surface it.
+    let hot = run_ok(legion_cmd(dir.path()).args([
+        "recall",
+        "--repo",
+        "kelex",
+        "--context",
+        "mapping rule",
+    ]));
+    assert!(
+        !hot.contains("spent-but-historic"),
+        "persisted reflection leaked into hot recall: {hot}"
+    );
+
+    // `--archives` (cold-only, the deep-dive) must still reach it -- the
+    // row and its search index entry both survive persist.
+    let cold = run_ok(legion_cmd(dir.path()).args([
+        "recall",
+        "--repo",
+        "kelex",
+        "--context",
+        "mapping rule",
+        "--archives",
+    ]));
+    assert!(
+        cold.contains("spent-but-historic"),
+        "persisted reflection not reachable via --archives: {cold}"
+    );
+
+    // The successful persist is audited distinctly from a permanent forget.
+    let audit_stdout =
+        run_ok(legion_cmd(dir.path()).args(["audit", "--action", "archive-reflection", "--json"]));
+    assert!(
+        audit_stdout.contains("\"outcome\": \"success\""),
+        "successful persist should be audited, got: {audit_stdout}"
+    );
+}
+
+#[test]
+fn forget_persist_rejects_wrong_repo_safety_check() {
+    // The --repo safety guard applies to --persist exactly as it does to
+    // a permanent forget -- it is a flag on the same command, not a
+    // reimplementation.
+    let dir = tempfile::tempdir().unwrap();
+
+    let id = run_ok(legion_cmd(dir.path()).args([
+        "reflect",
+        "--repo",
+        "kelex",
+        "--text",
+        "doomed persist attempt",
+    ]))
+    .trim()
+    .to_string();
+
+    let (_stdout, stderr) = run_fail(legion_cmd(dir.path()).args([
+        "forget",
+        "--id",
+        &id,
+        "--repo",
+        "rafters",
+        "--persist",
+    ]));
+    assert!(
+        stderr.contains("repo safety check failed"),
+        "expected safety check error, got: {stderr}"
+    );
+
+    // Reflection must still be live and hot -- the rejected persist must
+    // not have archived it.
+    let stdout = run_ok(legion_cmd(dir.path()).args([
+        "recall",
+        "--repo",
+        "kelex",
+        "--context",
+        "doomed persist",
+    ]));
+    assert!(
+        stdout.contains("doomed persist attempt"),
+        "reflection should still be hot after rejected persist, got: {stdout}"
+    );
+}
+
+#[test]
+fn forget_persist_drops_identity_root_from_whoami() {
+    // AC: the persisted reflection no longer appears in whoami.
+    let dir = tempfile::tempdir().unwrap();
+
+    let id = run_ok(legion_cmd(dir.path()).args([
+        "reflect",
+        "--repo",
+        "test",
+        "--whoami",
+        "--text",
+        "superseded identity root",
+    ]))
+    .trim()
+    .to_string();
+    assert_uuid_format(&id);
+
+    let before = run_ok(legion_cmd(dir.path()).args(["whoami", "--repo", "test"]));
+    assert!(before.contains("superseded identity root"));
+
+    run_ok(legion_cmd(dir.path()).args(["forget", "--id", &id, "--persist"]));
+
+    let after = run_ok(legion_cmd(dir.path()).args(["whoami", "--repo", "test"]));
+    assert!(
+        !after.contains("superseded identity root"),
+        "persisted identity root must not surface in whoami: {after}"
+    );
+}
+
+#[test]
+fn forget_persist_drops_workflow_root_from_whatami() {
+    // AC: the persisted reflection no longer appears in whatami --
+    // whatami reads domain=workflow roots through the same
+    // get_domain_roots backer whoami uses.
+    let dir = tempfile::tempdir().unwrap();
+
+    let id = run_ok(legion_cmd(dir.path()).args([
+        "reflect",
+        "--repo",
+        "test",
+        "--domain",
+        "workflow",
+        "--text",
+        "superseded operating rule",
+    ]))
+    .trim()
+    .to_string();
+    assert_uuid_format(&id);
+
+    let before = run_ok(legion_cmd(dir.path()).args(["whatami", "--repo", "test"]));
+    assert!(before.contains("superseded operating rule"));
+
+    run_ok(legion_cmd(dir.path()).args(["forget", "--id", &id, "--persist"]));
+
+    let after = run_ok(legion_cmd(dir.path()).args(["whatami", "--repo", "test"]));
+    assert!(
+        !after.contains("superseded operating rule"),
+        "persisted workflow root must not surface in whatami: {after}"
+    );
+}
+
+#[test]
+fn recall_domain_archives_reaches_persisted_reflections() {
+    // Closes the #457 gap this issue owns: --domain combined with
+    // --archives used to silently ignore the archive-mode filter (v1
+    // scope note at src/cli/memory.rs). Post-#782, a persisted
+    // domain-scoped reflection is invisible hot but reachable cold.
+    let dir = tempfile::tempdir().unwrap();
+
+    let id = run_ok(legion_cmd(dir.path()).args([
+        "reflect",
+        "--repo",
+        "test",
+        "--domain",
+        "checkpoint",
+        "--text",
+        "persisted checkpoint beat",
+    ]))
+    .trim()
+    .to_string();
+    assert_uuid_format(&id);
+
+    run_ok(legion_cmd(dir.path()).args(["forget", "--id", &id, "--persist"]));
+
+    // Hot --domain (default) must not surface it.
+    let hot =
+        run_ok(legion_cmd(dir.path()).args(["recall", "--repo", "test", "--domain", "checkpoint"]));
+    assert!(
+        !hot.contains("persisted checkpoint beat"),
+        "persisted reflection leaked into hot --domain recall: {hot}"
+    );
+
+    // --domain --archives must reach it.
+    let cold = run_ok(legion_cmd(dir.path()).args([
+        "recall",
+        "--repo",
+        "test",
+        "--domain",
+        "checkpoint",
+        "--archives",
+    ]));
+    assert!(
+        cold.contains("persisted checkpoint beat"),
+        "--domain --archives did not reach the persisted reflection: {cold}"
+    );
+}
+
+#[test]
+fn recall_latest_archives_reaches_persisted_reflections() {
+    // Same #457 gap, the --latest half.
+    let dir = tempfile::tempdir().unwrap();
+
+    let id = run_ok(legion_cmd(dir.path()).args([
+        "reflect",
+        "--repo",
+        "test",
+        "--text",
+        "persisted latest beat",
+    ]))
+    .trim()
+    .to_string();
+    assert_uuid_format(&id);
+
+    run_ok(legion_cmd(dir.path()).args(["forget", "--id", &id, "--persist"]));
+
+    // Hot --latest (default) must not surface it.
+    let hot = run_ok(legion_cmd(dir.path()).args(["recall", "--repo", "test", "--latest"]));
+    assert!(
+        !hot.contains("persisted latest beat"),
+        "persisted reflection leaked into hot --latest recall: {hot}"
+    );
+
+    // --latest --archives must reach it.
+    let cold =
+        run_ok(legion_cmd(dir.path()).args(["recall", "--repo", "test", "--latest", "--archives"]));
+    assert!(
+        cold.contains("persisted latest beat"),
+        "--latest --archives did not reach the persisted reflection: {cold}"
+    );
+}
+
+#[test]
 fn verbose_shows_confirmation() {
     let dir = tempfile::tempdir().unwrap();
 

--- a/tests/integration/memory.rs
+++ b/tests/integration/memory.rs
@@ -910,17 +910,34 @@ fn recall_domain_archives_reaches_persisted_reflections() {
     .to_string();
     assert_uuid_format(&id);
 
+    // A second, still-hot reflection in the same domain -- lets
+    // --include-archives (Both mode) below prove it merges hot and cold
+    // rather than just re-testing the Cold-only path a second time.
+    run_ok(legion_cmd(dir.path()).args([
+        "reflect",
+        "--repo",
+        "test",
+        "--domain",
+        "checkpoint",
+        "--text",
+        "hot checkpoint beat",
+    ]));
+
     run_ok(legion_cmd(dir.path()).args(["forget", "--id", &id, "--persist"]));
 
-    // Hot --domain (default) must not surface it.
+    // Hot --domain (default) must not surface the persisted one.
     let hot =
         run_ok(legion_cmd(dir.path()).args(["recall", "--repo", "test", "--domain", "checkpoint"]));
     assert!(
         !hot.contains("persisted checkpoint beat"),
         "persisted reflection leaked into hot --domain recall: {hot}"
     );
+    assert!(
+        hot.contains("hot checkpoint beat"),
+        "hot reflection missing from hot --domain recall: {hot}"
+    );
 
-    // --domain --archives must reach it.
+    // --domain --archives (Cold-only) must reach ONLY the persisted one.
     let cold = run_ok(legion_cmd(dir.path()).args([
         "recall",
         "--repo",
@@ -932,6 +949,24 @@ fn recall_domain_archives_reaches_persisted_reflections() {
     assert!(
         cold.contains("persisted checkpoint beat"),
         "--domain --archives did not reach the persisted reflection: {cold}"
+    );
+    assert!(
+        !cold.contains("hot checkpoint beat"),
+        "--domain --archives (Cold-only) leaked the hot reflection: {cold}"
+    );
+
+    // --domain --include-archives (Both mode) must reach BOTH.
+    let both = run_ok(legion_cmd(dir.path()).args([
+        "recall",
+        "--repo",
+        "test",
+        "--domain",
+        "checkpoint",
+        "--include-archives",
+    ]));
+    assert!(
+        both.contains("persisted checkpoint beat") && both.contains("hot checkpoint beat"),
+        "--domain --include-archives did not merge hot and cold: {both}"
     );
 }
 
@@ -951,21 +986,47 @@ fn recall_latest_archives_reaches_persisted_reflections() {
     .to_string();
     assert_uuid_format(&id);
 
+    // A second, still-hot reflection -- lets --include-archives (Both
+    // mode) below prove it merges hot and cold rather than just
+    // re-testing the Cold-only path a second time.
+    run_ok(legion_cmd(dir.path()).args(["reflect", "--repo", "test", "--text", "hot latest beat"]));
+
     run_ok(legion_cmd(dir.path()).args(["forget", "--id", &id, "--persist"]));
 
-    // Hot --latest (default) must not surface it.
+    // Hot --latest (default) must not surface the persisted one.
     let hot = run_ok(legion_cmd(dir.path()).args(["recall", "--repo", "test", "--latest"]));
     assert!(
         !hot.contains("persisted latest beat"),
         "persisted reflection leaked into hot --latest recall: {hot}"
     );
+    assert!(
+        hot.contains("hot latest beat"),
+        "hot reflection missing from hot --latest recall: {hot}"
+    );
 
-    // --latest --archives must reach it.
+    // --latest --archives (Cold-only) must reach ONLY the persisted one.
     let cold =
         run_ok(legion_cmd(dir.path()).args(["recall", "--repo", "test", "--latest", "--archives"]));
     assert!(
         cold.contains("persisted latest beat"),
         "--latest --archives did not reach the persisted reflection: {cold}"
+    );
+    assert!(
+        !cold.contains("hot latest beat"),
+        "--latest --archives (Cold-only) leaked the hot reflection: {cold}"
+    );
+
+    // --latest --include-archives (Both mode) must reach BOTH.
+    let both = run_ok(legion_cmd(dir.path()).args([
+        "recall",
+        "--repo",
+        "test",
+        "--latest",
+        "--include-archives",
+    ]));
+    assert!(
+        both.contains("persisted latest beat") && both.contains("hot latest beat"),
+        "--latest --include-archives did not merge hot and cold: {both}"
     );
 }
 


### PR DESCRIPTION
## Summary

Adds `legion forget --id X --persist` as the manual soft-archive verb for reflections, reusing the #457 `archived_at`/`ArchiveMode` machinery end to end instead of building a parallel disposition. Also closes the #457 coverage gap this issue explicitly owned as a must-ship-together requirement: `recall --archives` / `--include-archives` now reach persisted reflections through the `--domain` and `--latest` paths, which previously silently stayed hot-only. Also adds the shared liveness fix noted in the build notes: `get_domain_roots` (whoami/whatami's shared backer) now filters `archived_at IS NULL` unconditionally.

Closes #782.

## Acceptance criteria mapping

### 1. `legion forget --id X --persist` marks the reflection archived (reversible), keeps the row + search index, honors the `--repo` guard.

`Database::archive_reflection` (src/db/reflections.rs:715) sets `archived_at = COALESCE(archived_at, now)` via UPDATE, never DELETE -- the row survives. No tantivy `index.delete()` call is made on the persist path (src/cli/memory.rs:291-311), unlike the permanent-delete path a few lines below, so the search index entry survives too. "Reversible" describes the tier semantics, not a shipped un-persist command: the row and its `archived_at` timestamp are ordinary column state (see the doc comment on `archive_reflection`), not a destructive rewrite, so restoring visibility is a future `--unpersist` flag away, not foreclosed by this change -- see criterion 4 for the explicit one-way policy this ships with today. The `--repo` guard is inherited, not reimplemented: `handle_forget` (src/cli/memory.rs:238) runs the existing repo-mismatch check *before* branching on `persist`, so both dispositions share one guard.
Evidence: `forget_persist_rejects_wrong_repo_safety_check` (tests/integration/memory.rs) proves the guard rejects a persist with the wrong `--repo`. `forget_persist_archives_out_of_hot_recall_but_reachable_via_archives` proves row+index survival indirectly but rigorously: it calls `recall --context ... --archives`, which routes through the tantivy search index (`SearchIndex::search` -> id -> `get_reflection_by_id_in_mode(Cold)`); if persist had dropped the tantivy doc, the id would never come back and the test's `cold.contains(...)` assertion would fail. It passes.

### 2. The persisted reflection no longer appears in hot `recall` / `whoami` / `whatami`.

Hot `recall` (BM25/hybrid) was already filtered via `get_reflection_by_id_in_mode(Hot)` (pre-existing #457 machinery, unchanged) -- this PR just gives it something to filter, since nothing wrote `archived_at` on self reflections before. `whoami` is backed by `get_identity_roots` -> `get_domain_roots` (src/db/reflections.rs:861), which now adds `AND archived_at IS NULL` unconditionally. `whatami` reads `domain=workflow` roots through that same `get_domain_roots` (src/cli/misc.rs:197), so the identical fix covers both banners with one change.
Evidence: `forget_persist_archives_out_of_hot_recall_but_reachable_via_archives` (hot recall), `forget_persist_drops_identity_root_from_whoami` (whoami), `forget_persist_drops_workflow_root_from_whatami` (whatami) -- all in tests/integration/memory.rs.

### 3. `recall --archives --domain <d>` and `recall --archives --latest` reach persisted reflections (the #457 gap closed for these paths).

`get_reflections_by_domain` (src/db/reflections.rs:826) and `get_latest_self_reflections` (src/db/reflections.rs:793) now take an `ArchiveMode` parameter instead of no archive filter at all, threaded from `recall::recall_by_domain` (src/recall.rs:562) / `recall::recall_latest` (src/recall.rs:528), threaded in turn from `handle_recall`'s already-resolved `mode` variable (src/cli/memory.rs:355-390). The three archive-mode predicates (BM25/hybrid join, `--domain`, `--latest`) now share one `archive_mode_where_clause` helper (src/db/reflections.rs:174) so Hot/Cold/Both cannot drift out of sync across the three call sites.
Evidence: `recall_domain_archives_reaches_persisted_reflections` and `recall_latest_archives_reaches_persisted_reflections` (tests/integration/memory.rs) each show a persisted reflection absent from hot `--domain`/`--latest` output and present once `--archives` is added.

### 4. Un-persist path exists, or the one-way policy is documented.

No un-persist verb ships in this PR. Documented as a deliberate one-way policy on `archive_reflection`'s doc comment (src/db/reflections.rs:715) and the `--persist` flag's clap help (src/cli/mod.rs:139), matching the existing precedent in the same codebase: `document`'s `archive_document` (src/documents.rs:302) also ships writer-only with no unarchive command today, and nobody has needed one yet.
Evidence: doc comments at src/db/reflections.rs:715 and src/cli/mod.rs:139 state the policy explicitly; src/documents.rs:302 (`archive_document`) is the cited precedent.

### 5. Tests: persist -> absent from hot, present via `--archives` across the domain/latest paths.

Covered at two layers. DB-layer unit tests exercise the mechanism in isolation: `archive_reflection_sets_archived_at_and_survives_the_row`, `archive_reflection_is_idempotent`, `archive_reflection_nonexistent_returns_not_found`, `get_domain_roots_excludes_archived_roots`, `get_reflections_by_domain_respects_archive_mode`, `get_latest_self_reflections_respects_archive_mode` (all in src/db/reflections.rs). Integration tests exercise the same behavior through the compiled CLI binary end to end, listed under criteria 1-3 above.
Evidence: `cargo test` -- 1477 unit tests + 330 integration tests, all green (0 failed).

## Behavior change beyond the literal AC text (flagging explicitly)

`recall --domain <d>` and `recall --latest` previously applied **no** archive filter at all (there was no `mode` parameter on their DB backers). Post-#782, their default (Hot) now excludes archived rows, matching the BM25/hybrid path's long-standing default -- `--domain`/`--latest` were the inconsistent outlier, not the new behavior, and archived rows stay reachable via `--archives`/`--include-archives`. For `audience='self'` reflections (the only kind `get_latest_self_reflections` reads) this is inert today since no production writer archived self reflections before this PR; for team/bullpen posts read via `--domain`, a decay-archived post that used to surface in hot `--domain` recall will now be excluded, matching what BM25/hybrid recall already did for the same post.

## Not done

- `--cosine-only --archives` stays hot-only. `recall_cosine_only` ranks purely by embedding similarity against `db.get_embeddings()`, which has no archive-mode join -- adding one is a different feature (embedding-space filtering) than this issue's DB-join threading, and the Build Notes scoped this issue to `--domain`/`--latest` only. `handle_recall` now warns explicitly when `--cosine-only` is combined with `--archives`/`--include-archives` (src/cli/memory.rs).
- No un-persist / un-archive CLI verb (see criterion 4 -- documented as the accepted one-way policy for now).
- No retroactive retag of the mis-placed design reflections mentioned in the issue's linked design note (019f6222) -- that cleanup is explicitly queued behind #782/#783 landing, not part of this PR's scope.