### PR TITLE
feat(#773): finding-resolution gate -- findings ledger, git-log resolution, clean-refusal

### DIFF
--- a/plugin/skills/legion-review/SKILL.md
+++ b/plugin/skills/legion-review/SKILL.md
@@ -85,7 +85,10 @@ without guessing.
    2. A HIGH/MED finding from a PRIOR review run on this branch is still PENDING (neither a later
       commit touched its file nor was it explicitly dispositioned), or a prior LOW finding is
       still un-acked. Reconciliation against git log runs automatically at record time -- a fix
-      already landed in an earlier commit clears itself before this check runs.
+      already landed in an earlier commit clears itself before this check runs. **Resolution is
+      file-level, not content-aware**: ANY later commit touching the flagged file clears it, even
+      an unrelated edit -- on an active branch this can auto-resolve a finding nobody deliberately
+      addressed. Disposition explicitly if that distinction matters for a given finding.
 
    For anything still open in either case: `legion quality-gate finding-disposition --id
    <finding-id> --reason "won't fix: ..."` for a single finding, or `legion quality-gate

--- a/plugin/skills/legion-review/SKILL.md
+++ b/plugin/skills/legion-review/SKILL.md
@@ -73,17 +73,28 @@ without guessing.
    The gate is keyed on HEAD, so a new commit after review invalidates it -- re-run after
    fixes, exactly like the simplify gate.
 
-   **`--result clean` is refused (#773)** when a HIGH/MED finding from a PRIOR review run on this
-   branch is still PENDING (neither a later commit touched its file nor was it explicitly
-   dispositioned), or a LOW finding is still un-acked. Reconciliation runs automatically at record
-   time -- a fix already landed in an earlier commit clears itself. For anything still open:
-   `legion quality-gate finding-disposition --id <finding-id> --reason "won't fix: ..."` for a
-   single finding, or `legion quality-gate finding-ack --branch <branch> --skill legion-review
-   --reason "..."` to batch-clear a sweep of LOW findings. `legion quality-gate finding-list
-   --branch <branch> --skill legion-review` lists ids and current status. An `approved` decision
-   with non-blocking findings that are neither fixed nor dispositioned is exactly the hand-wave
-   this refusal exists to stop -- do not treat `approved` as license to skip step 5's ledger
-   bookkeeping just because the decision itself does not require a fix-and-re-review round.
+   **`--result clean` is refused (#773) in TWO cases, and the `approved && non-blocking findings`
+   case -- the one this issue exists to close -- is the first, not the second:**
+   1. **This same call's `findings[]` is non-empty.** An `approved` decision that still names
+      surviving LOW/MED findings in its sign-off must NOT be recorded with `--result clean` in
+      the same breath as reporting them -- record `--result issues` first (identical
+      `--details-json`, so the findings are persisted), then disposition or batch-ack each one,
+      THEN re-run `--result clean` with `findings[]` empty (or omit `--details-json`'s
+      `findings` key entirely). A clean call cannot carry its own findings, full stop -- there is
+      no "but they're only LOW" exception at this step.
+   2. A HIGH/MED finding from a PRIOR review run on this branch is still PENDING (neither a later
+      commit touched its file nor was it explicitly dispositioned), or a prior LOW finding is
+      still un-acked. Reconciliation against git log runs automatically at record time -- a fix
+      already landed in an earlier commit clears itself before this check runs.
+
+   For anything still open in either case: `legion quality-gate finding-disposition --id
+   <finding-id> --reason "won't fix: ..."` for a single finding, or `legion quality-gate
+   finding-ack --branch <branch> --skill legion-review --reason "..."` to batch-clear a sweep of
+   LOW findings. `legion quality-gate finding-list --branch <branch> --skill legion-review` lists
+   ids and current status. An `approved` decision with non-blocking findings that are neither
+   fixed nor dispositioned is exactly the hand-wave this refusal exists to stop -- do not treat
+   `approved` as license to skip the disposition/ack step just because the decision itself does
+   not require a fix-and-re-review round.
 
 6. **Report.** Emit the consolidated REVIEW REPORT (the agent definition's format): decision,
    per-dimension one-liners, surviving findings with file:line and fix suggestions, refuted

--- a/plugin/skills/legion-review/SKILL.md
+++ b/plugin/skills/legion-review/SKILL.md
@@ -63,8 +63,27 @@ without guessing.
      --details-json '<JSON: decision, findings[], refuted_count, dimensions_run>'
    ```
 
+   `findings[]`'s schema is pinned (#773) -- each entry MUST be
+   `{"file": "<path>", "line": <int or null>, "severity": "HIGH"|"MED"|"LOW", "summary": "<one-line
+   problem statement>"}`. This is what the finding-resolution ledger extracts and tracks toward
+   resolved-or-dispositioned; an entry missing any of these keys is silently dropped from the
+   ledger (the gate's own `--findings-count` stays the source of truth for the run, but that
+   individual finding will never surface for disposition).
+
    The gate is keyed on HEAD, so a new commit after review invalidates it -- re-run after
    fixes, exactly like the simplify gate.
+
+   **`--result clean` is refused (#773)** when a HIGH/MED finding from a PRIOR review run on this
+   branch is still PENDING (neither a later commit touched its file nor was it explicitly
+   dispositioned), or a LOW finding is still un-acked. Reconciliation runs automatically at record
+   time -- a fix already landed in an earlier commit clears itself. For anything still open:
+   `legion quality-gate finding-disposition --id <finding-id> --reason "won't fix: ..."` for a
+   single finding, or `legion quality-gate finding-ack --branch <branch> --skill legion-review
+   --reason "..."` to batch-clear a sweep of LOW findings. `legion quality-gate finding-list
+   --branch <branch> --skill legion-review` lists ids and current status. An `approved` decision
+   with non-blocking findings that are neither fixed nor dispositioned is exactly the hand-wave
+   this refusal exists to stop -- do not treat `approved` as license to skip step 5's ledger
+   bookkeeping just because the decision itself does not require a fix-and-re-review round.
 
 6. **Report.** Emit the consolidated REVIEW REPORT (the agent definition's format): decision,
    per-dimension one-liners, surviving findings with file:line and fix suggestions, refuted

--- a/plugin/skills/legion-simplify/SKILL.md
+++ b/plugin/skills/legion-simplify/SKILL.md
@@ -111,14 +111,16 @@ Error paths propagate via `?`. No stringly-typed state. Verdict: clean.
      --articulation-file /tmp/simplify-<branch>.md \
      --findings-json '[{"file": "src/foo.rs", "line": 42, "severity": "MED", "summary": "duplicate WHERE-clause construction"}]'
    ```
-   `--findings-json` is optional and omitted for a clean verdict with nothing to track.
-   `--findings-count` is the number of real structural findings you recorded (0 for a clean
-   verdict). The validator resolves the changed-file set from git, checks every file has a
-   non-boilerplate entry, then records the gate for HEAD.
-   - Clean -> the gate is recorded; proceed to pr-write. **Refused instead** when a HIGH/MED
+   `--findings-json` is optional and MUST be omitted (or empty) for a `--result clean` call --
+   passing findings alongside `--result clean` in the same call is refused (#773, see below), not
+   silently accepted. `--findings-count` is the number of real structural findings you recorded
+   (0 for a clean verdict). The validator resolves the changed-file set from git, checks every
+   file has a non-boilerplate entry, then records the gate for HEAD.
+   - Clean -> the gate is recorded; proceed to pr-write. **Refused instead** when: this same call's
+     `--findings-json` is non-empty (a clean verdict cannot carry its own findings), OR a HIGH/MED
      finding from a PRIOR run on this branch is still PENDING (neither a later commit touched its
-     file nor was it explicitly dispositioned), or a LOW finding is still un-acked (#773) -- see
-     "Finding resolution" below.
+     file nor was it explicitly dispositioned), OR a prior LOW finding is still un-acked (#773) --
+     see "Finding resolution" below.
    - Refused (coverage/substance) -> the output names the gap (an unaddressed file, a boilerplate
      entry). Fix it by actually reading that file and writing real reasoning -- do not pad to clear
      the check. Re-run.
@@ -140,9 +142,10 @@ in the findings ledger as PENDING until one of:
   `legion quality-gate finding-ack --branch <branch> --skill legion-simplify --reason "formatting only, deferred"`.
 
 Find finding ids with `legion quality-gate finding-list --branch <branch> --skill legion-simplify`.
-A `clean` verdict is refused until the PENDING set for this branch+skill is empty -- writing a
-finding down and then recording clean on a later commit without resolving or dispositioning it is
-exactly the hand-wave this closes.
+A `clean` verdict is refused until the PENDING set for this branch+skill is empty AND this call's
+own `--findings-json` is empty -- writing a finding down and then recording clean on a LATER commit
+without resolving or dispositioning it is one hand-wave this closes; recording clean in the SAME
+call you report the finding in is the other, and is refused just as hard.
 
 ## Pass Criteria for `legion pr create`
 

--- a/plugin/skills/legion-simplify/SKILL.md
+++ b/plugin/skills/legion-simplify/SKILL.md
@@ -134,7 +134,12 @@ in the findings ledger as PENDING until one of:
 
 - **Resolved automatically** -- a later commit on this branch touches the flagged file. Detected
   by git log at the next `quality-gate check`/`record` call; you do not need to do anything extra
-  beyond committing the fix.
+  beyond committing the fix. **Coarse by design:** this is file-level, not content-aware -- ANY
+  commit that touches the flagged file resolves the finding, even an unrelated edit elsewhere in
+  it, not only one that fixes the specific problem. On an active branch a file gets re-touched for
+  many reasons, so a finding can auto-resolve without ever being deliberately addressed. If that
+  matters for a specific finding, disposition or batch-ack it explicitly instead of relying on
+  auto-resolution to be a stand-in for "someone looked at this."
 - **Dispositioned** -- you decide not to fix it and say why:
   `legion quality-gate finding-disposition --id <finding-id> --reason "won't fix: intentional, see X"`.
 - **Batch-acked** -- for a sweep of LOW/cosmetic findings only, one shared reason clears all of

--- a/plugin/skills/legion-simplify/SKILL.md
+++ b/plugin/skills/legion-simplify/SKILL.md
@@ -96,29 +96,61 @@ Error paths propagate via `?`. No stringly-typed state. Verdict: clean.
 2. For EACH changed file: read it, review its hunks against the categories above, and write its
    `### <path>` entry with real reasoning.
 3. Write the articulation to a file (e.g. `/tmp/simplify-<branch>.md`).
-4. Validate and record:
+4. If your verdict has real findings (`--result issues`), also write them as structured JSON --
+   one object per finding, `{"file": "<path>", "line": <int or null>, "severity": "HIGH"|"MED"|"LOW",
+   "summary": "<one-line problem statement>"}`. This is separate from the prose articulation: the
+   articulation is for a human/reviewer to read, the structured array is what the finding-resolution
+   ledger (#773) tracks toward resolved-or-dispositioned. The prose is NOT parsed for findings --
+   only this array is.
+5. Validate and record:
    ```bash
    legion quality-gate check \
      --skill legion-simplify \
      --result <clean|issues> \
      --findings-count <N> \
-     --articulation-file /tmp/simplify-<branch>.md
+     --articulation-file /tmp/simplify-<branch>.md \
+     --findings-json '[{"file": "src/foo.rs", "line": 42, "severity": "MED", "summary": "duplicate WHERE-clause construction"}]'
    ```
+   `--findings-json` is optional and omitted for a clean verdict with nothing to track.
    `--findings-count` is the number of real structural findings you recorded (0 for a clean
    verdict). The validator resolves the changed-file set from git, checks every file has a
    non-boilerplate entry, then records the gate for HEAD.
-   - Clean -> the gate is recorded; proceed to pr-write.
-   - Refused -> the output names the gap (an unaddressed file, a boilerplate entry). Fix it by
-     actually reading that file and writing real reasoning -- do not pad to clear the check. Re-run.
-5. If your verdict is `issues`, fix the findings, then re-run from step 1 on the new HEAD (the
+   - Clean -> the gate is recorded; proceed to pr-write. **Refused instead** when a HIGH/MED
+     finding from a PRIOR run on this branch is still PENDING (neither a later commit touched its
+     file nor was it explicitly dispositioned), or a LOW finding is still un-acked (#773) -- see
+     "Finding resolution" below.
+   - Refused (coverage/substance) -> the output names the gap (an unaddressed file, a boilerplate
+     entry). Fix it by actually reading that file and writing real reasoning -- do not pad to clear
+     the check. Re-run.
+6. If your verdict is `issues`, fix the findings, then re-run from step 1 on the new HEAD (the
    gate is HEAD-keyed) until the articulation is clean.
+
+## Finding resolution (#773)
+
+A finding you record via `--findings-json` does not evaporate once the gate is recorded. It lives
+in the findings ledger as PENDING until one of:
+
+- **Resolved automatically** -- a later commit on this branch touches the flagged file. Detected
+  by git log at the next `quality-gate check`/`record` call; you do not need to do anything extra
+  beyond committing the fix.
+- **Dispositioned** -- you decide not to fix it and say why:
+  `legion quality-gate finding-disposition --id <finding-id> --reason "won't fix: intentional, see X"`.
+- **Batch-acked** -- for a sweep of LOW/cosmetic findings only, one shared reason clears all of
+  them at once (no per-item ceremony):
+  `legion quality-gate finding-ack --branch <branch> --skill legion-simplify --reason "formatting only, deferred"`.
+
+Find finding ids with `legion quality-gate finding-list --branch <branch> --skill legion-simplify`.
+A `clean` verdict is refused until the PENDING set for this branch+skill is empty -- writing a
+finding down and then recording clean on a later commit without resolving or dispositioning it is
+exactly the hand-wave this closes.
 
 ## Pass Criteria for `legion pr create`
 
 `legion pr create` checks the DB before opening the PR. The gate passes only when a gate row
 exists for the current HEAD commit hash with `result = "clean"`. Because the gate is recorded
 only by `legion quality-gate check`, a clean row now means an accepted per-file articulation
-exists -- not merely that someone typed "clean".
+exists -- not merely that someone typed "clean" -- AND that no prior finding on this branch is
+still sitting unresolved and undispositioned (#773).
 
 ## Notes
 
@@ -128,4 +160,4 @@ exists -- not merely that someone typed "clean".
   plausible-sounding wrong one -- that stays the reviewer's job, same division of labor as
   `legion pr write-check`. It can tell when an entry is empty, boilerplate, or points at
   nothing locatable, and it refuses those.
-- If you commit again after a clean gate, the gate no longer matches HEAD -- re-run step 4.
+- If you commit again after a clean gate, the gate no longer matches HEAD -- re-run step 5.

--- a/src/cli/verify.rs
+++ b/src/cli/verify.rs
@@ -291,14 +291,30 @@ pub(crate) fn handle_quality_gate(action: QualityGateAction) -> error::Result<()
             // findings (SKILL.md: "surviving MEDs named in the sign-off") --
             // a clean call that itself carries findings must be refused by
             // that call, not merely by some future one. Best-effort: a
-            // malformed `--details-json` (or one with no `findings` key at
-            // all, the common case for most skills) yields zero findings here
-            // rather than failing the record outright.
-            let raw_findings: Vec<finding_gate::RawFinding> = details_json
-                .as_deref()
-                .and_then(|d| serde_json::from_str::<serde_json::Value>(d).ok())
-                .map(|v| finding_gate::extract_findings_from_value(&v))
-                .unwrap_or_default();
+            // missing `findings` key (the common case for most skills, and
+            // for a genuinely clean legion-review run) yields zero findings
+            // here without complaint. A malformed `--details-json` payload
+            // (present but not valid JSON) ALSO yields zero findings -- this
+            // is a fail-open gap review flagged (a corrupted skill invocation
+            // could theoretically mask real findings) -- but is now loud on
+            // stderr rather than silent, so the caller sees it instead of the
+            // clean gate silently passing with no trace of why nothing was
+            // extracted.
+            let raw_findings: Vec<finding_gate::RawFinding> = match details_json.as_deref() {
+                Some(d) => match serde_json::from_str::<serde_json::Value>(d) {
+                    Ok(v) => finding_gate::extract_findings_from_value(&v),
+                    Err(e) => {
+                        eprintln!(
+                            "[legion] warning: --details-json present but failed to parse as \
+                             JSON ({e}) -- 0 findings extracted from it. If this call intended \
+                             to report findings, they will NOT be tracked by the \
+                             finding-resolution ledger (#773); fix the JSON and re-run."
+                        );
+                        Vec::new()
+                    }
+                },
+                None => Vec::new(),
+            };
 
             // Reconcile the PENDING finding ledger against this commit first
             // (a fix landed in an earlier commit must not still read as

--- a/src/cli/verify.rs
+++ b/src/cli/verify.rs
@@ -498,10 +498,9 @@ pub(crate) fn handle_quality_gate(action: QualityGateAction) -> error::Result<()
             let database = open_db()?;
             let finding = database.dispose_finding(&id, &reason)?;
             println!(
-                "[legion] dispositioned finding {} ({}{}): {}",
+                "[legion] dispositioned finding {} ({}): {}",
                 finding.id,
-                finding.file,
-                finding.line.map(|l| format!(":{l}")).unwrap_or_default(),
+                file_loc(&finding.file, finding.line),
                 reason
             );
         }
@@ -518,12 +517,7 @@ pub(crate) fn handle_quality_gate(action: QualityGateAction) -> error::Result<()
                 acked.len()
             );
             for f in &acked {
-                println!(
-                    "  - {} ({}{})",
-                    f.id,
-                    f.file,
-                    f.line.map(|l| format!(":{l}")).unwrap_or_default()
-                );
+                println!("  - {} ({})", f.id, file_loc(&f.file, f.line));
             }
         }
 
@@ -570,6 +564,17 @@ pub(crate) fn handle_quality_gate(action: QualityGateAction) -> error::Result<()
     Ok(())
 }
 
+/// Format a finding's location as `<file>` or `<file>:<line>` when a line is
+/// present. Shared by every finding print site (#773) so the `:<line>`
+/// formatting has one source instead of repeating
+/// `line.map(|l| format!(":{l}")).unwrap_or_default()` at each call site.
+fn file_loc(file: &str, line: Option<i64>) -> String {
+    match line {
+        Some(l) => format!("{file}:{l}"),
+        None => file.to_owned(),
+    }
+}
+
 /// The finding-resolution gate (#773), shared by the Record and Check arms.
 ///
 /// Always reconciles the PENDING set for `branch`/`skill` against
@@ -613,10 +618,9 @@ fn reconcile_and_refuse_if_findings_pending(
             .chain(refusal.trivial_unacked.iter())
         {
             eprintln!(
-                "  - [{}] {}{} {} (id {})",
+                "  - [{}] {} {} (id {})",
                 f.severity.as_str(),
-                f.file,
-                f.line.map(|l| format!(":{l}")).unwrap_or_default(),
+                file_loc(&f.file, f.line),
                 f.summary,
                 f.id,
             );
@@ -688,11 +692,7 @@ fn print_findings_table(rows: &[QualityGateFinding]) {
         let id_short: String = row.id.chars().take(8).collect();
         let branch_trunc: String = row.branch.chars().take(20).collect();
         let skill_trunc: String = row.skill.chars().take(16).collect();
-        let file_loc = match row.line {
-            Some(l) => format!("{}:{}", row.file, l),
-            None => row.file.clone(),
-        };
-        let file_trunc: String = file_loc.chars().take(30).collect();
+        let file_trunc: String = file_loc(&row.file, row.line).chars().take(30).collect();
         println!(
             "{:<8}  {:<20}  {:<16}  {:<30}  {:<4}  {:<14}  {}",
             id_short,

--- a/src/cli/verify.rs
+++ b/src/cli/verify.rs
@@ -285,19 +285,36 @@ pub(crate) fn handle_quality_gate(action: QualityGateAction) -> error::Result<()
 
             let database = open_db()?;
 
-            // #773: reconcile the PENDING finding ledger against this commit
-            // first (a fix landed in an earlier commit must not still read as
+            // #773: extract THIS call's own structured findings BEFORE the
+            // refusal check runs. legion-review's `approved` decision records
+            // `--result clean` in the SAME call as any surviving non-blocking
+            // findings (SKILL.md: "surviving MEDs named in the sign-off") --
+            // a clean call that itself carries findings must be refused by
+            // that call, not merely by some future one. Best-effort: a
+            // malformed `--details-json` (or one with no `findings` key at
+            // all, the common case for most skills) yields zero findings here
+            // rather than failing the record outright.
+            let raw_findings: Vec<finding_gate::RawFinding> = details_json
+                .as_deref()
+                .and_then(|d| serde_json::from_str::<serde_json::Value>(d).ok())
+                .map(|v| finding_gate::extract_findings_from_value(&v))
+                .unwrap_or_default();
+
+            // Reconcile the PENDING finding ledger against this commit first
+            // (a fix landed in an earlier commit must not still read as
             // pending), then -- only when this run claims `clean` -- refuse
-            // unless every non-trivial finding is resolved/dispositioned and
-            // every LOW finding is batch-acked. Runs for every skill, not
-            // just legion-review: a skill with no findings ever recorded
-            // simply has an empty pending set, so this is a no-op for it.
+            // unless every PRIOR non-trivial finding is resolved/dispositioned,
+            // every prior LOW finding is batch-acked, AND this run itself
+            // reports zero findings. Runs for every skill, not just
+            // legion-review: a skill with no findings ever recorded simply has
+            // an empty pending set, so this is a no-op for it.
             reconcile_and_refuse_if_findings_pending(
                 &database,
                 &branch,
                 &skill,
                 &commit_hash,
                 gate_result == GateResult::Clean,
+                &raw_findings,
             )?;
 
             let row = database.record_quality_gate(&QualityGateInput {
@@ -316,18 +333,12 @@ pub(crate) fn handle_quality_gate(action: QualityGateAction) -> error::Result<()
             // catching issues means simplify's clean verdict was wrong.
             crate::gate_trust::maybe_witness_from_review(&database, &row);
 
-            // #773: extract structured findings from the `findings` array
-            // inside `--details-json`, the legion-review contract
-            // (`{"decision": ..., "findings": [...], ...}`). A skill with no
-            // such key (or no --details-json at all) contributes zero
-            // findings here -- harmless, since findings_count above stays the
-            // authoritative count for that run either way.
-            if let Some(details) = details_json.as_deref()
-                && let Ok(value) = serde_json::from_str::<serde_json::Value>(details)
-            {
-                let raw_findings = finding_gate::extract_findings_from_value(&value);
-                persist_raw_findings(&database, &row, &raw_findings);
-            }
+            // #773: persist the findings extracted above, now that the gate
+            // row (and its id) exists. Only reached once the refusal check
+            // above has already passed -- a refused clean call never
+            // persists its findings; the caller re-runs with `--result
+            // issues` to persist them, then dispositions/acks.
+            persist_raw_findings(&database, &row, &raw_findings);
 
             println!("{}", row.id);
         }
@@ -461,13 +472,18 @@ pub(crate) fn handle_quality_gate(action: QualityGateAction) -> error::Result<()
 
             // #773: same reconcile-then-refuse gate as the Record arm, run
             // here since legion-simplify records clean exclusively through
-            // Check (Record refuses a clean result for it, #780).
+            // Check (Record refuses a clean result for it, #780). Also mirrors
+            // the Record arm in considering THIS run's own `raw_findings`
+            // (parsed above from `--findings-json`) -- a clean verdict
+            // reported alongside real findings must be refused by the same
+            // call that reports them, not just a later one.
             reconcile_and_refuse_if_findings_pending(
                 &database,
                 &branch,
                 &skill,
                 &commit_hash,
                 gate_result == GateResult::Clean,
+                &raw_findings,
             )?;
 
             let row = database.record_quality_gate(&QualityGateInput {
@@ -568,7 +584,9 @@ pub(crate) fn handle_quality_gate(action: QualityGateAction) -> error::Result<()
 /// present. Shared by every finding print site (#773) so the `:<line>`
 /// formatting has one source instead of repeating
 /// `line.map(|l| format!(":{l}")).unwrap_or_default()` at each call site.
-fn file_loc(file: &str, line: Option<i64>) -> String {
+/// Generic over the line type so both the persisted `i64` (`QualityGateFinding`)
+/// and the not-yet-persisted `u32` (`finding_gate::RawFinding`) share it.
+fn file_loc(file: &str, line: Option<impl std::fmt::Display>) -> String {
     match line {
         Some(l) => format!("{file}:{l}"),
         None => file.to_owned(),
@@ -580,20 +598,31 @@ fn file_loc(file: &str, line: Option<i64>) -> String {
 /// Always reconciles the PENDING set for `branch`/`skill` against
 /// `head_commit` first (a fix landed in an earlier commit resolves the
 /// finding before it can block anything). When `requesting_clean` is true,
-/// refuses the caller with a non-zero exit unless the post-reconcile PENDING
-/// set is empty -- no HIGH/MED finding left unresolved/undispositioned, and
-/// no LOW finding left un-acked. The predicate is branch+skill scoped and
-/// deliberately cross-commit: a `clean` run itself never has any of its own
-/// findings pending (it has none), so this only ever blocks on findings
-/// accumulated from PRIOR gate runs on the same branch -- which is the
-/// entire point (a finding written down on commit N must not evaporate just
-/// because commit N+1 reports clean).
+/// refuses the caller with a non-zero exit unless BOTH:
+///   - the post-reconcile PENDING set (findings from PRIOR gate runs on this
+///     branch+skill) is empty -- no HIGH/MED left unresolved/undispositioned,
+///     no LOW left un-acked, and
+///   - `current_raw_findings` (THIS call's own structured findings, parsed by
+///     the caller from `--details-json`/`--findings-json` before this
+///     function runs) is empty.
+///
+/// The second half is not optional bookkeeping: legion-review's `approved`
+/// decision records `--result clean` in the SAME call as any surviving
+/// non-blocking findings (its SKILL.md: "surviving MEDs named in the
+/// sign-off"), so a same-run reading of the predicate would let exactly the
+/// finding this issue exists to catch sail through on its very first gate
+/// call. A finding just extracted in this call has by definition not yet
+/// been through resolve/disposition/ack, so its mere presence blocks --
+/// there is no severity carve-out here the way there is for the PENDING set
+/// (LOW still blocks a same-call clean; it becomes ack-able only once
+/// persisted, which a refused call never does).
 fn reconcile_and_refuse_if_findings_pending(
     database: &db::Database,
     branch: &str,
     skill: &str,
     head_commit: &str,
     requesting_clean: bool,
+    current_raw_findings: &[finding_gate::RawFinding],
 ) -> error::Result<()> {
     if let Err(e) =
         finding_gate::reconcile_pending_findings(database, None, branch, skill, head_commit)
@@ -605,12 +634,13 @@ fn reconcile_and_refuse_if_findings_pending(
     }
     let pending = database.list_pending_findings(branch, skill)?;
     let refusal = finding_gate::evaluate_refusal(&pending);
-    if refusal.blocks() {
+    if refusal.blocks() || !current_raw_findings.is_empty() {
         eprintln!(
             "[legion] error: cannot record a clean gate for skill '{skill}' on branch '{branch}' \
-             -- {} non-trivial finding(s) and {} LOW finding(s) remain undispositioned (#773):",
-            refusal.blocking.len(),
-            refusal.trivial_unacked.len()
+             -- {} pending finding(s) from prior run(s) and {} finding(s) reported by THIS run \
+             remain unresolved/undispositioned (#773):",
+            refusal.blocking.len() + refusal.trivial_unacked.len(),
+            current_raw_findings.len(),
         );
         for f in refusal
             .blocking
@@ -618,18 +648,28 @@ fn reconcile_and_refuse_if_findings_pending(
             .chain(refusal.trivial_unacked.iter())
         {
             eprintln!(
-                "  - [{}] {} {} (id {})",
+                "  - [prior run, {}] {} {} (id {})",
                 f.severity.as_str(),
                 file_loc(&f.file, f.line),
                 f.summary,
                 f.id,
             );
         }
+        for f in current_raw_findings {
+            eprintln!(
+                "  - [this run, {}] {} {}",
+                f.severity,
+                file_loc(&f.file, f.line),
+                f.summary,
+            );
+        }
         eprintln!(
-            "\nResolve by touching the flagged file in a later commit, disposition one with \
-             'legion quality-gate finding-disposition --id <id> --reason \"...\"', or batch-ack \
-             LOW findings with 'legion quality-gate finding-ack --branch {branch} --skill {skill} \
-             --reason \"...\"'."
+            "\nA clean verdict cannot carry its own findings, nor leave a prior finding \
+             unresolved. Re-run with '--result issues' (same findings payload) to persist them, \
+             then disposition/ack them -- 'legion quality-gate finding-disposition --id <id> \
+             --reason \"...\"' for one, or 'legion quality-gate finding-ack --branch {branch} \
+             --skill {skill} --reason \"...\"' to batch-clear LOW findings -- or wait for a fix \
+             commit to resolve them automatically, then re-run '--result clean'."
         );
         return Err(error::LegionError::ExitWith(1));
     }
@@ -649,6 +689,18 @@ fn persist_raw_findings(
     gate: &QualityGateRow,
     raw_findings: &[finding_gate::RawFinding],
 ) {
+    if raw_findings.is_empty() {
+        return;
+    }
+    // #773: a re-run that reports the same still-open finding (identical
+    // file+severity+summary) must not pile up a fresh duplicate PENDING row
+    // every time -- two review passes over an unfixed MED would otherwise
+    // leave two rows to disposition instead of one. `unwrap_or_default`
+    // degrades to "no known duplicates" on a query failure rather than
+    // blocking the insert below on this best-effort dedup check.
+    let existing_pending = database
+        .list_pending_findings(&gate.branch, &gate.skill)
+        .unwrap_or_default();
     for rf in raw_findings {
         let severity: FindingSeverity = rf.severity.parse().unwrap_or_else(|_| {
             eprintln!(
@@ -658,6 +710,12 @@ fn persist_raw_findings(
             );
             FindingSeverity::Med
         });
+        let already_pending = existing_pending
+            .iter()
+            .any(|f| f.file == rf.file && f.severity == severity && f.summary == rf.summary);
+        if already_pending {
+            continue;
+        }
         if let Err(e) = database.insert_finding(&NewFindingInput {
             gate_id: &gate.id,
             branch: &gate.branch,
@@ -1349,6 +1407,7 @@ mod tests {
             "legion-simplify",
             "commit-a",
             true,
+            &[],
         )
         .unwrap_err();
         assert!(matches!(err, error::LegionError::ExitWith(1)));
@@ -1377,6 +1436,7 @@ mod tests {
             "legion-simplify",
             "commit-a",
             true,
+            &[],
         )
         .unwrap_err();
         assert!(matches!(err, error::LegionError::ExitWith(1)));
@@ -1408,6 +1468,7 @@ mod tests {
             "legion-simplify",
             "commit-a",
             true,
+            &[],
         )
         .expect("clean should be allowed once the pending finding is dispositioned");
     }
@@ -1423,6 +1484,7 @@ mod tests {
             "legion-simplify",
             "commit-a",
             true,
+            &[],
         )
         .expect("no pending findings should never refuse");
     }
@@ -1450,6 +1512,7 @@ mod tests {
             "legion-simplify",
             "commit-a",
             false,
+            &[],
         )
         .expect("an issues (non-clean) request must never be refused by the pending set");
     }
@@ -1488,8 +1551,267 @@ mod tests {
             "legion-simplify",
             "commit-a",
             true,
+            &[],
         )
         .expect("findings on another branch/skill must not block this one");
+    }
+
+    /// THE central case (#773): a clean request that itself carries a
+    /// finding must be refused by that SAME call, not merely a future one.
+    /// This is legion-review's `approved` decision recording `--result
+    /// clean` in the same invocation as any surviving non-blocking findings
+    /// (its SKILL.md: "surviving MEDs named in the sign-off") -- the pending
+    /// set is empty (nothing persisted yet), so only checking the pending
+    /// set would let this sail through.
+    #[test]
+    fn reconcile_and_refuse_blocks_clean_when_current_call_carries_a_finding() {
+        let db = test_db();
+        let current = vec![finding_gate::RawFinding {
+            file: "src/foo.rs".to_string(),
+            line: Some(10),
+            severity: "MED".to_string(),
+            summary: "unchecked input".to_string(),
+        }];
+
+        let err = reconcile_and_refuse_if_findings_pending(
+            &db,
+            "feat/x",
+            "legion-review",
+            "commit-a",
+            true,
+            &current,
+        )
+        .unwrap_err();
+        assert!(matches!(err, error::LegionError::ExitWith(1)));
+    }
+
+    /// The same-call refusal blocks on a LOW finding too -- a freshly
+    /// extracted finding has never been through batch-ack, so its severity
+    /// does not exempt it (mirrors `evaluate_refusal_low_blocks_until_acked`
+    /// for the PENDING-set case).
+    #[test]
+    fn reconcile_and_refuse_blocks_clean_when_current_call_carries_a_low_finding() {
+        let db = test_db();
+        let current = vec![finding_gate::RawFinding {
+            file: "src/foo.rs".to_string(),
+            line: None,
+            severity: "LOW".to_string(),
+            summary: "naming nit".to_string(),
+        }];
+
+        let err = reconcile_and_refuse_if_findings_pending(
+            &db,
+            "feat/x",
+            "legion-review",
+            "commit-a",
+            true,
+            &current,
+        )
+        .unwrap_err();
+        assert!(matches!(err, error::LegionError::ExitWith(1)));
+    }
+
+    /// A same-call finding does NOT block an `issues` request -- only a
+    /// `clean` claim triggers the refusal (mirrors
+    /// `reconcile_and_refuse_does_not_block_issues_result` for the
+    /// PENDING-set case).
+    #[test]
+    fn reconcile_and_refuse_current_call_findings_do_not_block_issues_result() {
+        let db = test_db();
+        let current = vec![finding_gate::RawFinding {
+            file: "src/foo.rs".to_string(),
+            line: Some(10),
+            severity: "HIGH".to_string(),
+            summary: "unchecked input".to_string(),
+        }];
+
+        reconcile_and_refuse_if_findings_pending(
+            &db,
+            "feat/x",
+            "legion-review",
+            "commit-a",
+            false,
+            &current,
+        )
+        .expect("an issues (non-clean) request must never be refused by this run's findings");
+    }
+
+    /// A clean call with an empty pending set AND an empty current-findings
+    /// slice is allowed -- the ordinary case (a genuinely clean run, or a
+    /// prior-commit fix already reconciled away everything).
+    #[test]
+    fn reconcile_and_refuse_allows_clean_with_no_pending_and_no_current_findings() {
+        let db = test_db();
+        reconcile_and_refuse_if_findings_pending(
+            &db,
+            "feat/x",
+            "legion-review",
+            "commit-a",
+            true,
+            &[],
+        )
+        .expect("no pending and no current findings should never refuse");
+    }
+
+    /// The regression end to end: simplify reports MED on commit A
+    /// (`--result issues`, persisted), fixes it and commits B, then requests
+    /// `--result clean` with no `--findings-json` on B -- reconcile resolves
+    /// the commit-A finding via the real git fixture, and the second call is
+    /// allowed. Mirrors the scenario named in review.
+    #[test]
+    fn reconcile_and_refuse_issues_then_fix_then_clean_end_to_end() {
+        let dir = tempfile::tempdir().unwrap();
+        // Minimal isolated git fixture -- mirrors finding_gate's own test
+        // helper (duplicated here for the same reason that file documents:
+        // a `#[cfg(test)]`-private helper in a sibling module is not
+        // importable across module boundaries without a shared export this
+        // one extra call site does not justify).
+        let git = |args: &[&str]| {
+            std::process::Command::new("git")
+                .current_dir(dir.path())
+                .env("GIT_CONFIG_GLOBAL", "/dev/null")
+                .env("GIT_CONFIG_SYSTEM", "/dev/null")
+                .args(
+                    [
+                        "-c",
+                        "user.name=Legion Test Fixture",
+                        "-c",
+                        "user.email=legion-test-fixture@example.invalid",
+                        "-c",
+                        "commit.gpgsign=false",
+                    ]
+                    .iter()
+                    .chain(args.iter()),
+                )
+                .output()
+                .unwrap()
+        };
+        git(&["init", "-q"]);
+        std::fs::write(dir.path().join("foo.rs"), "fn foo() {}\n").unwrap();
+        git(&["add", "foo.rs"]);
+        git(&["commit", "-q", "-m", "initial"]);
+        let commit_a = String::from_utf8_lossy(&git(&["rev-parse", "HEAD"]).stdout)
+            .trim()
+            .to_string();
+
+        let db = test_db();
+        db.insert_finding(&NewFindingInput {
+            gate_id: "gate-a",
+            branch: "feat/x",
+            skill: "legion-simplify",
+            origin_commit: &commit_a,
+            file: "foo.rs",
+            line: Some(1),
+            severity: FindingSeverity::Med,
+            summary: "duplicate logic",
+        })
+        .unwrap();
+
+        std::fs::write(dir.path().join("foo.rs"), "fn foo() { /* fixed */ }\n").unwrap();
+        git(&["add", "foo.rs"]);
+        git(&["commit", "-q", "-m", "fix foo"]);
+        let commit_b = String::from_utf8_lossy(&git(&["rev-parse", "HEAD"]).stdout)
+            .trim()
+            .to_string();
+
+        // reconcile_pending_findings shells to plain `git log` against the
+        // process cwd; point it at the fixture explicitly instead of
+        // mutating the real process cwd (a parallel-test hazard).
+        finding_gate::reconcile_pending_findings(
+            &db,
+            Some(dir.path()),
+            "feat/x",
+            "legion-simplify",
+            &commit_b,
+        )
+        .unwrap();
+
+        // Now the CLI-level helper (process-cwd git) sees an already-resolved
+        // finding and allows clean with no current findings.
+        reconcile_and_refuse_if_findings_pending(
+            &db,
+            "feat/x",
+            "legion-simplify",
+            &commit_b,
+            true,
+            &[],
+        )
+        .expect("the commit-A finding should already be resolved by the fixture reconcile above");
+    }
+
+    /// `persist_raw_findings` deduplicates: a re-run reporting the exact
+    /// same still-open finding (identical file+severity+summary) does not
+    /// pile up a second PENDING row.
+    #[test]
+    fn persist_raw_findings_dedupes_identical_pending_finding_across_reruns() {
+        let db = test_db();
+        let gate = db
+            .record_quality_gate(&QualityGateInput {
+                branch: "feat/x",
+                commit_hash: "commit-a",
+                skill: "legion-review",
+                result: GateResult::Issues,
+                findings_count: 1,
+                details: None,
+                provenance: GateProvenance::Asserted,
+                base: None,
+            })
+            .unwrap();
+        let raw = vec![finding_gate::RawFinding {
+            file: "src/foo.rs".to_string(),
+            line: Some(12),
+            severity: "MED".to_string(),
+            summary: "unchecked input".to_string(),
+        }];
+
+        persist_raw_findings(&db, &gate, &raw);
+        persist_raw_findings(&db, &gate, &raw);
+
+        let pending = db.list_pending_findings("feat/x", "legion-review").unwrap();
+        assert_eq!(
+            pending.len(),
+            1,
+            "re-persisting an identical finding must not create a duplicate row"
+        );
+    }
+
+    /// A genuinely different finding (different summary) on the same file
+    /// is NOT deduplicated away -- only an exact file+severity+summary match
+    /// is treated as "the same still-open finding".
+    #[test]
+    fn persist_raw_findings_does_not_dedupe_distinct_findings_on_the_same_file() {
+        let db = test_db();
+        let gate = db
+            .record_quality_gate(&QualityGateInput {
+                branch: "feat/x",
+                commit_hash: "commit-a",
+                skill: "legion-review",
+                result: GateResult::Issues,
+                findings_count: 2,
+                details: None,
+                provenance: GateProvenance::Asserted,
+                base: None,
+            })
+            .unwrap();
+        let raw = vec![
+            finding_gate::RawFinding {
+                file: "src/foo.rs".to_string(),
+                line: Some(12),
+                severity: "MED".to_string(),
+                summary: "unchecked input".to_string(),
+            },
+            finding_gate::RawFinding {
+                file: "src/foo.rs".to_string(),
+                line: Some(40),
+                severity: "MED".to_string(),
+                summary: "duplicate WHERE-clause construction".to_string(),
+            },
+        ];
+
+        persist_raw_findings(&db, &gate, &raw);
+
+        let pending = db.list_pending_findings("feat/x", "legion-review").unwrap();
+        assert_eq!(pending.len(), 2);
     }
 
     /// `persist_raw_findings` inserts one row per raw finding, tied to the

--- a/src/cli/verify.rs
+++ b/src/cli/verify.rs
@@ -708,20 +708,38 @@ fn persist_raw_findings(
     if raw_findings.is_empty() {
         return;
     }
-    // #773: a re-run that reports the same still-open finding (identical
-    // file+severity+summary) must not pile up a fresh duplicate PENDING row
-    // every time -- two review passes over an unfixed MED would otherwise
-    // leave two rows to disposition instead of one. `unwrap_or_default`
-    // degrades to "no known duplicates" on a query failure rather than
-    // blocking the insert below on this best-effort dedup check. `seen_this_call`
-    // extends the same key to duplicates WITHIN one `raw_findings` batch (a
-    // single malformed/duplicated `--findings-json` payload listing the same
-    // triple twice), not just across separate calls -- `existing_pending`
-    // alone cannot catch that, since neither copy is in the DB yet when the
-    // loop checks it.
-    let existing_pending = database
-        .list_pending_findings(&gate.branch, &gate.skill)
-        .unwrap_or_default();
+    // #773: a re-run that reports the same still-open OR already-waived
+    // finding (identical file+severity+summary) must not pile up a fresh
+    // duplicate PENDING row every time. Two dedup targets, deliberately not
+    // just one:
+    //   - PENDING: two review passes over an unfixed MED would otherwise
+    //     leave two rows to disposition instead of one.
+    //   - DISPOSITIONED: a finding explicitly waived ("won't fix:
+    //     intentional") must STAY waived if the same run keeps reporting it
+    //     -- checking PENDING alone would resurrect a fresh PENDING row the
+    //     moment the reviewer honestly re-lists the same MED they already
+    //     agreed not to fix, silently undoing the disposition and re-blocking
+    //     clean on a decision that was already made. RESOLVED is
+    //     deliberately excluded: a finding that recurs identically after
+    //     being fix-resolved is a regression worth a fresh PENDING row, not
+    //     something to suppress.
+    // `unwrap_or_default` degrades to "no known duplicates" on a query
+    // failure rather than blocking the insert below on this best-effort
+    // dedup check. `seen_this_call` extends the same key to duplicates
+    // WITHIN one `raw_findings` batch (a single malformed/duplicated
+    // `--findings-json` payload listing the same triple twice), not just
+    // across separate calls -- `existing_open` alone cannot catch that,
+    // since neither copy is in the DB yet when the loop checks it.
+    let existing_open: Vec<QualityGateFinding> = database
+        .list_findings(&FindingFilter {
+            branch: Some(gate.branch.clone()),
+            skill: Some(gate.skill.clone()),
+            status: None,
+        })
+        .unwrap_or_default()
+        .into_iter()
+        .filter(|f| f.status != FindingStatus::Resolved)
+        .collect();
     let mut seen_this_call: std::collections::HashSet<(String, FindingSeverity, String)> =
         std::collections::HashSet::new();
     for rf in raw_findings {
@@ -734,10 +752,10 @@ fn persist_raw_findings(
             FindingSeverity::Med
         });
         let key = (rf.file.clone(), severity, rf.summary.clone());
-        let already_pending = existing_pending
+        let already_open = existing_open
             .iter()
             .any(|f| f.file == rf.file && f.severity == severity && f.summary == rf.summary);
-        if already_pending || !seen_this_call.insert(key) {
+        if already_open || !seen_this_call.insert(key) {
             continue;
         }
         if let Err(e) = database.insert_finding(&NewFindingInput {
@@ -1871,6 +1889,110 @@ mod tests {
             pending.len(),
             1,
             "a duplicated entry within one batch must not double-insert"
+        );
+    }
+
+    /// Regression guard (pre-push review HIGH): a finding explicitly
+    /// dispositioned ("won't fix: intentional") must STAY dispositioned when
+    /// a later run reports the identical (file, severity, summary) again --
+    /// dedup must check DISPOSITIONED rows too, not only PENDING ones, or a
+    /// waiver silently resurrects as a fresh blocking PENDING row.
+    #[test]
+    fn persist_raw_findings_does_not_resurrect_a_dispositioned_finding() {
+        let db = test_db();
+        let gate = db
+            .record_quality_gate(&QualityGateInput {
+                branch: "feat/x",
+                commit_hash: "commit-a",
+                skill: "legion-review",
+                result: GateResult::Issues,
+                findings_count: 1,
+                details: None,
+                provenance: GateProvenance::Asserted,
+                base: None,
+            })
+            .unwrap();
+        let raw = vec![finding_gate::RawFinding {
+            file: "src/foo.rs".to_string(),
+            line: Some(12),
+            severity: "LOW".to_string(),
+            summary: "naming nit".to_string(),
+        }];
+        persist_raw_findings(&db, &gate, &raw);
+        let pending = db.list_pending_findings("feat/x", "legion-review").unwrap();
+        assert_eq!(pending.len(), 1);
+        db.dispose_finding(&pending[0].id, "won't fix: intentional")
+            .unwrap();
+
+        // A later run re-reports the exact same finding (e.g. an honest
+        // reviewer re-listing the same LOW they already agreed to waive).
+        persist_raw_findings(&db, &gate, &raw);
+
+        let still_pending = db.list_pending_findings("feat/x", "legion-review").unwrap();
+        assert!(
+            still_pending.is_empty(),
+            "re-reporting an already-dispositioned finding must not resurrect it as PENDING, \
+             got {still_pending:?}"
+        );
+        let all = db
+            .list_findings(&FindingFilter {
+                branch: Some("feat/x".to_string()),
+                skill: Some("legion-review".to_string()),
+                status: None,
+            })
+            .unwrap();
+        assert_eq!(
+            all.len(),
+            1,
+            "the disposition must still be the only row for this finding"
+        );
+        assert_eq!(all[0].status, FindingStatus::Dispositioned);
+    }
+
+    /// A finding that recurs identically AFTER being RESOLVED (fix landed,
+    /// then the same problem reappears) is treated as a fresh finding, not
+    /// deduped away -- a genuine regression deserves its own PENDING row,
+    /// unlike the dispositioned case above.
+    #[test]
+    fn persist_raw_findings_does_not_dedupe_against_a_resolved_finding() {
+        let db = test_db();
+        let gate = db
+            .record_quality_gate(&QualityGateInput {
+                branch: "feat/x",
+                commit_hash: "commit-a",
+                skill: "legion-simplify",
+                result: GateResult::Issues,
+                findings_count: 1,
+                details: None,
+                provenance: GateProvenance::Validated,
+                base: None,
+            })
+            .unwrap();
+        let raw = vec![finding_gate::RawFinding {
+            file: "src/foo.rs".to_string(),
+            line: Some(12),
+            severity: "MED".to_string(),
+            summary: "duplicate WHERE-clause construction".to_string(),
+        }];
+        persist_raw_findings(&db, &gate, &raw);
+        let pending = db
+            .list_pending_findings("feat/x", "legion-simplify")
+            .unwrap();
+        assert_eq!(pending.len(), 1);
+        db.mark_finding_resolved(&pending[0].id, "commit-fix")
+            .unwrap();
+
+        // The identical problem recurs -- a regression, not the same
+        // still-open finding.
+        persist_raw_findings(&db, &gate, &raw);
+
+        let now_pending = db
+            .list_pending_findings("feat/x", "legion-simplify")
+            .unwrap();
+        assert_eq!(
+            now_pending.len(),
+            1,
+            "a recurrence after RESOLVED must be tracked as a new PENDING finding"
         );
     }
 

--- a/src/cli/verify.rs
+++ b/src/cli/verify.rs
@@ -316,6 +316,24 @@ pub(crate) fn handle_quality_gate(action: QualityGateAction) -> error::Result<()
                 None => Vec::new(),
             };
 
+            // #773: a self-contradiction check that closes the remaining
+            // fail-open gap without imposing hard-refusal on every malformed
+            // `--details-json` (most skills never set a `findings` key at
+            // all, and that legitimate case must keep passing). See
+            // `findings_count_contradicts_extraction`'s doc comment.
+            if findings_count_contradicts_extraction(gate_result, findings_count, &raw_findings) {
+                eprintln!(
+                    "[legion] error: cannot record a clean gate for skill '{skill}' -- \
+                     --findings-count {findings_count} but 0 findings were extracted from \
+                     --details-json (#773). This means either --details-json is missing/malformed \
+                     for a run that claims real findings, or its `findings` array does not match \
+                     the {{file, line, severity, summary}} schema. Fix --details-json so the \
+                     findings it claims are actually tracked, or pass --findings-count 0 if there \
+                     truly are none."
+                );
+                return Err(error::LegionError::ExitWith(1));
+            }
+
             // Reconcile the PENDING finding ledger against this commit first
             // (a fix landed in an earlier commit must not still read as
             // pending), then -- only when this run claims `clean` -- refuse
@@ -419,6 +437,21 @@ pub(crate) fn handle_quality_gate(action: QualityGateAction) -> error::Result<()
                 Some(raw) => finding_gate::parse_findings_array(raw)?,
                 None => Vec::new(),
             };
+
+            // #773: same self-contradiction guard as the Record arm --
+            // `--findings-json` already hard-errors on malformed JSON above,
+            // so this mainly catches the "omitted --findings-json entirely
+            // while --findings-count claims real findings" case on a clean
+            // request, for symmetry and defense in depth.
+            if findings_count_contradicts_extraction(gate_result, findings_count, &raw_findings) {
+                eprintln!(
+                    "[legion] error: cannot record a clean gate for skill '{skill}' -- \
+                     --findings-count {findings_count} but --findings-json extracted none (#773). \
+                     Pass the findings via --findings-json so they are tracked, or pass \
+                     --findings-count 0 if there truly are none."
+                );
+                return Err(error::LegionError::ExitWith(1));
+            }
 
             // Resolve the changed-file set from git. `--base` overrides the
             // default main/origin-main resolution (#779); an unresolvable
@@ -594,6 +627,26 @@ pub(crate) fn handle_quality_gate(action: QualityGateAction) -> error::Result<()
         }
     }
     Ok(())
+}
+
+/// True when a `clean` request's own asserted `findings_count` contradicts
+/// what was actually extracted into `raw_findings` -- the skill claims N>0
+/// findings via `--findings-count` but ledger extraction produced none.
+/// Refusing on this closes the fail-open gap a totally-malformed or
+/// entirely-mismatched-schema `--details-json`/`--findings-json` payload
+/// would otherwise leave open (extraction degrades to an empty vec rather
+/// than erroring, since a missing `findings` key is the legitimate common
+/// case for most skills) WITHOUT imposing hard-refusal on every malformed
+/// payload -- only when the skill's own count says findings should exist and
+/// none were found is there no ambiguity that something was dropped versus
+/// never existed. Shared, pure, and unit-testable by both the `Record` and
+/// `Check` arms.
+fn findings_count_contradicts_extraction(
+    gate_result: GateResult,
+    findings_count: u64,
+    raw_findings: &[finding_gate::RawFinding],
+) -> bool {
+    gate_result == GateResult::Clean && findings_count > 0 && raw_findings.is_empty()
 }
 
 /// Format a finding's location as `<file>` or `<file>:<line>` when a line is
@@ -1423,6 +1476,53 @@ mod tests {
     }
 
     // --- finding-resolution gate wiring tests (#773) ---
+
+    // -- findings_count_contradicts_extraction (pure predicate) --
+
+    #[test]
+    fn findings_count_contradicts_extraction_true_when_count_positive_and_extraction_empty() {
+        assert!(findings_count_contradicts_extraction(
+            GateResult::Clean,
+            3,
+            &[]
+        ));
+    }
+
+    #[test]
+    fn findings_count_contradicts_extraction_false_when_count_zero() {
+        assert!(!findings_count_contradicts_extraction(
+            GateResult::Clean,
+            0,
+            &[]
+        ));
+    }
+
+    #[test]
+    fn findings_count_contradicts_extraction_false_when_extraction_non_empty() {
+        let raw = vec![finding_gate::RawFinding {
+            file: "src/foo.rs".to_string(),
+            line: None,
+            severity: "MED".to_string(),
+            summary: "x".to_string(),
+        }];
+        assert!(!findings_count_contradicts_extraction(
+            GateResult::Clean,
+            1,
+            &raw
+        ));
+    }
+
+    #[test]
+    fn findings_count_contradicts_extraction_false_for_issues_result() {
+        // The self-contradiction check only ever applies to a `clean`
+        // request -- an `issues` request with a mismatched count is a
+        // separate (unenforced, informational-field) concern, not this gate.
+        assert!(!findings_count_contradicts_extraction(
+            GateResult::Issues,
+            3,
+            &[]
+        ));
+    }
 
     /// `reconcile_and_refuse_if_findings_pending` refuses a `clean` request
     /// when a HIGH finding from a prior run on the same branch+skill is

--- a/src/cli/verify.rs
+++ b/src/cli/verify.rs
@@ -7,12 +7,14 @@ use clap::Subcommand;
 use crate::cli::util::{
     git_changed_files, git_head_commit_and_branch, open_db, read_file_or_stdin,
 };
+use crate::db::findings::{FindingFilter, NewFindingInput, QualityGateFinding};
 use crate::db::quality_gates::{
     QualityGateFilter, QualityGateInput, QualityGateRow, QualityGateStats,
 };
+use crate::finding_gate::{self, FindingSeverity, FindingStatus};
 use crate::gate_trust::emit_gate_trust;
 use crate::verify::{GateProvenance, GateResult};
-use crate::{error, gate_registry, kanban, simplify_check, verify};
+use crate::{db, error, gate_registry, kanban, simplify_check, verify};
 
 #[derive(Subcommand, Debug)]
 pub(crate) enum QualityGateAction {
@@ -155,6 +157,70 @@ pub(crate) enum QualityGateAction {
         /// visible in the audit trail.
         #[arg(long)]
         base: Option<String>,
+
+        /// Structured findings for this run, as a JSON array of
+        /// `{file, line, severity, summary}` objects (#773). Optional -- a
+        /// `clean` verdict with zero findings omits it. Fed into the
+        /// finding-resolution ledger: prose in the articulation is NOT
+        /// parsed for findings (not reliable enough to extract from), so a
+        /// skill reporting `--result issues` should pass its real findings
+        /// here to be tracked toward resolution/disposition.
+        #[arg(long)]
+        findings_json: Option<String>,
+    },
+
+    /// Disposition a single PENDING finding: mark it DISPOSITIONED with an
+    /// explicit reason (#773). A disposition is not a fix -- it is a
+    /// conscious "we are not fixing this, and here is why" -- so `--reason`
+    /// is required. Refused when the finding does not exist or is already
+    /// RESOLVED (a resolved finding needs no disposition).
+    FindingDisposition {
+        /// Id of the finding (from `quality-gate finding-list`).
+        #[arg(long)]
+        id: String,
+
+        /// Why this finding is not being fixed (required).
+        #[arg(long)]
+        reason: String,
+    },
+
+    /// Batch-acknowledge every PENDING LOW-severity finding on a
+    /// (branch, skill) pair with one shared reason (#773 AC3): the
+    /// "conscious sweep, not per-nit ceremony" carve-out for cosmetic
+    /// findings. Each finding is still dispositioned as its own row (own
+    /// `updated_at`, individually queryable), so the audit trail stays
+    /// per-finding even though the reason is shared across the sweep.
+    FindingAck {
+        /// Branch the findings were raised on.
+        #[arg(long)]
+        branch: String,
+
+        /// Skill the findings were raised under (e.g. "legion-simplify").
+        #[arg(long)]
+        skill: String,
+
+        /// Why these LOW findings are being waived as a batch (required).
+        #[arg(long)]
+        reason: String,
+    },
+
+    /// List findings for the audit surface (#773 AC4): which findings were
+    /// fixed (RESOLVED), waived (DISPOSITIONED), or are still PENDING, over
+    /// time. Filterable by branch, skill, and status; unfiltered lists
+    /// everything, newest first.
+    FindingList {
+        #[arg(long)]
+        branch: Option<String>,
+
+        #[arg(long)]
+        skill: Option<String>,
+
+        #[arg(long, value_parser = ["pending", "resolved", "dispositioned"])]
+        status: Option<String>,
+
+        /// Emit JSON array instead of a human table.
+        #[arg(long)]
+        json: bool,
     },
 
     /// Void a gate row: retire a known-false verdict without deleting it
@@ -218,6 +284,22 @@ pub(crate) fn handle_quality_gate(action: QualityGateAction) -> error::Result<()
             let (commit_hash, branch) = git_head_commit_and_branch()?;
 
             let database = open_db()?;
+
+            // #773: reconcile the PENDING finding ledger against this commit
+            // first (a fix landed in an earlier commit must not still read as
+            // pending), then -- only when this run claims `clean` -- refuse
+            // unless every non-trivial finding is resolved/dispositioned and
+            // every LOW finding is batch-acked. Runs for every skill, not
+            // just legion-review: a skill with no findings ever recorded
+            // simply has an empty pending set, so this is a no-op for it.
+            reconcile_and_refuse_if_findings_pending(
+                &database,
+                &branch,
+                &skill,
+                &commit_hash,
+                gate_result == GateResult::Clean,
+            )?;
+
             let row = database.record_quality_gate(&QualityGateInput {
                 branch: &branch,
                 commit_hash: &commit_hash,
@@ -233,6 +315,20 @@ pub(crate) fn handle_quality_gate(action: QualityGateAction) -> error::Result<()
             // upstream legion-simplify gate prediction for this commit -- review
             // catching issues means simplify's clean verdict was wrong.
             crate::gate_trust::maybe_witness_from_review(&database, &row);
+
+            // #773: extract structured findings from the `findings` array
+            // inside `--details-json`, the legion-review contract
+            // (`{"decision": ..., "findings": [...], ...}`). A skill with no
+            // such key (or no --details-json at all) contributes zero
+            // findings here -- harmless, since findings_count above stays the
+            // authoritative count for that run either way.
+            if let Some(details) = details_json.as_deref()
+                && let Ok(value) = serde_json::from_str::<serde_json::Value>(details)
+            {
+                let raw_findings = finding_gate::extract_findings_from_value(&value);
+                persist_raw_findings(&database, &row, &raw_findings);
+            }
+
             println!("{}", row.id);
         }
 
@@ -283,9 +379,19 @@ pub(crate) fn handle_quality_gate(action: QualityGateAction) -> error::Result<()
             articulation_file,
             findings_count,
             base,
+            findings_json,
         } => {
             // Parse and validate the result flag before touching the FS.
             let gate_result: GateResult = GateResult::from_str(&result)?;
+
+            // #773: parse --findings-json up front, before any FS/DB work --
+            // an explicitly-passed but malformed payload is a hard error
+            // (unlike the Record arm's --details-json, whose `findings` key
+            // is best-effort since most skills never set it).
+            let raw_findings = match findings_json.as_deref() {
+                Some(raw) => finding_gate::parse_findings_array(raw)?,
+                None => Vec::new(),
+            };
 
             // Resolve the changed-file set from git. `--base` overrides the
             // default main/origin-main resolution (#779); an unresolvable
@@ -345,10 +451,25 @@ pub(crate) fn handle_quality_gate(action: QualityGateAction) -> error::Result<()
                 "base": changed.base,
                 "cleared_renames_count": cleared_renames_json.len(),
                 "cleared_renames": cleared_renames_json,
+                "findings": raw_findings.iter().map(|f| serde_json::json!({
+                    "file": f.file, "line": f.line, "severity": f.severity, "summary": f.summary,
+                })).collect::<Vec<_>>(),
             })
             .to_string();
 
             let database = open_db()?;
+
+            // #773: same reconcile-then-refuse gate as the Record arm, run
+            // here since legion-simplify records clean exclusively through
+            // Check (Record refuses a clean result for it, #780).
+            reconcile_and_refuse_if_findings_pending(
+                &database,
+                &branch,
+                &skill,
+                &commit_hash,
+                gate_result == GateResult::Clean,
+            )?;
+
             let row = database.record_quality_gate(&QualityGateInput {
                 branch: &branch,
                 commit_hash: &commit_hash,
@@ -360,6 +481,7 @@ pub(crate) fn handle_quality_gate(action: QualityGateAction) -> error::Result<()
                 base: changed.base.as_deref(),
             })?;
             emit_gate_trust(&database, &row);
+            persist_raw_findings(&database, &row, &raw_findings);
 
             println!(
                 "[legion] simplify-check articulation accepted for skill '{skill}' \
@@ -370,6 +492,63 @@ pub(crate) fn handle_quality_gate(action: QualityGateAction) -> error::Result<()
                 changed.cleared_renames.len(),
                 row.id,
             );
+        }
+
+        QualityGateAction::FindingDisposition { id, reason } => {
+            let database = open_db()?;
+            let finding = database.dispose_finding(&id, &reason)?;
+            println!(
+                "[legion] dispositioned finding {} ({}{}): {}",
+                finding.id,
+                finding.file,
+                finding.line.map(|l| format!(":{l}")).unwrap_or_default(),
+                reason
+            );
+        }
+
+        QualityGateAction::FindingAck {
+            branch,
+            skill,
+            reason,
+        } => {
+            let database = open_db()?;
+            let acked = database.batch_ack_low_findings(&branch, &skill, &reason)?;
+            println!(
+                "[legion] batch-acked {} LOW finding(s) on branch '{branch}' skill '{skill}': {reason}",
+                acked.len()
+            );
+            for f in &acked {
+                println!(
+                    "  - {} ({}{})",
+                    f.id,
+                    f.file,
+                    f.line.map(|l| format!(":{l}")).unwrap_or_default()
+                );
+            }
+        }
+
+        QualityGateAction::FindingList {
+            branch,
+            skill,
+            status,
+            json,
+        } => {
+            let status_typed: Option<FindingStatus> = match status.as_deref() {
+                Some(s) => Some(s.parse()?),
+                None => None,
+            };
+            let database = open_db()?;
+            let rows: Vec<QualityGateFinding> = database.list_findings(&FindingFilter {
+                branch,
+                skill,
+                status: status_typed,
+            })?;
+
+            if json {
+                println!("{}", serde_json::to_string(&rows)?);
+            } else {
+                print_findings_table(&rows);
+            }
         }
 
         QualityGateAction::Void {
@@ -389,6 +568,142 @@ pub(crate) fn handle_quality_gate(action: QualityGateAction) -> error::Result<()
         }
     }
     Ok(())
+}
+
+/// The finding-resolution gate (#773), shared by the Record and Check arms.
+///
+/// Always reconciles the PENDING set for `branch`/`skill` against
+/// `head_commit` first (a fix landed in an earlier commit resolves the
+/// finding before it can block anything). When `requesting_clean` is true,
+/// refuses the caller with a non-zero exit unless the post-reconcile PENDING
+/// set is empty -- no HIGH/MED finding left unresolved/undispositioned, and
+/// no LOW finding left un-acked. The predicate is branch+skill scoped and
+/// deliberately cross-commit: a `clean` run itself never has any of its own
+/// findings pending (it has none), so this only ever blocks on findings
+/// accumulated from PRIOR gate runs on the same branch -- which is the
+/// entire point (a finding written down on commit N must not evaporate just
+/// because commit N+1 reports clean).
+fn reconcile_and_refuse_if_findings_pending(
+    database: &db::Database,
+    branch: &str,
+    skill: &str,
+    head_commit: &str,
+    requesting_clean: bool,
+) -> error::Result<()> {
+    if let Err(e) =
+        finding_gate::reconcile_pending_findings(database, None, branch, skill, head_commit)
+    {
+        eprintln!("[legion] warning: finding-resolution reconcile failed (non-fatal): {e}");
+    }
+    if !requesting_clean {
+        return Ok(());
+    }
+    let pending = database.list_pending_findings(branch, skill)?;
+    let refusal = finding_gate::evaluate_refusal(&pending);
+    if refusal.blocks() {
+        eprintln!(
+            "[legion] error: cannot record a clean gate for skill '{skill}' on branch '{branch}' \
+             -- {} non-trivial finding(s) and {} LOW finding(s) remain undispositioned (#773):",
+            refusal.blocking.len(),
+            refusal.trivial_unacked.len()
+        );
+        for f in refusal
+            .blocking
+            .iter()
+            .chain(refusal.trivial_unacked.iter())
+        {
+            eprintln!(
+                "  - [{}] {}{} {} (id {})",
+                f.severity.as_str(),
+                f.file,
+                f.line.map(|l| format!(":{l}")).unwrap_or_default(),
+                f.summary,
+                f.id,
+            );
+        }
+        eprintln!(
+            "\nResolve by touching the flagged file in a later commit, disposition one with \
+             'legion quality-gate finding-disposition --id <id> --reason \"...\"', or batch-ack \
+             LOW findings with 'legion quality-gate finding-ack --branch {branch} --skill {skill} \
+             --reason \"...\"'."
+        );
+        return Err(error::LegionError::ExitWith(1));
+    }
+    Ok(())
+}
+
+/// Persist structured findings extracted from a gate run, tied to the just-
+/// recorded `gate` row (#773). An unparseable severity is treated as MED
+/// (fail closed, with a warning) rather than dropped -- dropping a finding
+/// here because its severity string was unexpected would reopen the exact
+/// evaporation hole this ledger exists to close. A per-finding insert
+/// failure is logged and does not abort the rest -- this is additive audit
+/// substrate alongside the gate row, not the gate's own success/failure
+/// path.
+fn persist_raw_findings(
+    database: &db::Database,
+    gate: &QualityGateRow,
+    raw_findings: &[finding_gate::RawFinding],
+) {
+    for rf in raw_findings {
+        let severity: FindingSeverity = rf.severity.parse().unwrap_or_else(|_| {
+            eprintln!(
+                "[legion] warning: unknown finding severity '{}' for {} -- treating as MED \
+                 (fail closed, #773)",
+                rf.severity, rf.file
+            );
+            FindingSeverity::Med
+        });
+        if let Err(e) = database.insert_finding(&NewFindingInput {
+            gate_id: &gate.id,
+            branch: &gate.branch,
+            skill: &gate.skill,
+            origin_commit: &gate.commit_hash,
+            file: &rf.file,
+            line: rf.line.map(i64::from),
+            severity,
+            summary: &rf.summary,
+        }) {
+            eprintln!(
+                "[legion] warning: failed to persist finding for {}: {e}",
+                rf.file
+            );
+        }
+    }
+}
+
+/// Print finding rows as a human-readable table to stdout (#773 AC4 audit
+/// surface). Columns: id (first 8 chars), branch, skill, file:line,
+/// severity, status, created_at. An empty slice prints nothing.
+fn print_findings_table(rows: &[QualityGateFinding]) {
+    if rows.is_empty() {
+        return;
+    }
+    println!(
+        "{:<8}  {:<20}  {:<16}  {:<30}  {:<4}  {:<14}  CREATED",
+        "ID", "BRANCH", "SKILL", "FILE", "SEV", "STATUS"
+    );
+    println!("{}", "-".repeat(130));
+    for row in rows {
+        let id_short: String = row.id.chars().take(8).collect();
+        let branch_trunc: String = row.branch.chars().take(20).collect();
+        let skill_trunc: String = row.skill.chars().take(16).collect();
+        let file_loc = match row.line {
+            Some(l) => format!("{}:{}", row.file, l),
+            None => row.file.clone(),
+        };
+        let file_trunc: String = file_loc.chars().take(30).collect();
+        println!(
+            "{:<8}  {:<20}  {:<16}  {:<30}  {:<4}  {:<14}  {}",
+            id_short,
+            branch_trunc,
+            skill_trunc,
+            file_trunc,
+            row.severity.as_str(),
+            row.status.as_str(),
+            row.created_at,
+        );
+    }
 }
 
 /// Print gate rows as a human-readable table to stdout.
@@ -1005,5 +1320,241 @@ mod tests {
              got {:?}",
             report.findings
         );
+    }
+
+    // --- finding-resolution gate wiring tests (#773) ---
+
+    /// `reconcile_and_refuse_if_findings_pending` refuses a `clean` request
+    /// when a HIGH finding from a prior run on the same branch+skill is
+    /// still PENDING. `origin_commit == head_commit` short-circuits the git
+    /// reconcile call (no real git repo state needed for this test).
+    #[test]
+    fn reconcile_and_refuse_blocks_clean_when_high_finding_pending() {
+        let db = test_db();
+        db.insert_finding(&NewFindingInput {
+            gate_id: "gate-1",
+            branch: "feat/x",
+            skill: "legion-simplify",
+            origin_commit: "commit-a",
+            file: "src/foo.rs",
+            line: Some(10),
+            severity: FindingSeverity::High,
+            summary: "unchecked input",
+        })
+        .unwrap();
+
+        let err = reconcile_and_refuse_if_findings_pending(
+            &db,
+            "feat/x",
+            "legion-simplify",
+            "commit-a",
+            true,
+        )
+        .unwrap_err();
+        assert!(matches!(err, error::LegionError::ExitWith(1)));
+    }
+
+    /// A LOW finding also blocks `clean` until batch-acked (#773 AC3) --
+    /// regression guard against silently treating LOW as non-blocking.
+    #[test]
+    fn reconcile_and_refuse_blocks_clean_when_low_finding_unacked() {
+        let db = test_db();
+        db.insert_finding(&NewFindingInput {
+            gate_id: "gate-1",
+            branch: "feat/x",
+            skill: "legion-simplify",
+            origin_commit: "commit-a",
+            file: "src/foo.rs",
+            line: Some(10),
+            severity: FindingSeverity::Low,
+            summary: "naming nit",
+        })
+        .unwrap();
+
+        let err = reconcile_and_refuse_if_findings_pending(
+            &db,
+            "feat/x",
+            "legion-simplify",
+            "commit-a",
+            true,
+        )
+        .unwrap_err();
+        assert!(matches!(err, error::LegionError::ExitWith(1)));
+    }
+
+    /// Once the pending finding is dispositioned, the same (branch, skill,
+    /// head_commit) request no longer refuses.
+    #[test]
+    fn reconcile_and_refuse_allows_clean_after_disposition() {
+        let db = test_db();
+        let finding = db
+            .insert_finding(&NewFindingInput {
+                gate_id: "gate-1",
+                branch: "feat/x",
+                skill: "legion-simplify",
+                origin_commit: "commit-a",
+                file: "src/foo.rs",
+                line: Some(10),
+                severity: FindingSeverity::High,
+                summary: "unchecked input",
+            })
+            .unwrap();
+        db.dispose_finding(&finding.id, "won't fix: intentional")
+            .unwrap();
+
+        reconcile_and_refuse_if_findings_pending(
+            &db,
+            "feat/x",
+            "legion-simplify",
+            "commit-a",
+            true,
+        )
+        .expect("clean should be allowed once the pending finding is dispositioned");
+    }
+
+    /// An empty pending set never blocks -- the common case (no findings
+    /// ever raised for this branch+skill).
+    #[test]
+    fn reconcile_and_refuse_allows_clean_with_no_pending_findings() {
+        let db = test_db();
+        reconcile_and_refuse_if_findings_pending(
+            &db,
+            "feat/x",
+            "legion-simplify",
+            "commit-a",
+            true,
+        )
+        .expect("no pending findings should never refuse");
+    }
+
+    /// A pending HIGH finding does NOT block an `issues` request -- the
+    /// refusal only ever applies to a `clean` claim (#773 AC1).
+    #[test]
+    fn reconcile_and_refuse_does_not_block_issues_result() {
+        let db = test_db();
+        db.insert_finding(&NewFindingInput {
+            gate_id: "gate-1",
+            branch: "feat/x",
+            skill: "legion-simplify",
+            origin_commit: "commit-a",
+            file: "src/foo.rs",
+            line: Some(10),
+            severity: FindingSeverity::High,
+            summary: "unchecked input",
+        })
+        .unwrap();
+
+        reconcile_and_refuse_if_findings_pending(
+            &db,
+            "feat/x",
+            "legion-simplify",
+            "commit-a",
+            false,
+        )
+        .expect("an issues (non-clean) request must never be refused by the pending set");
+    }
+
+    /// Findings on a different branch or skill never leak into this
+    /// branch+skill's refusal decision.
+    #[test]
+    fn reconcile_and_refuse_scoped_to_branch_and_skill() {
+        let db = test_db();
+        db.insert_finding(&NewFindingInput {
+            gate_id: "gate-1",
+            branch: "feat/other",
+            skill: "legion-simplify",
+            origin_commit: "commit-a",
+            file: "src/foo.rs",
+            line: Some(10),
+            severity: FindingSeverity::High,
+            summary: "unchecked input",
+        })
+        .unwrap();
+        db.insert_finding(&NewFindingInput {
+            gate_id: "gate-2",
+            branch: "feat/x",
+            skill: "legion-review",
+            origin_commit: "commit-a",
+            file: "src/foo.rs",
+            line: Some(10),
+            severity: FindingSeverity::High,
+            summary: "unchecked input",
+        })
+        .unwrap();
+
+        reconcile_and_refuse_if_findings_pending(
+            &db,
+            "feat/x",
+            "legion-simplify",
+            "commit-a",
+            true,
+        )
+        .expect("findings on another branch/skill must not block this one");
+    }
+
+    /// `persist_raw_findings` inserts one row per raw finding, tied to the
+    /// gate row's id/branch/skill/commit, with parsed severity.
+    #[test]
+    fn persist_raw_findings_inserts_rows_tied_to_gate() {
+        let db = test_db();
+        let gate = db
+            .record_quality_gate(&QualityGateInput {
+                branch: "feat/x",
+                commit_hash: "commit-a",
+                skill: "legion-review",
+                result: GateResult::Issues,
+                findings_count: 1,
+                details: None,
+                provenance: GateProvenance::Asserted,
+                base: None,
+            })
+            .unwrap();
+        let raw = vec![finding_gate::RawFinding {
+            file: "src/foo.rs".to_string(),
+            line: Some(12),
+            severity: "HIGH".to_string(),
+            summary: "unchecked input".to_string(),
+        }];
+
+        persist_raw_findings(&db, &gate, &raw);
+
+        let pending = db.list_pending_findings("feat/x", "legion-review").unwrap();
+        assert_eq!(pending.len(), 1);
+        assert_eq!(pending[0].gate_id, gate.id);
+        assert_eq!(pending[0].origin_commit, "commit-a");
+        assert_eq!(pending[0].severity, FindingSeverity::High);
+        assert_eq!(pending[0].file, "src/foo.rs");
+    }
+
+    /// An unparseable severity string is treated as MED (fail closed), not
+    /// dropped -- dropping a structured finding here would reopen the
+    /// evaporation hole this ledger closes.
+    #[test]
+    fn persist_raw_findings_treats_unknown_severity_as_med() {
+        let db = test_db();
+        let gate = db
+            .record_quality_gate(&QualityGateInput {
+                branch: "feat/x",
+                commit_hash: "commit-a",
+                skill: "legion-review",
+                result: GateResult::Issues,
+                findings_count: 1,
+                details: None,
+                provenance: GateProvenance::Asserted,
+                base: None,
+            })
+            .unwrap();
+        let raw = vec![finding_gate::RawFinding {
+            file: "src/foo.rs".to_string(),
+            line: None,
+            severity: "URGENT".to_string(),
+            summary: "weird severity string".to_string(),
+        }];
+
+        persist_raw_findings(&db, &gate, &raw);
+
+        let pending = db.list_pending_findings("feat/x", "legion-review").unwrap();
+        assert_eq!(pending.len(), 1);
+        assert_eq!(pending[0].severity, FindingSeverity::Med);
     }
 }

--- a/src/cli/verify.rs
+++ b/src/cli/verify.rs
@@ -776,20 +776,32 @@ fn persist_raw_findings(
     //     deliberately excluded: a finding that recurs identically after
     //     being fix-resolved is a regression worth a fresh PENDING row, not
     //     something to suppress.
-    // `unwrap_or_default` degrades to "no known duplicates" on a query
-    // failure rather than blocking the insert below on this best-effort
-    // dedup check. `seen_this_call` extends the same key to duplicates
-    // WITHIN one `raw_findings` batch (a single malformed/duplicated
-    // `--findings-json` payload listing the same triple twice), not just
-    // across separate calls -- `existing_open` alone cannot catch that,
-    // since neither copy is in the DB yet when the loop checks it.
+    // A query failure degrades to "no known duplicates" rather than blocking
+    // the insert below on this best-effort dedup check -- but unlike every
+    // other degrade-and-continue path in this function, that failure is now
+    // logged (previously silent), since a silent dedup-lookup failure could
+    // otherwise resurrect an already-DISPOSITIONED finding with no trace of
+    // why. `seen_this_call` extends the same key to duplicates WITHIN one
+    // `raw_findings` batch (a single malformed/duplicated `--findings-json`
+    // payload listing the same triple twice), not just across separate calls
+    // -- `existing_open` alone cannot catch that, since neither copy is in
+    // the DB yet when the loop checks it.
     let existing_open: Vec<QualityGateFinding> = database
         .list_findings(&FindingFilter {
             branch: Some(gate.branch.clone()),
             skill: Some(gate.skill.clone()),
             status: None,
         })
-        .unwrap_or_default()
+        .unwrap_or_else(|e| {
+            eprintln!(
+                "[legion] warning: dedup lookup failed for branch '{}' skill '{}' ({e}) -- \
+                 proceeding as if no existing findings are open; a re-reported finding may insert \
+                 a duplicate PENDING row this call instead of being recognized as already \
+                 tracked (#773).",
+                gate.branch, gate.skill
+            );
+            Vec::new()
+        })
         .into_iter()
         .filter(|f| f.status != FindingStatus::Resolved)
         .collect();

--- a/src/cli/verify.rs
+++ b/src/cli/verify.rs
@@ -697,10 +697,17 @@ fn persist_raw_findings(
     // every time -- two review passes over an unfixed MED would otherwise
     // leave two rows to disposition instead of one. `unwrap_or_default`
     // degrades to "no known duplicates" on a query failure rather than
-    // blocking the insert below on this best-effort dedup check.
+    // blocking the insert below on this best-effort dedup check. `seen_this_call`
+    // extends the same key to duplicates WITHIN one `raw_findings` batch (a
+    // single malformed/duplicated `--findings-json` payload listing the same
+    // triple twice), not just across separate calls -- `existing_pending`
+    // alone cannot catch that, since neither copy is in the DB yet when the
+    // loop checks it.
     let existing_pending = database
         .list_pending_findings(&gate.branch, &gate.skill)
         .unwrap_or_default();
+    let mut seen_this_call: std::collections::HashSet<(String, FindingSeverity, String)> =
+        std::collections::HashSet::new();
     for rf in raw_findings {
         let severity: FindingSeverity = rf.severity.parse().unwrap_or_else(|_| {
             eprintln!(
@@ -710,10 +717,11 @@ fn persist_raw_findings(
             );
             FindingSeverity::Med
         });
+        let key = (rf.file.clone(), severity, rf.summary.clone());
         let already_pending = existing_pending
             .iter()
             .any(|f| f.file == rf.file && f.severity == severity && f.summary == rf.summary);
-        if already_pending {
+        if already_pending || !seen_this_call.insert(key) {
             continue;
         }
         if let Err(e) = database.insert_finding(&NewFindingInput {
@@ -1812,6 +1820,42 @@ mod tests {
 
         let pending = db.list_pending_findings("feat/x", "legion-review").unwrap();
         assert_eq!(pending.len(), 2);
+    }
+
+    /// The dedup guard also catches a duplicate WITHIN a single batch, not
+    /// only across separate calls -- a malformed `--findings-json` payload
+    /// listing the identical triple twice must still land exactly one row.
+    #[test]
+    fn persist_raw_findings_dedupes_within_the_same_batch() {
+        let db = test_db();
+        let gate = db
+            .record_quality_gate(&QualityGateInput {
+                branch: "feat/x",
+                commit_hash: "commit-a",
+                skill: "legion-review",
+                result: GateResult::Issues,
+                findings_count: 2,
+                details: None,
+                provenance: GateProvenance::Asserted,
+                base: None,
+            })
+            .unwrap();
+        let duplicate = finding_gate::RawFinding {
+            file: "src/foo.rs".to_string(),
+            line: Some(12),
+            severity: "MED".to_string(),
+            summary: "unchecked input".to_string(),
+        };
+        let raw = vec![duplicate.clone(), duplicate];
+
+        persist_raw_findings(&db, &gate, &raw);
+
+        let pending = db.list_pending_findings("feat/x", "legion-review").unwrap();
+        assert_eq!(
+            pending.len(),
+            1,
+            "a duplicated entry within one batch must not double-insert"
+        );
     }
 
     /// `persist_raw_findings` inserts one row per raw finding, tied to the

--- a/src/db/findings.rs
+++ b/src/db/findings.rs
@@ -105,7 +105,7 @@ pub struct FindingFilter {
 fn parse_severity_from_db(s: String) -> std::result::Result<FindingSeverity, rusqlite::Error> {
     s.parse().map_err(|e: LegionError| {
         rusqlite::Error::FromSqlConversionFailure(
-            8,
+            7,
             rusqlite::types::Type::Text,
             Box::new(std::io::Error::other(e.to_string())),
         )
@@ -550,6 +550,40 @@ mod tests {
             .unwrap();
         assert_eq!(pending.len(), 1);
         assert_eq!(pending[0].file, "src/b.rs");
+    }
+
+    /// `branch` and `skill` filters combine with AND semantics, not just
+    /// each in isolation -- a row matching only one of the two must not
+    /// appear when both are supplied.
+    #[test]
+    fn list_findings_filters_by_branch_and_skill_combined() {
+        let db = test_db();
+        // Matches both filters.
+        db.insert_finding(&input("gate-1", "src/match.rs", FindingSeverity::High))
+            .unwrap();
+        // Matches branch only (different skill).
+        let mut other_skill = input("gate-2", "src/other-skill.rs", FindingSeverity::High);
+        other_skill.skill = "legion-review";
+        db.insert_finding(&other_skill).unwrap();
+        // Matches skill only (different branch).
+        let mut other_branch = input("gate-3", "src/other-branch.rs", FindingSeverity::High);
+        other_branch.branch = "feat/other";
+        db.insert_finding(&other_branch).unwrap();
+        // Matches neither.
+        let mut neither = input("gate-4", "src/neither.rs", FindingSeverity::High);
+        neither.branch = "feat/other";
+        neither.skill = "legion-review";
+        db.insert_finding(&neither).unwrap();
+
+        let rows = db
+            .list_findings(&FindingFilter {
+                branch: Some("feat/x".to_string()),
+                skill: Some("legion-simplify".to_string()),
+                status: None,
+            })
+            .unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].file, "src/match.rs");
     }
 
     #[test]

--- a/src/db/findings.rs
+++ b/src/db/findings.rs
@@ -1,0 +1,561 @@
+//! Quality-gate findings ledger (#773): a `quality_gate_findings` row per
+//! structured finding a gate run (`legion-simplify`, `legion-review`)
+//! surfaced, keyed to the `quality_gates.id` row that recorded it. Owns the
+//! `quality_gate_findings` DDL.
+//!
+//! Before this table, a finding existed only as free text inside
+//! `quality_gates.details` -- once a gate was recorded "clean" (or even
+//! "issues"), the individual finding was unrecoverable except by re-reading
+//! that JSON blob by hand, and nothing forced it to ever be acted on. This
+//! table makes a finding a first-class row with a lifecycle: PENDING until a
+//! later commit demonstrably touches the flagged file (RESOLVED, detected by
+//! `crate::finding_gate::reconcile_pending_findings`) or an operator/agent
+//! explicitly says why it will not be fixed (DISPOSITIONED, via
+//! `dispose_finding` / `batch_ack_low_findings`). `crate::finding_gate`
+//! reads the PENDING set to decide whether a `clean` verdict may be
+//! recorded at all.
+
+use chrono::Utc;
+use rusqlite::Connection;
+use uuid::Uuid;
+
+use super::Database;
+use crate::error::{LegionError, Result};
+use crate::finding_gate::{FindingSeverity, FindingStatus};
+
+/// `quality_gate_findings` table (#773). New table -- no `migrate()` is
+/// needed yet; future column additions here follow the has_column-ALTER
+/// pattern the other domain files use (see `quality_gates::migrate`).
+pub(super) fn create_tables(conn: &Connection) -> Result<()> {
+    conn.execute_batch(
+        "CREATE TABLE IF NOT EXISTS quality_gate_findings (
+                id TEXT PRIMARY KEY,
+                gate_id TEXT NOT NULL,
+                branch TEXT NOT NULL,
+                skill TEXT NOT NULL,
+                origin_commit TEXT NOT NULL,
+                file TEXT NOT NULL,
+                line INTEGER,
+                severity TEXT NOT NULL,
+                summary TEXT NOT NULL,
+                status TEXT NOT NULL DEFAULT 'pending',
+                disposition_reason TEXT,
+                resolved_by_commit TEXT,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL
+            );
+            CREATE INDEX IF NOT EXISTS idx_quality_gate_findings_gate
+                ON quality_gate_findings(gate_id);
+            CREATE INDEX IF NOT EXISTS idx_quality_gate_findings_branch_skill_status
+                ON quality_gate_findings(branch, skill, status);",
+    )?;
+    Ok(())
+}
+
+/// One structured finding extracted from a quality-gate run, keyed to the
+/// `quality_gates.id` row that recorded it.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+pub struct QualityGateFinding {
+    pub id: String,
+    /// `quality_gates.id` of the gate row this finding was extracted from.
+    pub gate_id: String,
+    /// Denormalized from the gate row so the pending-set query (branch +
+    /// skill, #773's refusal predicate) never needs a join.
+    pub branch: String,
+    pub skill: String,
+    /// `quality_gates.commit_hash` of the gate row this finding was raised
+    /// on -- the commit resolution detection reconciles *from*.
+    pub origin_commit: String,
+    pub file: String,
+    pub line: Option<i64>,
+    pub severity: FindingSeverity,
+    pub summary: String,
+    pub status: FindingStatus,
+    /// Required alongside a DISPOSITIONED status -- a disposition with no
+    /// reason is not an audit trail (mirrors `quality_gates.void_reason`).
+    pub disposition_reason: Option<String>,
+    /// The commit that resolved this finding, set only when `status` is
+    /// RESOLVED (see `crate::finding_gate::reconcile_pending_findings`).
+    pub resolved_by_commit: Option<String>,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+/// Input for inserting a new finding (#773).
+pub struct NewFindingInput<'a> {
+    pub gate_id: &'a str,
+    pub branch: &'a str,
+    pub skill: &'a str,
+    pub origin_commit: &'a str,
+    pub file: &'a str,
+    pub line: Option<i64>,
+    pub severity: FindingSeverity,
+    pub summary: &'a str,
+}
+
+/// Filter parameters for `list_findings`, the audit surface (#773 AC4). All
+/// fields are optional; `None` means "no filter on this dimension".
+#[derive(Debug, Default)]
+pub struct FindingFilter {
+    pub branch: Option<String>,
+    pub skill: Option<String>,
+    pub status: Option<FindingStatus>,
+}
+
+fn parse_severity_from_db(s: String) -> std::result::Result<FindingSeverity, rusqlite::Error> {
+    s.parse().map_err(|e: LegionError| {
+        rusqlite::Error::FromSqlConversionFailure(
+            8,
+            rusqlite::types::Type::Text,
+            Box::new(std::io::Error::other(e.to_string())),
+        )
+    })
+}
+
+fn parse_status_from_db(s: String) -> std::result::Result<FindingStatus, rusqlite::Error> {
+    s.parse().map_err(|e: LegionError| {
+        rusqlite::Error::FromSqlConversionFailure(
+            9,
+            rusqlite::types::Type::Text,
+            Box::new(std::io::Error::other(e.to_string())),
+        )
+    })
+}
+
+/// Shared row-mapping closure for the 13-column `SELECT ... FROM
+/// quality_gate_findings` shape every read path here uses.
+fn row_to_finding(
+    row: &rusqlite::Row<'_>,
+) -> std::result::Result<QualityGateFinding, rusqlite::Error> {
+    let severity_str: String = row.get(7)?;
+    let status_str: String = row.get(9)?;
+    Ok(QualityGateFinding {
+        id: row.get(0)?,
+        gate_id: row.get(1)?,
+        branch: row.get(2)?,
+        skill: row.get(3)?,
+        origin_commit: row.get(4)?,
+        file: row.get(5)?,
+        line: row.get(6)?,
+        severity: parse_severity_from_db(severity_str)?,
+        summary: row.get(8)?,
+        status: parse_status_from_db(status_str)?,
+        disposition_reason: row.get(10)?,
+        resolved_by_commit: row.get(11)?,
+        created_at: row.get(12)?,
+        updated_at: row.get(13)?,
+    })
+}
+
+const SELECT_COLUMNS: &str = "id, gate_id, branch, skill, origin_commit, file, line, severity, \
+     summary, status, disposition_reason, resolved_by_commit, created_at, updated_at";
+
+impl Database {
+    /// Insert a new PENDING finding extracted from a just-recorded gate row.
+    pub fn insert_finding(&self, input: &NewFindingInput<'_>) -> Result<QualityGateFinding> {
+        let id = Uuid::now_v7().to_string();
+        let now = Utc::now().to_rfc3339();
+        self.conn.execute(
+            "INSERT INTO quality_gate_findings \
+             (id, gate_id, branch, skill, origin_commit, file, line, severity, summary, \
+              status, disposition_reason, resolved_by_commit, created_at, updated_at) \
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, NULL, NULL, ?11, ?11)",
+            rusqlite::params![
+                &id,
+                input.gate_id,
+                input.branch,
+                input.skill,
+                input.origin_commit,
+                input.file,
+                input.line,
+                input.severity.as_str(),
+                input.summary,
+                FindingStatus::Pending.as_str(),
+                &now,
+            ],
+        )?;
+        Ok(QualityGateFinding {
+            id,
+            gate_id: input.gate_id.to_owned(),
+            branch: input.branch.to_owned(),
+            skill: input.skill.to_owned(),
+            origin_commit: input.origin_commit.to_owned(),
+            file: input.file.to_owned(),
+            line: input.line,
+            severity: input.severity,
+            summary: input.summary.to_owned(),
+            status: FindingStatus::Pending,
+            disposition_reason: None,
+            resolved_by_commit: None,
+            created_at: now.clone(),
+            updated_at: now,
+        })
+    }
+
+    /// Look up a finding by id regardless of status, or `None` if it does not exist.
+    pub fn get_finding_by_id(&self, id: &str) -> Result<Option<QualityGateFinding>> {
+        let mut stmt = self.conn.prepare(&format!(
+            "SELECT {SELECT_COLUMNS} FROM quality_gate_findings WHERE id = ?1"
+        ))?;
+        let mut rows = stmt.query_map(rusqlite::params![id], row_to_finding)?;
+        match rows.next() {
+            Some(Ok(row)) => Ok(Some(row)),
+            Some(Err(e)) => Err(LegionError::Database(e)),
+            None => Ok(None),
+        }
+    }
+
+    /// PENDING findings for a (branch, skill) pair, oldest first -- the set
+    /// `crate::finding_gate::evaluate_refusal` and
+    /// `crate::finding_gate::reconcile_pending_findings` both read.
+    pub fn list_pending_findings(
+        &self,
+        branch: &str,
+        skill: &str,
+    ) -> Result<Vec<QualityGateFinding>> {
+        let mut stmt = self.conn.prepare(&format!(
+            "SELECT {SELECT_COLUMNS} FROM quality_gate_findings \
+             WHERE branch = ?1 AND skill = ?2 AND status = ?3 \
+             ORDER BY created_at ASC"
+        ))?;
+        let rows = stmt.query_map(
+            rusqlite::params![branch, skill, FindingStatus::Pending.as_str()],
+            row_to_finding,
+        )?;
+        let mut out = Vec::new();
+        for row in rows {
+            out.push(row.map_err(LegionError::Database)?);
+        }
+        Ok(out)
+    }
+
+    /// The audit surface (#773 AC4): every finding matching `filter`, newest
+    /// first, across every status -- fixed (RESOLVED), waived
+    /// (DISPOSITIONED), and PENDING alike.
+    pub fn list_findings(&self, filter: &FindingFilter) -> Result<Vec<QualityGateFinding>> {
+        let mut clauses: Vec<(&str, Box<dyn rusqlite::ToSql>)> = Vec::new();
+        if let Some(ref b) = filter.branch {
+            clauses.push(("branch = ?", Box::new(b.clone())));
+        }
+        if let Some(ref s) = filter.skill {
+            clauses.push(("skill = ?", Box::new(s.clone())));
+        }
+        if let Some(s) = filter.status {
+            clauses.push(("status = ?", Box::new(s.as_str().to_owned())));
+        }
+        let predicates: Vec<&str> = clauses.iter().map(|(p, _)| *p).collect();
+        let where_clause = if predicates.is_empty() {
+            String::new()
+        } else {
+            format!("WHERE {}", predicates.join(" AND "))
+        };
+        let sql = format!(
+            "SELECT {SELECT_COLUMNS} FROM quality_gate_findings {where_clause} \
+             ORDER BY created_at DESC"
+        );
+        let mut stmt = self.conn.prepare(&sql)?;
+        let rows = stmt.query_map(
+            rusqlite::params_from_iter(clauses.iter().map(|(_, v)| v.as_ref())),
+            row_to_finding,
+        )?;
+        let mut out = Vec::new();
+        for row in rows {
+            out.push(row.map_err(LegionError::Database)?);
+        }
+        Ok(out)
+    }
+
+    /// Mark a PENDING finding DISPOSITIONED with an explicit reason (#773 --
+    /// "silent drop is refused"). Errors when the finding does not exist, or
+    /// when it is not currently PENDING (a RESOLVED finding needs no
+    /// disposition; re-dispositioning an already-DISPOSITIONED one should go
+    /// through the same explicit id-scoped call, which this still permits --
+    /// only a RESOLVED finding is refused, since silently overriding proof of
+    /// a fix with a waiver would be the exact hole this table closes).
+    pub fn dispose_finding(&self, id: &str, reason: &str) -> Result<QualityGateFinding> {
+        let existing = self
+            .get_finding_by_id(id)?
+            .ok_or_else(|| LegionError::FindingNotFound(id.to_owned()))?;
+        if existing.status == FindingStatus::Resolved {
+            return Err(LegionError::FindingAlreadyResolved(id.to_owned()));
+        }
+        let now = Utc::now().to_rfc3339();
+        self.conn.execute(
+            "UPDATE quality_gate_findings \
+             SET status = ?1, disposition_reason = ?2, updated_at = ?3 \
+             WHERE id = ?4",
+            rusqlite::params![FindingStatus::Dispositioned.as_str(), reason, &now, id],
+        )?;
+        self.get_finding_by_id(id)?
+            .ok_or_else(|| LegionError::FindingNotFound(id.to_owned()))
+    }
+
+    /// Mark a finding RESOLVED with the commit that resolved it. Used only by
+    /// `crate::finding_gate::reconcile_pending_findings` (git-log detection),
+    /// never directly by a CLI verb -- a resolution is discovered, not
+    /// asserted.
+    pub fn mark_finding_resolved(
+        &self,
+        id: &str,
+        resolved_by_commit: &str,
+    ) -> Result<QualityGateFinding> {
+        let now = Utc::now().to_rfc3339();
+        let affected = self.conn.execute(
+            "UPDATE quality_gate_findings \
+             SET status = ?1, resolved_by_commit = ?2, updated_at = ?3 \
+             WHERE id = ?4",
+            rusqlite::params![
+                FindingStatus::Resolved.as_str(),
+                resolved_by_commit,
+                &now,
+                id
+            ],
+        )?;
+        if affected == 0 {
+            return Err(LegionError::FindingNotFound(id.to_owned()));
+        }
+        self.get_finding_by_id(id)?
+            .ok_or_else(|| LegionError::FindingNotFound(id.to_owned()))
+    }
+
+    /// Batch-acknowledge every PENDING LOW-severity finding for a
+    /// (branch, skill) pair with one shared reason (#773 AC3 -- "a conscious
+    /// sweep, not per-nit ceremony"). Each finding is still dispositioned
+    /// individually (its own row, its own `updated_at`), so the audit trail
+    /// stays per-finding even though the reason is shared. Returns the
+    /// findings that were acknowledged; an empty vec is not an error (there
+    /// may simply be nothing pending to ack).
+    pub fn batch_ack_low_findings(
+        &self,
+        branch: &str,
+        skill: &str,
+        reason: &str,
+    ) -> Result<Vec<QualityGateFinding>> {
+        let mut stmt = self.conn.prepare(&format!(
+            "SELECT {SELECT_COLUMNS} FROM quality_gate_findings \
+             WHERE branch = ?1 AND skill = ?2 AND status = ?3 AND severity = ?4 \
+             ORDER BY created_at ASC"
+        ))?;
+        let rows = stmt.query_map(
+            rusqlite::params![
+                branch,
+                skill,
+                FindingStatus::Pending.as_str(),
+                FindingSeverity::Low.as_str()
+            ],
+            row_to_finding,
+        )?;
+        let mut targets = Vec::new();
+        for row in rows {
+            targets.push(row.map_err(LegionError::Database)?);
+        }
+        let mut acked = Vec::with_capacity(targets.len());
+        for finding in &targets {
+            acked.push(self.dispose_finding(&finding.id, reason)?);
+        }
+        Ok(acked)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::testutil::test_db;
+
+    fn input<'a>(
+        gate_id: &'a str,
+        file: &'a str,
+        severity: FindingSeverity,
+    ) -> NewFindingInput<'a> {
+        NewFindingInput {
+            gate_id,
+            branch: "feat/x",
+            skill: "legion-simplify",
+            origin_commit: "commit-a",
+            file,
+            line: Some(42),
+            severity,
+            summary: "duplicate logic in two match arms",
+        }
+    }
+
+    #[test]
+    fn insert_and_lookup_finding_by_id() {
+        let db = test_db();
+        let row = db
+            .insert_finding(&input("gate-1", "src/foo.rs", FindingSeverity::Med))
+            .unwrap();
+        assert!(!row.id.is_empty());
+        assert_eq!(row.status, FindingStatus::Pending);
+        assert!(row.disposition_reason.is_none());
+        assert!(row.resolved_by_commit.is_none());
+
+        let fetched = db.get_finding_by_id(&row.id).unwrap().unwrap();
+        assert_eq!(fetched.file, "src/foo.rs");
+        assert_eq!(fetched.severity, FindingSeverity::Med);
+    }
+
+    #[test]
+    fn get_finding_by_id_missing_returns_none() {
+        let db = test_db();
+        assert!(db.get_finding_by_id("no-such-id").unwrap().is_none());
+    }
+
+    #[test]
+    fn list_pending_findings_scoped_to_branch_and_skill() {
+        let db = test_db();
+        db.insert_finding(&input("gate-1", "src/a.rs", FindingSeverity::High))
+            .unwrap();
+        let mut other_skill = input("gate-2", "src/b.rs", FindingSeverity::High);
+        other_skill.skill = "legion-review";
+        db.insert_finding(&other_skill).unwrap();
+        let mut other_branch = input("gate-3", "src/c.rs", FindingSeverity::High);
+        other_branch.branch = "feat/other";
+        db.insert_finding(&other_branch).unwrap();
+
+        let pending = db
+            .list_pending_findings("feat/x", "legion-simplify")
+            .unwrap();
+        assert_eq!(pending.len(), 1);
+        assert_eq!(pending[0].file, "src/a.rs");
+    }
+
+    #[test]
+    fn dispose_finding_sets_status_and_reason() {
+        let db = test_db();
+        let row = db
+            .insert_finding(&input("gate-1", "src/foo.rs", FindingSeverity::Low))
+            .unwrap();
+        let disposed = db
+            .dispose_finding(&row.id, "won't fix: intentional")
+            .unwrap();
+        assert_eq!(disposed.status, FindingStatus::Dispositioned);
+        assert_eq!(
+            disposed.disposition_reason.as_deref(),
+            Some("won't fix: intentional")
+        );
+    }
+
+    #[test]
+    fn dispose_finding_missing_id_errors() {
+        let db = test_db();
+        let err = db.dispose_finding("no-such-id", "reason").unwrap_err();
+        assert!(err.to_string().contains("no-such-id"));
+    }
+
+    #[test]
+    fn dispose_finding_refuses_an_already_resolved_row() {
+        let db = test_db();
+        let row = db
+            .insert_finding(&input("gate-1", "src/foo.rs", FindingSeverity::Med))
+            .unwrap();
+        db.mark_finding_resolved(&row.id, "commit-b").unwrap();
+        let err = db.dispose_finding(&row.id, "reason").unwrap_err();
+        assert!(err.to_string().contains(&row.id));
+    }
+
+    #[test]
+    fn mark_finding_resolved_sets_status_and_commit() {
+        let db = test_db();
+        let row = db
+            .insert_finding(&input("gate-1", "src/foo.rs", FindingSeverity::High))
+            .unwrap();
+        let resolved = db.mark_finding_resolved(&row.id, "commit-fix").unwrap();
+        assert_eq!(resolved.status, FindingStatus::Resolved);
+        assert_eq!(resolved.resolved_by_commit.as_deref(), Some("commit-fix"));
+    }
+
+    #[test]
+    fn mark_finding_resolved_missing_id_errors() {
+        let db = test_db();
+        let err = db
+            .mark_finding_resolved("no-such-id", "commit-x")
+            .unwrap_err();
+        assert!(err.to_string().contains("no-such-id"));
+    }
+
+    #[test]
+    fn resolved_finding_excluded_from_pending_list() {
+        let db = test_db();
+        let row = db
+            .insert_finding(&input("gate-1", "src/foo.rs", FindingSeverity::High))
+            .unwrap();
+        db.mark_finding_resolved(&row.id, "commit-fix").unwrap();
+        let pending = db
+            .list_pending_findings("feat/x", "legion-simplify")
+            .unwrap();
+        assert!(pending.is_empty());
+    }
+
+    #[test]
+    fn batch_ack_low_findings_only_touches_pending_low_severity() {
+        let db = test_db();
+        db.insert_finding(&input("gate-1", "src/low-a.rs", FindingSeverity::Low))
+            .unwrap();
+        db.insert_finding(&input("gate-1", "src/low-b.rs", FindingSeverity::Low))
+            .unwrap();
+        db.insert_finding(&input("gate-1", "src/high.rs", FindingSeverity::High))
+            .unwrap();
+
+        let acked = db
+            .batch_ack_low_findings("feat/x", "legion-simplify", "batch ack: formatting only")
+            .unwrap();
+        assert_eq!(acked.len(), 2);
+        assert!(
+            acked
+                .iter()
+                .all(|f| f.disposition_reason.as_deref() == Some("batch ack: formatting only"))
+        );
+
+        let pending = db
+            .list_pending_findings("feat/x", "legion-simplify")
+            .unwrap();
+        assert_eq!(pending.len(), 1);
+        assert_eq!(pending[0].severity, FindingSeverity::High);
+    }
+
+    #[test]
+    fn batch_ack_low_findings_empty_when_nothing_pending() {
+        let db = test_db();
+        let acked = db
+            .batch_ack_low_findings("feat/x", "legion-simplify", "reason")
+            .unwrap();
+        assert!(acked.is_empty());
+    }
+
+    #[test]
+    fn list_findings_filters_by_status() {
+        let db = test_db();
+        let a = db
+            .insert_finding(&input("gate-1", "src/a.rs", FindingSeverity::High))
+            .unwrap();
+        db.insert_finding(&input("gate-1", "src/b.rs", FindingSeverity::Med))
+            .unwrap();
+        db.dispose_finding(&a.id, "won't fix").unwrap();
+
+        let dispositioned = db
+            .list_findings(&FindingFilter {
+                status: Some(FindingStatus::Dispositioned),
+                ..Default::default()
+            })
+            .unwrap();
+        assert_eq!(dispositioned.len(), 1);
+        assert_eq!(dispositioned[0].file, "src/a.rs");
+
+        let pending = db
+            .list_findings(&FindingFilter {
+                status: Some(FindingStatus::Pending),
+                ..Default::default()
+            })
+            .unwrap();
+        assert_eq!(pending.len(), 1);
+        assert_eq!(pending[0].file, "src/b.rs");
+    }
+
+    #[test]
+    fn list_findings_empty_returns_empty_vec() {
+        let db = test_db();
+        let rows = db.list_findings(&FindingFilter::default()).unwrap();
+        assert!(rows.is_empty());
+    }
+}

--- a/src/db/findings.rs
+++ b/src/db/findings.rs
@@ -122,7 +122,7 @@ fn parse_status_from_db(s: String) -> std::result::Result<FindingStatus, rusqlit
     })
 }
 
-/// Shared row-mapping closure for the 13-column `SELECT ... FROM
+/// Shared row-mapping closure for the 14-column `SELECT ... FROM
 /// quality_gate_findings` shape every read path here uses.
 fn row_to_finding(
     row: &rusqlite::Row<'_>,

--- a/src/db/findings.rs
+++ b/src/db/findings.rs
@@ -592,4 +592,28 @@ mod tests {
         let rows = db.list_findings(&FindingFilter::default()).unwrap();
         assert!(rows.is_empty());
     }
+
+    /// `list_findings` orders newest first (matches `list_quality_gates`'s
+    /// own newest-first convention) -- the audit surface (#773 AC4) reads
+    /// top-down as "most recent first", not insertion order.
+    #[test]
+    fn list_findings_newest_first() {
+        let db = test_db();
+        db.insert_finding(&input("gate-1", "src/older.rs", FindingSeverity::High))
+            .unwrap();
+        // Force a strictly later timestamp, same technique
+        // `quality_gates.rs`'s own `list_quality_gates_newest_first` test
+        // uses for the same sub-second RFC3339 bucket collision risk.
+        std::thread::sleep(std::time::Duration::from_millis(1));
+        db.insert_finding(&input("gate-2", "src/newer.rs", FindingSeverity::High))
+            .unwrap();
+
+        let rows = db.list_findings(&FindingFilter::default()).unwrap();
+        assert_eq!(rows.len(), 2);
+        assert_eq!(
+            rows[0].file, "src/newer.rs",
+            "the newer row must sort first"
+        );
+        assert_eq!(rows[1].file, "src/older.rs");
+    }
 }

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -11,6 +11,7 @@ mod autonomy;
 mod board;
 pub mod css_symbols;
 mod documents;
+pub(crate) mod findings;
 mod health;
 mod heartbeat;
 pub mod inventory;
@@ -131,6 +132,7 @@ impl Database {
         health::create_tables(conn)?;
         audit::create_tables(conn)?;
         quality_gates::create_tables(conn)?;
+        findings::create_tables(conn)?;
         statusline_samples::create_tables(conn)?;
         wake::create_tables(conn)?;
         scip::create_tables(conn)?;

--- a/src/error.rs
+++ b/src/error.rs
@@ -201,6 +201,21 @@ pub enum LegionError {
     #[error("quality gate row not found: {0}")]
     QualityGateNotFound(String),
 
+    #[error("invalid finding severity: '{0}' (expected 'high', 'med', or 'low')")]
+    InvalidFindingSeverity(String),
+
+    #[error("invalid finding status: '{0}' (expected 'pending', 'resolved', or 'dispositioned')")]
+    InvalidFindingStatus(String),
+
+    #[error("quality gate finding not found: {0}")]
+    FindingNotFound(String),
+
+    #[error(
+        "finding {0} is already RESOLVED (a later commit demonstrably touched the flagged \
+         file) -- a resolved finding needs no disposition"
+    )]
+    FindingAlreadyResolved(String),
+
     #[error("delegation refused: {0}")]
     DelegationRefused(String),
 
@@ -332,6 +347,33 @@ mod tests {
     fn quality_gate_not_found_display() {
         let err = LegionError::QualityGateNotFound("gate-id-1".to_string());
         assert!(err.to_string().contains("gate-id-1"));
+    }
+
+    #[test]
+    fn invalid_finding_severity_display() {
+        let err = LegionError::InvalidFindingSeverity("critical".to_string());
+        assert!(err.to_string().contains("critical"));
+        assert!(err.to_string().contains("high"));
+    }
+
+    #[test]
+    fn invalid_finding_status_display() {
+        let err = LegionError::InvalidFindingStatus("waived".to_string());
+        assert!(err.to_string().contains("waived"));
+        assert!(err.to_string().contains("pending"));
+    }
+
+    #[test]
+    fn finding_not_found_display() {
+        let err = LegionError::FindingNotFound("finding-1".to_string());
+        assert!(err.to_string().contains("finding-1"));
+    }
+
+    #[test]
+    fn finding_already_resolved_display() {
+        let err = LegionError::FindingAlreadyResolved("finding-2".to_string());
+        assert!(err.to_string().contains("finding-2"));
+        assert!(err.to_string().contains("RESOLVED"));
     }
 
     #[test]

--- a/src/finding_gate.rs
+++ b/src/finding_gate.rs
@@ -39,7 +39,7 @@ use crate::error::{LegionError, Result};
 /// Severity of a structured finding (#773). Stored as lowercase string in
 /// `quality_gate_findings.severity`, mirroring `GateResult`'s
 /// Display/FromStr/serde symmetry in `verify.rs`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum FindingSeverity {
     High,

--- a/src/finding_gate.rs
+++ b/src/finding_gate.rs
@@ -1,0 +1,679 @@
+//! Finding-resolution gate (#773): the business-logic layer for
+//! `db::findings`, mirroring how `verify.rs` owns `GateResult` /
+//! `GateProvenance` while `db::quality_gates` owns their persistence.
+//!
+//! Three concerns live here:
+//!   - `FindingSeverity` / `FindingStatus`: the closed enums the findings
+//!     ledger is typed over.
+//!   - Structured extraction: `RawFinding` plus the two parse entry points
+//!     (`extract_findings_from_value` for `--details-json`'s `findings` key,
+//!     `parse_findings_array` for `--findings-json`'s bare array) that turn a
+//!     skill's structured JSON output into rows `db::findings::insert_finding`
+//!     can persist. Deliberately does NOT parse prose -- the legion-simplify
+//!     articulation's "Verdict: finding (duplication, MED)" convention is not
+//!     rigid enough to extract from reliably; that skill must emit
+//!     `--findings-json` instead (see plugin/skills/legion-simplify/SKILL.md).
+//!   - Resolution + refusal: `reconcile_pending_findings` (git-log-based
+//!     resolution detection: a commit after a finding's origin that touches
+//!     the flagged file resolves it) and `evaluate_refusal` (the pure
+//!     predicate a `clean` verdict must clear -- no non-trivial finding
+//!     pending, no un-acked LOW finding). The predicate is branch+skill
+//!     scoped and cross-commit BY DESIGN: a clean run itself has zero new
+//!     findings, so a same-run-only reading would make the gate vacuous, and
+//!     "a subsequent commit resolves it" only means anything measured against
+//!     prior gate runs on the same branch.
+
+use std::process::Command;
+use std::str::FromStr;
+
+use crate::db::Database;
+use crate::db::findings::QualityGateFinding;
+use crate::error::{LegionError, Result};
+
+/// Severity of a structured finding (#773). Stored as lowercase string in
+/// `quality_gate_findings.severity`, mirroring `GateResult`'s
+/// Display/FromStr/serde symmetry in `verify.rs`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum FindingSeverity {
+    High,
+    Med,
+    Low,
+}
+
+impl FindingSeverity {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::High => "high",
+            Self::Med => "med",
+            Self::Low => "low",
+        }
+    }
+
+    /// True for HIGH/MED -- a finding at this severity blocks a `clean`
+    /// verdict until it is resolved or explicitly dispositioned (#773 AC1/2).
+    /// LOW findings block too, but only until batch-acked (AC3) -- see
+    /// `evaluate_refusal`, which is where that distinction is applied, not
+    /// here; this predicate exists so callers never have to spell out
+    /// `!= Low` themselves.
+    pub fn is_non_trivial(self) -> bool {
+        matches!(self, Self::High | Self::Med)
+    }
+}
+
+impl std::fmt::Display for FindingSeverity {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl FromStr for FindingSeverity {
+    type Err = LegionError;
+
+    fn from_str(s: &str) -> Result<Self> {
+        match s.to_ascii_lowercase().as_str() {
+            "high" => Ok(Self::High),
+            "med" | "medium" => Ok(Self::Med),
+            "low" => Ok(Self::Low),
+            other => Err(LegionError::InvalidFindingSeverity(other.to_string())),
+        }
+    }
+}
+
+/// Lifecycle status of a structured finding (#773). Stored as lowercase
+/// string in `quality_gate_findings.status`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum FindingStatus {
+    /// Newly extracted; neither resolved nor dispositioned.
+    Pending,
+    /// A commit after the finding's origin demonstrably touched the flagged
+    /// file (`reconcile_pending_findings`).
+    Resolved,
+    /// An explicit reason was recorded for not fixing it (`dispose_finding`
+    /// / `batch_ack_low_findings`).
+    Dispositioned,
+}
+
+impl FindingStatus {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Pending => "pending",
+            Self::Resolved => "resolved",
+            Self::Dispositioned => "dispositioned",
+        }
+    }
+}
+
+impl std::fmt::Display for FindingStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl FromStr for FindingStatus {
+    type Err = LegionError;
+
+    fn from_str(s: &str) -> Result<Self> {
+        match s.to_ascii_lowercase().as_str() {
+            "pending" => Ok(Self::Pending),
+            "resolved" => Ok(Self::Resolved),
+            "dispositioned" => Ok(Self::Dispositioned),
+            other => Err(LegionError::InvalidFindingStatus(other.to_string())),
+        }
+    }
+}
+
+// --- Structured extraction ---
+
+/// A finding as a skill emits it over JSON, before severity has been parsed
+/// into `FindingSeverity`. `line` and `severity` are deliberately loose at
+/// this layer (skills emit `"HIGH"`/`"MED"`/`"LOW"`, or occasionally a
+/// less-clean value) -- the caller (`cli::verify`) maps an unparseable
+/// severity to MED with a warning rather than dropping the finding, since
+/// silently discarding a structured finding here would reopen exactly the
+/// evaporation hole this issue closes.
+#[derive(Debug, Clone, serde::Deserialize)]
+pub struct RawFinding {
+    pub file: String,
+    pub line: Option<u32>,
+    pub severity: String,
+    pub summary: String,
+}
+
+/// Pull the `findings` array out of a `--details-json` object, e.g. the
+/// legion-review contract (`{"decision": ..., "findings": [...], ...}`).
+/// Missing key, wrong shape, or an unparseable entry all degrade to "no
+/// finding from that slot" rather than failing the whole gate record --
+/// `findings_count` on the gate row itself stays the source of truth for how
+/// many findings a run reported; this ledger is additive audit substrate.
+pub fn extract_findings_from_value(value: &serde_json::Value) -> Vec<RawFinding> {
+    let Some(arr) = value.get("findings").and_then(|v| v.as_array()) else {
+        return Vec::new();
+    };
+    arr.iter()
+        .filter_map(|v| serde_json::from_value::<RawFinding>(v.clone()).ok())
+        .collect()
+}
+
+/// Parse a bare JSON array of findings, e.g. `legion quality-gate check
+/// --findings-json`'s payload. Unlike `extract_findings_from_value`, a
+/// malformed top-level payload (not a JSON array at all) IS an error -- the
+/// caller passed `--findings-json` explicitly, so garbage there should be
+/// loud, not silently treated as "no findings".
+pub fn parse_findings_array(raw: &str) -> Result<Vec<RawFinding>> {
+    serde_json::from_str::<Vec<RawFinding>>(raw).map_err(|e| {
+        LegionError::WorkSource(format!(
+            "--findings-json is not a JSON array of findings: {e}"
+        ))
+    })
+}
+
+// --- Refusal predicate ---
+
+/// The result of evaluating the PENDING set for a (branch, skill) pair
+/// against the refusal predicate (#773 AC1-3).
+#[derive(Debug, Default)]
+pub struct FindingRefusal {
+    /// PENDING findings at HIGH/MED severity -- block `clean` until resolved
+    /// or individually dispositioned.
+    pub blocking: Vec<QualityGateFinding>,
+    /// PENDING findings at LOW severity -- block `clean` until batch-acked,
+    /// but never require per-item ceremony (AC3).
+    pub trivial_unacked: Vec<QualityGateFinding>,
+}
+
+impl FindingRefusal {
+    /// True when a `clean` verdict must be refused.
+    pub fn blocks(&self) -> bool {
+        !self.blocking.is_empty() || !self.trivial_unacked.is_empty()
+    }
+}
+
+/// Pure predicate: partition an already-PENDING finding set into blocking
+/// (HIGH/MED) and trivial-unacked (LOW). Callers pass the PENDING set for a
+/// single (branch, skill) pair post-reconcile (`db::list_pending_findings`);
+/// a finding whose status is not PENDING is skipped defensively (it should
+/// never appear in that set, but this function makes no assumption about its
+/// caller having already filtered).
+pub fn evaluate_refusal(pending: &[QualityGateFinding]) -> FindingRefusal {
+    let mut refusal = FindingRefusal::default();
+    for finding in pending {
+        if finding.status != FindingStatus::Pending {
+            continue;
+        }
+        if finding.severity.is_non_trivial() {
+            refusal.blocking.push(finding.clone());
+        } else {
+            refusal.trivial_unacked.push(finding.clone());
+        }
+    }
+    refusal
+}
+
+// --- Resolution detection ---
+
+/// Pure predicate: given the commit hashes (oldest-first) that touched a
+/// file strictly after a finding's origin commit, return the one that
+/// resolved it -- the earliest commit in that range, i.e. the first commit
+/// that touched the file once the finding existed. `None` means still
+/// pending (the range was empty).
+pub fn resolving_commit(touching_commits_oldest_first: &[String]) -> Option<&String> {
+    touching_commits_oldest_first.first()
+}
+
+/// Thin git wrapper: commit hashes (oldest-first) that touched `file`
+/// strictly between `origin_commit` (exclusive) and `head_commit`
+/// (inclusive). File-level touch detection, not line-level -- `git log -L`
+/// line-tracking is fragile as unrelated edits shift line numbers, so this
+/// checks "did any commit since the finding was raised modify this file at
+/// all", the same granularity `cli::util::git_changed_files` already uses
+/// for the simplify coverage set.
+///
+/// Returns an empty vec (not an error) when the range is empty
+/// (`origin_commit == head_commit`) or git reports no matching commits. A
+/// git invocation failure IS an error -- it must never be silently read as
+/// "nothing touched it".
+///
+/// `repo_dir` sets the git invocation's working directory explicitly when
+/// `Some` (tests, against an isolated fixture repo); `None` runs against the
+/// process's current directory, which is always correct in production since
+/// every `legion` CLI invocation already runs from inside the repo it is
+/// operating on (matching `cli::util::git_changed_files`'s convention).
+pub fn commits_touching_file_in_range(
+    repo_dir: Option<&std::path::Path>,
+    origin_commit: &str,
+    head_commit: &str,
+    file: &str,
+) -> Result<Vec<String>> {
+    if origin_commit == head_commit {
+        return Ok(Vec::new());
+    }
+    let range = format!("{origin_commit}..{head_commit}");
+    let mut cmd = Command::new("git");
+    if let Some(dir) = repo_dir {
+        cmd.current_dir(dir);
+    }
+    let out = cmd
+        .args(["log", "--format=%H", "--reverse", &range, "--", file])
+        .output()
+        .map_err(|e| LegionError::WorkSource(format!("failed to run git log for {file}: {e}")))?;
+    if !out.status.success() {
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        return Err(LegionError::WorkSource(format!(
+            "git log --format=%H --reverse {range} -- {file} failed: {stderr}"
+        )));
+    }
+    Ok(String::from_utf8_lossy(&out.stdout)
+        .lines()
+        .map(str::to_owned)
+        .filter(|l| !l.trim().is_empty())
+        .collect())
+}
+
+/// Reconcile every PENDING finding on `branch`/`skill` against
+/// `head_commit`: for each whose flagged file was touched by a commit after
+/// its origin, mark it RESOLVED with that commit
+/// (`Database::mark_finding_resolved`). Best-effort per finding -- a git
+/// failure on one finding is logged to stderr and does not abort
+/// reconciling the rest, since a transient git error on one stale finding
+/// must not itself block a gate record/check that has nothing to do with
+/// it. Returns the number of findings resolved. Called unconditionally at
+/// the top of both `quality-gate record` and `quality-gate check`, before
+/// `evaluate_refusal` ever runs, so a fix landed in an earlier commit is
+/// never mistaken for still-pending.
+pub fn reconcile_pending_findings(
+    database: &Database,
+    repo_dir: Option<&std::path::Path>,
+    branch: &str,
+    skill: &str,
+    head_commit: &str,
+) -> Result<usize> {
+    let pending = database.list_pending_findings(branch, skill)?;
+    let mut resolved_count = 0usize;
+    for finding in pending {
+        match commits_touching_file_in_range(
+            repo_dir,
+            &finding.origin_commit,
+            head_commit,
+            &finding.file,
+        ) {
+            Ok(touching) => {
+                if let Some(commit) = resolving_commit(&touching) {
+                    match database.mark_finding_resolved(&finding.id, commit) {
+                        Ok(_) => resolved_count += 1,
+                        Err(e) => eprintln!(
+                            "[legion] warning: failed to mark finding {} resolved: {e}",
+                            finding.id
+                        ),
+                    }
+                }
+            }
+            Err(e) => eprintln!(
+                "[legion] warning: resolution check failed for finding {} ({}): {e}",
+                finding.id, finding.file
+            ),
+        }
+    }
+    Ok(resolved_count)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::findings::NewFindingInput;
+    use crate::db::testutil::test_db;
+
+    // --- FindingSeverity / FindingStatus ---
+
+    #[test]
+    fn severity_round_trips_through_str() {
+        for (s, expected) in [
+            ("high", FindingSeverity::High),
+            ("HIGH", FindingSeverity::High),
+            ("med", FindingSeverity::Med),
+            ("medium", FindingSeverity::Med),
+            ("MED", FindingSeverity::Med),
+            ("low", FindingSeverity::Low),
+        ] {
+            let parsed: FindingSeverity = s.parse().unwrap();
+            assert_eq!(parsed, expected);
+            assert_eq!(
+                parsed.as_str().parse::<FindingSeverity>().unwrap(),
+                expected
+            );
+        }
+    }
+
+    #[test]
+    fn severity_invalid_str_errors() {
+        assert!("critical".parse::<FindingSeverity>().is_err());
+    }
+
+    #[test]
+    fn severity_is_non_trivial() {
+        assert!(FindingSeverity::High.is_non_trivial());
+        assert!(FindingSeverity::Med.is_non_trivial());
+        assert!(!FindingSeverity::Low.is_non_trivial());
+    }
+
+    #[test]
+    fn status_round_trips_through_str() {
+        for (s, expected) in [
+            ("pending", FindingStatus::Pending),
+            ("resolved", FindingStatus::Resolved),
+            ("dispositioned", FindingStatus::Dispositioned),
+        ] {
+            let parsed: FindingStatus = s.parse().unwrap();
+            assert_eq!(parsed, expected);
+        }
+    }
+
+    #[test]
+    fn status_invalid_str_errors() {
+        assert!("waived".parse::<FindingStatus>().is_err());
+    }
+
+    // --- extraction ---
+
+    #[test]
+    fn extract_findings_from_value_pulls_findings_array() {
+        let value = serde_json::json!({
+            "decision": "changes_requested",
+            "findings": [
+                {"file": "src/foo.rs", "line": 12, "severity": "HIGH", "summary": "unchecked input"},
+                {"file": "src/bar.rs", "line": null, "severity": "LOW", "summary": "naming nit"},
+            ],
+            "refuted_count": 1,
+        });
+        let findings = extract_findings_from_value(&value);
+        assert_eq!(findings.len(), 2);
+        assert_eq!(findings[0].file, "src/foo.rs");
+        assert_eq!(findings[0].line, Some(12));
+        assert_eq!(findings[1].line, None);
+    }
+
+    #[test]
+    fn extract_findings_from_value_missing_key_returns_empty() {
+        let value = serde_json::json!({"decision": "approved"});
+        assert!(extract_findings_from_value(&value).is_empty());
+    }
+
+    #[test]
+    fn extract_findings_from_value_skips_malformed_entries() {
+        let value = serde_json::json!({
+            "findings": [
+                {"file": "src/foo.rs", "severity": "HIGH", "summary": "ok"},
+                {"file": "src/missing-fields.rs"},
+            ]
+        });
+        let findings = extract_findings_from_value(&value);
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].file, "src/foo.rs");
+    }
+
+    #[test]
+    fn parse_findings_array_parses_bare_array() {
+        let raw =
+            r#"[{"file": "src/foo.rs", "line": 10, "severity": "MED", "summary": "dup logic"}]"#;
+        let findings = parse_findings_array(raw).unwrap();
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].severity, "MED");
+    }
+
+    #[test]
+    fn parse_findings_array_rejects_non_array_payload() {
+        let err = parse_findings_array(r#"{"not": "an array"}"#).unwrap_err();
+        assert!(err.to_string().contains("--findings-json"));
+    }
+
+    // --- refusal predicate ---
+
+    fn finding(severity: FindingSeverity, status: FindingStatus) -> QualityGateFinding {
+        QualityGateFinding {
+            id: uuid::Uuid::now_v7().to_string(),
+            gate_id: "gate-1".to_string(),
+            branch: "feat/x".to_string(),
+            skill: "legion-simplify".to_string(),
+            origin_commit: "commit-a".to_string(),
+            file: "src/foo.rs".to_string(),
+            line: Some(10),
+            severity,
+            summary: "test finding".to_string(),
+            status,
+            disposition_reason: None,
+            resolved_by_commit: None,
+            created_at: "2026-07-14T00:00:00Z".to_string(),
+            updated_at: "2026-07-14T00:00:00Z".to_string(),
+        }
+    }
+
+    #[test]
+    fn evaluate_refusal_empty_set_does_not_block() {
+        let refusal = evaluate_refusal(&[]);
+        assert!(!refusal.blocks());
+    }
+
+    #[test]
+    fn evaluate_refusal_high_blocks() {
+        let refusal = evaluate_refusal(&[finding(FindingSeverity::High, FindingStatus::Pending)]);
+        assert!(refusal.blocks());
+        assert_eq!(refusal.blocking.len(), 1);
+        assert!(refusal.trivial_unacked.is_empty());
+    }
+
+    #[test]
+    fn evaluate_refusal_med_blocks() {
+        let refusal = evaluate_refusal(&[finding(FindingSeverity::Med, FindingStatus::Pending)]);
+        assert!(refusal.blocks());
+        assert_eq!(refusal.blocking.len(), 1);
+    }
+
+    #[test]
+    fn evaluate_refusal_low_blocks_until_acked() {
+        let refusal = evaluate_refusal(&[finding(FindingSeverity::Low, FindingStatus::Pending)]);
+        assert!(
+            refusal.blocks(),
+            "a LOW finding must block until batch-acked, not silently pass (#773 AC3)"
+        );
+        assert!(refusal.blocking.is_empty());
+        assert_eq!(refusal.trivial_unacked.len(), 1);
+    }
+
+    #[test]
+    fn evaluate_refusal_skips_non_pending_defensively() {
+        let refusal = evaluate_refusal(&[finding(FindingSeverity::High, FindingStatus::Resolved)]);
+        assert!(!refusal.blocks());
+    }
+
+    // --- resolving_commit (pure) ---
+
+    #[test]
+    fn resolving_commit_empty_range_is_none() {
+        assert!(resolving_commit(&[]).is_none());
+    }
+
+    #[test]
+    fn resolving_commit_returns_the_oldest_touching_commit() {
+        let commits = vec!["commit-1".to_string(), "commit-2".to_string()];
+        assert_eq!(resolving_commit(&commits), Some(&"commit-1".to_string()));
+    }
+
+    // --- reconcile_pending_findings (DB-level, no real git) ---
+
+    #[test]
+    fn reconcile_skips_findings_whose_origin_equals_head() {
+        // origin_commit == head_commit short-circuits before any git call --
+        // a finding just raised on this exact commit cannot be resolved by
+        // itself.
+        let db = test_db();
+        let finding = db
+            .insert_finding(&NewFindingInput {
+                gate_id: "gate-1",
+                branch: "feat/x",
+                skill: "legion-simplify",
+                origin_commit: "same-commit",
+                file: "src/foo.rs",
+                line: Some(1),
+                severity: FindingSeverity::High,
+                summary: "test",
+            })
+            .unwrap();
+
+        let resolved_count =
+            reconcile_pending_findings(&db, None, "feat/x", "legion-simplify", "same-commit")
+                .unwrap();
+        assert_eq!(resolved_count, 0);
+        let refetched = db.get_finding_by_id(&finding.id).unwrap().unwrap();
+        assert_eq!(refetched.status, FindingStatus::Pending);
+    }
+
+    #[test]
+    fn commits_touching_file_in_range_empty_when_origin_equals_head() {
+        let touching =
+            commits_touching_file_in_range(None, "same-hash", "same-hash", "src/foo.rs").unwrap();
+        assert!(touching.is_empty());
+    }
+
+    // --- real-git integration tests ---
+    //
+    // Isolated per-repo git identity/config, mirroring `inventory.rs`'s
+    // `fixture_git_command`/`run_git_fixture` -- this is a separate module in
+    // the same crate target, but that helper is `#[cfg(test)] mod`-private to
+    // `inventory.rs`, so it is not importable here; duplicating the isolation
+    // helper (rather than threading a new shared export through `testutil`
+    // for one more call site) matches the precedent that file's own comment
+    // already sets for the same tradeoff against the integration crate.
+
+    fn isolated_git_config_paths() -> &'static (std::path::PathBuf, std::path::PathBuf) {
+        static ISOLATED_GIT_CONFIG: std::sync::OnceLock<(std::path::PathBuf, std::path::PathBuf)> =
+            std::sync::OnceLock::new();
+        ISOLATED_GIT_CONFIG.get_or_init(|| {
+            let dir = tempfile::tempdir().expect("create isolated git config dir");
+            let global = dir.path().join("global.gitconfig");
+            let system = dir.path().join("system.gitconfig");
+            std::fs::write(&global, "").expect("write isolated global gitconfig");
+            std::fs::write(&system, "").expect("write isolated system gitconfig");
+            std::mem::forget(dir);
+            (global, system)
+        })
+    }
+
+    fn fixture_git_command(dir: &std::path::Path) -> Command {
+        let (global_config, system_config) = isolated_git_config_paths();
+        let mut cmd = Command::new("git");
+        cmd.current_dir(dir)
+            .env("GIT_CONFIG_GLOBAL", global_config)
+            .env("GIT_CONFIG_SYSTEM", system_config)
+            .env("GIT_DIR", dir.join(".git"))
+            .env("GIT_WORK_TREE", dir);
+        cmd
+    }
+
+    fn run_git_fixture(dir: &std::path::Path, args: &[&str]) -> String {
+        let mut full_args: Vec<&str> = vec![
+            "-c",
+            "user.name=Legion Test Fixture",
+            "-c",
+            "user.email=legion-test-fixture@example.invalid",
+            "-c",
+            "commit.gpgsign=false",
+        ];
+        full_args.extend_from_slice(args);
+        let out = fixture_git_command(dir)
+            .args(&full_args)
+            .output()
+            .unwrap_or_else(|e| panic!("git {args:?} failed to spawn in {dir:?}: {e}"));
+        assert!(
+            out.status.success(),
+            "git {args:?} exited non-zero in {dir:?}\nstderr: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+        String::from_utf8_lossy(&out.stdout).trim().to_string()
+    }
+
+    fn commit_file(dir: &std::path::Path, path: &str, contents: &str, message: &str) -> String {
+        std::fs::write(dir.join(path), contents).unwrap();
+        run_git_fixture(dir, &["add", path]);
+        run_git_fixture(dir, &["commit", "-q", "-m", message]);
+        run_git_fixture(dir, &["rev-parse", "HEAD"])
+    }
+
+    #[test]
+    fn commits_touching_file_in_range_finds_a_later_touch() {
+        let dir = tempfile::tempdir().unwrap();
+        run_git_fixture(dir.path(), &["init", "-q"]);
+        let origin = commit_file(dir.path(), "foo.rs", "fn foo() {}\n", "initial");
+        // An unrelated file changes first -- must not count as touching foo.rs.
+        commit_file(dir.path(), "bar.rs", "fn bar() {}\n", "unrelated change");
+        let fix_commit = commit_file(
+            dir.path(),
+            "foo.rs",
+            "fn foo() { /* fixed */ }\n",
+            "fix foo",
+        );
+
+        let touching =
+            commits_touching_file_in_range(Some(dir.path()), &origin, &fix_commit, "foo.rs")
+                .unwrap();
+        assert_eq!(touching, vec![fix_commit.clone()]);
+        assert_eq!(resolving_commit(&touching), Some(&fix_commit));
+    }
+
+    #[test]
+    fn commits_touching_file_in_range_empty_when_file_untouched_since_origin() {
+        let dir = tempfile::tempdir().unwrap();
+        run_git_fixture(dir.path(), &["init", "-q"]);
+        let origin = commit_file(dir.path(), "foo.rs", "fn foo() {}\n", "initial");
+        let head = commit_file(dir.path(), "bar.rs", "fn bar() {}\n", "unrelated change");
+
+        let touching =
+            commits_touching_file_in_range(Some(dir.path()), &origin, &head, "foo.rs").unwrap();
+        assert!(touching.is_empty());
+    }
+
+    #[test]
+    fn reconcile_pending_findings_marks_resolved_when_a_later_commit_touches_the_file() {
+        let dir = tempfile::tempdir().unwrap();
+        run_git_fixture(dir.path(), &["init", "-q"]);
+        let origin = commit_file(dir.path(), "foo.rs", "fn foo() {}\n", "initial");
+
+        let db = test_db();
+        let raised = db
+            .insert_finding(&NewFindingInput {
+                gate_id: "gate-1",
+                branch: "feat/x",
+                skill: "legion-simplify",
+                origin_commit: &origin,
+                file: "foo.rs",
+                line: Some(1),
+                severity: FindingSeverity::High,
+                summary: "duplicate logic",
+            })
+            .unwrap();
+
+        let fix_commit = commit_file(
+            dir.path(),
+            "foo.rs",
+            "fn foo() { /* fixed */ }\n",
+            "fix foo",
+        );
+
+        let resolved_count = reconcile_pending_findings(
+            &db,
+            Some(dir.path()),
+            "feat/x",
+            "legion-simplify",
+            &fix_commit,
+        )
+        .unwrap();
+
+        assert_eq!(resolved_count, 1);
+        let refetched = db.get_finding_by_id(&raised.id).unwrap().unwrap();
+        assert_eq!(refetched.status, FindingStatus::Resolved);
+        assert_eq!(
+            refetched.resolved_by_commit.as_deref(),
+            Some(fix_commit.as_str())
+        );
+    }
+}

--- a/src/finding_gate.rs
+++ b/src/finding_gate.rs
@@ -16,12 +16,18 @@
 //!   - Resolution + refusal: `reconcile_pending_findings` (git-log-based
 //!     resolution detection: a commit after a finding's origin that touches
 //!     the flagged file resolves it) and `evaluate_refusal` (the pure
-//!     predicate a `clean` verdict must clear -- no non-trivial finding
-//!     pending, no un-acked LOW finding). The predicate is branch+skill
-//!     scoped and cross-commit BY DESIGN: a clean run itself has zero new
-//!     findings, so a same-run-only reading would make the gate vacuous, and
-//!     "a subsequent commit resolves it" only means anything measured against
-//!     prior gate runs on the same branch.
+//!     predicate a `clean` verdict must clear against the PENDING set left
+//!     over from PRIOR gate runs on this branch+skill -- no non-trivial
+//!     finding pending, no un-acked LOW finding). This module's predicate is
+//!     necessarily cross-commit (a fix landed on an earlier commit resolves a
+//!     finding raised there), but it is NOT sufficient by itself: the CALLER
+//!     (`cli::verify::reconcile_and_refuse_if_findings_pending`) additionally
+//!     refuses a clean verdict that carries findings of its OWN in the same
+//!     call -- legion-review's `approved` decision records `--result clean`
+//!     in the very call that reports any surviving non-blocking findings, so
+//!     a same-run finding is not hypothetical and this module's cross-commit
+//!     predicate alone would let it straight through. See that function's
+//!     doc comment for the combined check.
 
 use std::process::Command;
 use std::str::FromStr;

--- a/src/finding_gate.rs
+++ b/src/finding_gate.rs
@@ -149,17 +149,37 @@ pub struct RawFinding {
 
 /// Pull the `findings` array out of a `--details-json` object, e.g. the
 /// legion-review contract (`{"decision": ..., "findings": [...], ...}`).
-/// Missing key, wrong shape, or an unparseable entry all degrade to "no
-/// finding from that slot" rather than failing the whole gate record --
-/// `findings_count` on the gate row itself stays the source of truth for how
-/// many findings a run reported; this ledger is additive audit substrate.
+/// Missing key or wrong top-level shape degrades to "no findings at all"
+/// silently -- the common case for most skills, which never set this key.
+/// An individual unparseable ENTRY within an otherwise-valid array degrades
+/// to "no finding from that slot" too (rather than failing the whole gate
+/// record), but is NOT silent: a length mismatch between the raw array and
+/// what parsed is logged to stderr, since a single mistyped entry
+/// (`"sumary"` for `"summary"`, a `"line"` that isn't a number) inside a
+/// `--result clean` call is otherwise the exact evaporation this ledger
+/// exists to close -- neither persisted nor seen by the same-call refusal
+/// check. `findings_count` on the gate row itself stays the source of truth
+/// for how many findings a run reported; this ledger is additive audit
+/// substrate.
 pub fn extract_findings_from_value(value: &serde_json::Value) -> Vec<RawFinding> {
     let Some(arr) = value.get("findings").and_then(|v| v.as_array()) else {
         return Vec::new();
     };
-    arr.iter()
+    let extracted: Vec<RawFinding> = arr
+        .iter()
         .filter_map(|v| serde_json::from_value::<RawFinding>(v.clone()).ok())
-        .collect()
+        .collect();
+    if extracted.len() != arr.len() {
+        eprintln!(
+            "[legion] warning: {} of {} entries in --details-json's `findings` array failed to \
+             parse as {{file, line, severity, summary}} and were dropped (#773) -- a dropped \
+             finding is neither tracked nor blocks a clean verdict. Fix the malformed entries \
+             and re-run if this was not intentional.",
+            arr.len() - extracted.len(),
+            arr.len(),
+        );
+    }
+    extracted
 }
 
 /// Parse a bare JSON array of findings, e.g. `legion quality-gate check
@@ -685,6 +705,68 @@ mod tests {
         assert_eq!(
             refetched.resolved_by_commit.as_deref(),
             Some(fix_commit.as_str())
+        );
+    }
+
+    /// Regression guard (pre-push review HIGH, coverage gap): a genuine git
+    /// failure -- here, `origin_commit` that is not a real revision at all,
+    /// simulating an unreachable/rewritten commit -- must surface as `Err`,
+    /// never silently read as "nothing touched it" (empty `Ok(vec![])`).
+    #[test]
+    fn commits_touching_file_in_range_errors_on_unreachable_origin_commit() {
+        let dir = tempfile::tempdir().unwrap();
+        run_git_fixture(dir.path(), &["init", "-q"]);
+        let head = commit_file(dir.path(), "foo.rs", "fn foo() {}\n", "initial");
+
+        let result = commits_touching_file_in_range(
+            Some(dir.path()),
+            "0000000000000000000000000000000000dead",
+            &head,
+            "foo.rs",
+        );
+        assert!(
+            result.is_err(),
+            "an unreachable origin_commit must error, not silently resolve to empty"
+        );
+    }
+
+    /// Regression guard (pre-push review HIGH, coverage gap): when git
+    /// itself fails for one PENDING finding (unreachable `origin_commit`,
+    /// e.g. after a rebase/amend rewrote history), `reconcile_pending_findings`
+    /// must NOT propagate that as an error from the whole call -- it logs and
+    /// leaves that finding PENDING (fail closed: still blocks `clean`) so a
+    /// git failure on one stale finding never blocks the gate record/check
+    /// this call has nothing to do with.
+    #[test]
+    fn reconcile_pending_findings_leaves_finding_pending_on_unreachable_origin_commit() {
+        let dir = tempfile::tempdir().unwrap();
+        run_git_fixture(dir.path(), &["init", "-q"]);
+        let head = commit_file(dir.path(), "foo.rs", "fn foo() {}\n", "initial");
+
+        let db = test_db();
+        let raised = db
+            .insert_finding(&NewFindingInput {
+                gate_id: "gate-1",
+                branch: "feat/x",
+                skill: "legion-simplify",
+                origin_commit: "0000000000000000000000000000000000dead",
+                file: "foo.rs",
+                line: Some(1),
+                severity: FindingSeverity::High,
+                summary: "duplicate logic",
+            })
+            .unwrap();
+
+        let resolved_count =
+            reconcile_pending_findings(&db, Some(dir.path()), "feat/x", "legion-simplify", &head)
+                .expect("a per-finding git failure must not fail the whole reconcile call");
+        assert_eq!(resolved_count, 0);
+
+        let refetched = db.get_finding_by_id(&raised.id).unwrap().unwrap();
+        assert_eq!(
+            refetched.status,
+            FindingStatus::Pending,
+            "a finding whose resolution check errored must stay PENDING, not silently resolve"
         );
     }
 }

--- a/src/finding_gate.rs
+++ b/src/finding_gate.rs
@@ -316,8 +316,13 @@ pub fn reconcile_pending_findings(
                 }
             }
             Err(e) => eprintln!(
-                "[legion] warning: resolution check failed for finding {} ({}): {e}",
-                finding.id, finding.file
+                "[legion] warning: resolution check failed for finding {} ({}): {e} -- this \
+                 finding stays PENDING and will keep blocking a clean verdict for branch \
+                 '{branch}' skill '{skill}' until it resolves. If '{}' is no longer a reachable \
+                 commit (branch history was rewritten via rebase/amend/force-push), git-log \
+                 resolution can never succeed for it -- disposition it explicitly instead: \
+                 'legion quality-gate finding-disposition --id {} --reason \"...\"'.",
+                finding.id, finding.file, finding.origin_commit, finding.id
             ),
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,7 @@ mod documents;
 mod embed;
 mod error;
 mod etc;
+mod finding_gate;
 mod gate_registry;
 mod gate_trust;
 mod graph;


### PR DESCRIPTION
## Summary

Findings from `legion-simplify`/`legion-review` runs used to live only as free text inside
`quality_gates.details` -- once a gate recorded a `clean` result, any non-blocking finding written
down alongside it was unrecoverable except by hand-parsing that JSON blob, and nothing forced it to
ever be acted on. This PR builds the missing substrate (a `quality_gate_findings` table keyed to
`quality_gates.id`, structured JSON extraction at record/check time, and git-log-based resolution
detection) and then the enforcement on top: `quality-gate record`/`check` now refuse a `clean`
verdict for a (branch, skill) pair while any HIGH/MED finding from a prior run is still pending
undispositioned, or any LOW finding is still un-acked. New CLI surface
(`finding-disposition`/`finding-ack`/`finding-list`) makes the disposition history queryable.

## Acceptance criteria mapping

### 1. Scope addition (Build Notes): findings table keyed to `quality_gates.id` (file, line, severity, status, disposition_reason, resolved_by_commit), structured extraction at gate-record time, git-log resolution detection
This is the load-bearing prerequisite the other ACs sit on. `src/db/findings.rs` adds the
`quality_gate_findings` table with exactly those columns plus `gate_id`/`branch`/`skill`/
`origin_commit`/`summary`/timestamps. Structured extraction happens in `src/finding_gate.rs`:
`extract_findings_from_value` pulls the `findings` array out of `--details-json` (the legion-review
contract), and a new `--findings-json` flag on `quality-gate check` (parsed by
`parse_findings_array`) covers legion-simplify, whose prose articulation is deliberately NOT parsed
(not reliable enough to extract structured data from -- see "Not done"). Git-log resolution
detection is `finding_gate::commits_touching_file_in_range` (a thin `git log --format=%H --reverse
<origin>..<head> -- <file>` wrapper) plus `reconcile_pending_findings`, which marks a finding
RESOLVED when a commit after its origin touched the flagged file.
Evidence: `src/db/findings.rs:29-52` (DDL), `src/finding_gate.rs:150-170` (extraction),
`src/finding_gate.rs:240-310` (resolution); integration-tested against a real git fixture repo in
`finding_gate::tests::reconcile_pending_findings_marks_resolved_when_a_later_commit_touches_the_file`.

### 2. `legion quality-gate record` (legion-simplify, legion-review) refuses `clean` while non-trivial findings from that same run remain neither resolved nor dispositioned
The refusal predicate covers TWO distinct cases, and both matter -- an earlier revision of this PR
covered only the second and missed the one the issue's problem statement actually names.
`reconcile_and_refuse_if_findings_pending` (`src/cli/verify.rs`) is called from both the `Record`
arm (gates legion-review's clean path) and the `Check` arm (gates legion-simplify's clean path,
since #780 already forces simplify's clean through `check` not `record`), and refuses when EITHER:
(a) this SAME call's own structured findings (extracted from `--details-json`/`--findings-json`
before the refusal check runs, not after) are non-empty -- this is legion-review's `approved &&
non-blocking-findings` shortcut, the exact failure mode the design doc names verbatim ("a run that
returns approved with three LOW findings and one MED finding exits clean with all four
untouched"); or (b) the reconciled PENDING set left over from PRIOR runs on this branch+skill still
has an unresolved HIGH/MED or an un-acked LOW. Reconciliation against git log always runs first, so
a fix already landed in an earlier commit clears itself before either check.
Evidence: `src/cli/verify.rs::reconcile_and_refuse_if_findings_pending`; unit tests
`cli::verify::tests::reconcile_and_refuse_blocks_clean_when_current_call_carries_a_finding` (case a,
the central regression guard), `reconcile_and_refuse_blocks_clean_when_high_finding_pending` (case
b), and `reconcile_and_refuse_issues_then_fix_then_clean_end_to_end` (both cases composed against a
real git fixture repo: issues-with-a-finding on commit A, fix on commit B, clean on B allowed).

A third, narrower guard closes the residual gap where extraction itself silently produced nothing
(malformed/mismatched-schema JSON) instead of correctly producing findings that case (a) would then
catch: `findings_count_contradicts_extraction` refuses `clean` when `--findings-count > 0` but
extraction produced an empty `raw_findings` -- the caller's own asserted count contradicts what the
ledger saw. Evidence: `src/cli/verify.rs::findings_count_contradicts_extraction`; unit tests
`findings_count_contradicts_extraction_true_when_count_positive_and_extraction_empty` and its three
negative-case siblings (count zero, non-empty extraction, `issues` result).

### 3. Each finding above the triviality threshold must be RESOLVED (a subsequent commit demonstrably touches the flagged file:line) or DISPOSITIONED with an explicit reason; silent drop is refused
RESOLVED is automatic (git-log detection, AC1 above). DISPOSITIONED requires an explicit
`--reason`: `legion quality-gate finding-disposition --id <id> --reason "..."` calls
`Database::dispose_finding`, which hard-errors (`LegionError::FindingNotFound`) on a missing id and
refuses (`FindingAlreadyResolved`) to disposition a finding that was already resolved out from under
it. There is no third path that clears a finding without one of these two -- `evaluate_refusal`
(`src/finding_gate.rs`) only removes a finding from the blocking set once its `status` is no longer
PENDING, and PENDING is the only status a freshly-extracted finding can have.
Evidence: `src/db/findings.rs::dispose_finding`; `db::findings::tests::dispose_finding_sets_status_and_reason`,
`dispose_finding_refuses_an_already_resolved_row`.

### 4. A triviality threshold (LOW/cosmetic) can be batch-acknowledged with a single one-line ack rather than per-item dispositioning
`legion quality-gate finding-ack --branch <b> --skill <s> --reason "..."` calls
`Database::batch_ack_low_findings`, which selects every PENDING LOW finding for that (branch, skill)
pair and dispositions each with the one shared reason -- one CLI invocation, one reason string, but
still one row per finding in the ledger (not a single opaque "batch" record), so the per-finding
audit trail (`resolved_by_commit`/`disposition_reason`/`updated_at`) survives the batch shortcut. A
LOW finding is NOT silently exempted from the refusal predicate -- `evaluate_refusal` still routes it
into `trivial_unacked` and blocks `clean` until acked; only the ceremony to clear it is reduced to one
call instead of N.
Evidence: `src/db/findings.rs::batch_ack_low_findings`;
`db::findings::tests::batch_ack_low_findings_only_touches_pending_low_severity`;
`finding_gate::tests::evaluate_refusal_low_blocks_until_acked` (regression guard against treating LOW
as non-blocking).

### 5. The disposition record is queryable (fixed vs. waived vs. pending) so a downstream gate / the operator can audit hand-wave rate over time
`legion quality-gate finding-list [--branch] [--skill] [--status pending|resolved|dispositioned]
[--json]` calls `Database::list_findings`, which -- unlike the PENDING-only lookup the refusal
predicate uses -- returns every finding across every status, newest first, so "which findings were
fixed vs. waived vs. pending" is a single query rather than a hand-audit. `--json` emits the full row
including `disposition_reason`/`resolved_by_commit` for tooling.
Evidence: `src/cli/verify.rs::QualityGateAction::FindingList` handler, `src/db/findings.rs::list_findings`;
`db::findings::tests::list_findings_filters_by_status`.

### 6. #780 composition: this issue's refusal must define combined semantics with #780's asserted-clean refusal on the same Record/Check arms
Both refusals stack rather than compete: #780's "a check-gated skill cannot self-report clean via
`record`" check runs first (unchanged, `src/cli/verify.rs:274-282` in the Record arm) and is a hard
gate independent of findings; #773's `reconcile_and_refuse_if_findings_pending` runs after it, once a
clean claim has already cleared #780's provenance bar, closing the *other* way a clean verdict could
be manufactured (no unvalidated self-report AND no unresolved finding sitting underneath a validated
one). Neither refusal can be satisfied by clearing the other.
Evidence: the `Record` arm's ordering in `src/cli/verify.rs` -- #780's check at the top of the
`Record` match arm, `reconcile_and_refuse_if_findings_pending` immediately after `open_db()`, before
`record_quality_gate` is ever called.

## Not done

- **AC "applies to the wave/workflow template too"** -- explicitly split out of this issue per the
  Build Notes into #788, covered by `docs/plans/2026-07-14-stop-gate-background-and-fixloop-doctrine.md`
  Part 2 (a design doctrine, not this PR's code). `.claude/workflows/wave2.js`'s fix-loop is untouched
  here.
- **Parsing findings out of legion-simplify's prose articulation** -- deliberately not built. The
  articulation's "Verdict: finding (duplication, MED)" convention is free-form prose, not a rigid
  format; a regex/heuristic parser over it would be unreliable in exactly the way this whole issue
  exists to prevent (a finding silently missed by a parser is indistinguishable from one that was
  never written down). Instead, `quality-gate check` gained a separate `--findings-json` flag for
  structured input, and the SKILL.md now documents emitting both the prose (for a human reader) and
  the JSON array (for the ledger).
- **Line-level resolution detection; resolution is coarse.** Resolution is file-level (`git log --
  <file>`), not `git log -L <line>,<line>:<file>` line-tracking, and ANY commit touching the flagged
  file resolves the finding -- an unrelated edit elsewhere in that file, not only one that fixes the
  named problem. Line-range tracking is fragile as unrelated edits shift line numbers across a
  file's history; file-level touch detection is the same granularity `cli::util::git_changed_files`
  already uses for the simplify coverage set. This is a real tradeoff (flagged in review as HIGH),
  not a bug: on an active branch a finding can auto-resolve without anyone deliberately addressing
  it. Both SKILL.md files now document it explicitly under "Finding resolution" so operators know to
  disposition explicitly when that distinction matters for a given finding, rather than relying on
  incidental resolution.
- **A malformed `--details-json`/`--findings-json` payload is now hard-refused, but only when
  `--findings-count` contradicts it.** `findings_count_contradicts_extraction` refuses `clean` when
  the skill's own `--findings-count > 0` but zero findings were actually extracted -- this closes
  the case that mattered (a run that KNOWS it found something but the ledger sees nothing). The one
  residual gap: a call that is internally self-consistent but wrong on both sides -- `--findings-count
  0` alongside a malformed/empty `--details-json`, when the skill actually intended to report
  findings -- has no internal contradiction to catch and still passes. This is now the caller's own
  bug (asserting 0 findings when it meant to report some), not a ledger gap; not hardened further,
  since the ledger has no way to know the caller's count is itself wrong.
- **`persist_raw_findings` insert/dedup-query failures degrade to best-effort, not hard-fail.** A
  failed `list_pending_findings` (used for cross-call dedup) degrades to "no known duplicates" rather
  than blocking the write; a failed `insert_finding` is logged to stderr and skipped rather than
  propagated. Both are rare DB-failure paths, consistent with this ledger's existing posture as
  additive audit substrate whose failure must not fail the gate record that already succeeded
  (`emit_gate_trust`'s established non-fatal-warning convention) -- but it means a persist failure on
  the DB layer is one more way a finding could, in principle, fail to be tracked. Not hardened
  further in this PR.
- **A finding whose `origin_commit` becomes unreachable (branch rewrite: `commit --amend`, rebase)
  blocks `clean` indefinitely**, not silently -- `git log <missing>..<head>` errors, reconcile logs a
  warning and leaves the finding PENDING, and the refusal keeps firing until it is manually
  dispositioned. Fails closed (safe direction) but is a confusing trap on any branch that rewrites
  history; not addressed further here (no detection/guidance for the specific "origin commit no
  longer resolves" case).
- **Backfilling structured findings for pre-#773 gate rows** -- historical `quality_gates.details`
  blobs are not retroactively parsed into `quality_gate_findings` rows. The ledger starts fresh from
  this PR forward.
- **Deduplicating findings across `--findings-json`/`--details-json` re-runs (and within one batch)
  is exact-match, not semantic.** A re-run (or a single payload) reporting the identical `(file,
  severity, summary)` triple as an already-PENDING finding does not insert a second row
  (`persist_raw_findings`'s `already_pending` / `seen_this_call` checks) -- but any change to the
  summary text between runs (e.g. a reviewer rewording the same underlying issue) is treated as a
  distinct finding, which can accumulate near-duplicate rows across several review passes on the same
  unfixed problem. A human/agent using `finding-list` will see both and can disposition the stale one.

## Revision notes

Three rounds of pre-push review (after the initial design-review pass that caught the central gap
below) found real gaps in earlier versions of this PR; each is fixed, not just flagged, and is
called out here so the fix is traceable to what caught it:

0. **The central case this issue names was initially unrefused.** The first revision gated only on
   the reconciled PENDING set (findings from PRIOR gate runs), which left legion-review's `approved
   && non-blocking-findings` shortcut -- a `clean` verdict recorded in the SAME call as the findings
   that justify it -- unrefused, exactly the failure mode the design doc names verbatim. Fixed by
   extracting `raw_findings` BEFORE the refusal check in both the `Record` and `Check` arms and
   blocking on either the current call's findings or the reconciled PENDING set (AC #2 above);
   findings are now persisted only after a clean call has cleared the refusal, so a refused call
   never orphans rows nobody can query.
1. **Pre-push review, round 1** then found: a within-batch dedup gap on that fix (the same finding
   listed twice in one `--findings-json`/`--details-json` payload double-inserted -- fixed with a
   `seen_this_call` guard alongside the cross-call one), a column-index typo in
   `parse_severity_from_db` (cosmetic, error text only), and a missing combined branch+skill filter
   test on `list_findings` (added).
2. **Pre-push review, round 2** then found the dedup fix from round 1 above had its own gap: dedup
   checked only PENDING rows, so a finding explicitly DISPOSITIONED ("won't fix: intentional")
   resurrected as a fresh PENDING row the moment a later run re-reported the identical (file,
   severity, summary) -- the waiver silently didn't stick. Fixed by widening the dedup source to
   every non-RESOLVED finding (PENDING + DISPOSITIONED); RESOLVED is deliberately still excluded so
   a genuine regression after a fix still gets tracked as new.
3. **Pre-push review, round 3** found a third evaporation gap at finer granularity: within an
   otherwise-valid `--details-json` `findings` array, a single malformed entry (mistyped key,
   wrong-typed field) was silently dropped by `extract_findings_from_value`'s `filter_map(...).ok()`
   -- neither persisted nor seen by the same-call refusal check. Fixed with a length-mismatch warning
   (parsed count vs. raw array length) so a dropped entry is now loud, not silent; behavior (drop and
   continue) is otherwise unchanged, since refusing the whole gate on one bad entry would again be a
   stricter contract than this best-effort path was built for. That round also flagged two previously
   untested fail paths -- a genuine git failure (unreachable `origin_commit`) must surface as `Err`
   from `commits_touching_file_in_range`, and `reconcile_pending_findings` must not propagate that as
   a whole-call error -- both now covered by real-git-fixture tests.
4. **Pre-push review, round 4** re-raised the fail-open malformed-JSON gap, this time with a concrete
   mitigation: the skill's own `--findings-count` is a cross-check already available at the call
   site. Implemented as `findings_count_contradicts_extraction` (pure, unit-tested, shared by both
   arms): refuses `clean` when `--findings-count > 0` but extraction produced nothing. Deliberately
   narrower than "refuse on any malformed JSON" -- that would break the common, legitimate case where
   a skill never sets a `findings` key at all.
5. **Pre-push review, round 5** found the dedup lookup's own query failure degraded silently (no
   log), unlike every other fail path in `persist_raw_findings`, which could resurrect a
   DISPOSITIONED finding with no trace of why on a transient DB read error. Fixed with a matching
   `eprintln!` on that path; behavior unchanged, visibility restored.

Remaining HIGH-severity observations from these rounds -- coarse (file-level, not content-aware)
resolution granularity, best-effort `persist_raw_findings` insert/dedup-query failure handling, and
an unreachable `origin_commit` after history rewrite -- are documented above as accepted tradeoffs
rather than further hardened. Each fails in the safe direction (over-resolving, staying
stuck-PENDING, or over-blocking on a duplicate row -- not silently vanishing a finding an operator
could have acted on); see the AC #2 mapping and the Not-done bullets above for the reasoning behind
each.

Closes #773
