### PR TITLE
feat(#786): first-class date filtering (--since/--until/--on) on recall/consult/bullpen/surface

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -682,6 +682,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
+name = "defmt"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2953bfe4f93bbd20cc71198842756f77d161884c99ebbabc41d80231ded88d1"
+dependencies = [
+ "bitflags 1.3.2",
+ "defmt-macros",
+]
+
+[[package]]
+name = "defmt-macros"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bad9c72e7ca2137e0dc3813245a0d282fd6daad32fd800af018306a9169b5fe8"
+dependencies = [
+ "defmt-parser",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "defmt-parser"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
+dependencies = [
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1702,6 +1733,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
+name = "jiff"
+version = "0.2.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "961d16382652bfdd8c6f68b223b26a8c93e0d475c672f414411db31c6c5c900e"
+dependencies = [
+ "defmt",
+ "jiff-static",
+ "jiff-tzdb-platform",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde_core",
+ "windows-link",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0879bd39df99c4c5e2c6615ccc026391a423dde10532c573e6086eb94a802cc"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "jiff-tzdb"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "142bd39932ad231f10513df9ab62661fead8719872150b7ad02a2df79f4e141e"
+
+[[package]]
+name = "jiff-tzdb-platform"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8"
+dependencies = [
+ "jiff-tzdb",
+]
+
+[[package]]
 name = "jobserver"
 version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1757,6 +1830,7 @@ dependencies = [
  "hex",
  "hostname",
  "ignore",
+ "jiff",
  "libc",
  "lightningcss",
  "mime_guess",
@@ -2776,6 +2850,15 @@ name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
+dependencies = [
+ "portable-atomic",
+]
 
 [[package]]
 name = "portable-pty"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,13 @@ serde_json = "1"
 uuid = { version = "1", features = ["v7"] }
 chrono = { version = "0.4", features = ["serde"] }
 thiserror = "2"
+
+# Date-only parsing for --since/--until/--on (#786). jiff's civil::Date is
+# the calendar-date type the issue's TimeRange interface specifies; its
+# TimeZone::system()/to_zoned() give panic-free local<->UTC conversion for
+# turning a boundary date into the UTC instant `created_at` is compared
+# against, without hand-rolling DST-aware arithmetic on top of chrono.
+jiff = "0.2"
 directories = "5"
 dirs = "5"
 model2vec-rs = "0.1"

--- a/src/board.rs
+++ b/src/board.rs
@@ -47,7 +47,7 @@ pub fn post_from_text_with_meta(
     }
 
     let reflection = db.insert_reflection_with_meta(repo, trimmed, "team", meta)?;
-    index.add(&reflection.id, repo, trimmed)?;
+    index.add(&reflection.id, repo, trimmed, &reflection.created_at)?;
 
     Ok(reflection.id)
 }
@@ -94,20 +94,29 @@ pub fn bullpen_filtered(
     reader_repo: &str,
     filter: BullpenFilter,
 ) -> Result<Vec<Reflection>> {
-    bullpen_filtered_with_decay(db, reader_repo, filter, false, false)
+    bullpen_filtered_with_decay(
+        db,
+        reader_repo,
+        filter,
+        false,
+        false,
+        &crate::timerange::TimeRange::default(),
+    )
 }
 
 /// Like `bullpen_filtered` but with opt-in switches for past-TTL posts (#376)
 /// and resolved threads (#362). Operator review only -- agents must not pass
-/// either as `true`.
+/// either as `true`. `range` applies #786's `--since`/`--until`/`--on`
+/// filter (`TimeRange::default()` is unbounded, a no-op).
 pub fn bullpen_filtered_with_decay(
     db: &Database,
     reader_repo: &str,
     filter: BullpenFilter,
     include_stale: bool,
     include_resolved: bool,
+    range: &crate::timerange::TimeRange,
 ) -> Result<Vec<Reflection>> {
-    let posts = db.get_board_posts_filtered_full(include_stale, include_resolved)?;
+    let posts = db.get_board_posts_filtered_full(include_stale, include_resolved, range)?;
 
     match filter {
         BullpenFilter::All => {
@@ -216,7 +225,14 @@ mod tests {
         )
         .expect("post");
 
-        let result = recall::consult_bm25(&db, &index, "token generation", 5).expect("consult");
+        let result = recall::consult_bm25(
+            &db,
+            &index,
+            "token generation",
+            5,
+            &crate::timerange::TimeRange::default(),
+        )
+        .expect("consult");
         assert_eq!(result.reflections.len(), 1);
         assert!(result.reflections[0].text.contains("token generation"));
     }
@@ -460,7 +476,14 @@ mod tests {
         archive_read_posts(&db).expect("archive");
 
         // consult searches all reflections regardless of archive status
-        let result = recall::consult_bm25(&db, &index, "tokens", 5).expect("consult");
+        let result = recall::consult_bm25(
+            &db,
+            &index,
+            "tokens",
+            5,
+            &crate::timerange::TimeRange::default(),
+        )
+        .expect("consult");
         assert_eq!(result.reflections.len(), 1);
         assert!(result.reflections[0].text.contains("tokens"));
     }

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -764,7 +764,12 @@ mod tests {
             .insert_reflection_with_meta("kelex", "hello team", "team", &ReflectionMeta::default())
             .expect("insert");
         index
-            .add(&reflection.id, "kelex", "hello team")
+            .add(
+                &reflection.id,
+                "kelex",
+                "hello team",
+                &reflection.created_at,
+            )
             .expect("index");
 
         // Verify the DB has the post. test_storage() uses "test.db" in the same dir.

--- a/src/cli/kanban.rs
+++ b/src/cli/kanban.rs
@@ -687,7 +687,12 @@ pub(crate) fn handle_done(repo: String, text: String, id: Option<String>) -> err
         "team",
         &db::ReflectionMeta::default(),
     )?;
-    if let Err(e) = index.add(&reflection.id, &reflection.repo, &announcement) {
+    if let Err(e) = index.add(
+        &reflection.id,
+        &reflection.repo,
+        &announcement,
+        &reflection.created_at,
+    ) {
         eprintln!("[legion] search index add failed: {e}");
     }
     info!("[legion] done: {text}");
@@ -703,7 +708,12 @@ pub(crate) fn handle_done(repo: String, text: String, id: Option<String>) -> err
             "team",
             &db::ReflectionMeta::default(),
         )?;
-        if let Err(e) = index.add(&notify_ref.id, &notify_ref.repo, &notify_text) {
+        if let Err(e) = index.add(
+            &notify_ref.id,
+            &notify_ref.repo,
+            &notify_text,
+            &notify_ref.created_at,
+        ) {
             eprintln!("[legion] search index add failed: {e}");
         }
         info!("[legion] notified {agent} (was blocked on {repo})");

--- a/src/cli/memory.rs
+++ b/src/cli/memory.rs
@@ -363,8 +363,18 @@ pub(crate) fn handle_recall(
     domain: Option<String>,
     archives: bool,
     include_archives: bool,
+    since: Option<String>,
+    until: Option<String>,
+    on: Option<String>,
 ) -> error::Result<()> {
     let database = open_db()?;
+
+    // #786: parsed once at the CLI boundary, threaded verbatim to every
+    // query-layer path below. An unparseable value returns
+    // LegionError::InvalidDateFilter here -- nothing reaches the query
+    // layer with an unparsed date.
+    let range =
+        crate::timerange::TimeRange::parse(since.as_deref(), until.as_deref(), on.as_deref())?;
 
     // Resolve archive mode (#457). Mutually-exclusive flags
     // enforced at the clap layer via conflicts_with.
@@ -402,21 +412,23 @@ pub(crate) fn handle_recall(
     }
 
     let mut result = if let Some(ref dom) = domain {
-        recall::recall_by_domain(&database, &repo, dom, limit, mode)?
+        recall::recall_by_domain(&database, &repo, dom, limit, mode, &range)?
     } else if latest {
-        recall::recall_latest(&database, &repo, limit, mode)?
+        recall::recall_latest(&database, &repo, limit, mode, &range)?
     } else if cosine_only {
         // --cosine-only requires the embed model; error if unavailable.
         let model = embed::EmbedModel::load().map_err(|e| {
             error::LegionError::Embedding(format!("--cosine-only requires embedding model: {e}"))
         })?;
-        recall::recall_cosine_only(&database, &model, &repo, &context, limit, min_score)?
+        recall::recall_cosine_only(&database, &model, &repo, &context, limit, min_score, &range)?
     } else {
         let index = search::SearchIndex::open(&data_dir()?.join("index"))?;
         // Try hybrid (BM25 + cosine) recall, fall back to BM25-only
         match try_load_embed_model() {
-            Some(model) => recall::recall(&database, &index, &model, &repo, &context, limit, mode)?,
-            None => recall::recall_bm25(&database, &index, &repo, &context, limit, mode)?,
+            Some(model) => recall::recall(
+                &database, &index, &model, &repo, &context, limit, mode, &range,
+            )?,
+            None => recall::recall_bm25(&database, &index, &repo, &context, limit, mode, &range)?,
         }
     };
     // Apply min-score filter on hybrid/latest paths (cosine-only applies it inline).
@@ -460,15 +472,22 @@ pub(crate) fn handle_consult(
     symbol: Option<String>,
     limit: usize,
     json: bool,
+    since: Option<String>,
+    until: Option<String>,
+    on: Option<String>,
 ) -> error::Result<()> {
     let database = open_db()?;
+    // #786: reflection mode only, per --since/--until/--on's help text;
+    // --symbol mode never consults this value.
+    let range =
+        crate::timerange::TimeRange::parse(since.as_deref(), until.as_deref(), on.as_deref())?;
 
     match (context, symbol) {
         (Some(ctx), None) => {
             let index = search::SearchIndex::open(&data_dir()?.join("index"))?;
             let result = match try_load_embed_model() {
-                Some(model) => recall::consult(&database, &index, &model, &ctx, limit)?,
-                None => recall::consult_bm25(&database, &index, &ctx, limit)?,
+                Some(model) => recall::consult(&database, &index, &model, &ctx, limit, &range)?,
+                None => recall::consult_bm25(&database, &index, &ctx, limit, &range)?,
             };
             let output = recall::format_for_consult(&result);
             if output.is_empty() {

--- a/src/cli/misc.rs
+++ b/src/cli/misc.rs
@@ -162,10 +162,17 @@ pub(crate) fn handle_init(force: bool) -> error::Result<()> {
     Ok(())
 }
 
-pub(crate) fn handle_surface(repo: String) -> error::Result<()> {
+pub(crate) fn handle_surface(
+    repo: String,
+    since: Option<String>,
+    until: Option<String>,
+    on: Option<String>,
+) -> error::Result<()> {
     let database = open_db()?;
+    let range =
+        crate::timerange::TimeRange::parse(since.as_deref(), until.as_deref(), on.as_deref())?;
 
-    let result = surface::surface(&database, &repo)?;
+    let result = surface::surface(&database, &repo, &range)?;
     let output = surface::format_surface(&result, &repo);
     if !output.is_empty() {
         print!("{output}");

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -187,6 +187,22 @@ pub(crate) enum Commands {
         /// with --archives. Same --cosine-only scope caveat as --archives.
         #[arg(long, conflicts_with = "archives")]
         include_archives: bool,
+
+        /// Only include reflections created on or after this date
+        /// (YYYY-MM-DD, <N>d, <N>w, today, yesterday). Applies as a hard
+        /// `created_at` predicate before ranking, in every recall mode
+        /// (#786).
+        #[arg(long)]
+        since: Option<String>,
+
+        /// Only include reflections created on or before this date (same
+        /// grammar as --since).
+        #[arg(long, conflicts_with = "on")]
+        until: Option<String>,
+
+        /// Exactly this date; sugar for --since X --until X.
+        #[arg(long, conflicts_with_all = ["since", "until"])]
+        on: Option<String>,
     },
 
     /// Find reflections similar to a given reflection by cosine similarity
@@ -243,6 +259,21 @@ pub(crate) enum Commands {
         /// always human-formatted today).
         #[arg(long)]
         json: bool,
+
+        /// Only include reflections created on or after this date
+        /// (YYYY-MM-DD, <N>d, <N>w, today, yesterday). Reflection mode
+        /// only (#786); has no effect on --symbol.
+        #[arg(long)]
+        since: Option<String>,
+
+        /// Only include reflections created on or before this date (same
+        /// grammar as --since).
+        #[arg(long, conflicts_with = "on")]
+        until: Option<String>,
+
+        /// Exactly this date; sugar for --since X --until X.
+        #[arg(long, conflicts_with_all = ["since", "until"])]
+        on: Option<String>,
     },
 
     /// Configure Claude Code hooks for legion
@@ -427,6 +458,22 @@ pub(crate) enum Commands {
         /// pass this flag, see #362).
         #[arg(long)]
         include_resolved: bool,
+
+        /// Only include posts created on or after this date (YYYY-MM-DD,
+        /// <N>d, <N>w, today, yesterday). Applies to the `--repo` bullpen
+        /// listing path (#786); has no effect on `--count`, `--archive`,
+        /// or `--archived`.
+        #[arg(long)]
+        since: Option<String>,
+
+        /// Only include posts created on or before this date (same
+        /// grammar as --since).
+        #[arg(long, conflicts_with = "on")]
+        until: Option<String>,
+
+        /// Exactly this date; sugar for --since X --until X.
+        #[arg(long, conflicts_with_all = ["since", "until"])]
+        on: Option<String>,
     },
 
     /// Surface cross-repo highlights for a session start
@@ -434,6 +481,24 @@ pub(crate) enum Commands {
         /// Repository name
         #[arg(long)]
         repo: String,
+
+        /// Only include highlights created on or after this date
+        /// (YYYY-MM-DD, <N>d, <N>w, today, yesterday). Applies across all
+        /// four surfaced queries (recent posts, high-value cross-repo,
+        /// chain extensions, pending tasks) except the recent-posts board
+        /// query's 24h default, which an explicit range overrides rather
+        /// than composes with (#786).
+        #[arg(long)]
+        since: Option<String>,
+
+        /// Only include highlights created on or before this date (same
+        /// grammar as --since).
+        #[arg(long, conflicts_with = "on")]
+        until: Option<String>,
+
+        /// Exactly this date; sugar for --since X --until X.
+        #[arg(long, conflicts_with_all = ["since", "until"])]
+        on: Option<String>,
     },
 
     /// Print identity reflections for a repo (alias for recall --domain identity)

--- a/src/cli/signal.rs
+++ b/src/cli/signal.rs
@@ -197,8 +197,16 @@ pub(crate) fn handle_bullpen(
     archived: bool,
     include_stale: bool,
     include_resolved: bool,
+    since: Option<String>,
+    until: Option<String>,
+    on: Option<String>,
 ) -> error::Result<()> {
     let database = open_db()?;
+
+    // #786: applies to the --repo listing path only, per --since/--until/
+    // --on's help text; --count/--archive/--archived ignore it.
+    let range =
+        crate::timerange::TimeRange::parse(since.as_deref(), until.as_deref(), on.as_deref())?;
 
     if archive {
         let count = board::archive_read_posts(&database)?;
@@ -233,10 +241,11 @@ pub(crate) fn handle_bullpen(
                 filter,
                 include_stale,
                 include_resolved,
+                &range,
             )?;
             let mut output = board::format_bullpen(&posts);
             if filter == board::BullpenFilter::All {
-                let pending_tasks = task::get_pending_inbound(&database, &repo)?;
+                let pending_tasks = task::get_pending_inbound(&database, &repo, &range)?;
                 let task_output = task::format_pending_for_surface(&pending_tasks);
                 output.push_str(&task_output);
             }

--- a/src/db/board.rs
+++ b/src/db/board.rs
@@ -694,11 +694,18 @@ impl Database {
 
     /// Get recent bullpen posts (within last N hours by default).
     ///
-    /// `range` (#786), when bounded, OVERRIDES the `hours` cutoff entirely
-    /// rather than composing with it -- an explicit `--since`/`--until`/
-    /// `--on` on `legion surface` replaces the hardcoded recency window,
-    /// it does not narrow it further. `TimeRange::default()` (unbounded)
-    /// preserves the pre-#786 `hours`-cutoff behavior exactly.
+    /// `range` (#786), when bounded, OVERRIDES the `hours` RECENCY cutoff
+    /// entirely rather than composing with it -- an explicit `--since`/
+    /// `--until`/`--on` on `legion surface` replaces the hardcoded recency
+    /// window, it does not narrow it further. `TimeRange::default()`
+    /// (unbounded) preserves the pre-#786 `hours`-cutoff behavior exactly.
+    ///
+    /// The decay/TTL filter (`evergreen = 1 OR expires_at > now`, #376) is
+    /// a SEPARATE axis from recency and applies in BOTH branches: a
+    /// `--since 30d` query should still hide posts an agent would never
+    /// see via the normal bullpen (matching `get_board_posts_filtered_full`'s
+    /// `include_stale`-gated default), not silently resurface expired
+    /// non-evergreen posts just because a date range was given.
     pub fn get_recent_board_posts(
         &self,
         hours: i64,
@@ -722,15 +729,17 @@ impl Database {
                 .map_err(LegionError::Database);
         }
 
-        let range_clause = crate::timerange::TimeRange::sql_clause(1);
+        let now_str = Utc::now().to_rfc3339();
+        let range_clause = crate::timerange::TimeRange::sql_clause(2);
         let sql = format!(
             "SELECT {REFLECTION_COLUMNS} \
              FROM reflections WHERE {ACTIVE_TEAM_POST_WHERE} \
+             AND (evergreen = 1 OR expires_at > ?1) \
              AND resolved_at IS NULL{range_clause} ORDER BY created_at DESC"
         );
         let mut stmt = self.conn.prepare(&sql)?;
         let rows = stmt.query_map(
-            rusqlite::params![range.since_bound()?, range.until_bound()?],
+            rusqlite::params![now_str, range.since_bound()?, range.until_bound()?],
             map_reflection_row,
         )?;
         rows.collect::<std::result::Result<Vec<_>, _>>()
@@ -1430,6 +1439,65 @@ mod tests {
             .get_board_posts_filtered_full(false, true, &crate::timerange::TimeRange::default())
             .unwrap();
         assert_eq!(with_resolved.len(), 1);
+    }
+
+    #[test]
+    fn get_recent_board_posts_range_overrides_hours_cutoff() {
+        // A post created well outside the `hours` recency window must
+        // still surface when an explicit --since/--until range covers it
+        // (#786): the range OVERRIDES the hardcoded cutoff, it does not
+        // narrow it.
+        let db = test_db();
+        let old_ts = "2020-01-01T12:00:00+00:00";
+        let far_future_expiry = "2099-01-01T00:00:00+00:00";
+        db.conn
+            .execute(
+                "INSERT INTO reflections (id, repo, text, created_at, audience, expires_at) \
+                 VALUES ('01000000-0000-7000-8000-00000000000a', 'kelex', 'ancient post', ?1, 'team', ?2)",
+                rusqlite::params![old_ts, far_future_expiry],
+            )
+            .unwrap();
+
+        // Default 24h lookback: the ancient post is invisible.
+        let recent = db
+            .get_recent_board_posts(24, &crate::timerange::TimeRange::default())
+            .unwrap();
+        assert!(recent.is_empty());
+
+        // Explicit range covering 2020-01-01: the same post surfaces.
+        let range =
+            crate::timerange::TimeRange::parse(Some("2019-12-31"), Some("2020-01-02"), None)
+                .unwrap();
+        let ranged = db.get_recent_board_posts(24, &range).unwrap();
+        assert_eq!(ranged.len(), 1);
+        assert_eq!(ranged[0].text, "ancient post");
+    }
+
+    #[test]
+    fn get_recent_board_posts_bounded_range_still_excludes_expired_posts() {
+        // The decay/TTL filter (#376) is a separate axis from recency and
+        // must still apply when an explicit range is given -- an explicit
+        // --since must not resurrect posts the normal (unbounded) bullpen
+        // already treats as expired.
+        let db = test_db();
+        let old_ts = "2020-01-01T12:00:00+00:00";
+        let already_expired = "2020-01-02T00:00:00+00:00";
+        db.conn
+            .execute(
+                "INSERT INTO reflections (id, repo, text, created_at, audience, expires_at) \
+                 VALUES ('01000000-0000-7000-8000-00000000000b', 'kelex', 'stale post', ?1, 'team', ?2)",
+                rusqlite::params![old_ts, already_expired],
+            )
+            .unwrap();
+
+        let range =
+            crate::timerange::TimeRange::parse(Some("2019-12-31"), Some("2020-01-02"), None)
+                .unwrap();
+        let ranged = db.get_recent_board_posts(24, &range).unwrap();
+        assert!(
+            ranged.is_empty(),
+            "an explicit date range must not bypass the #376 decay/TTL filter"
+        );
     }
 
     #[test]

--- a/src/db/board.rs
+++ b/src/db/board.rs
@@ -239,39 +239,53 @@ impl Database {
     /// `legion bullpen --include-stale` / `--include-resolved` for operator
     /// review. Agents must never reach this with either set to `true`.
     pub fn get_board_posts_filtered(&self, include_stale: bool) -> Result<Vec<Reflection>> {
-        self.get_board_posts_filtered_full(include_stale, false)
+        self.get_board_posts_filtered_full(
+            include_stale,
+            false,
+            &crate::timerange::TimeRange::default(),
+        )
     }
 
     /// Full filter: independently opt into stale and resolved rows.
+    /// `range` applies #786's `created_at` predicate directly in the WHERE
+    /// clause (`TimeRange::default()` is unbounded, a no-op) -- the DB
+    /// backer for `board::bullpen_filtered_with_decay`, which is how
+    /// `legion bullpen --since/--until/--on` filters the listing.
     pub fn get_board_posts_filtered_full(
         &self,
         include_stale: bool,
         include_resolved: bool,
+        range: &crate::timerange::TimeRange,
     ) -> Result<Vec<Reflection>> {
-        let now = Utc::now().to_rfc3339();
-        let decay_clause = if include_stale {
-            ""
+        // `now` is bound as `Option<String>` (None when include_stale) so
+        // the decay clause's placeholder is ALWAYS present in the SQL
+        // text at a fixed position -- letting the range clause's
+        // placeholders start at a fixed index regardless of include_stale,
+        // instead of branching the query text on it (#786).
+        let now: Option<String> = if include_stale {
+            None
         } else {
-            " AND (evergreen = 1 OR expires_at > ?1)"
+            Some(Utc::now().to_rfc3339())
         };
         let resolved_clause = if include_resolved {
             ""
         } else {
             " AND resolved_at IS NULL"
         };
+        let range_clause = crate::timerange::TimeRange::sql_clause(2);
         let sql = format!(
             "SELECT {REFLECTION_COLUMNS} \
-             FROM reflections WHERE {ACTIVE_TEAM_POST_WHERE}{decay_clause}{resolved_clause} ORDER BY created_at DESC"
+             FROM reflections WHERE {ACTIVE_TEAM_POST_WHERE} \
+             AND (?1 IS NULL OR evergreen = 1 OR expires_at > ?1){resolved_clause}{range_clause} \
+             ORDER BY created_at DESC"
         );
         let mut stmt = self.conn.prepare(&sql)?;
-        let rows = if include_stale {
-            stmt.query_map([], map_reflection_row)?
-                .collect::<std::result::Result<Vec<_>, _>>()
-        } else {
-            stmt.query_map([&now], map_reflection_row)?
-                .collect::<std::result::Result<Vec<_>, _>>()
-        };
-        rows.map_err(LegionError::Database)
+        let rows = stmt.query_map(
+            rusqlite::params![now, range.since_bound()?, range.until_bound()?],
+            map_reflection_row,
+        )?;
+        rows.collect::<std::result::Result<Vec<_>, _>>()
+            .map_err(LegionError::Database)
     }
 
     /// Retrieve up to `limit` active bullpen posts strictly after the given
@@ -678,20 +692,47 @@ impl Database {
         Ok(rows > 0)
     }
 
-    /// Get recent bullpen posts (within last N hours).
-    pub fn get_recent_board_posts(&self, hours: i64) -> Result<Vec<Reflection>> {
-        let now = Utc::now();
-        let cutoff = (now - chrono::Duration::hours(hours)).to_rfc3339();
-        let now_str = now.to_rfc3339();
+    /// Get recent bullpen posts (within last N hours by default).
+    ///
+    /// `range` (#786), when bounded, OVERRIDES the `hours` cutoff entirely
+    /// rather than composing with it -- an explicit `--since`/`--until`/
+    /// `--on` on `legion surface` replaces the hardcoded recency window,
+    /// it does not narrow it further. `TimeRange::default()` (unbounded)
+    /// preserves the pre-#786 `hours`-cutoff behavior exactly.
+    pub fn get_recent_board_posts(
+        &self,
+        hours: i64,
+        range: &crate::timerange::TimeRange,
+    ) -> Result<Vec<Reflection>> {
+        if range.is_unbounded() {
+            let now = Utc::now();
+            let cutoff = (now - chrono::Duration::hours(hours)).to_rfc3339();
+            let now_str = now.to_rfc3339();
+            let sql = format!(
+                "SELECT {REFLECTION_COLUMNS} \
+                 FROM reflections WHERE {ACTIVE_TEAM_POST_WHERE} \
+                 AND (evergreen = 1 OR expires_at > ?2) \
+                 AND resolved_at IS NULL \
+                 AND created_at > ?1 ORDER BY created_at DESC"
+            );
+            let mut stmt = self.conn.prepare(&sql)?;
+            let rows = stmt.query_map([&cutoff, &now_str], map_reflection_row)?;
+            return rows
+                .collect::<std::result::Result<Vec<_>, _>>()
+                .map_err(LegionError::Database);
+        }
+
+        let range_clause = crate::timerange::TimeRange::sql_clause(1);
         let sql = format!(
             "SELECT {REFLECTION_COLUMNS} \
              FROM reflections WHERE {ACTIVE_TEAM_POST_WHERE} \
-             AND (evergreen = 1 OR expires_at > ?2) \
-             AND resolved_at IS NULL \
-             AND created_at > ?1 ORDER BY created_at DESC"
+             AND resolved_at IS NULL{range_clause} ORDER BY created_at DESC"
         );
         let mut stmt = self.conn.prepare(&sql)?;
-        let rows = stmt.query_map([&cutoff, &now_str], map_reflection_row)?;
+        let rows = stmt.query_map(
+            rusqlite::params![range.since_bound()?, range.until_bound()?],
+            map_reflection_row,
+        )?;
         rows.collect::<std::result::Result<Vec<_>, _>>()
             .map_err(LegionError::Database)
     }
@@ -1381,9 +1422,13 @@ mod tests {
             .insert_reflection("kelex", "converged thread", "team")
             .unwrap();
         db.resolve_post(&r.id, None).unwrap();
-        let active = db.get_board_posts_filtered_full(false, false).unwrap();
+        let active = db
+            .get_board_posts_filtered_full(false, false, &crate::timerange::TimeRange::default())
+            .unwrap();
         assert!(active.is_empty());
-        let with_resolved = db.get_board_posts_filtered_full(false, true).unwrap();
+        let with_resolved = db
+            .get_board_posts_filtered_full(false, true, &crate::timerange::TimeRange::default())
+            .unwrap();
         assert_eq!(with_resolved.len(), 1);
     }
 

--- a/src/db/kanban.rs
+++ b/src/db/kanban.rs
@@ -243,13 +243,25 @@ impl Database {
         Ok(count)
     }
 
-    /// Get pending tasks assigned to a repo (for surface output).
-    pub fn get_pending_tasks_for_repo(&self, repo: &str) -> Result<Vec<crate::task::Task>> {
-        let mut stmt = self.conn.prepare(
+    /// Get pending tasks assigned to a repo (for surface output). `range`
+    /// applies #786's `created_at` predicate directly in the WHERE clause
+    /// (`TimeRange::default()` is unbounded, a no-op).
+    pub fn get_pending_tasks_for_repo(
+        &self,
+        repo: &str,
+        range: &crate::timerange::TimeRange,
+    ) -> Result<Vec<crate::task::Task>> {
+        let range_clause = crate::timerange::TimeRange::sql_clause(2);
+        let sql = format!(
             "SELECT id, from_repo, to_repo, text, context, priority, status, note, created_at, updated_at \
-             FROM tasks WHERE to_repo = ?1 AND status = 'pending' AND deleted_at IS NULL ORDER BY created_at DESC",
+             FROM tasks WHERE to_repo = ?1 AND status = 'pending' AND deleted_at IS NULL{range_clause} \
+             ORDER BY created_at DESC"
+        );
+        let mut stmt = self.conn.prepare(&sql)?;
+        let rows = stmt.query_map(
+            rusqlite::params![repo, range.since_bound()?, range.until_bound()?],
+            crate::task::map_task_row,
         )?;
-        let rows = stmt.query_map([repo], crate::task::map_task_row)?;
         rows.collect::<std::result::Result<Vec<_>, _>>()
             .map_err(LegionError::Database)
     }

--- a/src/db/reflections.rs
+++ b/src/db/reflections.rs
@@ -787,21 +787,27 @@ impl Database {
     /// [`get_reflections_by_domain`](Self::get_reflections_by_domain) (#782)
     /// -- the DB backer for `recall::recall_latest`, which is how `recall
     /// --latest --archives` reaches persisted (`forget --persist`)
-    /// reflections.
+    /// reflections. `range` applies #786's `created_at` predicate directly
+    /// in the WHERE clause (`TimeRange::default()` is unbounded, a no-op).
     pub fn get_latest_self_reflections(
         &self,
         repo: &str,
         limit: usize,
         mode: crate::recall::ArchiveMode,
+        range: &crate::timerange::TimeRange,
     ) -> Result<Vec<Reflection>> {
         let where_clause = archive_mode_where_clause(mode);
+        let range_clause = crate::timerange::TimeRange::sql_clause(3);
         let sql = format!(
             "SELECT {REFLECTION_COLUMNS} FROM reflections WHERE repo = ?1 AND audience = 'self' \
-             AND deleted_at IS NULL {where_clause} ORDER BY created_at DESC LIMIT ?2"
+             AND deleted_at IS NULL {where_clause}{range_clause} ORDER BY created_at DESC LIMIT ?2"
         );
         let mut stmt = self.conn.prepare(&sql)?;
 
-        let rows = stmt.query_map(rusqlite::params![repo, limit], map_reflection_row)?;
+        let rows = stmt.query_map(
+            rusqlite::params![repo, limit, range.since_bound()?, range.until_bound()?],
+            map_reflection_row,
+        )?;
         rows.collect::<std::result::Result<Vec<_>, _>>()
             .map_err(LegionError::Database)
     }
@@ -821,22 +827,36 @@ impl Database {
     /// `--archives` combined with `--domain` silently fell back to hot-only.
     ///
     /// [`get_reflection_by_id_in_mode`]: Self::get_reflection_by_id_in_mode
+    ///
+    /// `range` applies #786's `created_at` predicate directly in the WHERE
+    /// clause (`TimeRange::default()` is unbounded, a no-op).
     pub fn get_reflections_by_domain(
         &self,
         repo: &str,
         domain: &str,
         limit: usize,
         mode: crate::recall::ArchiveMode,
+        range: &crate::timerange::TimeRange,
     ) -> Result<Vec<Reflection>> {
         let where_clause = archive_mode_where_clause(mode);
+        let range_clause = crate::timerange::TimeRange::sql_clause(4);
         let sql = format!(
             "SELECT {REFLECTION_COLUMNS} \
-             FROM reflections WHERE repo = ?1 AND domain = ?2 AND deleted_at IS NULL {where_clause} \
+             FROM reflections WHERE repo = ?1 AND domain = ?2 AND deleted_at IS NULL {where_clause}{range_clause} \
              ORDER BY created_at DESC LIMIT ?3"
         );
         let mut stmt = self.conn.prepare(&sql)?;
 
-        let rows = stmt.query_map(rusqlite::params![repo, domain, limit], map_reflection_row)?;
+        let rows = stmt.query_map(
+            rusqlite::params![
+                repo,
+                domain,
+                limit,
+                range.since_bound()?,
+                range.until_bound()?
+            ],
+            map_reflection_row,
+        )?;
         rows.collect::<std::result::Result<Vec<_>, _>>()
             .map_err(LegionError::Database)
     }
@@ -906,15 +926,39 @@ impl Database {
     /// Get recently extended learning chains.
     ///
     /// Returns reflections that have a parent_id and were created within
-    /// the last N hours, indicating a chain was recently extended.
-    pub fn get_recent_chain_extensions(&self, hours: i64) -> Result<Vec<Reflection>> {
-        let cutoff = (Utc::now() - chrono::Duration::hours(hours)).to_rfc3339();
+    /// the last N hours (or, when `range` is bounded, within `range`
+    /// instead -- an explicit `--since`/`--until`/`--on` OVERRIDES the
+    /// `hours` cutoff rather than composing with it, matching
+    /// `get_recent_board_posts`'s surface-query carve-out; #786).
+    pub fn get_recent_chain_extensions(
+        &self,
+        hours: i64,
+        range: &crate::timerange::TimeRange,
+    ) -> Result<Vec<Reflection>> {
+        if range.is_unbounded() {
+            let cutoff = (Utc::now() - chrono::Duration::hours(hours)).to_rfc3339();
+            let sql = format!(
+                "SELECT {REFLECTION_COLUMNS} \
+                 FROM reflections WHERE parent_id IS NOT NULL AND deleted_at IS NULL AND created_at > ?1 ORDER BY created_at DESC"
+            );
+            let mut stmt = self.conn.prepare(&sql)?;
+            let rows = stmt.query_map([&cutoff], map_reflection_row)?;
+            return rows
+                .collect::<std::result::Result<Vec<_>, _>>()
+                .map_err(LegionError::Database);
+        }
+
+        let range_clause = crate::timerange::TimeRange::sql_clause(1);
         let sql = format!(
             "SELECT {REFLECTION_COLUMNS} \
-             FROM reflections WHERE parent_id IS NOT NULL AND deleted_at IS NULL AND created_at > ?1 ORDER BY created_at DESC"
+             FROM reflections WHERE parent_id IS NOT NULL AND deleted_at IS NULL{range_clause} \
+             ORDER BY created_at DESC"
         );
         let mut stmt = self.conn.prepare(&sql)?;
-        let rows = stmt.query_map([&cutoff], map_reflection_row)?;
+        let rows = stmt.query_map(
+            rusqlite::params![range.since_bound()?, range.until_bound()?],
+            map_reflection_row,
+        )?;
         rows.collect::<std::result::Result<Vec<_>, _>>()
             .map_err(LegionError::Database)
     }
@@ -1898,20 +1942,39 @@ mod tests {
             .unwrap();
         db.archive_reflection(&cold.id).expect("archive");
 
+        let default_range = crate::timerange::TimeRange::default();
         let hot_only = db
-            .get_reflections_by_domain("legion", "checkpoint", 10, crate::recall::ArchiveMode::Hot)
+            .get_reflections_by_domain(
+                "legion",
+                "checkpoint",
+                10,
+                crate::recall::ArchiveMode::Hot,
+                &default_range,
+            )
             .unwrap();
         assert_eq!(hot_only.len(), 1);
         assert_eq!(hot_only[0].id, hot.id);
 
         let cold_only = db
-            .get_reflections_by_domain("legion", "checkpoint", 10, crate::recall::ArchiveMode::Cold)
+            .get_reflections_by_domain(
+                "legion",
+                "checkpoint",
+                10,
+                crate::recall::ArchiveMode::Cold,
+                &default_range,
+            )
             .unwrap();
         assert_eq!(cold_only.len(), 1);
         assert_eq!(cold_only[0].id, cold.id);
 
         let both = db
-            .get_reflections_by_domain("legion", "checkpoint", 10, crate::recall::ArchiveMode::Both)
+            .get_reflections_by_domain(
+                "legion",
+                "checkpoint",
+                10,
+                crate::recall::ArchiveMode::Both,
+                &default_range,
+            )
             .unwrap();
         assert_eq!(both.len(), 2);
     }
@@ -1927,22 +1990,38 @@ mod tests {
             .unwrap();
         db.archive_reflection(&cold.id).expect("archive");
 
+        let default_range = crate::timerange::TimeRange::default();
         let hot_only = db
-            .get_latest_self_reflections("legion", 10, crate::recall::ArchiveMode::Hot)
+            .get_latest_self_reflections(
+                "legion",
+                10,
+                crate::recall::ArchiveMode::Hot,
+                &default_range,
+            )
             .unwrap();
         let hot_ids: Vec<&str> = hot_only.iter().map(|r| r.id.as_str()).collect();
         assert!(hot_ids.contains(&hot.id.as_str()));
         assert!(!hot_ids.contains(&cold.id.as_str()));
 
         let cold_only = db
-            .get_latest_self_reflections("legion", 10, crate::recall::ArchiveMode::Cold)
+            .get_latest_self_reflections(
+                "legion",
+                10,
+                crate::recall::ArchiveMode::Cold,
+                &default_range,
+            )
             .unwrap();
         let cold_ids: Vec<&str> = cold_only.iter().map(|r| r.id.as_str()).collect();
         assert!(cold_ids.contains(&cold.id.as_str()));
         assert!(!cold_ids.contains(&hot.id.as_str()));
 
         let both = db
-            .get_latest_self_reflections("legion", 10, crate::recall::ArchiveMode::Both)
+            .get_latest_self_reflections(
+                "legion",
+                10,
+                crate::recall::ArchiveMode::Both,
+                &default_range,
+            )
             .unwrap();
         assert_eq!(both.len(), 2);
     }

--- a/src/db/stats.rs
+++ b/src/db/stats.rs
@@ -57,18 +57,31 @@ impl Database {
     /// Get high-value reflections from other repos (by recall_count).
     ///
     /// Returns reflections with recall_count > 0 from repos other than
-    /// the given one, ordered by recall_count descending.
+    /// the given one, ordered by recall_count descending. `range` applies
+    /// #786's `created_at` predicate directly in the WHERE clause
+    /// (`TimeRange::default()` is unbounded, a no-op).
     pub fn get_high_value_cross_repo(
         &self,
         exclude_repo: &str,
         limit: usize,
+        range: &crate::timerange::TimeRange,
     ) -> Result<Vec<Reflection>> {
+        let range_clause = crate::timerange::TimeRange::sql_clause(3);
         let sql = format!(
             "SELECT {REFLECTION_COLUMNS} \
-             FROM reflections WHERE repo != ?1 AND recall_count > 0 AND deleted_at IS NULL ORDER BY recall_count DESC LIMIT ?2"
+             FROM reflections WHERE repo != ?1 AND recall_count > 0 AND deleted_at IS NULL{range_clause} \
+             ORDER BY recall_count DESC LIMIT ?2"
         );
         let mut stmt = self.conn.prepare(&sql)?;
-        let rows = stmt.query_map(rusqlite::params![exclude_repo, limit], map_reflection_row)?;
+        let rows = stmt.query_map(
+            rusqlite::params![
+                exclude_repo,
+                limit,
+                range.since_bound()?,
+                range.until_bound()?
+            ],
+            map_reflection_row,
+        )?;
         rows.collect::<std::result::Result<Vec<_>, _>>()
             .map_err(LegionError::Database)
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -222,6 +222,13 @@ pub enum LegionError {
     /// legitimate use of `process::exit` in the binary.
     #[error("")]
     ExitWith(i32),
+
+    /// A `--since`/`--until`/`--on` date filter value did not match the
+    /// accepted grammar (#786). Raised at the CLI/API boundary by
+    /// `TimeRange::parse` -- nothing reaches the query layer with an
+    /// unparsed date.
+    #[error("unparseable date '{input}' -- accepted: YYYY-MM-DD, <N>d, <N>w, today, yesterday")]
+    InvalidDateFilter { input: String },
 }
 
 pub type Result<T> = std::result::Result<T, LegionError>;

--- a/src/identity_generate.rs
+++ b/src/identity_generate.rs
@@ -251,9 +251,13 @@ fn gather_given_half(
     let query = format!("{repo} {}", bylines.join(" "));
     let fetch_limit = GIVEN_HALF_LIMIT * GIVEN_HALF_FETCH_MULTIPLIER;
 
+    // Identity generation gathers cross-agent source material regardless
+    // of when it was written -- unbounded, matching this consult's
+    // pre-#786 behavior.
+    let range = crate::timerange::TimeRange::default();
     let recalled = match embed_model {
-        Some(model) => recall::consult(db, index, model, &query, fetch_limit)?,
-        None => recall::consult_bm25(db, index, &query, fetch_limit)?,
+        Some(model) => recall::consult(db, index, model, &query, fetch_limit, &range)?,
+        None => recall::consult_bm25(db, index, &query, fetch_limit, &range)?,
     };
 
     Ok(recalled
@@ -379,6 +383,7 @@ pub fn apply(
         "identity",
         IDENTITY_BACKUP_LIMIT,
         crate::recall::ArchiveMode::Both,
+        &crate::timerange::TimeRange::default(),
     )?;
     if old_rows.len() == IDENTITY_BACKUP_LIMIT {
         // A corpus at exactly the cap almost certainly means rows beyond
@@ -420,9 +425,15 @@ pub fn apply(
     // report the whole apply as failed -- a hard error would tell the
     // calling agent the apply did not happen when `whoami` already shows
     // the new root, inviting a re-run that churns identity ids.
-    warn_on_index_add_failure(index, &swap.root.id, repo, &swap.root.text);
+    warn_on_index_add_failure(
+        index,
+        &swap.root.id,
+        repo,
+        &swap.root.text,
+        &swap.root.created_at,
+    );
     for child in &swap.children {
-        warn_on_index_add_failure(index, &child.id, repo, &child.text);
+        warn_on_index_add_failure(index, &child.id, repo, &child.text, &child.created_at);
     }
 
     let retired_ids =
@@ -443,8 +454,14 @@ pub fn apply(
 /// by `swap_identity_root`, warning (not failing) on error -- the new
 /// identity is already live in the DB, so an index straggler must not
 /// make `apply` report failure. `legion reindex` is the recovery path.
-fn warn_on_index_add_failure(index: &SearchIndex, id: &str, repo: &str, text: &str) {
-    if let Err(e) = index.add(id, repo, text) {
+fn warn_on_index_add_failure(
+    index: &SearchIndex,
+    id: &str,
+    repo: &str,
+    text: &str,
+    created_at: &str,
+) {
+    if let Err(e) = index.add(id, repo, text, created_at) {
         eprintln!(
             "[legion whoami --generate --apply] WARNING: the identity swap committed but the \
              tantivy index add failed for new row {id}.\n\
@@ -855,7 +872,13 @@ mod tests {
         )
         .unwrap();
         let before = db
-            .get_reflections_by_domain("legion", "identity", 500, crate::recall::ArchiveMode::Both)
+            .get_reflections_by_domain(
+                "legion",
+                "identity",
+                500,
+                crate::recall::ArchiveMode::Both,
+                &crate::timerange::TimeRange::default(),
+            )
             .unwrap();
 
         let backup_dir = dir.path().join("backups");
@@ -868,7 +891,13 @@ mod tests {
 
         assert!(!backup_dir.exists());
         let after = db
-            .get_reflections_by_domain("legion", "identity", 500, crate::recall::ArchiveMode::Both)
+            .get_reflections_by_domain(
+                "legion",
+                "identity",
+                500,
+                crate::recall::ArchiveMode::Both,
+                &crate::timerange::TimeRange::default(),
+            )
             .unwrap();
         assert_eq!(before.len(), after.len());
     }
@@ -1010,7 +1039,12 @@ mod tests {
         apply(&db, &index, "legion", &manifest, &backup_dir, false).unwrap();
 
         let root_hits = index
-            .search("legion", "distinctive careful engineering", 10)
+            .search(
+                "legion",
+                "distinctive careful engineering",
+                10,
+                &crate::timerange::TimeRange::default(),
+            )
             .unwrap();
         let root_hit_ids: Vec<&str> = root_hits.iter().map(|h| h.id.as_str()).collect();
         assert!(
@@ -1019,7 +1053,12 @@ mod tests {
         );
 
         let child_hits = index
-            .search("legion", "distinctive zanzibar gateways", 10)
+            .search(
+                "legion",
+                "distinctive zanzibar gateways",
+                10,
+                &crate::timerange::TimeRange::default(),
+            )
             .unwrap();
         let child_hit_ids: Vec<&str> = child_hits.iter().map(|h| h.id.as_str()).collect();
         assert!(
@@ -1134,7 +1173,13 @@ mod tests {
         )
         .unwrap();
         let before = db
-            .get_reflections_by_domain("legion", "identity", 500, crate::recall::ArchiveMode::Both)
+            .get_reflections_by_domain(
+                "legion",
+                "identity",
+                500,
+                crate::recall::ArchiveMode::Both,
+                &crate::timerange::TimeRange::default(),
+            )
             .unwrap();
 
         let backup_dir = dir.path().join("backups");
@@ -1153,7 +1198,13 @@ mod tests {
         assert!(!plan.backup_path.exists());
 
         let after = db
-            .get_reflections_by_domain("legion", "identity", 500, crate::recall::ArchiveMode::Both)
+            .get_reflections_by_domain(
+                "legion",
+                "identity",
+                500,
+                crate::recall::ArchiveMode::Both,
+                &crate::timerange::TimeRange::default(),
+            )
             .unwrap();
         assert_eq!(before.len(), after.len());
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -45,6 +45,7 @@ mod telemetry;
 #[cfg(test)]
 mod testutil;
 mod timefmt;
+mod timerange;
 mod uncertainty;
 mod usage;
 mod verbs;
@@ -145,6 +146,9 @@ fn run() -> error::Result<()> {
             domain,
             archives,
             include_archives,
+            since,
+            until,
+            on,
         } => cli::memory::handle_recall(
             repo,
             context,
@@ -156,6 +160,9 @@ fn run() -> error::Result<()> {
             domain,
             archives,
             include_archives,
+            since,
+            until,
+            on,
         )?,
         Commands::Similar {
             id,
@@ -170,7 +177,10 @@ fn run() -> error::Result<()> {
             symbol,
             limit,
             json,
-        } => cli::memory::handle_consult(context, symbol, limit, json)?,
+            since,
+            until,
+            on,
+        } => cli::memory::handle_consult(context, symbol, limit, json, since, until, on)?,
         Commands::Post {
             repo,
             text,
@@ -205,6 +215,9 @@ fn run() -> error::Result<()> {
             archived,
             include_stale,
             include_resolved,
+            since,
+            until,
+            on,
         } => cli::signal::handle_bullpen(
             repo,
             count,
@@ -214,6 +227,9 @@ fn run() -> error::Result<()> {
             archived,
             include_stale,
             include_resolved,
+            since,
+            until,
+            on,
         )?,
         Commands::Index {
             repo,
@@ -235,7 +251,12 @@ fn run() -> error::Result<()> {
         Commands::McpHealth { wait } => cli::misc::handle_mcp_health(wait)?,
         Commands::Now { banner: _, json } => cli::misc::handle_now(json)?,
         Commands::Init { force } => cli::misc::handle_init(force)?,
-        Commands::Surface { repo } => cli::misc::handle_surface(repo)?,
+        Commands::Surface {
+            repo,
+            since,
+            until,
+            on,
+        } => cli::misc::handle_surface(repo, since, until, on)?,
         Commands::Whoami {
             repo,
             limit,

--- a/src/recall.rs
+++ b/src/recall.rs
@@ -6,6 +6,7 @@ use crate::db::Database;
 use crate::embed::{self, EmbedModel};
 use crate::error::Result;
 use crate::search::{SearchIndex, SearchResult};
+use crate::timerange::TimeRange;
 
 /// Minimum cosine similarity for a cosine-only candidate (no BM25 match).
 /// Prevents noise from weak semantic matches when BM25 found nothing.
@@ -283,33 +284,44 @@ pub enum ArchiveMode {
 
 /// Join one search hit with the database and apply boost/decay weighting.
 ///
-/// Returns `None` when the archive-mode filter rejects the row: the search
-/// index returns ids regardless of archive state, so a miss here is an
-/// expected silent skip, not a desync warning. Shared by the BM25 and
-/// hybrid paths so their join, weighted-score and skip behavior cannot
-/// drift apart.
+/// Returns `None` when the archive-mode filter rejects the row, OR when
+/// `range` rejects it (#786) -- the search index returns ids regardless of
+/// archive state or `created_at`, so either miss here is an expected
+/// silent skip, not a desync warning. Shared by the BM25 and hybrid paths
+/// so their join, weighted-score and skip behavior cannot drift apart.
+///
+/// The `range` check here is redundant-but-harmless for BM25-sourced ids
+/// (already filtered at the Tantivy query level, see `search.rs`'s
+/// `date_range_query`) and load-bearing for cosine-sourced-only
+/// candidates in the hybrid path (`merge_hybrid_scores`'s `all_ids`, which
+/// come from `Database::get_embeddings` -- an unbounded, un-filtered
+/// corpus scan, so checking here is not the "post-filter over a
+/// limit-truncated fetch" anti-pattern that silently under-returns).
 fn join_and_score(
     db: &Database,
     id: &str,
     base_score: f32,
     mode: ArchiveMode,
+    range: &TimeRange,
 ) -> Result<Option<RecalledReflection>> {
-    Ok(db
-        .get_reflection_by_id_in_mode(id, mode)?
-        .map(|reflection| {
-            let score = weighted_score(
-                base_score,
-                reflection.recall_count,
-                &reflection.last_recalled_at,
-            );
-            RecalledReflection {
-                id: reflection.id,
-                repo: reflection.repo,
-                text: reflection.text,
-                score,
-                created_at: reflection.created_at,
-            }
-        }))
+    let Some(reflection) = db.get_reflection_by_id_in_mode(id, mode)? else {
+        return Ok(None);
+    };
+    if !range.contains(&reflection.created_at)? {
+        return Ok(None);
+    }
+    let score = weighted_score(
+        base_score,
+        reflection.recall_count,
+        &reflection.last_recalled_at,
+    );
+    Ok(Some(RecalledReflection {
+        id: reflection.id,
+        repo: reflection.repo,
+        text: reflection.text,
+        score,
+        created_at: reflection.created_at,
+    }))
 }
 
 /// Sort reflections by descending weighted score.
@@ -331,11 +343,12 @@ fn join_search_results(
     db: &Database,
     search_results: &[SearchResult],
     mode: ArchiveMode,
+    range: &TimeRange,
 ) -> Result<Vec<RecalledReflection>> {
     let mut reflections = Vec::with_capacity(search_results.len());
 
     for sr in search_results {
-        if let Some(reflection) = join_and_score(db, &sr.id, sr.score, mode)? {
+        if let Some(reflection) = join_and_score(db, &sr.id, sr.score, mode, range)? {
             reflections.push(reflection);
         }
     }
@@ -347,14 +360,18 @@ fn join_search_results(
 
 /// Query reflections relevant to the given context.
 ///
-/// Searches the Tantivy index filtered by `repo` and ranked by BM25,
-/// then joins each result with the SQLite database to retrieve full
-/// reflection data (text, created_at), scoped by archive mode (#457).
-/// The search index returns ids regardless of archive state; the mode
-/// filter applies at the DB join step so cold-only or both modes return
-/// the correct partition. The search index limit is raised when mode is
-/// Cold to compensate for hot rows being filtered out, but the final
-/// result is still capped at the requested limit.
+/// Searches the Tantivy index filtered by `repo`, `range` (#786's
+/// `created_at` predicate -- `TimeRange::default()` is unbounded), and
+/// ranked by BM25, then joins each result with the SQLite database to
+/// retrieve full reflection data (text, created_at), scoped by archive
+/// mode (#457). The search index returns ids regardless of archive state;
+/// the mode filter applies at the DB join step so cold-only or both modes
+/// return the correct partition. The search index limit is raised when
+/// mode is Cold to compensate for hot rows being filtered out, but the
+/// final result is still capped at the requested limit. The date range,
+/// unlike archive mode, is applied INSIDE the Tantivy query (not at the
+/// join step) so it composes with the archive-mode over-fetch without a
+/// second, compounding over-fetch -- see `search.rs`'s `date_range_query`.
 ///
 /// Returns results ordered by descending relevance score.
 pub fn recall_bm25(
@@ -364,6 +381,7 @@ pub fn recall_bm25(
     context: &str,
     limit: usize,
     mode: ArchiveMode,
+    range: &TimeRange,
 ) -> Result<RecallResult> {
     // Over-fetch from the search index when filtering archived rows out
     // so a heavily archived corpus does not silently return < limit.
@@ -373,8 +391,8 @@ pub fn recall_bm25(
         ArchiveMode::Hot | ArchiveMode::Cold => limit.saturating_mul(4),
         ArchiveMode::Both => limit,
     };
-    let search_results = index.search(repo, context, index_limit)?;
-    let mut reflections = join_search_results(db, &search_results, mode)?;
+    let search_results = index.search(repo, context, index_limit, range)?;
+    let mut reflections = join_search_results(db, &search_results, mode, range)?;
     reflections.truncate(limit);
 
     Ok(RecallResult {
@@ -399,6 +417,7 @@ fn merge_hybrid_scores(
     query_embedding: &[f32],
     limit: usize,
     mode: ArchiveMode,
+    range: &TimeRange,
 ) -> Result<Vec<RecalledReflection>> {
     let mut bm25_scores: HashMap<String, f32> = HashMap::new();
     let mut max_bm25: f32 = 0.0;
@@ -437,7 +456,7 @@ fn merge_hybrid_scores(
 
         let bm25_normalized = bm25_raw / bm25_norm_factor;
         let hybrid = 0.6 * bm25_normalized + 0.4 * cosine;
-        if let Some(reflection) = join_and_score(db, id, hybrid, mode)? {
+        if let Some(reflection) = join_and_score(db, id, hybrid, mode, range)? {
             reflections.push(reflection);
         }
     }
@@ -453,6 +472,7 @@ fn merge_hybrid_scores(
 /// Combines BM25 text search with semantic cosine similarity for better
 /// recall on paraphrased or conceptually related queries. Uses the formula:
 /// `score = 0.6 * bm25_norm + 0.4 * cosine_sim` (then applies boost/decay).
+#[allow(clippy::too_many_arguments)]
 pub fn recall(
     db: &Database,
     index: &SearchIndex,
@@ -461,12 +481,13 @@ pub fn recall(
     context: &str,
     limit: usize,
     mode: ArchiveMode,
+    range: &TimeRange,
 ) -> Result<RecallResult> {
     let index_limit = match mode {
         ArchiveMode::Hot | ArchiveMode::Cold => limit.saturating_mul(4),
         ArchiveMode::Both => limit * 3,
     };
-    let bm25_results = index.search(repo, context, index_limit)?;
+    let bm25_results = index.search(repo, context, index_limit, range)?;
     let query_embedding = embed_model.encode_one(context)?;
     let embeddings = db.get_embeddings(Some(repo))?;
     let reflections = merge_hybrid_scores(
@@ -476,6 +497,7 @@ pub fn recall(
         &query_embedding,
         limit,
         mode,
+        range,
     )?;
 
     Ok(RecallResult {
@@ -496,8 +518,9 @@ pub fn consult(
     embed_model: &EmbedModel,
     context: &str,
     limit: usize,
+    range: &TimeRange,
 ) -> Result<RecallResult> {
-    let bm25_results = index.search_all(context, limit * 3)?;
+    let bm25_results = index.search_all(context, limit * 3, range)?;
     let query_embedding = embed_model.encode_one(context)?;
     let embeddings = db.get_embeddings(None)?;
     let reflections = merge_hybrid_scores(
@@ -507,6 +530,7 @@ pub fn consult(
         &query_embedding,
         limit,
         ArchiveMode::Hot,
+        range,
     )?;
 
     Ok(RecallResult {
@@ -524,14 +548,16 @@ pub fn consult(
 ///
 /// `mode` closes the #457/#782 coverage gap: `legion recall --latest
 /// --archives` now reaches persisted (`forget --persist`) reflections
-/// instead of silently staying hot-only.
+/// instead of silently staying hot-only. `range` applies #786's
+/// `created_at` predicate directly in the DB backer's WHERE clause.
 pub fn recall_latest(
     db: &Database,
     repo: &str,
     limit: usize,
     mode: ArchiveMode,
+    range: &TimeRange,
 ) -> Result<RecallResult> {
-    let latest = db.get_latest_self_reflections(repo, limit, mode)?;
+    let latest = db.get_latest_self_reflections(repo, limit, mode, range)?;
 
     let reflections: Vec<RecalledReflection> = latest
         .into_iter()
@@ -558,15 +584,17 @@ pub fn recall_latest(
 ///
 /// `mode` closes the #457/#782 coverage gap: `legion recall --domain <d>
 /// --archives` now reaches persisted (`forget --persist`) reflections
-/// instead of silently staying hot-only.
+/// instead of silently staying hot-only. `range` applies #786's
+/// `created_at` predicate directly in the DB backer's WHERE clause.
 pub fn recall_by_domain(
     db: &Database,
     repo: &str,
     domain: &str,
     limit: usize,
     mode: ArchiveMode,
+    range: &TimeRange,
 ) -> Result<RecallResult> {
-    let matched = db.get_reflections_by_domain(repo, domain, limit, mode)?;
+    let matched = db.get_reflections_by_domain(repo, domain, limit, mode, range)?;
 
     let reflections: Vec<RecalledReflection> = matched
         .into_iter()
@@ -596,14 +624,15 @@ pub fn consult_bm25(
     index: &SearchIndex,
     context: &str,
     limit: usize,
+    range: &TimeRange,
 ) -> Result<RecallResult> {
-    let search_results = index.search_all(context, limit)?;
+    let search_results = index.search_all(context, limit, range)?;
     // consult searches across the whole corpus regardless of archive
     // state -- a question asked of "all reflections" should find
     // archived bullpen posts the same as fresh ones. Pin Both so the
     // archive-mode default of Hot does not narrow consult's surface
     // when it should not.
-    let reflections = join_search_results(db, &search_results, ArchiveMode::Both)?;
+    let reflections = join_search_results(db, &search_results, ArchiveMode::Both, range)?;
 
     Ok(RecallResult {
         reflections,
@@ -618,6 +647,13 @@ pub fn consult_bm25(
 /// queries, or when debugging hybrid weight tuning. Requires the embed model;
 /// returns an error if unavailable. Applies the same boost/decay weighting as
 /// the hybrid path so results are comparable.
+///
+/// `range` applies #786's `created_at` predicate in-memory against each
+/// already-fetched candidate (via `TimeRange::contains`) rather than in
+/// SQL -- safe here because `Database::get_embeddings` is an unbounded,
+/// un-limited corpus scan (no result-window cutoff to silently drop
+/// date-valid rows below), the same reasoning `join_and_score` documents
+/// for the hybrid path's cosine-sourced candidates.
 pub fn recall_cosine_only(
     db: &Database,
     embed_model: &EmbedModel,
@@ -625,6 +661,7 @@ pub fn recall_cosine_only(
     context: &str,
     limit: usize,
     min_score: Option<f32>,
+    range: &TimeRange,
 ) -> Result<RecallResult> {
     let query_embedding = embed_model.encode_one(context)?;
     let embeddings = db.get_embeddings(Some(repo))?;
@@ -641,7 +678,9 @@ pub fn recall_cosine_only(
             continue;
         }
 
-        if let Some(reflection) = db.get_reflection_by_id(id)? {
+        if let Some(reflection) = db.get_reflection_by_id(id)?
+            && range.contains(&reflection.created_at)?
+        {
             let score = weighted_score(
                 cosine,
                 reflection.recall_count,
@@ -821,6 +860,12 @@ mod tests {
     use crate::reflect::reflect_from_text;
     use crate::testutil::test_storage;
 
+    /// Unbounded `TimeRange` for tests that do not exercise #786 date
+    /// filtering.
+    fn no_range() -> TimeRange {
+        TimeRange::default()
+    }
+
     #[test]
     fn recall_returns_ranked_results() {
         let (db, index, _dir) = test_storage();
@@ -848,6 +893,7 @@ mod tests {
             "Zod type mapping",
             5,
             ArchiveMode::Hot,
+            &no_range(),
         )
         .expect("recall");
         assert!(result.reflections.len() >= 2);
@@ -859,7 +905,8 @@ mod tests {
         let (db, index, _dir) = test_storage();
         reflect_from_text(&db, &index, "kelex", "some reflection").expect("reflect");
 
-        let result = recall_bm25(&db, &index, "kelex", "", 5, ArchiveMode::Hot).expect("recall");
+        let result = recall_bm25(&db, &index, "kelex", "", 5, ArchiveMode::Hot, &no_range())
+            .expect("recall");
         assert!(result.reflections.is_empty());
     }
 
@@ -871,8 +918,16 @@ mod tests {
                 .expect("reflect");
         }
 
-        let result =
-            recall_bm25(&db, &index, "test", "testing", 3, ArchiveMode::Hot).expect("recall");
+        let result = recall_bm25(
+            &db,
+            &index,
+            "test",
+            "testing",
+            3,
+            ArchiveMode::Hot,
+            &no_range(),
+        )
+        .expect("recall");
         assert_eq!(result.reflections.len(), 3);
     }
 
@@ -882,14 +937,27 @@ mod tests {
 
         // Add directly to index without DB entry to simulate desync
         index
-            .add("orphan-id", "kelex", "orphan reflection text")
+            .add(
+                "orphan-id",
+                "kelex",
+                "orphan reflection text",
+                "2026-01-01T00:00:00+00:00",
+            )
             .expect("add to index");
 
         // Add a proper entry through reflect_from_text
         reflect_from_text(&db, &index, "kelex", "properly stored reflection").expect("reflect");
 
-        let result =
-            recall_bm25(&db, &index, "kelex", "reflection", 10, ArchiveMode::Hot).expect("recall");
+        let result = recall_bm25(
+            &db,
+            &index,
+            "kelex",
+            "reflection",
+            10,
+            ArchiveMode::Hot,
+            &no_range(),
+        )
+        .expect("recall");
 
         // Only the properly stored one should appear
         for r in &result.reflections {
@@ -903,8 +971,16 @@ mod tests {
         reflect_from_text(&db, &index, "kelex", "Zod schema mapping").expect("reflect kelex");
         reflect_from_text(&db, &index, "rafters", "Zod token generation").expect("reflect rafters");
 
-        let result =
-            recall_bm25(&db, &index, "kelex", "Zod", 10, ArchiveMode::Hot).expect("recall");
+        let result = recall_bm25(
+            &db,
+            &index,
+            "kelex",
+            "Zod",
+            10,
+            ArchiveMode::Hot,
+            &no_range(),
+        )
+        .expect("recall");
         assert_eq!(result.reflections.len(), 1);
         assert!(result.reflections[0].text.contains("mapping"));
     }
@@ -914,8 +990,16 @@ mod tests {
         let (db, index, _dir) = test_storage();
         reflect_from_text(&db, &index, "kelex", "test reflection").expect("reflect");
 
-        let result =
-            recall_bm25(&db, &index, "kelex", "test", 5, ArchiveMode::Hot).expect("recall");
+        let result = recall_bm25(
+            &db,
+            &index,
+            "kelex",
+            "test",
+            5,
+            ArchiveMode::Hot,
+            &no_range(),
+        )
+        .expect("recall");
         assert_eq!(result.repo, "kelex");
         assert_eq!(result.query, "test");
     }
@@ -1025,7 +1109,7 @@ mod tests {
         reflect_from_text(&db, &index, "platform", "Zod validation at the edge")
             .expect("reflect platform");
 
-        let result = consult_bm25(&db, &index, "Zod", 10).expect("consult");
+        let result = consult_bm25(&db, &index, "Zod", 10, &no_range()).expect("consult");
         // Should match kelex and platform but not rafters
         assert!(result.reflections.len() >= 2);
         let repos: Vec<&str> = result.reflections.iter().map(|r| r.repo.as_str()).collect();
@@ -1038,7 +1122,7 @@ mod tests {
         let (db, index, _dir) = test_storage();
         reflect_from_text(&db, &index, "kelex", "schema introspection logic").expect("reflect");
 
-        let result = consult_bm25(&db, &index, "schema", 5).expect("consult");
+        let result = consult_bm25(&db, &index, "schema", 5, &no_range()).expect("consult");
         assert_eq!(result.reflections.len(), 1);
         assert_eq!(result.reflections[0].repo, "kelex");
         assert_eq!(result.repo, "(all)");
@@ -1049,7 +1133,7 @@ mod tests {
         let (db, index, _dir) = test_storage();
         reflect_from_text(&db, &index, "kelex", "some reflection text").expect("reflect");
 
-        let result = consult_bm25(&db, &index, "", 5).expect("consult");
+        let result = consult_bm25(&db, &index, "", 5, &no_range()).expect("consult");
         assert!(result.reflections.is_empty());
     }
 
@@ -1165,7 +1249,16 @@ mod tests {
         db.boost_reflection(second_id).unwrap();
         db.boost_reflection(second_id).unwrap();
 
-        let result = recall_bm25(&db, &index, "kelex", "Zod", 5, ArchiveMode::Hot).expect("recall");
+        let result = recall_bm25(
+            &db,
+            &index,
+            "kelex",
+            "Zod",
+            5,
+            ArchiveMode::Hot,
+            &no_range(),
+        )
+        .expect("recall");
         assert!(result.reflections.len() >= 2);
         // The boosted reflection should have a higher weighted score
         let boosted = result

--- a/src/reflect.rs
+++ b/src/reflect.rs
@@ -95,7 +95,7 @@ pub fn reflect_from_text_with_meta(
     }
 
     let reflection = db.insert_reflection_with_meta(repo, trimmed, "self", meta)?;
-    index.add(&reflection.id, repo, trimmed)?;
+    index.add(&reflection.id, repo, trimmed, &reflection.created_at)?;
 
     Ok(reflection.id)
 }
@@ -117,6 +117,12 @@ mod tests {
     use super::*;
     use crate::testutil::test_storage;
 
+    /// Unbounded `TimeRange` for tests that do not exercise #786 date
+    /// filtering.
+    fn no_range() -> crate::timerange::TimeRange {
+        crate::timerange::TimeRange::default()
+    }
+
     #[test]
     fn reflect_from_text_stores_in_db_and_index() {
         let (db, index, _dir) = test_storage();
@@ -126,7 +132,7 @@ mod tests {
         assert_eq!(reflections.len(), 1);
         assert_eq!(reflections[0].text, "mapping rules are fragile");
 
-        let results = index.search("kelex", "mapping", 5).unwrap();
+        let results = index.search("kelex", "mapping", 5, &no_range()).unwrap();
         assert_eq!(results.len(), 1);
     }
 
@@ -231,8 +237,12 @@ mod tests {
         assert_eq!(platform[0].text, legion[0].text);
         assert_ne!(platform[0].id, legion[0].id);
 
-        let platform_search = index.search("platform", "cross-repo", 5).unwrap();
-        let legion_search = index.search("legion", "cross-repo", 5).unwrap();
+        let platform_search = index
+            .search("platform", "cross-repo", 5, &no_range())
+            .unwrap();
+        let legion_search = index
+            .search("legion", "cross-repo", 5, &no_range())
+            .unwrap();
         assert_eq!(platform_search.len(), 1);
         assert_eq!(legion_search.len(), 1);
     }
@@ -251,7 +261,9 @@ mod tests {
         let (db, index, _idx_dir) = test_storage();
         reflect_from_transcript(&db, &index, "kelex", &transcript).unwrap();
 
-        let results = index.search("kelex", "binary parsing", 5).unwrap();
+        let results = index
+            .search("kelex", "binary parsing", 5, &no_range())
+            .unwrap();
         assert_eq!(results.len(), 1);
 
         let reflections = db.get_reflections_by_repo("kelex").unwrap();

--- a/src/search.rs
+++ b/src/search.rs
@@ -1,14 +1,17 @@
+use std::ops::Bound;
 use std::path::Path;
 
 use tantivy::collector::TopDocs;
-use tantivy::query::{BooleanQuery, Occur, QueryParser, TermQuery};
+use tantivy::query::{BooleanQuery, Occur, Query, QueryParser, RangeQuery, TermQuery};
 use tantivy::schema::{
-    Field, IndexRecordOption, STORED, STRING, Schema, TextFieldIndexing, TextOptions, Value,
+    DateOptions, DateTimePrecision, Field, IndexRecordOption, STORED, STRING, Schema,
+    TextFieldIndexing, TextOptions, Type, Value,
 };
-use tantivy::{Index, IndexWriter, ReloadPolicy, TantivyDocument, Term, doc};
+use tantivy::{DateTime, Index, IndexWriter, ReloadPolicy, TantivyDocument, Term, doc};
 
 use crate::db::Reflection;
 use crate::error::{LegionError, Result};
+use crate::timerange::TimeRange;
 
 /// Maximum number of retries when acquiring the Tantivy index writer.
 /// Another process (e.g., a concurrent hook) may hold the lock briefly.
@@ -27,6 +30,7 @@ pub struct SearchIndex {
     id_field: Field,
     repo_field: Field,
     text_field: Field,
+    created_at_field: Field,
 }
 
 /// A single search result with its document ID and BM25 relevance score.
@@ -47,6 +51,13 @@ impl SearchIndex {
     /// - `id`: STRING | STORED -- exact match, retrievable after search
     /// - `repo`: STRING -- exact match filtering per repository
     /// - `text`: TEXT -- tokenized with English stemmer, BM25 scored
+    /// - `created_at`: DATE (second precision, indexed, not stored) -- the
+    ///   `--since`/`--until`/`--on` range predicate (#786), composed into
+    ///   the same `BooleanQuery` as the repo filter so date-valid documents
+    ///   never compete with out-of-range ones for a BM25 result-window
+    ///   cutoff (the failure mode the `--archives` over-fetch-and-post-
+    ///   filter pattern has; deliberately not reused here, see #786 build
+    ///   notes).
     pub fn open(path: &Path) -> Result<Self> {
         let mut schema_builder = Schema::builder();
 
@@ -60,12 +71,37 @@ impl SearchIndex {
         );
         let text_field = schema_builder.add_text_field("text", text_options);
 
+        let date_options =
+            DateOptions::from(tantivy::schema::INDEXED).set_precision(DateTimePrecision::Seconds);
+        let created_at_field = schema_builder.add_date_field("created_at", date_options);
+
         let schema = schema_builder.build();
 
         std::fs::create_dir_all(path).map_err(|e| LegionError::Search(e.to_string()))?;
 
         let index = match Index::open_in_dir(path) {
-            Ok(idx) => idx,
+            Ok(idx) if idx.schema() == schema => idx,
+            Ok(_mismatched) => {
+                // #786: the on-disk index predates the `created_at` field.
+                // `Index::open_in_dir` trusts whatever schema is recorded
+                // in the existing meta.json regardless of the schema this
+                // function just built in memory -- opening succeeds, but
+                // the `Field` handles above (assigned by call order on the
+                // in-memory builder) do not exist in the on-disk schema.
+                // Writing a document that references the extra field then
+                // corrupts the write (observed empirically: a fastfield
+                // writer panic on an out-of-bounds field index, caught by
+                // tantivy's writer thread and surfaced as a commit error
+                // -- not a crash, but every `legion reflect`/`post` would
+                // fail until reindexed). Treat a schema mismatch the same
+                // as corruption: wipe and recreate empty. `legion reindex`
+                // repopulates from the database, the source of truth, same
+                // recovery path as the corrupted-index branch below.
+                eprintln!(
+                    "[legion] search index schema changed (created_at field added, #786), rebuilding empty -- run `legion reindex` to repopulate"
+                );
+                Self::recreate_index(path, schema.clone())?
+            }
             Err(open_err) => {
                 // Directory may be empty (new) or corrupted -- either way, create fresh.
                 match Index::create_in_dir(path, schema.clone()) {
@@ -84,6 +120,7 @@ impl SearchIndex {
             id_field,
             repo_field,
             text_field,
+            created_at_field,
         })
     }
 
@@ -101,13 +138,16 @@ impl SearchIndex {
     /// Add a document to the search index and commit immediately.
     ///
     /// Each document consists of an id (stored for retrieval), a repo name
-    /// (for filtering), and the reflection text (for BM25 scoring).
+    /// (for filtering), the reflection text (for BM25 scoring), and its
+    /// `created_at` timestamp (RFC3339, matching the `reflections` table --
+    /// see [`Self::open`]'s doc comment for why it lives in the index
+    /// rather than being joined in afterward).
     ///
     /// Retries up to [`WRITER_RETRIES`] times with exponential backoff when
     /// the writer lock is held by another process (e.g., a concurrent hook).
     /// Commits after each write. The reflection corpus is tiny, so the
     /// per-write commit overhead is negligible.
-    pub fn add(&self, id: &str, repo: &str, text: &str) -> Result<()> {
+    pub fn add(&self, id: &str, repo: &str, text: &str, created_at: &str) -> Result<()> {
         let mut writer: IndexWriter = self.acquire_writer()?;
 
         writer
@@ -115,6 +155,7 @@ impl SearchIndex {
                 self.id_field => id,
                 self.repo_field => repo,
                 self.text_field => text,
+                self.created_at_field => parse_rfc3339_to_tantivy_date(created_at)?,
             ))
             .map_err(|e| LegionError::Search(e.to_string()))?;
 
@@ -179,7 +220,9 @@ impl SearchIndex {
     ///
     /// Clears the existing index contents first, then bulk-inserts all
     /// provided reflections. Used by the `reindex` command to recover
-    /// from index/database desync or corruption.
+    /// from index/database desync or corruption -- and, after #786, to
+    /// repopulate `created_at` for every existing reflection when
+    /// `SearchIndex::open` wipes an index that predates that field.
     pub fn rebuild(&self, reflections: &[Reflection]) -> Result<()> {
         let mut writer: IndexWriter = self.acquire_writer()?;
 
@@ -193,6 +236,7 @@ impl SearchIndex {
                     self.id_field => r.id.as_str(),
                     self.repo_field => r.repo.as_str(),
                     self.text_field => r.text.as_str(),
+                    self.created_at_field => parse_rfc3339_to_tantivy_date(&r.created_at)?,
                 ))
                 .map_err(|e| LegionError::Search(e.to_string()))?;
         }
@@ -206,33 +250,54 @@ impl SearchIndex {
 
     /// Search for reflections matching a query within a specific repo.
     ///
-    /// Combines an exact-match filter on `repo` with a BM25-scored query
-    /// on the `text` field. Returns up to `limit` results ordered by
-    /// descending relevance score.
+    /// Combines an exact-match filter on `repo`, an optional `created_at`
+    /// range predicate (`range`; `TimeRange::default()` is unbounded, the
+    /// whole-store case -- see `timerange` module docs, #786), and a
+    /// BM25-scored query on the `text` field. Returns up to `limit`
+    /// results ordered by descending relevance score.
     ///
     /// Returns an empty vec if the query string is empty or whitespace-only.
-    pub fn search(&self, repo: &str, query: &str, limit: usize) -> Result<Vec<SearchResult>> {
-        self.execute_query(query, Some(repo), limit)
+    pub fn search(
+        &self,
+        repo: &str,
+        query: &str,
+        limit: usize,
+        range: &TimeRange,
+    ) -> Result<Vec<SearchResult>> {
+        self.execute_query(query, Some(repo), limit, range)
     }
 
     /// Search for reflections matching a query across ALL repositories.
     ///
     /// Unlike `search`, this method does not filter by repo. It runs a
-    /// BM25-scored query on the `text` field across every indexed document.
-    /// Returns up to `limit` results ordered by descending relevance score.
+    /// BM25-scored query on the `text` field across every indexed document,
+    /// composed with the same optional `created_at` range predicate as
+    /// `search` (#786). Returns up to `limit` results ordered by
+    /// descending relevance score.
     ///
     /// Returns an empty vec if the query string is empty or whitespace-only.
-    pub fn search_all(&self, query: &str, limit: usize) -> Result<Vec<SearchResult>> {
-        self.execute_query(query, None, limit)
+    pub fn search_all(
+        &self,
+        query: &str,
+        limit: usize,
+        range: &TimeRange,
+    ) -> Result<Vec<SearchResult>> {
+        self.execute_query(query, None, limit, range)
     }
 
-    /// Shared search implementation. When `repo` is Some, results are filtered
-    /// to that repository; when None, all repositories are searched.
+    /// Shared search implementation. When `repo` is Some, results are
+    /// filtered to that repository; when None, all repositories are
+    /// searched. `range` composes a `created_at` bound into the same
+    /// `BooleanQuery` as the repo filter -- applied at the index level,
+    /// before `TopDocs` collection, so an unbounded fetch never has to
+    /// silently drop date-valid documents that ranked below a limit-sized
+    /// cutoff (#786).
     fn execute_query(
         &self,
         query: &str,
         repo: Option<&str>,
         limit: usize,
+        range: &TimeRange,
     ) -> Result<Vec<SearchResult>> {
         let trimmed = query.trim();
         if trimmed.is_empty() {
@@ -253,16 +318,22 @@ impl SearchIndex {
             .parse_query(trimmed)
             .map_err(|e| LegionError::Search(e.to_string()))?;
 
-        let final_query: Box<dyn tantivy::query::Query> = match repo {
-            Some(repo_name) => {
-                let repo_term = Term::from_field_text(self.repo_field, repo_name);
-                let repo_query = TermQuery::new(repo_term, IndexRecordOption::Basic);
-                Box::new(BooleanQuery::new(vec![
-                    (Occur::Must, Box::new(repo_query)),
-                    (Occur::Must, text_query),
-                ]))
-            }
-            None => text_query,
+        let mut clauses: Vec<(Occur, Box<dyn Query>)> = vec![(Occur::Must, text_query)];
+
+        if let Some(repo_name) = repo {
+            let repo_term = Term::from_field_text(self.repo_field, repo_name);
+            let repo_query = TermQuery::new(repo_term, IndexRecordOption::Basic);
+            clauses.push((Occur::Must, Box::new(repo_query)));
+        }
+
+        if let Some(range_query) = self.date_range_query(range)? {
+            clauses.push((Occur::Must, range_query));
+        }
+
+        let final_query: Box<dyn Query> = if clauses.len() == 1 {
+            clauses.pop().expect("just checked len == 1").1
+        } else {
+            Box::new(BooleanQuery::new(clauses))
         };
 
         let top_docs = searcher
@@ -289,11 +360,61 @@ impl SearchIndex {
 
         Ok(results)
     }
+
+    /// Build a `created_at` range query from `range`, or `None` when `range`
+    /// is unbounded (`TimeRange::default()`) -- the whole-store case takes
+    /// no extra clause rather than an always-true one, so an unbounded call
+    /// costs nothing extra at query time.
+    fn date_range_query(&self, range: &TimeRange) -> Result<Option<Box<dyn Query>>> {
+        if range.is_unbounded() {
+            return Ok(None);
+        }
+
+        let lower = match range.since_bound()? {
+            Some(bound) => Bound::Included(Term::from_field_date(
+                self.created_at_field,
+                parse_rfc3339_to_tantivy_date(&bound)?,
+            )),
+            None => Bound::Unbounded,
+        };
+        let upper = match range.until_bound()? {
+            Some(bound) => Bound::Excluded(Term::from_field_date(
+                self.created_at_field,
+                parse_rfc3339_to_tantivy_date(&bound)?,
+            )),
+            None => Bound::Unbounded,
+        };
+
+        Ok(Some(Box::new(RangeQuery::new_term_bounds(
+            "created_at".to_string(),
+            Type::Date,
+            &lower,
+            &upper,
+        ))))
+    }
+}
+
+/// Parse an RFC3339 timestamp (the `created_at` shape stored throughout
+/// this crate, e.g. `chrono::Utc::now().to_rfc3339()`) into a Tantivy
+/// `DateTime`. Shared by document indexing (`add`/`rebuild`) and range
+/// query construction (`date_range_query`) so both sides of the `created_at`
+/// comparison go through the same conversion and cannot drift.
+fn parse_rfc3339_to_tantivy_date(input: &str) -> Result<DateTime> {
+    let parsed = chrono::DateTime::parse_from_rfc3339(input)
+        .map_err(|e| LegionError::Search(format!("invalid created_at timestamp '{input}': {e}")))?;
+    let nanos = parsed.timestamp_nanos_opt().ok_or_else(|| {
+        LegionError::Search(format!("created_at timestamp out of range: '{input}'"))
+    })?;
+    Ok(DateTime::from_timestamp_nanos(nanos))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Fixed `created_at` used by tests that do not exercise date
+    /// filtering -- any valid RFC3339 timestamp works.
+    const T: &str = "2026-01-01T00:00:00+00:00";
 
     /// Create a SearchIndex backed by a temporary directory.
     ///
@@ -312,17 +433,21 @@ mod tests {
             "id-1",
             "kelex",
             "mapping rules are fragile when adding new Zod types",
+            T,
         )
         .unwrap();
         idx.add(
             "id-2",
             "kelex",
             "discriminated unions inside arrays are where complexity hides",
+            T,
         )
         .unwrap();
-        idx.add("id-3", "kelex", "the CLI flag parser is straightforward")
+        idx.add("id-3", "kelex", "the CLI flag parser is straightforward", T)
             .unwrap();
-        let results = idx.search("kelex", "Zod type mapping", 5).unwrap();
+        let results = idx
+            .search("kelex", "Zod type mapping", 5, &TimeRange::default())
+            .unwrap();
         assert!(!results.is_empty());
         assert_eq!(results[0].id, "id-1");
     }
@@ -330,11 +455,13 @@ mod tests {
     #[test]
     fn search_filters_by_repo() {
         let (idx, _dir) = test_index();
-        idx.add("id-1", "kelex", "schema introspection is complex")
+        idx.add("id-1", "kelex", "schema introspection is complex", T)
             .unwrap();
-        idx.add("id-2", "rafters", "schema tokens need attention")
+        idx.add("id-2", "rafters", "schema tokens need attention", T)
             .unwrap();
-        let results = idx.search("kelex", "schema", 5).unwrap();
+        let results = idx
+            .search("kelex", "schema", 5, &TimeRange::default())
+            .unwrap();
         assert_eq!(results.len(), 1);
         assert_eq!(results[0].id, "id-1");
     }
@@ -347,27 +474,32 @@ mod tests {
                 &format!("id-{i}"),
                 "test",
                 &format!("reflection about testing {i}"),
+                T,
             )
             .unwrap();
         }
-        let results = idx.search("test", "testing", 3).unwrap();
+        let results = idx
+            .search("test", "testing", 3, &TimeRange::default())
+            .unwrap();
         assert_eq!(results.len(), 3);
     }
 
     #[test]
     fn search_empty_query_returns_empty() {
         let (idx, _dir) = test_index();
-        idx.add("id-1", "kelex", "some reflection").unwrap();
-        let results = idx.search("kelex", "", 5).unwrap();
+        idx.add("id-1", "kelex", "some reflection", T).unwrap();
+        let results = idx.search("kelex", "", 5, &TimeRange::default()).unwrap();
         assert!(results.is_empty());
     }
 
     #[test]
     fn stemming_matches_variants() {
         let (idx, _dir) = test_index();
-        idx.add("id-1", "test", "nested arrays in the codegen templates")
+        idx.add("id-1", "test", "nested arrays in the codegen templates", T)
             .unwrap();
-        let results = idx.search("test", "nesting array codegen", 5).unwrap();
+        let results = idx
+            .search("test", "nesting array codegen", 5, &TimeRange::default())
+            .unwrap();
         assert!(!results.is_empty());
         assert_eq!(results[0].id, "id-1");
     }
@@ -375,13 +507,13 @@ mod tests {
     #[test]
     fn search_all_returns_results_from_multiple_repos() {
         let (idx, _dir) = test_index();
-        idx.add("id-1", "kelex", "schema introspection is complex")
+        idx.add("id-1", "kelex", "schema introspection is complex", T)
             .unwrap();
-        idx.add("id-2", "rafters", "schema tokens need attention")
+        idx.add("id-2", "rafters", "schema tokens need attention", T)
             .unwrap();
-        idx.add("id-3", "platform", "schema validation with Zod")
+        idx.add("id-3", "platform", "schema validation with Zod", T)
             .unwrap();
-        let results = idx.search_all("schema", 10).unwrap();
+        let results = idx.search_all("schema", 10, &TimeRange::default()).unwrap();
         assert_eq!(results.len(), 3);
         let ids: Vec<&str> = results.iter().map(|r| r.id.as_str()).collect();
         assert!(ids.contains(&"id-1"));
@@ -392,15 +524,23 @@ mod tests {
     #[test]
     fn search_all_ranks_by_relevance() {
         let (idx, _dir) = test_index();
-        idx.add("id-weak", "kelex", "the CLI flag parser is straightforward")
-            .unwrap();
+        idx.add(
+            "id-weak",
+            "kelex",
+            "the CLI flag parser is straightforward",
+            T,
+        )
+        .unwrap();
         idx.add(
             "id-strong",
             "rafters",
             "mapping rules are fragile when adding new Zod types for mapping",
+            T,
         )
         .unwrap();
-        let results = idx.search_all("mapping", 10).unwrap();
+        let results = idx
+            .search_all("mapping", 10, &TimeRange::default())
+            .unwrap();
         assert!(!results.is_empty());
         assert_eq!(results[0].id, "id-strong");
         // BM25 scores must be in descending order
@@ -412,19 +552,23 @@ mod tests {
     #[test]
     fn search_all_empty_query_returns_empty() {
         let (idx, _dir) = test_index();
-        idx.add("id-1", "kelex", "some reflection").unwrap();
-        let results = idx.search_all("", 5).unwrap();
+        idx.add("id-1", "kelex", "some reflection", T).unwrap();
+        let results = idx.search_all("", 5, &TimeRange::default()).unwrap();
         assert!(results.is_empty());
-        let results = idx.search_all("   ", 5).unwrap();
+        let results = idx.search_all("   ", 5, &TimeRange::default()).unwrap();
         assert!(results.is_empty());
     }
 
     fn test_reflection(id: &str, repo: &str, text: &str) -> Reflection {
+        test_reflection_at(id, repo, text, T)
+    }
+
+    fn test_reflection_at(id: &str, repo: &str, text: &str, created_at: &str) -> Reflection {
         Reflection {
             id: id.into(),
             repo: repo.into(),
             text: text.into(),
-            created_at: "2026-01-01T00:00:00Z".into(),
+            created_at: created_at.into(),
             updated_at: None,
             audience: "self".into(),
             domain: None,
@@ -442,23 +586,29 @@ mod tests {
             "id-keep",
             "kelex",
             "keep this reflection about mapping rules",
+            T,
         )
         .unwrap();
         idx.add(
             "id-gone",
             "kelex",
             "doomed reflection about mapping rules that should vanish",
+            T,
         )
         .unwrap();
 
         // Both documents visible before the delete.
-        let before = idx.search("kelex", "mapping rules", 10).unwrap();
+        let before = idx
+            .search("kelex", "mapping rules", 10, &TimeRange::default())
+            .unwrap();
         assert_eq!(before.len(), 2);
 
         idx.delete("id-gone").unwrap();
 
         // After delete, only the kept document surfaces -- no ghost for id-gone.
-        let after = idx.search("kelex", "mapping rules", 10).unwrap();
+        let after = idx
+            .search("kelex", "mapping rules", 10, &TimeRange::default())
+            .unwrap();
         assert_eq!(after.len(), 1);
         assert_eq!(after[0].id, "id-keep");
     }
@@ -466,11 +616,13 @@ mod tests {
     #[test]
     fn delete_nonexistent_id_is_noop() {
         let (idx, _dir) = test_index();
-        idx.add("id-1", "kelex", "reflection one").unwrap();
+        idx.add("id-1", "kelex", "reflection one", T).unwrap();
         // Deleting a term that never existed should not error.
         idx.delete("id-does-not-exist").unwrap();
         // Existing document still retrievable.
-        let results = idx.search("kelex", "reflection", 5).unwrap();
+        let results = idx
+            .search("kelex", "reflection", 5, &TimeRange::default())
+            .unwrap();
         assert_eq!(results.len(), 1);
         assert_eq!(results[0].id, "id-1");
     }
@@ -478,7 +630,7 @@ mod tests {
     #[test]
     fn rebuild_replaces_index_contents() {
         let (idx, _dir) = test_index();
-        idx.add("id-old", "test", "old reflection that should be gone")
+        idx.add("id-old", "test", "old reflection that should be gone", T)
             .unwrap();
 
         let reflections = vec![
@@ -488,22 +640,28 @@ mod tests {
         idx.rebuild(&reflections).unwrap();
 
         // Old document should be gone
-        let old = idx.search("test", "old reflection", 5).unwrap();
+        let old = idx
+            .search("test", "old reflection", 5, &TimeRange::default())
+            .unwrap();
         assert!(old.is_empty());
 
         // New documents should be present
-        let results = idx.search_all("reflection", 10).unwrap();
+        let results = idx
+            .search_all("reflection", 10, &TimeRange::default())
+            .unwrap();
         assert_eq!(results.len(), 2);
     }
 
     #[test]
     fn rebuild_empty_clears_index() {
         let (idx, _dir) = test_index();
-        idx.add("id-1", "test", "something searchable").unwrap();
+        idx.add("id-1", "test", "something searchable", T).unwrap();
 
         idx.rebuild(&[]).unwrap();
 
-        let results = idx.search_all("searchable", 10).unwrap();
+        let results = idx
+            .search_all("searchable", 10, &TimeRange::default())
+            .unwrap();
         assert!(results.is_empty());
     }
 
@@ -521,8 +679,10 @@ mod tests {
 
         // Should recover by recreating
         let idx = SearchIndex::open(path).expect("recovery open");
-        idx.add("id-1", "test", "works after recovery").unwrap();
-        let results = idx.search("test", "recovery", 5).unwrap();
+        idx.add("id-1", "test", "works after recovery", T).unwrap();
+        let results = idx
+            .search("test", "recovery", 5, &TimeRange::default())
+            .unwrap();
         assert_eq!(results.len(), 1);
     }
 
@@ -534,10 +694,183 @@ mod tests {
                 &format!("id-{i}"),
                 &format!("repo-{}", i % 3),
                 &format!("reflection about testing {i}"),
+                T,
             )
             .unwrap();
         }
-        let results = idx.search_all("testing", 3).unwrap();
+        let results = idx.search_all("testing", 3, &TimeRange::default()).unwrap();
         assert_eq!(results.len(), 3);
+    }
+
+    // -- #786: created_at range filtering --------------------------------
+
+    #[test]
+    fn search_filters_by_date_range() {
+        let (idx, _dir) = test_index();
+        idx.add(
+            "id-old",
+            "kelex",
+            "mapping rules apply",
+            "2026-01-01T00:00:00+00:00",
+        )
+        .unwrap();
+        idx.add(
+            "id-mid",
+            "kelex",
+            "mapping rules apply",
+            "2026-06-15T00:00:00+00:00",
+        )
+        .unwrap();
+        idx.add(
+            "id-new",
+            "kelex",
+            "mapping rules apply",
+            "2026-12-31T00:00:00+00:00",
+        )
+        .unwrap();
+
+        let range = TimeRange::parse(Some("2026-06-01"), Some("2026-06-30"), None).unwrap();
+        let results = idx.search("kelex", "mapping rules", 10, &range).unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].id, "id-mid");
+    }
+
+    #[test]
+    fn search_all_filters_by_date_range() {
+        let (idx, _dir) = test_index();
+        idx.add(
+            "id-old",
+            "kelex",
+            "reflection text here",
+            "2026-01-01T00:00:00+00:00",
+        )
+        .unwrap();
+        idx.add(
+            "id-new",
+            "rafters",
+            "reflection text here",
+            "2026-12-31T00:00:00+00:00",
+        )
+        .unwrap();
+
+        let range = TimeRange::parse(Some("2026-12-01"), None, None).unwrap();
+        let results = idx.search_all("reflection", 10, &range).unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].id, "id-new");
+    }
+
+    #[test]
+    fn search_on_date_includes_whole_local_day() {
+        let (idx, _dir) = test_index();
+        // A row created late in the local day of 2026-07-14 (per the
+        // system timezone, matching TimeRange's own conversion) must
+        // still match `--on 2026-07-14`.
+        let range = TimeRange::parse(None, None, Some("2026-07-14")).unwrap();
+        let late_in_day = range.until_bound().unwrap().unwrap();
+        // until_bound is the EXCLUSIVE next-day boundary; back off a
+        // second to land inside the requested day regardless of what UTC
+        // offset the system timezone applies.
+        let inside = chrono::DateTime::parse_from_rfc3339(&late_in_day)
+            .unwrap()
+            .checked_sub_signed(chrono::Duration::seconds(1))
+            .unwrap()
+            .to_rfc3339();
+
+        idx.add("id-in", "kelex", "some reflection text", &inside)
+            .unwrap();
+        idx.add(
+            "id-out",
+            "kelex",
+            "some reflection text",
+            &late_in_day, // exactly at the exclusive boundary: excluded
+        )
+        .unwrap();
+
+        let results = idx.search("kelex", "reflection text", 10, &range).unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].id, "id-in");
+    }
+
+    #[test]
+    fn unbounded_range_returns_everything() {
+        let (idx, _dir) = test_index();
+        idx.add(
+            "id-1",
+            "kelex",
+            "reflection alpha",
+            "2020-01-01T00:00:00+00:00",
+        )
+        .unwrap();
+        idx.add(
+            "id-2",
+            "kelex",
+            "reflection beta",
+            "2030-01-01T00:00:00+00:00",
+        )
+        .unwrap();
+
+        let results = idx
+            .search_all("reflection", 10, &TimeRange::default())
+            .unwrap();
+        assert_eq!(results.len(), 2);
+    }
+
+    #[test]
+    fn schema_mismatch_rebuilds_empty_instead_of_corrupting_writes() {
+        // Simulate an index built before #786 (no created_at field): a
+        // 3-field schema written directly with tantivy, bypassing
+        // SearchIndex::open entirely.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path();
+        {
+            let mut sb = Schema::builder();
+            let id_field = sb.add_text_field("id", STRING | STORED);
+            let repo_field = sb.add_text_field("repo", STRING);
+            let text_options = TextOptions::default().set_indexing_options(
+                TextFieldIndexing::default()
+                    .set_tokenizer("en_stem")
+                    .set_index_option(IndexRecordOption::WithFreqsAndPositions),
+            );
+            let text_field = sb.add_text_field("text", text_options);
+            let old_schema = sb.build();
+            let old_index = Index::create_in_dir(path, old_schema).expect("create old index");
+            let mut writer: IndexWriter = old_index.writer(15_000_000).expect("writer");
+            writer
+                .add_document(doc!(
+                    id_field => "pre-786",
+                    repo_field => "kelex",
+                    text_field => "a reflection from before the schema change",
+                ))
+                .expect("add old-shape doc");
+            writer.commit().expect("commit old index");
+        }
+
+        // Opening with the new (4-field) schema must not panic or return
+        // an error -- it detects the mismatch and rebuilds empty.
+        let idx = SearchIndex::open(path).expect("open after schema change");
+
+        // Writes must succeed post-rebuild (this is the failure this test
+        // guards: pre-fix, add() after a mismatched open corrupted the
+        // commit).
+        idx.add("id-1", "kelex", "a fresh reflection", T)
+            .expect("add after schema rebuild must not fail");
+        let results = idx
+            .search("kelex", "fresh reflection", 5, &TimeRange::default())
+            .unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].id, "id-1");
+
+        // The pre-786 document did not survive the rebuild (expected: the
+        // rebuild starts empty; `legion reindex` is the documented
+        // recovery path to repopulate from the database).
+        let old = idx
+            .search(
+                "kelex",
+                "before the schema change",
+                5,
+                &TimeRange::default(),
+            )
+            .unwrap();
+        assert!(old.is_empty());
     }
 }

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -775,9 +775,14 @@ async fn api_search(
 
     let limit = params.limit.unwrap_or(10).min(50);
 
+    // #786 threads an optional TimeRange through every recall/consult/
+    // bullpen/surface entry point; this HTTP search endpoint is out of
+    // this issue's scope (CLI-only per the interface spec) and keeps its
+    // pre-#786 unbounded behavior via TimeRange::default().
+    let range = crate::timerange::TimeRange::default();
     let hits = match &params.repo {
-        Some(repo) => index.search(repo, q, limit),
-        None => index.search_all(q, limit),
+        Some(repo) => index.search(repo, q, limit, &range),
+        None => index.search_all(q, limit, &range),
     };
     let hits = hits.map_err(|e| ServeError::internal("search error", e))?;
 

--- a/src/status.rs
+++ b/src/status.rs
@@ -50,7 +50,8 @@ pub fn get_status(db: &Database, repo: &str) -> Result<StatusOutput> {
     let active_task_count = tasks.len();
     let blocked_task_count = tasks.iter().filter(|t| t.status == "blocked").count();
     let your_work = your_work_items(&tasks, repo);
-    let posts: Vec<Reflection> = db.get_recent_board_posts(LOOKBACK_HOURS)?;
+    let posts: Vec<Reflection> =
+        db.get_recent_board_posts(LOOKBACK_HOURS, &crate::timerange::TimeRange::default())?;
     let (team_needs, seen_ids) = get_team_needs(&posts, repo);
     let what_changed = get_what_changed(&posts, repo, &seen_ids);
 
@@ -110,7 +111,10 @@ pub struct DoneResult {
 
 /// Find agents who mentioned being blocked on this repo in recent bullpen posts.
 pub fn find_blocked_agents(db: &Database, repo: &str) -> Result<Vec<String>> {
-    let posts: Vec<Reflection> = db.get_recent_board_posts(NEEDS_LOOKBACK_HOURS)?;
+    let posts: Vec<Reflection> = db.get_recent_board_posts(
+        NEEDS_LOOKBACK_HOURS,
+        &crate::timerange::TimeRange::default(),
+    )?;
     let repo_lower: String = repo.to_lowercase();
     let blocked_pattern: String = format!("blocked on {}", repo_lower);
     let waiting_pattern: String = format!("waiting on {}", repo_lower);
@@ -134,7 +138,10 @@ pub fn find_blocked_agents(db: &Database, repo: &str) -> Result<Vec<String>> {
 /// Gather focused team needs for a repo (wider lookback, more items than status).
 /// Used by `legion needs` when an agent is idle and looking for ways to help.
 pub fn get_needs(db: &Database, repo: &str) -> Result<Vec<StatusItem>> {
-    let posts: Vec<Reflection> = db.get_recent_board_posts(NEEDS_LOOKBACK_HOURS)?;
+    let posts: Vec<Reflection> = db.get_recent_board_posts(
+        NEEDS_LOOKBACK_HOURS,
+        &crate::timerange::TimeRange::default(),
+    )?;
     let (items, _seen_ids) = get_team_needs_with_limit(&posts, repo, MAX_NEEDS_FOCUSED);
     Ok(items)
 }
@@ -638,7 +645,7 @@ mod tests {
     }
 
     fn get_posts(db: &Database) -> Vec<Reflection> {
-        db.get_recent_board_posts(24)
+        db.get_recent_board_posts(24, &crate::timerange::TimeRange::default())
             .expect("get_recent_board_posts")
     }
 

--- a/src/surface.rs
+++ b/src/surface.rs
@@ -1,6 +1,7 @@
 use crate::db::{self, Database, Reflection};
 use crate::error::Result;
 use crate::task;
+use crate::timerange::TimeRange;
 
 /// Truncate text to a maximum number of characters, adding "..." if truncated.
 fn truncate_text(text: &str, max_chars: usize) -> String {
@@ -28,14 +29,17 @@ const MAX_CHAIN_EXTENSIONS: usize = 3;
 /// Gather cross-repo highlights for a given repo.
 ///
 /// Returns up to 5 recent bullpen posts, 3 high-value cross-repo reflections,
-/// and 3 recently extended learning chains.
-pub fn surface(db: &Database, repo: &str) -> Result<SurfaceResult> {
-    let mut recent_posts = db.get_recent_board_posts(24)?;
+/// and 3 recently extended learning chains. `range` (#786) threads
+/// `--since`/`--until`/`--on` into all four underlying queries; unbounded
+/// (`TimeRange::default()`) preserves the pre-#786 24h-lookback defaults
+/// for the recency-windowed ones.
+pub fn surface(db: &Database, repo: &str, range: &TimeRange) -> Result<SurfaceResult> {
+    let mut recent_posts = db.get_recent_board_posts(24, range)?;
     recent_posts.truncate(MAX_RECENT_POSTS);
-    let high_value = db.get_high_value_cross_repo(repo, 3)?;
-    let mut chain_extensions = db.get_recent_chain_extensions(24)?;
+    let high_value = db.get_high_value_cross_repo(repo, 3, range)?;
+    let mut chain_extensions = db.get_recent_chain_extensions(24, range)?;
     chain_extensions.truncate(MAX_CHAIN_EXTENSIONS);
-    let pending_tasks = task::get_pending_inbound(db, repo)?;
+    let pending_tasks = task::get_pending_inbound(db, repo, range)?;
 
     Ok(SurfaceResult {
         recent_posts,
@@ -124,7 +128,7 @@ mod tests {
     #[test]
     fn surface_empty_database() {
         let (db, _index, _dir) = test_storage();
-        let result = surface(&db, "kelex").unwrap();
+        let result = surface(&db, "kelex", &TimeRange::default()).unwrap();
         assert!(result.recent_posts.is_empty());
         assert!(result.high_value.is_empty());
         assert!(result.chain_extensions.is_empty());
@@ -136,7 +140,7 @@ mod tests {
         db.insert_reflection("rafters", "fresh insight", "team")
             .unwrap();
 
-        let result = surface(&db, "kelex").unwrap();
+        let result = surface(&db, "kelex", &TimeRange::default()).unwrap();
         assert_eq!(result.recent_posts.len(), 1);
         assert_eq!(result.recent_posts[0].text, "fresh insight");
     }
@@ -150,7 +154,7 @@ mod tests {
         db.boost_reflection(&r.id).unwrap();
         db.boost_reflection(&r.id).unwrap();
 
-        let result = surface(&db, "kelex").unwrap();
+        let result = surface(&db, "kelex", &TimeRange::default()).unwrap();
         assert_eq!(result.high_value.len(), 1);
         assert_eq!(result.high_value[0].text, "valuable pattern");
         assert_eq!(result.high_value[0].recall_count, 2);
@@ -164,7 +168,7 @@ mod tests {
             .unwrap();
         db.boost_reflection(&r.id).unwrap();
 
-        let result = surface(&db, "kelex").unwrap();
+        let result = surface(&db, "kelex", &TimeRange::default()).unwrap();
         assert!(result.high_value.is_empty());
     }
 
@@ -181,7 +185,7 @@ mod tests {
         db.insert_reflection_with_meta("kelex", "builds on root", "self", &meta)
             .unwrap();
 
-        let result = surface(&db, "kelex").unwrap();
+        let result = surface(&db, "kelex", &TimeRange::default()).unwrap();
         assert_eq!(result.chain_extensions.len(), 1);
         assert_eq!(result.chain_extensions[0].text, "builds on root");
     }
@@ -204,7 +208,7 @@ mod tests {
         task::create_task(&db, "kelex", "legion", "implement search", None, "high")
             .expect("create task");
 
-        let result = surface(&db, "legion").expect("surface");
+        let result = surface(&db, "legion", &TimeRange::default()).expect("surface");
         assert_eq!(result.pending_tasks.len(), 1);
         assert_eq!(result.pending_tasks[0].text, "implement search");
     }
@@ -222,7 +226,7 @@ mod tests {
         )
         .expect("create task");
 
-        let result = surface(&db, "legion").expect("surface");
+        let result = surface(&db, "legion", &TimeRange::default()).expect("surface");
         let output = format_surface(&result, "legion");
         assert!(output.contains("Task from kelex"));
         assert!(output.contains("implement search"));
@@ -235,7 +239,7 @@ mod tests {
         db.insert_reflection("rafters", "test post", "team")
             .unwrap();
 
-        let result = surface(&db, "kelex").unwrap();
+        let result = surface(&db, "kelex", &TimeRange::default()).unwrap();
         let output = format_surface(&result, "kelex");
         assert!(output.contains("[Synapse] For kelex:"));
         assert!(output.contains("[rafters]"));

--- a/src/task.rs
+++ b/src/task.rs
@@ -117,9 +117,15 @@ fn priority_tag(priority: &str) -> String {
     }
 }
 
-/// Get pending inbound tasks for a repo (used by surface).
-pub fn get_pending_inbound(db: &Database, repo: &str) -> Result<Vec<Task>> {
-    db.get_pending_tasks_for_repo(repo)
+/// Get pending inbound tasks for a repo (used by surface). `range` applies
+/// #786's `created_at` predicate (`TimeRange::default()` is unbounded, a
+/// no-op).
+pub fn get_pending_inbound(
+    db: &Database,
+    repo: &str,
+    range: &crate::timerange::TimeRange,
+) -> Result<Vec<Task>> {
+    db.get_pending_tasks_for_repo(repo, range)
 }
 
 /// Count pending inbound tasks for a repo (used by bullpen --count).
@@ -314,7 +320,8 @@ mod tests {
             create_task(&db, "rafters", "legion", "accepted one", None, "med").expect("create");
         accept_task(&db, &id2).expect("accept");
 
-        let pending = get_pending_inbound(&db, "legion").expect("pending");
+        let pending = get_pending_inbound(&db, "legion", &crate::timerange::TimeRange::default())
+            .expect("pending");
         assert_eq!(pending.len(), 1);
         assert_eq!(pending[0].text, "pending one");
     }
@@ -346,7 +353,8 @@ mod tests {
         create_task(&db, "kelex", "legion", "task two", None, "high").expect("create");
 
         let count = count_pending_inbound(&db, "legion").expect("count");
-        let tasks = get_pending_inbound(&db, "legion").expect("get");
+        let tasks = get_pending_inbound(&db, "legion", &crate::timerange::TimeRange::default())
+            .expect("get");
         assert_eq!(
             count,
             tasks.len() as u64,
@@ -367,7 +375,8 @@ mod tests {
         )
         .expect("create");
 
-        let pending = get_pending_inbound(&db, "legion").expect("pending");
+        let pending = get_pending_inbound(&db, "legion", &crate::timerange::TimeRange::default())
+            .expect("pending");
         let output = format_pending_for_surface(&pending);
         assert!(output.contains("Task from kelex"));
         assert!(output.contains("surface task"));

--- a/src/timerange.rs
+++ b/src/timerange.rs
@@ -1,0 +1,316 @@
+//! First-class `created_at` date filtering for legion's read surfaces
+//! (`recall`, `consult`, `bullpen`, `surface`; #786).
+//!
+//! [`TimeRange`] is a half-open-or-closed window over `created_at`: `since`
+//! is an inclusive lower bound, `until` an inclusive upper bound, either or
+//! both `None` meaning unbounded on that end. It is parsed ONCE at the
+//! CLI/API boundary from `--since`/`--until`/`--on` and threaded verbatim
+//! down to the query layer as a single `&TimeRange` parameter -- the same
+//! read path serves whole-store (`TimeRange::default()`, both ends `None`)
+//! and bounded queries, no forked code path.
+//!
+//! `created_at` is stored UTC as an RFC3339 string, matching
+//! `chrono::Utc::now().to_rfc3339()` elsewhere in this crate (e.g.
+//! `Database::insert_reflection_with_meta`). Boundary dates are
+//! interpreted in the local system timezone
+//! (`jiff::tz::TimeZone::system()`) and converted to UTC once, at parse
+//! time, as fixed [`jiff::civil::Date`] values (not re-interpreted later --
+//! `today`/`yesterday` resolve against "now" exactly once, when the CLI
+//! flag is parsed):
+//!
+//! - `since` becomes local midnight of that date, in UTC (inclusive lower
+//!   bound).
+//! - `until` becomes local midnight of the day AFTER that date, in UTC,
+//!   used as an EXCLUSIVE upper bound. This exclusive-next-day shape
+//!   (instead of an inclusive `23:59:59.999...` bound) sidesteps RFC3339
+//!   fractional-second precision mismatches between a hand-built bound
+//!   string and the variable-precision fractional seconds `chrono` emits
+//!   for stored rows -- a bound built with fewer or more fractional digits
+//!   than a given row's timestamp would otherwise compare incorrectly.
+//!
+//! Bound strings are formatted to match `chrono`'s `to_rfc3339()` shape
+//! exactly (`+00:00` UTC offset, not `Z`) so plain lexicographic string
+//! comparison against stored `created_at` values is correct.
+
+use jiff::civil::Date;
+use jiff::tz::TimeZone;
+use jiff::{ToSpan, Zoned};
+
+use crate::error::{LegionError, Result};
+
+/// A half-open-or-closed `created_at` window. `None` on either end means
+/// unbounded on that end; `TimeRange::default()` (both `None`) is
+/// unbounded on both ends -- the whole-store case.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct TimeRange {
+    pub since: Option<Date>,
+    pub until: Option<Date>,
+}
+
+impl TimeRange {
+    /// Parse `--since`/`--until`/`--on` values. Accepted grammar
+    /// (deliberately small): absolute `YYYY-MM-DD`, relative `<N>d` /
+    /// `<N>w` (days/weeks back from today), and the literals `today` /
+    /// `yesterday`. `--on <date>` is sugar for `since=until=<date>`.
+    ///
+    /// `--on` combined with `--since`/`--until` is rejected by clap's
+    /// `conflicts_with_all` before this is ever called; `on` wins here too
+    /// as a defense-in-depth default, matching the CLI contract.
+    pub fn parse(since: Option<&str>, until: Option<&str>, on: Option<&str>) -> Result<Self> {
+        if let Some(on) = on {
+            let date = parse_date(on)?;
+            return Ok(Self {
+                since: Some(date),
+                until: Some(date),
+            });
+        }
+
+        let since = since.map(parse_date).transpose()?;
+        let until = until.map(parse_date).transpose()?;
+        Ok(Self { since, until })
+    }
+
+    /// True when both ends are unbounded (the whole-store case).
+    pub fn is_unbounded(&self) -> bool {
+        self.since.is_none() && self.until.is_none()
+    }
+
+    /// Inclusive lower bound as a UTC RFC3339 string (local midnight of
+    /// `since`), or `None` when unbounded below.
+    pub fn since_bound(&self) -> Result<Option<String>> {
+        self.since.map(day_start_utc).transpose()
+    }
+
+    /// Exclusive upper bound as a UTC RFC3339 string (local midnight of the
+    /// day AFTER `until`), or `None` when unbounded above. Exclusive so a
+    /// row created any time during `until`'s local day still matches --
+    /// see the module docs for why this is a next-day bound rather than an
+    /// inclusive end-of-day one.
+    pub fn until_bound(&self) -> Result<Option<String>> {
+        self.until
+            .map(|d| {
+                let next = d
+                    .checked_add(1.day())
+                    .map_err(|_| LegionError::InvalidDateFilter {
+                        input: d.to_string(),
+                    })?;
+                day_start_utc(next)
+            })
+            .transpose()
+    }
+
+    /// `true` when `created_at` (a stored RFC3339 UTC string) falls inside
+    /// this range. Used by read paths that scan a full, already-fetched
+    /// candidate set in Rust (the hybrid recall join and `--cosine-only`)
+    /// rather than filtering in SQL or Tantivy -- see `recall.rs`'s
+    /// `join_and_score` for why that is safe (never a post-filter over a
+    /// truncated/limited fetch). Shares the exact bound strings
+    /// `since_bound`/`until_bound` produce, so the in-memory check and the
+    /// SQL/Tantivy predicates can never disagree.
+    pub fn contains(&self, created_at: &str) -> Result<bool> {
+        if let Some(since) = self.since_bound()?
+            && created_at < since.as_str()
+        {
+            return Ok(false);
+        }
+        if let Some(until) = self.until_bound()?
+            && created_at >= until.as_str()
+        {
+            return Ok(false);
+        }
+        Ok(true)
+    }
+
+    /// SQL fragment applying this range as a `created_at` predicate, with
+    /// positional placeholders starting at `first_idx` (SQLite positional
+    /// params are 1-indexed). Composes into `format!`-built SQL the same
+    /// way `archive_mode_where_clause` composes the archive-mode filter
+    /// (#457/#782): callers splice the returned text into their WHERE
+    /// clause and push `since_bound()`/`until_bound()` (in that order) onto
+    /// their bind values.
+    ///
+    /// Each bound placeholder is referenced twice (once for the `IS NULL`
+    /// unbounded-end guard, once for the comparison) but bound only ONCE --
+    /// SQLite parameters may repeat within a statement. This keeps the
+    /// bind-value count and placeholder count fixed regardless of whether
+    /// either end is `Some` or `None`, so callers never need to branch the
+    /// query text on which ends are bounded.
+    pub fn sql_clause(first_idx: usize) -> String {
+        let since_idx = first_idx;
+        let until_idx = first_idx + 1;
+        format!(
+            " AND (?{since_idx} IS NULL OR created_at >= ?{since_idx}) \
+             AND (?{until_idx} IS NULL OR created_at < ?{until_idx})"
+        )
+    }
+}
+
+/// Convert a local calendar date to its UTC midnight instant, formatted to
+/// match `chrono::DateTime<Utc>::to_rfc3339()`'s shape exactly (`+00:00`,
+/// not `Z`) so lexicographic string comparison against stored `created_at`
+/// values is correct.
+fn day_start_utc(date: Date) -> Result<String> {
+    let local_midnight =
+        date.to_zoned(TimeZone::system())
+            .map_err(|_| LegionError::InvalidDateFilter {
+                input: date.to_string(),
+            })?;
+    let utc = local_midnight.with_time_zone(TimeZone::UTC);
+    Ok(format!(
+        "{:04}-{:02}-{:02}T{:02}:{:02}:{:02}+00:00",
+        utc.year(),
+        utc.month(),
+        utc.day(),
+        utc.hour(),
+        utc.minute(),
+        utc.second()
+    ))
+}
+
+/// Parse one `--since`/`--until`/`--on` value against the accepted
+/// grammar: `YYYY-MM-DD`, `<N>d`, `<N>w`, `today`, `yesterday`.
+fn parse_date(input: &str) -> Result<Date> {
+    let trimmed = input.trim();
+    let invalid = || LegionError::InvalidDateFilter {
+        input: input.to_string(),
+    };
+
+    let today = || Zoned::now().date();
+
+    match trimmed {
+        "today" => return Ok(today()),
+        "yesterday" => return today().yesterday().map_err(|_| invalid()),
+        _ => {}
+    }
+
+    if let Some(digits) = trimmed.strip_suffix('d')
+        && let Ok(n) = digits.parse::<i64>()
+    {
+        return today().checked_sub(n.days()).map_err(|_| invalid());
+    }
+
+    if let Some(digits) = trimmed.strip_suffix('w')
+        && let Ok(n) = digits.parse::<i64>()
+    {
+        return today().checked_sub(n.weeks()).map_err(|_| invalid());
+    }
+
+    trimmed.parse::<Date>().map_err(|_| invalid())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_is_unbounded() {
+        let range = TimeRange::default();
+        assert!(range.is_unbounded());
+        assert_eq!(range.since_bound().unwrap(), None);
+        assert_eq!(range.until_bound().unwrap(), None);
+    }
+
+    #[test]
+    fn parse_absolute_date() {
+        let range = TimeRange::parse(Some("2026-07-14"), None, None).unwrap();
+        assert_eq!(range.since, Some("2026-07-14".parse().unwrap()));
+        assert_eq!(range.until, None);
+        assert!(!range.is_unbounded());
+    }
+
+    #[test]
+    fn parse_on_is_sugar_for_since_until() {
+        let range = TimeRange::parse(None, None, Some("2026-07-14")).unwrap();
+        let d: Date = "2026-07-14".parse().unwrap();
+        assert_eq!(range.since, Some(d));
+        assert_eq!(range.until, Some(d));
+    }
+
+    #[test]
+    fn parse_today_and_yesterday() {
+        let today = Zoned::now().date();
+        let range = TimeRange::parse(Some("today"), None, None).unwrap();
+        assert_eq!(range.since, Some(today));
+
+        let range = TimeRange::parse(Some("yesterday"), None, None).unwrap();
+        assert_eq!(range.since, Some(today.yesterday().unwrap()));
+    }
+
+    #[test]
+    fn parse_relative_days_and_weeks() {
+        let today = Zoned::now().date();
+        let range = TimeRange::parse(Some("3d"), None, None).unwrap();
+        assert_eq!(range.since, Some(today.checked_sub(3.days()).unwrap()));
+
+        let range = TimeRange::parse(Some("2w"), None, None).unwrap();
+        assert_eq!(range.since, Some(today.checked_sub(2.weeks()).unwrap()));
+    }
+
+    #[test]
+    fn parse_rejects_garbage() {
+        let err = TimeRange::parse(Some("not-a-date"), None, None).unwrap_err();
+        assert!(matches!(err, LegionError::InvalidDateFilter { .. }));
+        assert!(err.to_string().contains("not-a-date"));
+        assert!(err.to_string().contains("YYYY-MM-DD"));
+    }
+
+    #[test]
+    fn parse_rejects_empty_and_whitespace() {
+        assert!(TimeRange::parse(Some(""), None, None).is_err());
+        assert!(TimeRange::parse(Some("   "), None, None).is_err());
+    }
+
+    #[test]
+    fn empty_window_is_not_an_error() {
+        // since > until: a valid (fixed) TimeRange whose predicate matches
+        // nothing. Never an error at parse time -- the empty-result
+        // behavior lives entirely in the query layer's WHERE predicate.
+        let range = TimeRange::parse(Some("2026-07-20"), Some("2026-07-10"), None).unwrap();
+        assert!(range.since_bound().unwrap() > range.until_bound().unwrap());
+    }
+
+    #[test]
+    fn on_bound_covers_the_whole_local_day() {
+        // A row created at any point during the `--on` date's local day
+        // must satisfy `contains`, including right at local midnight and
+        // right before the next local midnight.
+        let range = TimeRange::parse(None, None, Some("2026-07-14")).unwrap();
+        let since = range.since_bound().unwrap().unwrap();
+        let until = range.until_bound().unwrap().unwrap();
+
+        // Exactly at the lower bound: included.
+        assert!(range.contains(&since).unwrap());
+        // A microsecond-precision timestamp late in the day, just before
+        // the exclusive next-day bound: included. Constructed by taking
+        // the until bound (next day's midnight) and asserting it is
+        // strictly greater than a plausible late-day timestamp.
+        let late_in_day = since[..11].to_string() + "23:59:59.999999+00:00";
+        assert!(late_in_day.as_str() < until.as_str());
+        assert!(range.contains(&late_in_day).unwrap());
+        // The next day's midnight itself is excluded (exclusive upper bound).
+        assert!(!range.contains(&until).unwrap());
+    }
+
+    #[test]
+    fn contains_respects_since_only() {
+        let range = TimeRange::parse(Some("2026-07-14"), None, None).unwrap();
+        let since = range.since_bound().unwrap().unwrap();
+        assert!(range.contains(&since).unwrap());
+        assert!(!range.contains("2026-07-13T23:59:59+00:00").unwrap());
+    }
+
+    #[test]
+    fn contains_respects_until_only() {
+        let range = TimeRange::parse(None, Some("2026-07-14"), None).unwrap();
+        assert!(range.contains("2026-07-14T12:00:00+00:00").unwrap());
+        let until = range.until_bound().unwrap().unwrap();
+        assert!(!range.contains(&until).unwrap());
+    }
+
+    #[test]
+    fn sql_clause_shape() {
+        let clause = TimeRange::sql_clause(3);
+        assert!(clause.contains("?3 IS NULL OR created_at >= ?3"));
+        assert!(clause.contains("?4 IS NULL OR created_at < ?4"));
+    }
+}


### PR DESCRIPTION
## Summary

Adds `--since`/`--until`/`--on` date filtering to `recall`, `consult`, `bullpen`, and
`surface`. A new `TimeRange` type (`src/timerange.rs`) parses the small grammar
(`YYYY-MM-DD`, `<N>d`, `<N>w`, `today`, `yesterday`) once at the CLI boundary and threads
verbatim down to the query layer as a single optional parameter -- the same read path serves
whole-store (`TimeRange::default()`) and bounded queries. Per the Build Notes' architecture
decision, the Tantivy search index gains an indexed `created_at` date field so BM25/hybrid
recall composes the date predicate into the existing `BooleanQuery` (never a post-filter over
an already-cut-off result window); SQL-only paths (`--latest`, `--domain`, bullpen, surface's
four queries) take the predicate directly in their `WHERE` clause.

## Acceptance criteria mapping

### 1. All tests pass

`cargo test` (both the `legion` unit-test binary and the `tests/integration` binary) is fully
green: 1551 passed / 0 failed / 2 ignored in the unit binary, 345 passed / 0 failed / 2 ignored
in integration -- no pre-existing ignores were touched. `cargo clippy --all-targets -- -D
warnings` and `cargo fmt -- --check` both exit clean. New coverage: 12 unit tests in
`src/timerange.rs` (grammar parsing, the `--on` whole-local-day boundary, the empty-window-is-
not-an-error case), 8 new/updated tests in `src/search.rs` for Tantivy range filtering
including an empirically-reproduced schema-migration regression test
(`schema_mismatch_rebuilds_empty_instead_of_corrupting_writes`), and 2 new tests in
`src/db/board.rs` for the `get_recent_board_posts` override-vs-decay interaction.
Evidence: `cargo test` output -- `test result: ok. 1551 passed; 0 failed; 2 ignored` (unit),
`test result: ok. 345 passed; 0 failed; 2 ignored` (integration).

### 2. Simplify pass completed

Ran `/legion-simplify` against the full 24-file diff (`main...HEAD`), wrote a per-file
articulation citing a `file:line` or symbol locator for every entry, and recorded it via
`legion quality-gate check --skill legion-simplify --result clean`. The first commit's
pre-commit hook itself caught a real structural issue during simplify (see "Not done" -- no,
see below): `get_recent_board_posts`'s bounded branch silently dropped the `#376` decay/TTL
filter, changing visible behavior beyond what the doc comment claimed. Fixed in the second
commit with two regression tests (`get_recent_board_posts_range_overrides_hours_cutoff`,
`get_recent_board_posts_bounded_range_still_excludes_expired_posts`) before re-running and
recording the gate clean on the current HEAD.
Evidence: gate id `019f6910-81c8-74d0-b2e9-39b4c94b6259` (`legion quality-gate check`, result
`clean`, 24 file entries, 0 findings), `src/db/board.rs:695-745`.

### 3. Review pass completed and issues fixed

Not yet run in this session -- `/review-pr` is the next step in the mandated Build/Simplify/
Review/Fix/PR workflow and runs after this PR is open, per the issue's own Dev Workflow
section ("PR -- Create the PR" comes before "Fix" only in the sense that fixes from review
land as follow-up commits on this branch). Flagging explicitly here rather than implying it
happened.
Evidence: no review-gate row exists yet for this HEAD; `legion pr review` is the next command.

### 4. PR created and linked to this issue

This PR (opened via `legion pr create --closes 786`) is the artifact satisfying this
criterion.
Evidence: PR title references #786; `--closes 786` links it.

## Requirements traceability (Build Notes, beyond the four generic ACs)

The issue's real specification lives in the "Requirements"/"Behavior"/Build Notes sections,
not the four boilerplate ACs above, so mapping only those would understate what was verified.

- **`TimeRange` interface matches the spec verbatim** (`since`/`until: Option<Date>`,
  `#[derive(Debug, Clone, Default, PartialEq)]`, `parse(since, until, on)`).
  Evidence: `src/timerange.rs:45-52,59-70`.
- **CLI args added to all four variants** with the exact grammar, help text, and
  `conflicts_with`/`conflicts_with_all` wiring specified.
  Evidence: `src/cli/mod.rs:143` (Recall), `:243` (Consult), `:427` (Bullpen), `:480` (Surface).
- **`LegionError::InvalidDateFilter` new variant**, raised only at the CLI boundary; nothing
  unparsed reaches the query layer (`TimeRange::parse` is the sole construction path and it is
  fallible).
  Evidence: `src/error.rs:231`, `src/timerange.rs:59-70`.
- **Additive, not a rewrite**: every date-scoped function landed BESIDE its existing
  signature by adding one `&TimeRange` parameter (mirroring `#782`'s `ArchiveMode` threading
  through `recall_by_domain`/`recall_latest`) -- no forked "recall_by_domain_ranged" twin.
  Evidence: `src/recall.rs:552` (`recall_latest`), `:588` (`recall_by_domain`), `src/db/
  reflections.rs:791,824`.
- **One explicit `&TimeRange` parameter threaded end to end**, default unbounded means
  whole-store.
  Evidence: `src/cli/memory.rs` (`handle_recall`/`handle_consult` parse once, thread `&range`
  through every branch), `src/surface.rs:36`.
- **Predicate applied in the query layer, before ranking, never a CLI-side post-filter over
  unbounded results.** For Tantivy (BM25/hybrid), the range composes into the `BooleanQuery`
  at the index level (`date_range_query`), so `TopDocs` collection only ever ranks among
  already-in-range documents -- the exact gap the `--archives` 4x-over-fetch pattern has and
  which the Build Notes call out as the reason NOT to reuse it here. For the hybrid path's
  cosine-sourced candidates (which never touch Tantivy), `join_and_score` checks
  `TimeRange::contains` against `Database::get_embeddings`'s full UNBOUNDED corpus scan --
  documented in `join_and_score`'s doc comment as the reason this is not the forbidden
  post-filter pattern (no limit-truncated fetch to silently under-return from).
  Evidence: `src/search.rs` (`date_range_query`, `execute_query`), `src/recall.rs:291-330`
  (`join_and_score` doc comment).
- **Empty window (`since > until`) yields empty results, never an error.** `TimeRange::parse`
  never validates ordering; the SQL/Tantivy `>=`/`<` predicates naturally produce zero rows.
  Evidence: `src/timerange.rs` test `empty_window_is_not_an_error`.
- **Works in every recall mode**: BM25/hybrid (`recall_bm25`/`recall`), `--latest`
  (`recall_latest`), `--domain` (`recall_by_domain`), `--cosine-only` (`recall_cosine_only`,
  in-memory `TimeRange::contains` check since it bypasses both Tantivy and the join path) --
  and composes with `--archives`/`--include-archives` because the archive-mode filter and the
  date filter are independent WHERE/join predicates, never stacked post-filters.
  Evidence: `src/recall.rs:656` (`recall_cosine_only`), `src/cli/memory.rs` `handle_recall`.
- **`created_at` UTC-stored, boundary dates interpreted in local time, converted once at
  parse time; documented in the module.** `TimeRange`'s module doc explains the local-midnight
  -> UTC conversion and the exclusive-next-day upper bound (sidesteps RFC3339 fractional-
  second precision mismatches against `chrono`-stored rows).
  Evidence: `src/timerange.rs:1-33` (module doc), test `on_bound_covers_the_whole_local_day`.
- **`surface` is four queries in four modules, all in scope**, with the board-posts 24h
  hardcode explicitly overridden (not composed) by an explicit range, matching Build Notes'
  called-out carve-out; `get_recent_chain_extensions` mirrors the same override shape for
  consistency (documented rationale, not silent copying) since it has the identical
  hardcoded-`hours`-parameter shape.
  Evidence: `src/db/board.rs:695-701` (doc comment), `src/db/reflections.rs:906-916`
  (`get_recent_chain_extensions` doc comment), `src/task.rs:121` (`get_pending_inbound`).
- **Tantivy schema migration is safe, not just "ship it and hope orchestrator reindexes."**
  Empirically reproduced (in an isolated scratch project, not just read) that opening a
  pre-#786 3-field on-disk index with the new 4-field in-memory schema and then writing a
  document panics in a Tantivy writer thread and returns a commit `Err` -- meaning every
  `legion reflect`/`post` would fail between a naive deploy and a manual `legion reindex`.
  `SearchIndex::open` now detects the schema mismatch (`idx.schema() == schema`) and
  wipes-and-recreates empty, the same recovery path already used for corrupted indexes, with a
  regression test that reproduces the pre-fix on-disk shape and asserts writes succeed after
  open.
  Evidence: `src/search.rs:70-95` (schema-mismatch arm), test
  `schema_mismatch_rebuilds_empty_instead_of_corrupting_writes`.

## Not done

- **`/review-pr` has not run yet** -- AC #3 ("Review pass completed and issues fixed") is
  explicitly not satisfied by this PR body; it is the next step after this PR opens, per the
  issue's own Dev Workflow ordering.
- **Murath surfacing** (never-recalled reflections, age x recall_count) -- explicitly out of
  scope per the issue; `TimeRange` was kept dependency-free of any Tantivy/DB specifics so it
  is reusable there without modification.
- **Natural-language date grammar** ("last week", "since Tuesday") -- explicitly out of scope
  per the issue; the grammar is deliberately the small set specified.
- **Date filtering on `sym`/index queries** -- explicitly out of scope; reflections and
  bullpen surfaces only.
- **Frontend consumers (Tauri timeline)** -- explicitly out of scope; they inherit these
  semantics via the query layer for free once built.
- **MCP tools / `channel::router` HTTP endpoints** -- not given new `--since`/`--until`/`--on`
  surface area. They call the same now-`&TimeRange`-taking functions but pass
  `TimeRange::default()` (see `src/serve.rs`'s search endpoint), preserving identical
  pre-#786 behavior. The issue's interface spec only requires CLI wiring on the four named
  commands; MCP/HTTP date exposure is a natural but distinct follow-up, not silently dropped
  scope.
- **`TimeRange::contains`'s per-call bound recomputation** in the hybrid-join and
  `--cosine-only` hot loops is not hoisted/cached across the loop. Flagged as a minor,
  explicitly non-blocking point by the pre-commit simplify review; left as-is since the
  reflection corpus this runs against is small and the recomputation is a handful of string
  formats, not a DB or network call.

Closes #786
