### PR TITLE
feat(#784): whoami --generate gather/apply, consuming #785's identity swap

### DIFF
--- a/src/cli/misc.rs
+++ b/src/cli/misc.rs
@@ -4,10 +4,11 @@
 use clap::Subcommand;
 
 use crate::cli::datadir::data_dir;
-use crate::cli::util::open_db;
+use crate::cli::memory::try_load_embed_model;
+use crate::cli::util::{open_db, open_db_and_index};
 use crate::{
-    daemon, error, init, kanban, mcp, now, recall, serve, stats, status, statusline, surface, task,
-    watch, worksource,
+    daemon, error, identity_generate, init, kanban, mcp, now, recall, serve, stats, status,
+    statusline, surface, task, watch, worksource,
 };
 
 #[derive(Subcommand)]
@@ -189,6 +190,64 @@ pub(crate) fn handle_whoami(repo: String, limit: usize) -> error::Result<()> {
     }
     let output = recall::format_whoami(&repo, &entries);
     print!("{output}");
+    Ok(())
+}
+
+/// `legion whoami --generate`: gather claimed-half + given-half source
+/// material and print it as JSON for the calling agent to synthesize into
+/// an `IdentityManifest` by hand. Flag validation (both `--vault-repo` and
+/// a non-empty `--byline` required) returns `LegionError::WhoamiGenerate`
+/// naming the missing flag(s), per this command's error-handling contract.
+pub(crate) fn handle_whoami_generate(
+    repo: String,
+    vault_repo: Option<String>,
+    byline: Vec<String>,
+) -> error::Result<()> {
+    let vault_repo = vault_repo.ok_or_else(|| {
+        error::LegionError::WhoamiGenerate(
+            "--vault-repo is required with --generate (unless --apply is also set)".to_string(),
+        )
+    })?;
+    if byline.is_empty() {
+        return Err(error::LegionError::WhoamiGenerate(
+            "at least one --byline is required with --generate (unless --apply is also set)"
+                .to_string(),
+        ));
+    }
+
+    let (database, index) = open_db_and_index()?;
+    let embed_model = try_load_embed_model();
+    let bundle = identity_generate::gather(
+        &database,
+        &index,
+        embed_model.as_ref(),
+        &repo,
+        &vault_repo,
+        &byline,
+    )?;
+    println!("{}", serde_json::to_string_pretty(&bundle)?);
+    Ok(())
+}
+
+/// `legion whoami --generate --apply`: read an authored `IdentityManifest`
+/// from `--from-file` and perform the guarded identity-chain swap (or, with
+/// `--dry-run`, report the plan without writing or deleting anything).
+pub(crate) fn handle_whoami_apply(
+    repo: String,
+    from_file: Option<std::path::PathBuf>,
+    dry_run: bool,
+) -> error::Result<()> {
+    let from_file = from_file.ok_or_else(|| {
+        error::LegionError::WhoamiGenerate("--from-file is required with --apply".to_string())
+    })?;
+    let manifest_text = std::fs::read_to_string(&from_file)?;
+    let manifest: identity_generate::IdentityManifest = serde_json::from_str(&manifest_text)?;
+
+    let (database, index) = open_db_and_index()?;
+    let backup_dir = data_dir()?.join("identity-backups");
+    let result =
+        identity_generate::apply(&database, &index, &repo, &manifest, &backup_dir, dry_run)?;
+    println!("{}", serde_json::to_string_pretty(&result)?);
     Ok(())
 }
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -430,9 +430,42 @@ pub(crate) enum Commands {
         #[arg(long)]
         repo: String,
 
-        /// Maximum number of identity reflections to return
+        /// Maximum number of identity reflections to return (plain listing
+        /// mode only; ignored when --generate is set)
         #[arg(long, default_value_t = 50)]
         limit: usize,
+
+        /// Enter generate mode: gather claimed-half (self-authored) and
+        /// given-half (cross-agent) source material for an identity rebuild
+        /// (default), or write an authored replacement (with --apply).
+        #[arg(long)]
+        generate: bool,
+
+        /// Repo (must be present in watch.toml) holding the agent's bylined
+        /// writing. Required with --generate unless --apply is also set.
+        #[arg(long, requires = "generate")]
+        vault_repo: Option<String>,
+
+        /// Comma-separated byline(s)/author name(s) to match against each
+        /// candidate file's frontmatter `author` field. Required with
+        /// --generate unless --apply is also set.
+        #[arg(long, value_delimiter = ',', requires = "generate")]
+        byline: Vec<String>,
+
+        /// Switch --generate into apply mode: perform the guarded swap from
+        /// an authored manifest instead of gathering source material.
+        #[arg(long, requires = "generate")]
+        apply: bool,
+
+        /// Path to the authored manifest (JSON: IdentityManifest shape).
+        /// Required with --apply.
+        #[arg(long, requires = "apply")]
+        from_file: Option<PathBuf>,
+
+        /// Compute and report the apply plan without writing or deleting
+        /// anything. Apply mode only.
+        #[arg(long, requires = "apply")]
+        dry_run: bool,
     },
 
     /// Print the operating contract for a repo -- how I operate, distinct from

--- a/src/db/reflections.rs
+++ b/src/db/reflections.rs
@@ -68,7 +68,6 @@ pub struct ReflectionMeta {
 
 /// Result of [`Database::swap_identity_root`]: the ids removed, the new
 /// root, and any chained children inserted after it (in chain order).
-#[allow(dead_code)] // consumed by #784 (whoami --generate), not yet landed
 pub struct IdentitySwapResult {
     pub deleted_ids: Vec<String>,
     pub root: Reflection,
@@ -369,7 +368,6 @@ impl Database {
     /// `new_root_text` becomes the new root (`parent_id = None`).
     /// `chained_texts`, if any, are inserted afterward as a chain: the
     /// first follows the new root, each subsequent one follows the last.
-    #[allow(dead_code)] // consumed by #784 (whoami --generate), not yet landed
     pub fn swap_identity_root(
         &self,
         repo: &str,

--- a/src/error.rs
+++ b/src/error.rs
@@ -105,6 +105,9 @@ pub enum LegionError {
     #[error("etc error: {0}")]
     Etc(String),
 
+    #[error("whoami --generate error: {0}")]
+    WhoamiGenerate(String),
+
     #[error("watch already running (pid {0})")]
     WatchAlreadyRunning(u32),
 

--- a/src/identity_generate.rs
+++ b/src/identity_generate.rs
@@ -1,0 +1,1003 @@
+//! `legion whoami --generate` (#784): rebuild an agent's identity chain
+//! from its own bylined writing (the claimed half) and cross-agent
+//! reflections about it (the given half), through a repeatable,
+//! invariant-enforcing command instead of the by-hand process used to
+//! rebuild legion's own `whoami` on 2026-07-14.
+//!
+//! `legion` has no LLM-calling capability in the binary -- this module
+//! does not author banner prose. Gather mode (`gather`) deterministically
+//! retrieves and packages source material; apply mode (`apply`) performs
+//! the guarded, invariant-checked swap once that material has been
+//! synthesized into an [`IdentityManifest`] by the calling agent.
+
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::db::{Database, Reflection};
+use crate::embed::EmbedModel;
+use crate::error::{LegionError, Result};
+use crate::recall;
+use crate::search::SearchIndex;
+
+/// Backup/retirement scan reads at most this many domain=identity rows
+/// per repo -- well beyond the whoami default root limit (50) and any
+/// plausible chain length, so the pre-apply backup never silently
+/// truncates the corpus it is meant to protect.
+pub const IDENTITY_BACKUP_LIMIT: usize = 500;
+
+/// How many given-half (cross-agent) reflections `gather` pulls via
+/// hybrid consult. Not exposed as a CLI flag -- keeps the surface
+/// minimal; raise if a real run proves too shallow.
+const GIVEN_HALF_LIMIT: usize = 15;
+
+/// `gather` over-fetches by this factor before filtering out self-repo
+/// rows, so a query where self-authored reflections rank highly still
+/// leaves room for `GIVEN_HALF_LIMIT` genuine cross-agent hits rather
+/// than silently under-filling.
+const GIVEN_HALF_FETCH_MULTIPLIER: usize = 3;
+
+/// File extensions `gather` treats as frontmatter-capable. Enumeration
+/// is never narrowed further -- byline filtering happens after
+/// frontmatter extraction, not before (see `gather`).
+const CLAIMED_HALF_EXTENSIONS: [&str; 3] = ["md", "mdx", "astro"];
+
+/// One claimed-half source: a file in `vault_repo` whose frontmatter
+/// `author` field (not filename) matched one of the requested bylines.
+/// `body` is the full file content, not an excerpt -- gather's whole
+/// purpose is putting the actual musing/story/concept text, unsanitized,
+/// in front of the synthesizing agent.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ClaimedSource {
+    pub repo: String,
+    pub path: String,
+    pub byline: String,
+    pub body: String,
+}
+
+/// One given-half source: a cross-agent reflection (repo != the target
+/// repo) surfaced by hybrid consult against `"<repo> <bylines...>"`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GivenSource {
+    pub id: String,
+    pub repo: String,
+    pub text: String,
+    pub score: f32,
+}
+
+/// Full gather-mode output. Printed as JSON to stdout by the CLI
+/// handler; the calling agent reads it and authors an `IdentityManifest`
+/// by hand -- `gather` performs no synthesis.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GatherBundle {
+    pub repo: String,
+    pub vault_repo: String,
+    pub bylines: Vec<String>,
+    pub claimed: Vec<ClaimedSource>,
+    pub given: Vec<GivenSource>,
+}
+
+/// An authored identity replacement: one root plus an ordered chain of
+/// `--follows` children (empty chain is valid -- a root-only identity is
+/// a legitimate outcome).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct IdentityManifest {
+    pub root: String,
+    #[serde(default)]
+    pub chain: Vec<String>,
+}
+
+/// Ids and backup location from a completed (non-dry-run) apply.
+#[derive(Debug, Clone, Serialize)]
+pub struct ApplyOutcome {
+    /// New chain ids, root first.
+    pub new_ids: Vec<String>,
+    pub backup_path: PathBuf,
+    /// Old domain=identity ids retired (deleted) as part of this apply.
+    pub retired_ids: Vec<String>,
+}
+
+/// What a `--dry-run` apply would do, computed without any write.
+#[derive(Debug, Clone, Serialize)]
+pub struct ApplyPlan {
+    pub would_retire: Vec<String>,
+    pub would_create: usize,
+    pub backup_path: PathBuf,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(untagged)]
+pub enum ApplyResult {
+    Applied(ApplyOutcome),
+    Planned(ApplyPlan),
+}
+
+/// Gather claimed-half + given-half source material for `repo`'s
+/// identity rebuild. Enumerates every frontmatter-capable file
+/// (`.md`/`.mdx`/`.astro`) in `vault_repo`'s file inventory and extracts
+/// `author` from each -- enumeration is never narrowed by byline, since
+/// the byline is a filename heuristic the frontmatter check exists to
+/// replace. Returns `LegionError::WhoamiGenerate` if zero files match
+/// after filtering.
+pub fn gather(
+    db: &Database,
+    index: &SearchIndex,
+    embed_model: Option<&EmbedModel>,
+    repo: &str,
+    vault_repo: &str,
+    bylines: &[String],
+) -> Result<GatherBundle> {
+    let workdir = vault_repo_workdir(vault_repo)?;
+    let claimed = gather_claimed_half(db, vault_repo, &workdir, bylines)?;
+    let given = gather_given_half(db, index, embed_model, repo, bylines)?;
+
+    Ok(GatherBundle {
+        repo: repo.to_owned(),
+        vault_repo: vault_repo.to_owned(),
+        bylines: bylines.to_vec(),
+        claimed,
+        given,
+    })
+}
+
+/// Resolve `vault_repo`'s workdir from watch.toml, the same
+/// repo-validation error `sym etc find-content`/`find-file` already use
+/// for an unknown repo. Impure shell around `resolve_vault_repo_workdir`
+/// (the pure, unit-testable lookup) -- `data_dir()` caches its result in
+/// a process-wide `OnceLock`, so exercising this wrapper's `LEGION_DATA_DIR`
+/// resolution itself needs a fresh subprocess (covered by the
+/// `tests/integration/whoami_generate.rs` CLI tests), not a unit test.
+fn vault_repo_workdir(vault_repo: &str) -> Result<PathBuf> {
+    let watch_path = crate::data_dir()?.join("watch.toml");
+    let repos = crate::watch::list_repos_in_config(&watch_path)?;
+    resolve_vault_repo_workdir(&repos, vault_repo)
+}
+
+/// Find `vault_repo` among already-loaded watch.toml entries and return
+/// its workdir, or `LegionError::WatchConfig` naming the repo -- the same
+/// error `sym etc find-content`/`find-file` return for an unknown repo.
+fn resolve_vault_repo_workdir(
+    repos: &[crate::watch::WatchRepoConfig],
+    vault_repo: &str,
+) -> Result<PathBuf> {
+    let entry = repos.iter().find(|r| r.name == vault_repo).ok_or_else(|| {
+        LegionError::WatchConfig(format!(
+            "repo '{vault_repo}' not in watch.toml. Add it with `legion watch add {vault_repo} <path>`."
+        ))
+    })?;
+    Ok(PathBuf::from(&entry.workdir))
+}
+
+/// Enumerate `vault_repo`'s frontmatter-capable files, extract `author`
+/// from each, and keep the ones matching a requested byline.
+fn gather_claimed_half(
+    db: &Database,
+    vault_repo: &str,
+    workdir: &Path,
+    bylines: &[String],
+) -> Result<Vec<ClaimedSource>> {
+    let filter = crate::db::inventory::InventoryFilter {
+        repo: Some(vault_repo),
+        ext: None,
+        lang: None,
+    };
+    let entries = db.list_file_inventory(&filter)?;
+
+    let mut claimed = Vec::new();
+    for entry in &entries {
+        if !CLAIMED_HALF_EXTENSIONS.contains(&entry.ext.as_deref().unwrap_or("")) {
+            continue;
+        }
+        let abs_path = workdir.join(&entry.path);
+
+        // A candidate whose extract_field call fails (no frontmatter,
+        // missing `author` field, unparseable YAML) is silently skipped,
+        // not treated as an error.
+        let Ok(author_value) = crate::etc::extract_field(&abs_path, "author") else {
+            continue;
+        };
+        let Some(matched_byline) = matching_byline(&author_value, bylines) else {
+            continue;
+        };
+
+        let body = std::fs::read_to_string(&abs_path)?;
+        claimed.push(ClaimedSource {
+            repo: vault_repo.to_owned(),
+            path: entry.path.clone(),
+            byline: matched_byline,
+            body,
+        });
+    }
+
+    if claimed.is_empty() {
+        return Err(LegionError::WhoamiGenerate(format!(
+            "no claimed-half sources found in vault_repo '{vault_repo}' for bylines: {}",
+            bylines.join(", ")
+        )));
+    }
+
+    Ok(claimed)
+}
+
+/// Check whether a `serde_json::Value` extracted from a frontmatter
+/// `author` field (a string, or an array of strings) contains one of
+/// `bylines` (case-sensitive exact match). Returns the matched byline.
+fn matching_byline(value: &serde_json::Value, bylines: &[String]) -> Option<String> {
+    match value {
+        serde_json::Value::String(s) => bylines.iter().find(|b| b.as_str() == s).cloned(),
+        serde_json::Value::Array(items) => items.iter().find_map(|item| match item {
+            serde_json::Value::String(s) => bylines.iter().find(|b| b.as_str() == s).cloned(),
+            _ => None,
+        }),
+        _ => None,
+    }
+}
+
+/// Populate the given-half via a hybrid-consult-style query (BM25 +
+/// cosine when an embed model is available, BM25-only otherwise --
+/// precedent `try_load_embed_model`'s Some/None branch in
+/// `src/cli/memory.rs`) against `"<repo> <bylines...>"`, excluding
+/// self-authored rows (`entry.repo == repo`) since those are claimed-half
+/// even if they happen to live outside `vault_repo`. An empty result is
+/// not an error.
+fn gather_given_half(
+    db: &Database,
+    index: &SearchIndex,
+    embed_model: Option<&EmbedModel>,
+    repo: &str,
+    bylines: &[String],
+) -> Result<Vec<GivenSource>> {
+    let query = format!("{repo} {}", bylines.join(" "));
+    let fetch_limit = GIVEN_HALF_LIMIT * GIVEN_HALF_FETCH_MULTIPLIER;
+
+    let recalled = match embed_model {
+        Some(model) => recall::consult(db, index, model, &query, fetch_limit)?,
+        None => recall::consult_bm25(db, index, &query, fetch_limit)?,
+    };
+
+    Ok(recalled
+        .reflections
+        .into_iter()
+        .filter(|r| r.repo != repo)
+        .take(GIVEN_HALF_LIMIT)
+        .map(|r| GivenSource {
+            id: r.id,
+            repo: r.repo,
+            text: r.text,
+            score: r.score,
+        })
+        .collect())
+}
+
+/// Validate `manifest` against this command's own structural invariants
+/// (NOT the global orphan-root guard -- that lives in
+/// `insert_reflection_with_meta`/`IdentityRootExists` and is unaffected
+/// by this check). Checks: `root` is non-empty after trimming; `root`'s
+/// byte length does not exceed `recall::WHOAMI_BYTE_CAP`; neither `root`
+/// nor any `chain` entry contains the case-insensitive substring "what i
+/// am". Returns `LegionError::WhoamiGenerate` naming the specific field
+/// and reason on the first violation found.
+pub fn validate_manifest(manifest: &IdentityManifest) -> Result<()> {
+    if manifest.root.trim().is_empty() {
+        return Err(LegionError::WhoamiGenerate(
+            "manifest root is empty or all-whitespace".to_owned(),
+        ));
+    }
+    if manifest.root.len() > recall::WHOAMI_BYTE_CAP {
+        return Err(LegionError::WhoamiGenerate(format!(
+            "manifest root is {} bytes, exceeding the {}-byte whoami cap",
+            manifest.root.len(),
+            recall::WHOAMI_BYTE_CAP
+        )));
+    }
+    if contains_forbidden_phrase(&manifest.root) {
+        return Err(LegionError::WhoamiGenerate(
+            "manifest root contains the forbidden phrase \"what i am\"".to_owned(),
+        ));
+    }
+    for (i, entry) in manifest.chain.iter().enumerate() {
+        if contains_forbidden_phrase(entry) {
+            return Err(LegionError::WhoamiGenerate(format!(
+                "manifest chain[{i}] contains the forbidden phrase \"what i am\""
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn contains_forbidden_phrase(text: &str) -> bool {
+    text.to_lowercase().contains("what i am")
+}
+
+/// Apply mode: replace `repo`'s identity chain with `manifest`.
+///
+/// 1. `validate_manifest(manifest)` -- first gate, before any read or
+///    write, so an invalid manifest is a pure no-op.
+/// 2. Capture the full pre-existing `domain=identity` rows for `repo`
+///    (`get_reflections_by_domain`, `IDENTITY_BACKUP_LIMIT`) -- read-only.
+/// 3. If `dry_run`, return `ApplyResult::Planned` here. Nothing below
+///    this line runs.
+/// 4. Write the captured rows as JSON to a backup file under
+///    `backup_dir`, before anything is written or deleted.
+/// 5. Perform the swap via `Database::swap_identity_root` (#785): delete
+///    every live identity root, insert the new root and chained
+///    children, all inside one transaction. Either the whole thing
+///    commits or rusqlite's automatic rollback on a dropped, uncommitted
+///    transaction restores the old identity -- no two-live-roots and no
+///    observable zero-root window. This replaces the
+///    insert-then-verify-then-delete sequence an earlier draft of this
+///    function used, which the insert-time `IdentityRootExists` guard
+///    (#785) refuses outright: the guard sees the old root still live
+///    and rejects the new insert before the swap can even begin, with no
+///    `--force` escape by design.
+/// 6. `swap_identity_root` only clears root-level rows (deliberately
+///    non-cascading -- see its own doc comment); a replaced root's old
+///    `--follows` children are left dangling. This command's own
+///    retirement contract is the full pre-existing corpus (matching the
+///    backup captured in step 2), not just the root(s), so any backed-up
+///    id the swap did not already remove is deleted here explicitly.
+///    Each leftover delete is best-effort and mirrors `handle_forget`'s
+///    partial-failure handling: the swap has already committed by this
+///    point, so a cleanup failure must not report the whole apply as
+///    failed -- the backup file written in step 4 is the recovery path.
+/// 7. Sync the search index for the new root, new children, and every
+///    retired id (`swap_identity_root` only touches the database, the
+///    same split-write `reflect_from_text_with_meta` already has).
+pub fn apply(
+    db: &Database,
+    index: &SearchIndex,
+    repo: &str,
+    manifest: &IdentityManifest,
+    backup_dir: &Path,
+    dry_run: bool,
+) -> Result<ApplyResult> {
+    validate_manifest(manifest)?;
+
+    let old_rows = db.get_reflections_by_domain(repo, "identity", IDENTITY_BACKUP_LIMIT)?;
+    let would_retire: Vec<String> = old_rows.iter().map(|r| r.id.clone()).collect();
+    let backup_path = backup_dir.join(format!("identity-backup-{repo}-{}.json", Uuid::now_v7()));
+
+    if dry_run {
+        return Ok(ApplyResult::Planned(ApplyPlan {
+            would_retire,
+            would_create: 1 + manifest.chain.len(),
+            backup_path,
+        }));
+    }
+
+    std::fs::create_dir_all(backup_dir)?;
+    std::fs::write(&backup_path, serde_json::to_vec_pretty(&old_rows)?)?;
+
+    let chained_texts: Vec<&str> = manifest.chain.iter().map(String::as_str).collect();
+    let swap = db.swap_identity_root(repo, manifest.root.trim(), &chained_texts, "self")?;
+
+    index.add(&swap.root.id, repo, &swap.root.text)?;
+    for child in &swap.children {
+        index.add(&child.id, repo, &child.text)?;
+    }
+
+    let retired_ids =
+        retire_old_identity_rows(db, index, &old_rows, &swap.deleted_ids, &backup_path);
+
+    let new_ids: Vec<String> = std::iter::once(swap.root.id.clone())
+        .chain(swap.children.iter().map(|c| c.id.clone()))
+        .collect();
+
+    Ok(ApplyResult::Applied(ApplyOutcome {
+        new_ids,
+        backup_path,
+        retired_ids,
+    }))
+}
+
+/// Best-effort tantivy delete for an id already removed from the
+/// database, warning (not failing) on a per-id error -- mirrors
+/// `handle_forget`'s partial-failure handling: the caller's own write
+/// already committed, so an index-side straggler must not report the
+/// whole apply as failed. `legion reindex` is the stated recovery path.
+fn warn_on_index_delete_failure(index: &SearchIndex, id: &str) {
+    if let Err(e) = index.delete(id) {
+        eprintln!(
+            "[legion whoami --generate --apply] WARNING: SQLite delete succeeded but tantivy index delete failed for {id}.\n\
+             The reflection is gone from the database but may still appear in BM25 recall results\n\
+             as a ghost document until the index is rebuilt. Run `legion reindex` to reconcile.\n\
+             Underlying error: {e}"
+        );
+    }
+}
+
+/// Retire every id captured in `old_rows` (the full pre-swap backup),
+/// so this command's own retirement contract -- the whole pre-existing
+/// corpus, not just the root(s) -- holds regardless of
+/// `swap_identity_root`'s narrower, deliberately non-cascading delete.
+/// Two cases per id:
+///
+/// - In `swap_deleted_ids` (the root(s) `swap_identity_root` already
+///   removed from the database, inside its own transaction): only the
+///   search index needs to catch up, since `swap_identity_root` never
+///   touches it (database-only, like every other write in that
+///   module).
+/// - Not in `swap_deleted_ids` (a surviving `--follows` chain child --
+///   `swap_identity_root` deliberately does not cascade to these, see
+///   its own doc comment): delete from both stores here.
+///
+/// Every delete is best-effort and warns rather than fails -- see
+/// `apply`'s step 6 for why. Returns the full set of ids retired: the
+/// swap's own database deletions plus whatever this pass additionally
+/// removed.
+fn retire_old_identity_rows(
+    db: &Database,
+    index: &SearchIndex,
+    old_rows: &[Reflection],
+    swap_deleted_ids: &[String],
+    backup_path: &Path,
+) -> Vec<String> {
+    let swap_deleted: std::collections::HashSet<&str> =
+        swap_deleted_ids.iter().map(String::as_str).collect();
+    let mut retired_ids: Vec<String> = swap_deleted_ids.to_vec();
+
+    for id in swap_deleted_ids {
+        warn_on_index_delete_failure(index, id);
+    }
+
+    for row in old_rows {
+        if swap_deleted.contains(row.id.as_str()) {
+            continue;
+        }
+        match db.delete_reflection(&row.id) {
+            Ok(_) => {
+                retired_ids.push(row.id.clone());
+                warn_on_index_delete_failure(index, &row.id);
+            }
+            Err(e) => {
+                eprintln!(
+                    "[legion whoami --generate --apply] WARNING: could not retire leftover old identity row {}: {e}.\n\
+                     It remains in the database; recover the pre-apply state from {} if needed.",
+                    row.id,
+                    backup_path.display()
+                );
+            }
+        }
+    }
+
+    retired_ids
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::ReflectionMeta;
+    use crate::testutil::test_storage;
+
+    // -- matching_byline -----------------------------------------------
+
+    #[test]
+    fn matching_byline_string_exact_match() {
+        let value = serde_json::json!("legion");
+        let bylines = vec!["legion".to_string(), "other".to_string()];
+        assert_eq!(
+            matching_byline(&value, &bylines),
+            Some("legion".to_string())
+        );
+    }
+
+    #[test]
+    fn matching_byline_string_no_match() {
+        let value = serde_json::json!("someone-else");
+        let bylines = vec!["legion".to_string()];
+        assert_eq!(matching_byline(&value, &bylines), None);
+    }
+
+    #[test]
+    fn matching_byline_array_match() {
+        let value = serde_json::json!(["someone-else", "legion"]);
+        let bylines = vec!["legion".to_string()];
+        assert_eq!(
+            matching_byline(&value, &bylines),
+            Some("legion".to_string())
+        );
+    }
+
+    #[test]
+    fn matching_byline_case_sensitive() {
+        let value = serde_json::json!("Legion");
+        let bylines = vec!["legion".to_string()];
+        assert_eq!(matching_byline(&value, &bylines), None);
+    }
+
+    // -- gather: claimed half --------------------------------------------
+
+    fn write_file(dir: &Path, rel: &str, content: &str) {
+        let path = dir.join(rel);
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).unwrap();
+        }
+        std::fs::write(path, content).unwrap();
+    }
+
+    fn seed_inventory_entry(
+        db: &Database,
+        repo: &str,
+        path: &str,
+        ext: &str,
+    ) -> crate::db::inventory::FileInventoryEntry {
+        let entry = crate::db::inventory::FileInventoryEntry {
+            repo: repo.to_owned(),
+            path: path.to_owned(),
+            ext: Some(ext.to_owned()),
+            lang: None,
+            size: 0,
+            mtime: chrono::Utc::now().to_rfc3339(),
+            symbol_count: 0,
+        };
+        db.upsert_file_inventory(std::slice::from_ref(&entry))
+            .unwrap();
+        entry
+    }
+
+    fn fake_watch_repo(name: &str, workdir: &str) -> crate::watch::WatchRepoConfig {
+        crate::watch::WatchRepoConfig {
+            name: name.to_owned(),
+            workdir: workdir.to_owned(),
+            agent: None,
+            broadcast_tags: vec![],
+            extra: toml::Table::new(),
+        }
+    }
+
+    #[test]
+    fn gather_claimed_half_finds_date_titled_file_by_frontmatter_not_filename() {
+        let (db, _index, dir) = test_storage();
+        let vault_dir = dir.path().join("vault");
+        std::fs::create_dir_all(&vault_dir).unwrap();
+        // No byline substring anywhere in the filename -- the exact case a
+        // filename-glob approach would silently miss.
+        write_file(
+            &vault_dir,
+            "2026-07-01-persistence.md",
+            "---\nauthor: legion\n---\n\nPersistence is a discipline, not a feature.\n",
+        );
+        seed_inventory_entry(&db, "vault-repo", "2026-07-01-persistence.md", "md");
+
+        let bylines = vec!["legion".to_string()];
+        let claimed =
+            gather_claimed_half(&db, "vault-repo", &vault_dir, &bylines).expect("gather ok");
+
+        assert_eq!(claimed.len(), 1);
+        assert_eq!(claimed[0].byline, "legion");
+        assert_eq!(claimed[0].path, "2026-07-01-persistence.md");
+    }
+
+    #[test]
+    fn gather_claimed_half_filters_by_frontmatter_author_not_all_files() {
+        let (db, _index, dir) = test_storage();
+        let vault_dir = dir.path().join("vault");
+        std::fs::create_dir_all(&vault_dir).unwrap();
+        write_file(&vault_dir, "mine.md", "---\nauthor: legion\n---\n\nmine\n");
+        write_file(
+            &vault_dir,
+            "theirs.md",
+            "---\nauthor: someone-else\n---\n\ntheirs\n",
+        );
+        seed_inventory_entry(&db, "vault-repo", "mine.md", "md");
+        seed_inventory_entry(&db, "vault-repo", "theirs.md", "md");
+
+        let bylines = vec!["legion".to_string()];
+        let claimed =
+            gather_claimed_half(&db, "vault-repo", &vault_dir, &bylines).expect("gather ok");
+
+        assert_eq!(claimed.len(), 1);
+        assert_eq!(claimed[0].byline, "legion");
+        assert_eq!(claimed[0].path, "mine.md");
+    }
+
+    #[test]
+    fn gather_claimed_half_skips_file_with_no_frontmatter() {
+        let (db, _index, dir) = test_storage();
+        let vault_dir = dir.path().join("vault");
+        std::fs::create_dir_all(&vault_dir).unwrap();
+        write_file(&vault_dir, "mine.md", "---\nauthor: legion\n---\n\nmine\n");
+        write_file(
+            &vault_dir,
+            "plain.md",
+            "just a plain markdown file, no frontmatter\n",
+        );
+        seed_inventory_entry(&db, "vault-repo", "mine.md", "md");
+        seed_inventory_entry(&db, "vault-repo", "plain.md", "md");
+
+        let bylines = vec!["legion".to_string()];
+        let claimed =
+            gather_claimed_half(&db, "vault-repo", &vault_dir, &bylines).expect("gather ok");
+
+        assert_eq!(claimed.len(), 1);
+        assert_eq!(claimed[0].path, "mine.md");
+    }
+
+    #[test]
+    fn gather_claimed_half_body_is_byte_identical_to_fixture() {
+        let (db, _index, dir) = test_storage();
+        let vault_dir = dir.path().join("vault");
+        std::fs::create_dir_all(&vault_dir).unwrap();
+        let body =
+            "---\nauthor: legion\n---\n\nParagraph one, with detail.\n\nParagraph two, distinct.\n";
+        write_file(&vault_dir, "mine.md", body);
+        seed_inventory_entry(&db, "vault-repo", "mine.md", "md");
+
+        let bylines = vec!["legion".to_string()];
+        let claimed =
+            gather_claimed_half(&db, "vault-repo", &vault_dir, &bylines).expect("gather ok");
+
+        assert_eq!(claimed.len(), 1);
+        assert_eq!(claimed[0].body, body);
+    }
+
+    #[test]
+    fn gather_claimed_half_empty_returns_whoami_generate_error() {
+        let (db, _index, dir) = test_storage();
+        let vault_dir = dir.path().join("vault");
+        std::fs::create_dir_all(&vault_dir).unwrap();
+        write_file(
+            &vault_dir,
+            "theirs.md",
+            "---\nauthor: someone-else\n---\n\ntheirs\n",
+        );
+        seed_inventory_entry(&db, "vault-repo", "theirs.md", "md");
+
+        let bylines = vec!["legion".to_string()];
+        let err = gather_claimed_half(&db, "vault-repo", &vault_dir, &bylines).unwrap_err();
+        match err {
+            LegionError::WhoamiGenerate(msg) => {
+                assert!(msg.contains("vault-repo"));
+                assert!(msg.contains("legion"));
+            }
+            other => panic!("expected WhoamiGenerate, got {other:?}"),
+        }
+    }
+
+    // -- gather: given half -----------------------------------------------
+
+    #[test]
+    fn gather_given_half_excludes_self_repo() {
+        let (db, index, _dir) = test_storage();
+        crate::reflect::reflect_from_text(&db, &index, "legion", "legion talks about itself")
+            .unwrap();
+        crate::reflect::reflect_from_text(&db, &index, "rafters", "legion is a careful engineer")
+            .unwrap();
+
+        let given =
+            gather_given_half(&db, &index, None, "legion", &["legion".to_string()]).unwrap();
+
+        assert_eq!(given.len(), 1);
+        assert_eq!(given[0].repo, "rafters");
+    }
+
+    #[test]
+    fn gather_given_half_empty_is_not_an_error() {
+        let (db, index, _dir) = test_storage();
+        crate::reflect::reflect_from_text(&db, &index, "legion", "unrelated content").unwrap();
+
+        let given = gather_given_half(
+            &db,
+            &index,
+            None,
+            "legion",
+            &["nonexistent-byline".to_string()],
+        )
+        .unwrap();
+
+        assert!(given.is_empty());
+    }
+
+    // -- resolve_vault_repo_workdir -------------------------------------------
+    //
+    // `gather`'s own watch.toml resolution (via `data_dir()`, cached in a
+    // process-wide `OnceLock`) is exercised end-to-end by
+    // `tests/integration/whoami_generate.rs`, which spawns a fresh `legion`
+    // subprocess per `common::legion_cmd`'s documented pattern. These tests
+    // cover the pure lookup `vault_repo_workdir` delegates to.
+
+    #[test]
+    fn resolve_vault_repo_workdir_unknown_repo_returns_watch_config_error() {
+        let repos = vec![fake_watch_repo("known-repo", "/tmp/known-repo")];
+        let err = resolve_vault_repo_workdir(&repos, "ghost-vault-repo").unwrap_err();
+        match err {
+            LegionError::WatchConfig(msg) => assert!(msg.contains("ghost-vault-repo")),
+            other => panic!("expected WatchConfig, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn resolve_vault_repo_workdir_known_repo_returns_its_workdir() {
+        let repos = vec![
+            fake_watch_repo("other-repo", "/tmp/other-repo"),
+            fake_watch_repo("vault-repo", "/tmp/vault-repo"),
+        ];
+        let workdir = resolve_vault_repo_workdir(&repos, "vault-repo").unwrap();
+        assert_eq!(workdir, PathBuf::from("/tmp/vault-repo"));
+    }
+
+    // -- validate_manifest --------------------------------------------------
+
+    #[test]
+    fn validate_manifest_rejects_empty_root() {
+        let manifest = IdentityManifest {
+            root: "   ".to_string(),
+            chain: vec![],
+        };
+        let err = validate_manifest(&manifest).unwrap_err();
+        assert!(matches!(err, LegionError::WhoamiGenerate(_)));
+    }
+
+    #[test]
+    fn validate_manifest_rejects_oversized_root() {
+        let manifest = IdentityManifest {
+            root: "x".repeat(recall::WHOAMI_BYTE_CAP + 1),
+            chain: vec![],
+        };
+        let err = validate_manifest(&manifest).unwrap_err();
+        match err {
+            LegionError::WhoamiGenerate(msg) => {
+                assert!(msg.contains(&(recall::WHOAMI_BYTE_CAP + 1).to_string()));
+                assert!(msg.contains(&recall::WHOAMI_BYTE_CAP.to_string()));
+            }
+            other => panic!("expected WhoamiGenerate, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn validate_manifest_rejects_forbidden_phrase_in_chain_names_index() {
+        let manifest = IdentityManifest {
+            root: "a careful builder".to_string(),
+            chain: vec![
+                "an early chapter".to_string(),
+                "knows What I Am deeply".to_string(),
+            ],
+        };
+        let err = validate_manifest(&manifest).unwrap_err();
+        match err {
+            LegionError::WhoamiGenerate(msg) => {
+                assert!(msg.contains("chain[1]"));
+                assert!(!msg.contains("root"));
+            }
+            other => panic!("expected WhoamiGenerate, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn validate_manifest_accepts_empty_chain() {
+        let manifest = IdentityManifest {
+            root: "a careful builder".to_string(),
+            chain: vec![],
+        };
+        assert!(validate_manifest(&manifest).is_ok());
+    }
+
+    // -- apply ----------------------------------------------------------------
+
+    #[test]
+    fn apply_invalid_manifest_writes_nothing_and_changes_nothing() {
+        let (db, index, dir) = test_storage();
+        db.insert_reflection_with_meta(
+            "legion",
+            "old identity root",
+            "self",
+            &ReflectionMeta {
+                domain: Some("identity".to_string()),
+                tags: None,
+                parent_id: None,
+            },
+        )
+        .unwrap();
+        let before = db
+            .get_reflections_by_domain("legion", "identity", 500)
+            .unwrap();
+
+        let backup_dir = dir.path().join("backups");
+        let manifest = IdentityManifest {
+            root: "".to_string(),
+            chain: vec![],
+        };
+        let err = apply(&db, &index, "legion", &manifest, &backup_dir, false).unwrap_err();
+        assert!(matches!(err, LegionError::WhoamiGenerate(_)));
+
+        assert!(!backup_dir.exists());
+        let after = db
+            .get_reflections_by_domain("legion", "identity", 500)
+            .unwrap();
+        assert_eq!(before.len(), after.len());
+    }
+
+    #[test]
+    fn apply_writes_backup_containing_root_and_chain_child_before_any_change() {
+        let (db, index, dir) = test_storage();
+        let root = db
+            .insert_reflection_with_meta(
+                "legion",
+                "old root",
+                "self",
+                &ReflectionMeta {
+                    domain: Some("identity".to_string()),
+                    tags: None,
+                    parent_id: None,
+                },
+            )
+            .unwrap();
+        db.insert_reflection_with_meta(
+            "legion",
+            "old chain child",
+            "self",
+            &ReflectionMeta {
+                domain: Some("identity".to_string()),
+                tags: None,
+                parent_id: Some(root.id.clone()),
+            },
+        )
+        .unwrap();
+
+        let backup_dir = dir.path().join("backups");
+        let manifest = IdentityManifest {
+            root: "new root".to_string(),
+            chain: vec![],
+        };
+        let result = apply(&db, &index, "legion", &manifest, &backup_dir, false).unwrap();
+        let outcome = match result {
+            ApplyResult::Applied(o) => o,
+            ApplyResult::Planned(_) => panic!("expected Applied"),
+        };
+
+        let backup_content = std::fs::read_to_string(&outcome.backup_path).unwrap();
+        let backed_up: Vec<Reflection> = serde_json::from_str(&backup_content).unwrap();
+        assert_eq!(backed_up.len(), 2);
+    }
+
+    #[test]
+    fn apply_replaces_root_and_retires_every_old_id_including_dangling_children() {
+        let (db, index, dir) = test_storage();
+        let root = db
+            .insert_reflection_with_meta(
+                "legion",
+                "old root",
+                "self",
+                &ReflectionMeta {
+                    domain: Some("identity".to_string()),
+                    tags: None,
+                    parent_id: None,
+                },
+            )
+            .unwrap();
+        let child = db
+            .insert_reflection_with_meta(
+                "legion",
+                "old chain child",
+                "self",
+                &ReflectionMeta {
+                    domain: Some("identity".to_string()),
+                    tags: None,
+                    parent_id: Some(root.id.clone()),
+                },
+            )
+            .unwrap();
+
+        let backup_dir = dir.path().join("backups");
+        let manifest = IdentityManifest {
+            root: "new root".to_string(),
+            chain: vec!["new chain entry".to_string()],
+        };
+        let result = apply(&db, &index, "legion", &manifest, &backup_dir, false).unwrap();
+        let outcome = match result {
+            ApplyResult::Applied(o) => o,
+            ApplyResult::Planned(_) => panic!("expected Applied"),
+        };
+
+        assert_eq!(outcome.new_ids.len(), 2);
+        assert!(outcome.retired_ids.contains(&root.id));
+        assert!(outcome.retired_ids.contains(&child.id));
+
+        let roots = db.get_identity_roots("legion", 50).unwrap();
+        assert_eq!(roots.len(), 1);
+        assert_eq!(roots[0].text, "new root");
+
+        assert!(db.get_reflection_by_id(&root.id).unwrap().is_none());
+        assert!(db.get_reflection_by_id(&child.id).unwrap().is_none());
+    }
+
+    #[test]
+    fn apply_removes_swap_deleted_root_from_search_index_not_just_the_database() {
+        // Seed via reflect_from_text_with_meta (not insert_reflection_with_meta
+        // directly) so the old root actually lands in the search index too,
+        // the same as every real `legion reflect --whoami` write -- a
+        // DB-only fixture would never exercise the index-sync path at all.
+        let (db, index, dir) = test_storage();
+        let root_id = crate::reflect::reflect_from_text_with_meta(
+            &db,
+            &index,
+            "legion",
+            "an old distinctive root about careful engineering",
+            &ReflectionMeta {
+                domain: Some("identity".to_string()),
+                tags: None,
+                parent_id: None,
+            },
+        )
+        .unwrap();
+
+        let backup_dir = dir.path().join("backups");
+        let manifest = IdentityManifest {
+            root: "new root".to_string(),
+            chain: vec![],
+        };
+        apply(&db, &index, "legion", &manifest, &backup_dir, false).unwrap();
+
+        // swap_identity_root deletes the old root from the database only
+        // (it never touches tantivy); apply() must still sync the index
+        // for every retired id, including the swap's own deletions, or
+        // the old root persists as a ghost document in BM25 results.
+        let hits = index
+            .search("legion", "distinctive careful engineering", 10)
+            .unwrap();
+        let hit_ids: Vec<&str> = hits.iter().map(|h| h.id.as_str()).collect();
+        assert!(
+            !hit_ids.contains(&root_id.as_str()),
+            "old root must not still be findable in the search index: {hit_ids:?}"
+        );
+    }
+
+    #[test]
+    fn apply_chain_order_matches_manifest() {
+        let (db, index, dir) = test_storage();
+        let backup_dir = dir.path().join("backups");
+        let manifest = IdentityManifest {
+            root: "new root".to_string(),
+            chain: vec!["first".to_string(), "second".to_string()],
+        };
+        let result = apply(&db, &index, "legion", &manifest, &backup_dir, false).unwrap();
+        let outcome = match result {
+            ApplyResult::Applied(o) => o,
+            ApplyResult::Planned(_) => panic!("expected Applied"),
+        };
+
+        let chain = db.get_chain(&outcome.new_ids[0]).unwrap();
+        let texts: Vec<&str> = chain.iter().map(|r| r.text.as_str()).collect();
+        assert_eq!(texts, vec!["new root", "first", "second"]);
+    }
+
+    #[test]
+    fn apply_dry_run_changes_nothing_and_writes_no_file() {
+        let (db, index, dir) = test_storage();
+        db.insert_reflection_with_meta(
+            "legion",
+            "old root",
+            "self",
+            &ReflectionMeta {
+                domain: Some("identity".to_string()),
+                tags: None,
+                parent_id: None,
+            },
+        )
+        .unwrap();
+        let before = db
+            .get_reflections_by_domain("legion", "identity", 500)
+            .unwrap();
+
+        let backup_dir = dir.path().join("backups");
+        let manifest = IdentityManifest {
+            root: "new root".to_string(),
+            chain: vec!["child".to_string()],
+        };
+        let result = apply(&db, &index, "legion", &manifest, &backup_dir, true).unwrap();
+        let plan = match result {
+            ApplyResult::Planned(p) => p,
+            ApplyResult::Applied(_) => panic!("expected Planned"),
+        };
+
+        assert_eq!(plan.would_retire, vec![before[0].id.clone()]);
+        assert_eq!(plan.would_create, 2);
+        assert!(!plan.backup_path.exists());
+
+        let after = db
+            .get_reflections_by_domain("legion", "identity", 500)
+            .unwrap();
+        assert_eq!(before.len(), after.len());
+    }
+}

--- a/src/identity_generate.rs
+++ b/src/identity_generate.rs
@@ -310,6 +310,23 @@ fn contains_forbidden_phrase(text: &str) -> bool {
     text.to_lowercase().contains("what i am")
 }
 
+/// Reduce an arbitrary string to a safe single filename component:
+/// every char outside `[A-Za-z0-9._-]` becomes `-`. `repo` flows into
+/// the backup filename, and `Path::join` would interpret a `/` (or a
+/// `..` segment) in it as path structure, silently relocating the
+/// recovery file outside `backup_dir`.
+fn sanitize_filename_component(raw: &str) -> String {
+    raw.chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '-') {
+                c
+            } else {
+                '-'
+            }
+        })
+        .collect()
+}
+
 /// Apply mode: replace `repo`'s identity chain with `manifest`.
 ///
 /// 1. `validate_manifest(manifest)` -- first gate, before any read or
@@ -372,7 +389,11 @@ pub fn apply(
         );
     }
     let would_retire: Vec<String> = old_rows.iter().map(|r| r.id.clone()).collect();
-    let backup_path = backup_dir.join(format!("identity-backup-{repo}-{}.json", Uuid::now_v7()));
+    let backup_path = backup_dir.join(format!(
+        "identity-backup-{}-{}.json",
+        sanitize_filename_component(repo),
+        Uuid::now_v7()
+    ));
 
     if dry_run {
         return Ok(ApplyResult::Planned(ApplyPlan {
@@ -1029,6 +1050,49 @@ mod tests {
         let roots = db.get_identity_roots("legion", 50).unwrap();
         assert_eq!(roots.len(), 1);
         assert_eq!(roots[0].text, "first ever root");
+    }
+
+    #[test]
+    fn apply_backup_path_stays_inside_backup_dir_for_hostile_repo_name() {
+        // `repo` flows into the backup filename; a value carrying path
+        // separators must not relocate the recovery file outside
+        // backup_dir (Path::join would treat `/` as structure).
+        let (db, index, dir) = test_storage();
+        let backup_dir = dir.path().join("backups");
+        let manifest = IdentityManifest {
+            root: "new root".to_string(),
+            chain: vec![],
+        };
+        let result = apply(
+            &db,
+            &index,
+            "../../escape/attempt",
+            &manifest,
+            &backup_dir,
+            false,
+        )
+        .unwrap();
+        let outcome = match result {
+            ApplyResult::Applied(o) => o,
+            ApplyResult::Planned(_) => panic!("expected Applied"),
+        };
+
+        assert!(
+            outcome.backup_path.parent() == Some(backup_dir.as_path()),
+            "backup must be a direct child of backup_dir, got {}",
+            outcome.backup_path.display()
+        );
+        assert!(outcome.backup_path.exists());
+    }
+
+    #[test]
+    fn sanitize_filename_component_neutralizes_separators() {
+        assert_eq!(
+            sanitize_filename_component("../../etc/passwd"),
+            "..-..-etc-passwd"
+        );
+        assert_eq!(sanitize_filename_component("legion"), "legion");
+        assert_eq!(sanitize_filename_component("my repo\\x"), "my-repo-x");
     }
 
     #[test]

--- a/src/identity_generate.rs
+++ b/src/identity_generate.rs
@@ -343,7 +343,10 @@ fn contains_forbidden_phrase(text: &str) -> bool {
 ///    failed -- the backup file written in step 4 is the recovery path.
 /// 7. Sync the search index for the new root, new children, and every
 ///    retired id (`swap_identity_root` only touches the database, the
-///    same split-write `reflect_from_text_with_meta` already has).
+///    same split-write `reflect_from_text_with_meta` already has). All
+///    of step 7 is best-effort warn-not-fail: the swap committed in
+///    step 5, so from here on the database is the truth and `legion
+///    reindex` is the recovery path for any index straggler.
 pub fn apply(
     db: &Database,
     index: &SearchIndex,
@@ -355,6 +358,19 @@ pub fn apply(
     validate_manifest(manifest)?;
 
     let old_rows = db.get_reflections_by_domain(repo, "identity", IDENTITY_BACKUP_LIMIT)?;
+    if old_rows.len() == IDENTITY_BACKUP_LIMIT {
+        // A corpus at exactly the cap almost certainly means rows beyond
+        // it were cut off by the SQL LIMIT -- and both the backup and the
+        // retirement pass below operate only on what was captured. Make
+        // the boundary loud instead of silently protecting (and retiring)
+        // a truncated set.
+        eprintln!(
+            "[legion whoami --generate --apply] WARNING: identity corpus for '{repo}' hit the \
+             backup scan cap ({IDENTITY_BACKUP_LIMIT} rows) -- rows beyond the cap are neither \
+             backed up nor retired by this apply. Audit `legion recall --repo {repo} --domain \
+             identity` before trusting this run's backup."
+        );
+    }
     let would_retire: Vec<String> = old_rows.iter().map(|r| r.id.clone()).collect();
     let backup_path = backup_dir.join(format!("identity-backup-{repo}-{}.json", Uuid::now_v7()));
 
@@ -372,9 +388,15 @@ pub fn apply(
     let chained_texts: Vec<&str> = manifest.chain.iter().map(String::as_str).collect();
     let swap = db.swap_identity_root(repo, manifest.root.trim(), &chained_texts, "self")?;
 
-    index.add(&swap.root.id, repo, &swap.root.text)?;
+    // Post-commit index writes are best-effort, same as the retirement
+    // pass below: the DB swap has already committed, so an index-side
+    // failure here must warn (recovery: `legion reindex`) rather than
+    // report the whole apply as failed -- a hard error would tell the
+    // calling agent the apply did not happen when `whoami` already shows
+    // the new root, inviting a re-run that churns identity ids.
+    warn_on_index_add_failure(index, &swap.root.id, repo, &swap.root.text);
     for child in &swap.children {
-        index.add(&child.id, repo, &child.text)?;
+        warn_on_index_add_failure(index, &child.id, repo, &child.text);
     }
 
     let retired_ids =
@@ -389,6 +411,23 @@ pub fn apply(
         backup_path,
         retired_ids,
     }))
+}
+
+/// Best-effort tantivy add for a row already committed to the database
+/// by `swap_identity_root`, warning (not failing) on error -- the new
+/// identity is already live in the DB, so an index straggler must not
+/// make `apply` report failure. `legion reindex` is the recovery path.
+fn warn_on_index_add_failure(index: &SearchIndex, id: &str, repo: &str, text: &str) {
+    if let Err(e) = index.add(id, repo, text) {
+        eprintln!(
+            "[legion whoami --generate --apply] WARNING: the identity swap committed but the \
+             tantivy index add failed for new row {id}.\n\
+             The new identity is live in the database (whoami shows it) but will not surface in \
+             BM25 recall results\n\
+             until the index is rebuilt. Run `legion reindex` to reconcile. Do NOT re-run apply.\n\
+             Underlying error: {e}"
+        );
+    }
 }
 
 /// Best-effort tantivy delete for an id already removed from the
@@ -903,11 +942,14 @@ mod tests {
     }
 
     #[test]
-    fn apply_removes_swap_deleted_root_from_search_index_not_just_the_database() {
+    fn apply_removes_all_retired_ids_from_search_index_not_just_the_database() {
         // Seed via reflect_from_text_with_meta (not insert_reflection_with_meta
-        // directly) so the old root actually lands in the search index too,
+        // directly) so the old rows actually land in the search index too,
         // the same as every real `legion reflect --whoami` write -- a
         // DB-only fixture would never exercise the index-sync path at all.
+        // Covers BOTH retirement branches: the swap-deleted root (index-only
+        // sync -- swap_identity_root never touches tantivy) and the leftover
+        // chain child (full db+index delete in retire_old_identity_rows).
         let (db, index, dir) = test_storage();
         let root_id = crate::reflect::reflect_from_text_with_meta(
             &db,
@@ -921,6 +963,18 @@ mod tests {
             },
         )
         .unwrap();
+        let child_id = crate::reflect::reflect_from_text_with_meta(
+            &db,
+            &index,
+            "legion",
+            "an old distinctive chapter about zanzibar gateways",
+            &ReflectionMeta {
+                domain: Some("identity".to_string()),
+                tags: None,
+                parent_id: Some(root_id.clone()),
+            },
+        )
+        .unwrap();
 
         let backup_dir = dir.path().join("backups");
         let manifest = IdentityManifest {
@@ -929,18 +983,52 @@ mod tests {
         };
         apply(&db, &index, "legion", &manifest, &backup_dir, false).unwrap();
 
-        // swap_identity_root deletes the old root from the database only
-        // (it never touches tantivy); apply() must still sync the index
-        // for every retired id, including the swap's own deletions, or
-        // the old root persists as a ghost document in BM25 results.
-        let hits = index
+        let root_hits = index
             .search("legion", "distinctive careful engineering", 10)
             .unwrap();
-        let hit_ids: Vec<&str> = hits.iter().map(|h| h.id.as_str()).collect();
+        let root_hit_ids: Vec<&str> = root_hits.iter().map(|h| h.id.as_str()).collect();
         assert!(
-            !hit_ids.contains(&root_id.as_str()),
-            "old root must not still be findable in the search index: {hit_ids:?}"
+            !root_hit_ids.contains(&root_id.as_str()),
+            "swap-deleted old root must not still be findable in the search index: {root_hit_ids:?}"
         );
+
+        let child_hits = index
+            .search("legion", "distinctive zanzibar gateways", 10)
+            .unwrap();
+        let child_hit_ids: Vec<&str> = child_hits.iter().map(|h| h.id.as_str()).collect();
+        assert!(
+            !child_hit_ids.contains(&child_id.as_str()),
+            "retired leftover chain child must not still be findable in the search index: {child_hit_ids:?}"
+        );
+    }
+
+    #[test]
+    fn apply_with_no_preexisting_identity_rows_bootstraps_cleanly() {
+        // Plausible first-run state: no prior identity at all. The apply
+        // must bootstrap (swap_identity_root handles the no-prior-root
+        // case), retire nothing, and still write a (empty-corpus) backup.
+        let (db, index, dir) = test_storage();
+        let backup_dir = dir.path().join("backups");
+        let manifest = IdentityManifest {
+            root: "first ever root".to_string(),
+            chain: vec!["first chapter".to_string()],
+        };
+        let result = apply(&db, &index, "legion", &manifest, &backup_dir, false).unwrap();
+        let outcome = match result {
+            ApplyResult::Applied(o) => o,
+            ApplyResult::Planned(_) => panic!("expected Applied"),
+        };
+
+        assert_eq!(outcome.new_ids.len(), 2);
+        assert!(outcome.retired_ids.is_empty());
+
+        let backed_up: Vec<Reflection> =
+            serde_json::from_str(&std::fs::read_to_string(&outcome.backup_path).unwrap()).unwrap();
+        assert!(backed_up.is_empty());
+
+        let roots = db.get_identity_roots("legion", 50).unwrap();
+        assert_eq!(roots.len(), 1);
+        assert_eq!(roots[0].text, "first ever root");
     }
 
     #[test]
@@ -999,5 +1087,51 @@ mod tests {
             .get_reflections_by_domain("legion", "identity", 500)
             .unwrap();
         assert_eq!(before.len(), after.len());
+    }
+
+    // -- retire_old_identity_rows: db-delete failure is warn-not-fail -------
+
+    #[test]
+    fn retire_old_identity_rows_warns_and_continues_when_a_db_delete_fails() {
+        // Exercises the `Err` branch of `db.delete_reflection` inside
+        // `retire_old_identity_rows` directly, rather than through `apply`
+        // -- there is no in-process way to force that specific race (the
+        // row vanishing between apply's initial capture and this cleanup
+        // pass) through the public API. A synthetic `Reflection` whose id
+        // was never actually inserted reproduces the same `Err` path
+        // deterministically: `delete_reflection` returns
+        // `LegionError::ReflectionNotFound` for any id it can't find,
+        // which is exactly the shape a genuine race would also produce.
+        let (db, index, dir) = test_storage();
+        let backup_path = dir.path().join("backups/unused.json");
+
+        let ghost_row = Reflection {
+            id: "00000000-0000-7000-8000-000000000000".to_string(),
+            repo: "legion".to_string(),
+            text: "never actually inserted".to_string(),
+            created_at: chrono::Utc::now().to_rfc3339(),
+            updated_at: None,
+            audience: "self".to_string(),
+            domain: Some("identity".to_string()),
+            tags: None,
+            recall_count: 0,
+            last_recalled_at: None,
+            parent_id: None,
+        };
+
+        // Must not panic despite the delete failing, and must not report
+        // the ghost id as retired -- it was never actually removed.
+        let retired_ids = retire_old_identity_rows(
+            &db,
+            &index,
+            std::slice::from_ref(&ghost_row),
+            &[],
+            &backup_path,
+        );
+
+        assert!(
+            !retired_ids.contains(&ghost_row.id),
+            "a row whose delete failed must not be reported as retired: {retired_ids:?}"
+        );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,6 +13,7 @@ mod etc;
 mod gate_trust;
 mod graph;
 mod health;
+mod identity_generate;
 mod init;
 mod inventory;
 #[allow(dead_code)] // Items used by tests + pending surface/status/serve migration
@@ -234,7 +235,24 @@ fn run() -> error::Result<()> {
         Commands::Now { banner: _, json } => cli::misc::handle_now(json)?,
         Commands::Init { force } => cli::misc::handle_init(force)?,
         Commands::Surface { repo } => cli::misc::handle_surface(repo)?,
-        Commands::Whoami { repo, limit } => cli::misc::handle_whoami(repo, limit)?,
+        Commands::Whoami {
+            repo,
+            limit,
+            generate,
+            vault_repo,
+            byline,
+            apply,
+            from_file,
+            dry_run,
+        } => {
+            if !generate {
+                cli::misc::handle_whoami(repo, limit)?
+            } else if apply {
+                cli::misc::handle_whoami_apply(repo, from_file, dry_run)?
+            } else {
+                cli::misc::handle_whoami_generate(repo, vault_repo, byline)?
+            }
+        }
         Commands::Whatami { repo, limit } => cli::misc::handle_whatami(repo, limit)?,
         Commands::Stats { repo } => cli::misc::handle_stats(repo)?,
         Commands::Telemetry { action } => cli::ops::handle_telemetry(action)?,

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -28,4 +28,5 @@ mod sym_tree;
 mod task;
 mod uncertainty;
 mod usage;
+mod whoami_generate;
 mod worksource_pr;

--- a/tests/integration/whoami_generate.rs
+++ b/tests/integration/whoami_generate.rs
@@ -1,0 +1,229 @@
+//! CLI end-to-end tests for `legion whoami --generate` (gather mode) and
+//! `legion whoami --generate --apply` (apply mode) (#784).
+//!
+//! The pure gather/apply/validate logic is unit-tested in
+//! `src/identity_generate.rs`; these tests exercise the actual binary
+//! surface: flag validation, the real `watch.toml` repo-resolution error
+//! path (`Database::data_dir()` caches its result in a process-wide
+//! `OnceLock`, so this can only be exercised from a fresh subprocess --
+//! see `src/identity_generate.rs::vault_repo_workdir`'s doc comment), a
+//! real `legion index` seeded file inventory, and the full gather -> author
+//! manifest -> apply --dry-run -> apply round trip.
+
+use crate::common::{legion_cmd, run_fail, run_ok};
+
+/// Seed a watch.toml in the data dir pointing at `repos` (name, workdir).
+fn seed_watch_toml(data_dir: &std::path::Path, repos: &[(&str, &std::path::Path)]) {
+    let mut toml = String::new();
+    for (name, workdir) in repos {
+        toml.push_str(&format!(
+            "[[repos]]\nname = \"{}\"\nworkdir = \"{}\"\n\n",
+            name,
+            workdir.display().to_string().replace('\\', "/")
+        ));
+    }
+    std::fs::write(data_dir.join("watch.toml"), toml).expect("seed watch.toml");
+}
+
+#[test]
+fn generate_without_vault_repo_or_byline_fails_loudly() {
+    let data_dir = tempfile::tempdir().expect("data dir");
+
+    let (_stdout, stderr) =
+        run_fail(legion_cmd(data_dir.path()).args(["whoami", "--repo", "legion", "--generate"]));
+    assert!(
+        stderr.contains("--vault-repo") || stderr.contains("--byline"),
+        "expected a flag-validation message naming the missing flag, got:\n{stderr}"
+    );
+}
+
+#[test]
+fn generate_apply_without_from_file_fails_loudly() {
+    let data_dir = tempfile::tempdir().expect("data dir");
+
+    let (_stdout, stderr) = run_fail(legion_cmd(data_dir.path()).args([
+        "whoami",
+        "--repo",
+        "legion",
+        "--generate",
+        "--apply",
+    ]));
+    assert!(
+        stderr.contains("--from-file"),
+        "expected a flag-validation message naming --from-file, got:\n{stderr}"
+    );
+}
+
+#[test]
+fn generate_unknown_vault_repo_returns_watch_config_error() {
+    let data_dir = tempfile::tempdir().expect("data dir");
+    let known_dir = tempfile::tempdir().expect("known dir");
+    seed_watch_toml(data_dir.path(), &[("known-repo", known_dir.path())]);
+
+    let (_stdout, stderr) = run_fail(legion_cmd(data_dir.path()).args([
+        "whoami",
+        "--repo",
+        "legion",
+        "--generate",
+        "--vault-repo",
+        "ghost-vault-repo",
+        "--byline",
+        "legion",
+    ]));
+    assert!(
+        stderr.contains("ghost-vault-repo") && stderr.contains("watch.toml"),
+        "expected a watch.toml repo-not-found message naming the repo, got:\n{stderr}"
+    );
+}
+
+#[test]
+fn generate_gathers_claimed_and_given_halves() {
+    let data_dir = tempfile::tempdir().expect("data dir");
+    let vault_dir = tempfile::tempdir().expect("vault dir");
+    let state_dir = tempfile::tempdir().expect("state dir");
+
+    // Date-titled filename, no byline substring in the path -- the exact
+    // case a filename-glob approach would miss.
+    std::fs::write(
+        vault_dir.path().join("2026-07-01-persistence.md"),
+        "---\nauthor: legion\n---\n\nPersistence is a discipline, not a feature.\n",
+    )
+    .expect("write claimed fixture");
+    std::fs::write(
+        vault_dir.path().join("unrelated.md"),
+        "---\nauthor: someone-else\n---\n\nnot a match\n",
+    )
+    .expect("write non-matching fixture");
+    seed_watch_toml(data_dir.path(), &[("vault-repo", vault_dir.path())]);
+
+    run_ok(
+        legion_cmd(data_dir.path())
+            .env("XDG_STATE_HOME", state_dir.path())
+            .args(["index", "vault-repo"]),
+    );
+
+    // A given-half reflection authored by a different repo about "legion".
+    run_ok(legion_cmd(data_dir.path()).args([
+        "reflect",
+        "--repo",
+        "rafters",
+        "--text",
+        "legion is careful about identity invariants",
+    ]));
+
+    let stdout = run_ok(legion_cmd(data_dir.path()).args([
+        "whoami",
+        "--repo",
+        "legion",
+        "--generate",
+        "--vault-repo",
+        "vault-repo",
+        "--byline",
+        "legion",
+    ]));
+
+    let bundle: serde_json::Value =
+        serde_json::from_str(stdout.trim()).expect("stdout is a JSON GatherBundle");
+    assert_eq!(bundle["repo"], "legion");
+    assert_eq!(bundle["vault_repo"], "vault-repo");
+    let claimed = bundle["claimed"].as_array().expect("claimed array");
+    assert_eq!(
+        claimed.len(),
+        1,
+        "expected exactly one claimed match: {claimed:?}"
+    );
+    assert_eq!(claimed[0]["path"], "2026-07-01-persistence.md");
+    assert_eq!(claimed[0]["byline"], "legion");
+    assert!(
+        claimed[0]["body"]
+            .as_str()
+            .unwrap()
+            .contains("Persistence is a discipline"),
+        "expected the full file body, got: {claimed:?}"
+    );
+}
+
+#[test]
+fn apply_dry_run_then_full_apply_round_trip() {
+    let data_dir = tempfile::tempdir().expect("data dir");
+
+    // Seed an old identity root so the swap has something to replace.
+    run_ok(legion_cmd(data_dir.path()).args([
+        "reflect",
+        "--repo",
+        "gen-test-repo",
+        "--text",
+        "old identity root",
+        "--whoami",
+    ]));
+
+    let manifest_path = data_dir.path().join("manifest.json");
+    std::fs::write(
+        &manifest_path,
+        serde_json::json!({
+            "root": "a careful builder of durable systems",
+            "chain": ["learned that backups come before deletes"]
+        })
+        .to_string(),
+    )
+    .expect("write manifest");
+
+    // --dry-run: reports the plan, writes nothing.
+    let dry_run_out = run_ok(legion_cmd(data_dir.path()).args([
+        "whoami",
+        "--repo",
+        "gen-test-repo",
+        "--generate",
+        "--apply",
+        "--from-file",
+        manifest_path.to_str().unwrap(),
+        "--dry-run",
+    ]));
+    let planned: serde_json::Value =
+        serde_json::from_str(dry_run_out.trim()).expect("stdout is a JSON ApplyPlan");
+    assert_eq!(planned["would_create"], 2);
+    let would_retire = planned["would_retire"]
+        .as_array()
+        .expect("would_retire array");
+    assert_eq!(would_retire.len(), 1);
+    let backup_path = planned["backup_path"].as_str().expect("backup_path string");
+    assert!(
+        !std::path::Path::new(backup_path).exists(),
+        "dry-run must not write a backup file"
+    );
+
+    // Real apply: root replaced, chain in place, old root retired.
+    let apply_out = run_ok(legion_cmd(data_dir.path()).args([
+        "whoami",
+        "--repo",
+        "gen-test-repo",
+        "--generate",
+        "--apply",
+        "--from-file",
+        manifest_path.to_str().unwrap(),
+    ]));
+    let applied: serde_json::Value =
+        serde_json::from_str(apply_out.trim()).expect("stdout is a JSON ApplyOutcome");
+    let new_ids = applied["new_ids"].as_array().expect("new_ids array");
+    assert_eq!(new_ids.len(), 2);
+    let retired_ids = applied["retired_ids"]
+        .as_array()
+        .expect("retired_ids array");
+    assert_eq!(retired_ids.len(), 1);
+    let applied_backup_path = applied["backup_path"].as_str().expect("backup_path string");
+    assert!(
+        std::path::Path::new(applied_backup_path).exists(),
+        "apply must write the pre-apply backup file"
+    );
+
+    let whoami_out =
+        run_ok(legion_cmd(data_dir.path()).args(["whoami", "--repo", "gen-test-repo"]));
+    assert!(
+        whoami_out.contains("a careful builder of durable systems"),
+        "expected the new root text in whoami output, got:\n{whoami_out}"
+    );
+    assert!(
+        !whoami_out.contains("old identity root"),
+        "old identity root must be retired, got:\n{whoami_out}"
+    );
+}

--- a/tests/integration/whoami_generate.rs
+++ b/tests/integration/whoami_generate.rs
@@ -141,6 +141,21 @@ fn generate_gathers_claimed_and_given_halves() {
             .contains("Persistence is a discipline"),
         "expected the full file body, got: {claimed:?}"
     );
+
+    // given-half: the cross-agent "rafters" reflection about "legion"
+    // must surface via the real recall::consult (BM25-or-hybrid) path --
+    // asserted end-to-end, not just via the unit-level gather_given_half
+    // tests, since this is the only place the real consult wiring
+    // (including whichever embed-model branch this environment takes) is
+    // exercised through the actual binary.
+    let given = bundle["given"].as_array().expect("given array");
+    assert!(
+        given.iter().any(|g| g["repo"] == "rafters"
+            && g["text"]
+                .as_str()
+                .is_some_and(|t| t.contains("careful about identity invariants"))),
+        "expected the cross-repo rafters reflection in given: {given:?}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
Closes #784.

## Summary

Adds `legion whoami --generate` (gather mode: claimed-half via file
inventory + frontmatter `author` matching, given-half via hybrid/BM25
consult) and `legion whoami --generate --apply` (apply mode: guarded
identity-chain replacement from an authored `IdentityManifest`).

Per the issue's Build Notes (blocking correction, verified against
`src/db/reflections.rs` at HEAD), apply mode does NOT insert-then-
delete. It consumes #785's `Database::swap_identity_root` -- a single
transaction that deletes the old identity root(s) and inserts the new
root plus chained children together, so there is never a two-live-
roots state (which the insert-time `IdentityRootExists` guard would
refuse) or an observable zero-root window.

## Acceptance criteria mapping

### All tests pass

`cargo test` passes in full: 1498 unit tests via `cargo test --bin
legion` plus 329 integration tests via `cargo test --test integration`,
0 failed, 2 ignored (pre-existing, unrelated to this change), run with
`--test-threads=4` after two unrelated pre-existing tests
(`serve::tests::serve_refuses_port_held_by_live_daemon_with_pointer`,
`worksource::tests::call_plugin_timeout::*`) flaked once under full
parallelism from port/process contention on a shared machine -- both
pass individually and neither file is touched by this diff.
`cargo clippy --all-targets -- -D warnings` and `cargo fmt -- --check`
are both clean.
Evidence: `src/identity_generate.rs` `#[cfg(test)] mod tests` (27
tests) and `tests/integration/whoami_generate.rs` (5 tests) both
green.

### Simplify pass completed

`legion quality-gate check --skill legion-simplify` recorded a passing
gate (result `issues`, per-file located evidence across all 8 changed
files -- `src/identity_generate.rs`, `src/cli/misc.rs`,
`src/cli/mod.rs`, `src/main.rs`, `src/error.rs`,
`src/db/reflections.rs`, `tests/integration/main.rs`,
`tests/integration/whoami_generate.rs`).
Evidence: `fn retire_old_identity_rows`, `fn warn_on_index_add_failure`,
and `fn sanitize_filename_component` (`src/identity_generate.rs`) are
the extracted, single-responsibility results of that pass, replacing
inline logic.

### Review pass completed and issues fixed

Three review passes ran across two pre-commit/pre-push hook stages,
each catching real issues fixed before this PR -- full detail in
"Review-caught issues, fixed before this PR" below:

1. Pre-commit (commit `b820eac`): `swap_identity_root` deletes are
   DB-only, so old identity roots were never removed from the tantivy
   search index -- fixed with a new regression test before that
   commit landed.
2. Pre-push, round 1 (commit `ad225b2`): post-commit `index.add` calls
   hard-failing after the DB swap had already committed
   (mis-reporting a succeeded apply as failed), plus a test-coverage
   gap around post-commit/retirement failure paths.
3. Pre-push, round 2 (commit `71202c4` plus this PR's final commit):
   `repo` flowing unsanitized into the backup filename (path-traversal
   hardening), plus the given-half consult path having no end-to-end
   assertion.

Evidence: `fn warn_on_index_add_failure`,
`fn retire_old_identity_rows_warns_and_continues_when_a_db_delete_fails`,
`fn sanitize_filename_component` (`src/identity_generate.rs`), and the
given-half assertion in
`generate_gathers_claimed_and_given_halves`
(`tests/integration/whoami_generate.rs`) -- all added in response to
review findings.

### PR created and linked to this issue

This pull request, opened with `Closes #784` at the top of this body,
against branch `feat/784-whoami-generate`.
Evidence: the `Closes #784` line at the top of this document; commits
`b820eac`, `ad225b2`, `71202c4`, and this PR's final commit on this
branch.

## Requirements -> implementation mapping

### Interface (`src/cli/mod.rs`, `src/main.rs`)

- `Whoami` variant extended with `generate`, `vault_repo`, `byline`,
  `apply`, `from_file`, `dry_run` exactly as specified --
  `src/cli/mod.rs:428-465`.
- `Commands::Whoami` dispatch arm three-way branches on
  (generate, apply) into `handle_whoami` / `handle_whoami_apply` /
  `handle_whoami_generate` -- `src/main.rs:237-253`.
- `src/identity_generate.rs` (new module): `GatherBundle`,
  `ClaimedSource`, `GivenSource`, `IdentityManifest`, `ApplyOutcome`,
  `ApplyPlan`, `ApplyResult`, `gather()`, `validate_manifest()`,
  `apply()`, `IDENTITY_BACKUP_LIMIT` / `GIVEN_HALF_LIMIT` constants --
  all present, matching the spec'd shapes (lines 28-121 for
  types/constants, 123 `gather`, 281 `validate_manifest`, 347 `apply`).
- **Deviation (Build Notes-directed)**: `gather`'s `embed_model`
  parameter is `Option<&EmbedModel>`, not `&EmbedModel`, per the Build
  Notes' explicit correction citing `src/cli/memory.rs:372-375`'s
  `try_load_embed_model` Some/None precedent --
  `src/identity_generate.rs:123-133` (`gather`) and `:244-278`
  (`gather_given_half`, which branches `recall::consult` vs
  `recall::consult_bm25` on the option). CLI wiring:
  `src/cli/misc.rs` `handle_whoami_generate` calls
  `cli::memory::try_load_embed_model()`.
- **Deviation (Build Notes-directed)**: `apply` does not do
  insert-then-verify-then-delete. It calls
  `db.swap_identity_root(...)` (src/identity_generate.rs:373), the
  #785 transactional primitive, then syncs the search index (which
  `swap_identity_root` never touches) and retires any leftover
  non-root chain children the swap's deliberately non-cascading delete
  didn't remove (`retire_old_identity_rows`, :429-464). New error
  variant `LegionError::WhoamiGenerate(String)` placed immediately
  after `Etc` -- `src/error.rs:105-108`.

### Gather mode behavior

- Enumeration filtered to `md`/`mdx`/`astro` only, never by a
  byline-derived filename glob -- `CLAIMED_HALF_EXTENSIONS`
  (identity_generate.rs:44) and the ext check at :189. Test:
  `gather_claimed_half_finds_date_titled_file_by_frontmatter_not_filename`
  (:550) seeds a date-titled file with no byline substring in the path
  whose frontmatter `author` matches, and asserts it's found -- both
  as a unit test and end-to-end via
  `tests/integration/whoami_generate.rs`'s
  `generate_gathers_claimed_and_given_halves`.
- `extract_field(path, "author")` gates each candidate; byline match
  is a case-sensitive exact match against a string or array-of-strings
  value, matched byline recorded on `ClaimedSource::byline` --
  `matching_byline` (:226-236). Tests:
  `matching_byline_string_exact_match`,
  `matching_byline_array_match`, `matching_byline_case_sensitive`
  (case-sensitivity explicitly asserted), plus
  `gather_claimed_half_filters_by_frontmatter_author_not_all_files`
  (:573) for the two-files-one-matches CLI-shaped scenario.
- A candidate whose `extract_field` fails is silently skipped, not an
  error -- the `let Ok(...) = ... else { continue }` at
  identity_generate.rs:196-198. Test:
  `gather_claimed_half_skips_file_with_no_frontmatter` (:596).
- `ClaimedSource::body` is the full file content
  (`std::fs::read_to_string`, :204), not an excerpt. Test:
  `gather_claimed_half_body_is_byte_identical_to_fixture` (:618)
  asserts byte-identical against a multi-paragraph fixture.
- Empty `claimed` after filtering returns
  `LegionError::WhoamiGenerate` naming both `vault_repo` and the
  searched `bylines` -- :210-215. Test:
  `gather_claimed_half_empty_returns_whoami_generate_error` (:636)
  asserts on the variant and that the message contains both.
- `given` populated via hybrid-consult-style query against
  `"<repo> <bylines...>"`, filtered to exclude `entry.repo == repo` --
  `gather_given_half` (:244-278). Test:
  `gather_given_half_excludes_self_repo` (:661) seeds a self-repo and
  a cross-repo reflection both mentioning the query and asserts only
  the cross-repo one survives.
- Empty `given` is not an error -- `gather_given_half_empty_is_not_an_error`
  (:676).
- Unknown `vault_repo` returns `LegionError::WatchConfig`, matching
  `sym etc find-content`/`find-file`'s pattern (`resolve_vault_repo_workdir`,
  :160-170, reused by the impure `vault_repo_workdir` wrapper at
  :151-158). Unit test:
  `resolve_vault_repo_workdir_unknown_repo_returns_watch_config_error`
  (:701) against the pure lookup (kept pure deliberately -- `data_dir()`
  caches in a process-wide `OnceLock` per its own doc comment, so the
  real end-to-end path needs a fresh subprocess). CLI end-to-end:
  `tests/integration/whoami_generate.rs`'s
  `generate_unknown_vault_repo_returns_watch_config_error`.

### Apply mode behavior

- `validate_manifest` rejects empty/whitespace `root`
  (identity_generate.rs:282-286, test `validate_manifest_rejects_empty_root`
  :723), oversized `root` naming both the actual length and the cap
  (:287-293, test `validate_manifest_rejects_oversized_root` :733 at
  cap+1 byte), and "what i am" (case-insensitive) in `root` or any
  `chain[i]`, naming which entry failed (:294-305, test
  `validate_manifest_rejects_forbidden_phrase_in_chain_names_index`
  :749 asserts the message names `chain[1]`, not `root`). Empty chain
  is valid (:768).
- Invalid manifest performs zero backup writes and zero DB changes --
  `validate_manifest(manifest)?` is the first line of `apply`
  (:355), strictly before the `get_reflections_by_domain` capture.
  Test: `apply_invalid_manifest_writes_nothing_and_changes_nothing`
  (:779) asserts no file at the computed backup path and an unchanged
  row count.
- Backup writes the FULL pre-existing `domain=identity` corpus (via
  `get_reflections_by_domain`, not `get_identity_roots`) before any
  insert/delete -- :357, :369-370. Test:
  `apply_writes_backup_containing_root_and_chain_child_before_any_change`
  (:812) seeds a root + a follows-child and asserts the backup file
  contains both.
- New root + chain inserted via `swap_identity_root`, one transaction
  -- :373. Test: `apply_chain_order_matches_manifest` (:947) asserts
  `db.get_chain(new_root_id)` returns root, then each chain entry, in
  order.
- On success, exactly one identity root exists and every id captured
  in the pre-apply backup is gone -- `apply_replaces_root_and_retires_every_old_id_including_dangling_children`
  (:855) asserts `get_identity_roots` returns exactly the new root and
  both the old root and its dangling `--follows` child are
  `get_reflection_by_id`-absent afterward.
- `--dry-run` performs zero inserts/deletes/file-writes and returns
  `Planned` with `would_retire` == the captured old ids and
  `would_create` == `1 + chain.len()` -- :361-367. Test:
  `apply_dry_run_changes_nothing_and_writes_no_file` (:966), plus CLI
  end-to-end in `apply_dry_run_then_full_apply_round_trip`.

### Error handling

- `WhoamiGenerate(String)` covers gather-mode flag validation
  (`src/cli/misc.rs` `handle_whoami_generate`), zero claimed-half
  matches, all `validate_manifest` failures, and CLI-layer
  `--from-file`/`--vault-repo`/`--byline` validation
  (`handle_whoami_apply`/`handle_whoami_generate`).
- Unknown `vault_repo` reuses `LegionError::WatchConfig` (see above).
- Per-file `extract_field` failures are caught, not propagated (see
  above); only a `list_file_inventory` DB error propagates as
  `LegionError::Database`.
- File I/O (vault file reads, backup file write) propagates through
  the existing `LegionError::Io`.

## Review-caught issues, fixed before this PR (worth flagging explicitly)

The pre-commit hook's nested review caught a real bug on the first
commit attempt: `swap_identity_root` only touches the database (never
tantivy), so the old identity root(s) it deletes were never
`index.delete`d -- they'd persist as ghost documents in BM25
recall/consult results until a manual `legion reindex`, contradicting
this module's own "sync the index for every retired id" contract.
Fixed by splitting the retire helper (renamed
`retire_leftover_old_rows` -> `retire_old_identity_rows`) into two
explicit passes -- index-only sync for the swap's own database-deleted
root(s), full db+index delete for genuine leftover chain children --
and a regression test that seeds via `reflect_from_text_with_meta` (so
rows actually land in tantivy, unlike the DB-only fixtures the other
apply tests use) and asserts `index.search` no longer returns them
after apply.

The pre-push review then raised two HIGH (non-blocking, per the
review's own verdict) findings, both fixed in the follow-up commit
(`fix(#784): address pre-push review HIGHs`), plus a third,
proactive hardening made while addressing them:

1. **[HIGH, from review]** `apply`'s post-commit `index.add(...)?`
   calls hard-failed after the DB swap had already committed -- the
   command reported failure while `whoami` already showed the new
   root, inviting an id-churning re-run. Now routed through
   `warn_on_index_add_failure` (symmetric with
   `warn_on_index_delete_failure`, explicit "Do NOT re-run apply"
   guidance); `apply`'s step-7 doc comment now states the whole
   post-commit index phase is best-effort with `legion reindex` as the
   recovery path.
2. **[HIGH, from review]** Test gaps: the index-sync regression test
   grew into
   `apply_removes_all_retired_ids_from_search_index_not_just_the_database`
   covering BOTH retirement branches (swap-deleted root index-only
   sync AND leftover chain child db+index delete);
   `apply_with_no_preexisting_identity_rows_bootstraps_cleanly` covers
   the first-run bootstrap state (empty `retired_ids`, empty-corpus
   backup still written, exactly one root after); and
   `retire_old_identity_rows_warns_and_continues_when_a_db_delete_fails`
   exercises the `delete_reflection` `Err` branch directly, asserting
   warn-and-continue neither panics nor falsely reports the id as
   retired.
3. **[proactive, not review-flagged]** Silent truncation at
   `IDENTITY_BACKUP_LIMIT`: `old_rows.len() == IDENTITY_BACKUP_LIMIT`
   now emits a loud warning that rows beyond the cap are neither
   backed up nor retired, instead of silently protecting a capped set.
   Added while addressing the two findings above, not itself a review
   finding -- flagging the distinction for accuracy.

A third pre-push review pass raised a HIGH (path-traversal hardening)
and a coverage gap, both fixed:

4. **[HIGH, from review]** `repo` flowed unsanitized into the backup
   filename (`format!("identity-backup-{repo}-...")`); a `repo` value
   carrying `/` or a `..` segment would be interpreted by `Path::join`
   as path structure and could relocate the recovery file outside
   `backup_dir`. Added `sanitize_filename_component` (every char
   outside `[A-Za-z0-9._-]` becomes `-`) at the single `backup_path`
   construction site, plus
   `apply_backup_path_stays_inside_backup_dir_for_hostile_repo_name`
   (asserts the backup lands inside `backup_dir` for a
   `"../../escape/attempt"`-shaped repo) and
   `sanitize_filename_component_neutralizes_separators`.
5. **[coverage gap, from review]** The given-half (cross-agent
   `recall::consult` path) was asserted only at the unit level with
   `embed_model: None` -- the real CLI binary's consult wiring
   (including whichever embed-model branch the runtime environment
   takes) had no end-to-end assertion.
   `generate_gathers_claimed_and_given_halves`
   (`tests/integration/whoami_generate.rs`) now also asserts the
   seeded cross-repo `rafters` reflection appears in `bundle["given"]`.

## Non-blocking review notes (not fixed, flagging per doctrine)

1. `validate_manifest` does not byte-cap or empty-check `chain`
   entries (only the forbidden-phrase check applies to them), matching
   the issue's literal spec, which only requires the byte cap and
   empty check on `root`. Chain children never render in the boot
   banner (`get_domain_roots` excludes them), which is what
   `WHOAMI_BYTE_CAP` protects -- but an empty-string chain entry would
   still insert as a blank follows-child. Left as spec'd; flag if this
   should be tightened.
2. On a `swap_identity_root` failure after the backup write, the
   backup file is left orphaned on disk (harmless; accumulates in the
   backup dir). Left as-is -- an orphaned backup of a swap that did
   NOT happen is arguably the safest artifact to keep, not clean up.
3. `gather_given_half` excludes only `entry.repo == repo`; a
   self-authored reflection stored under a different repo would still
   count as given-half. Matches the issue's literal filter spec
   (`entry.repo == repo` is the stated exclusion).
4. `gather_claimed_half`'s per-candidate handling is intentionally
   asymmetric: an `extract_field` parse failure is silently skipped,
   but `std::fs::read_to_string` failing on an already-matched file
   propagates as a hard `LegionError::Io`. The third review pass
   flagged this as a HIGH; left as-is because the issue's Error
   Handling section explicitly specifies "File I/O for reading vault
   files ... propagates through the existing `LegionError::Io`" --
   changing this to skip-with-warn would deviate from that spec, not
   fix a bug. Flag if the spec itself should change.
5. `apply` step 6/7 non-atomicity: if the process dies after
   `swap_identity_root` commits but before `retire_old_identity_rows`
   finishes, leftover old `--follows` children can survive with a
   `parent_id` pointing at a deleted root. Acknowledged, matches the
   issue's own stated design (best-effort retirement, backup file is
   the recovery path) -- explicit reviewer sign-off requested per the
   third review pass's framing, not a code change.
6. `warn_on_index_add_failure` and the `IDENTITY_BACKUP_LIMIT`
   cap-warning branch have no dedicated unit test forcing that
   specific failure (tantivy write failure / a 500-row corpus are both
   impractical to synthesize in-process). The third review pass noted
   this as acceptable to leave; flagging per doctrine rather than
   silently accepting.
7. A fourth review pass reconfirmed (1) and (6) above and additionally
   noted `--generate --apply` silently accepts and ignores
   `--vault-repo`/`--byline` (clap's `requires = "generate"` allows
   them alongside `--apply`, but `handle_whoami_apply` never reads
   them). Not a correctness issue -- gather-only flags simply have no
   effect in apply mode -- but flagged as a UX foot-gun worth a
   `conflicts_with` or a doc note in a follow-up.

## Not done (explicit, out-of-scope items from the issue, honored)

- The domain=identity orphan-root guard gap -- separate issue per the
  issue's own Out of Scope section.
- Any LLM-driven authoring inside the binary -- `gather` is pure
  retrieval, `apply` is pure write; the calling agent authors the
  `IdentityManifest`.
- `pre-whoami-rewrite.sh` hook changes -- apply calls
  `swap_identity_root`/index directly, not through `legion reflect
  --whoami`, so the existing hook is untouched and doesn't intercept
  it, as the issue specifies.
- `legion whatami --generate` -- domain=workflow equivalent, out of
  scope per the issue.
- Scheduling/hook-triggered auto-`--generate` -- manual invocation
  only, per the issue.
- A `--pattern` narrowing flag for gather's enumeration -- not added,
  per the issue's explicit Out of Scope.

## Test evidence

- `cargo test` (unit): 1498 passed, 0 failed, 2 ignored (27 in
  `identity_generate::tests`).
- `cargo test --test integration`: 329 passed, 0 failed, 2 ignored
  (includes the 5 `tests/integration/whoami_generate.rs` tests).
- `cargo clippy --all-targets -- -D warnings`: clean.
- `cargo fmt -- --check`: clean.
