### PR TITLE
feat(#783): reflect retag -- in-place domain UPDATE off the boot banners

### DIFF
--- a/src/cli/memory.rs
+++ b/src/cli/memory.rs
@@ -235,6 +235,84 @@ pub(crate) fn handle_reflect(
     Ok(())
 }
 
+/// `legion reflect retag --id X --set-domain <name|none>` (#783): move a
+/// live reflection between domains in place. The literal `none` clears
+/// the domain. Pure DB metadata write -- `domain` has no tantivy
+/// presence, so unlike `forget` there is no index side to reconcile and
+/// `open_db` suffices.
+pub(crate) fn handle_retag(id: String, set_domain: String) -> error::Result<()> {
+    let database = open_db()?;
+
+    let new_domain = if set_domain == "none" {
+        None
+    } else {
+        Some(set_domain.as_str())
+    };
+
+    // Peek first so the audit row and the confirmation line can name the
+    // old domain, matching handle_forget's peek-then-write shape.
+    let existing = database
+        .get_reflection_by_id(&id)?
+        .ok_or_else(|| error::LegionError::ReflectionNotFound(id.clone()))?;
+    let old_domain = existing.domain.clone();
+
+    let details = format!(
+        "from={} to={}",
+        old_domain.as_deref().unwrap_or("none"),
+        new_domain.unwrap_or("none")
+    );
+    let write_audit = |outcome: &str| {
+        audit(
+            &database,
+            &db::AuditInput {
+                agent: &existing.repo,
+                action: "retag-reflection",
+                target_type: "reflection",
+                target_ref: &id,
+                task_id: None,
+                source_type: "legion",
+                details: Some(&details),
+                outcome,
+            },
+        );
+    };
+
+    let retagged = match database.retag_reflection(&id, new_domain) {
+        Ok(r) => r,
+        Err(
+            e @ (error::LegionError::RetagLastIdentityRoot { .. }
+            | error::LegionError::RetagLastWorkflowRoot { .. }
+            | error::LegionError::IdentityRootExists { .. }),
+        ) => {
+            // Guard refusals are forensically relevant for the same
+            // reason handle_forget audits its --repo rejections: we want
+            // a trace of every attempt to mutate a root, not just the
+            // ones that landed.
+            write_audit("rejected");
+            return Err(e);
+        }
+        Err(e) => return Err(e),
+    };
+    write_audit("success");
+
+    let preview: String = retagged.text.chars().take(80).collect();
+    let ellipsis = if retagged.text.chars().count() > 80 {
+        "..."
+    } else {
+        ""
+    };
+    println!(
+        "retagged reflection {} ({}): domain {} -> {}: {}{} -- still hot and recallable; id, chain, and recall_count unchanged.",
+        id,
+        retagged.repo,
+        old_domain.as_deref().unwrap_or("none"),
+        retagged.domain.as_deref().unwrap_or("none"),
+        preview,
+        ellipsis
+    );
+    Ok(())
+}
+
 pub(crate) fn handle_forget(id: String, repo: Option<String>, persist: bool) -> error::Result<()> {
     let (database, index) = open_db_and_index()?;
 

--- a/src/cli/memory.rs
+++ b/src/cli/memory.rs
@@ -293,7 +293,13 @@ pub(crate) fn handle_retag(id: String, set_domain: String) -> error::Result<()> 
         }
         Err(e) => return Err(e),
     };
-    write_audit("success");
+
+    // `retag_reflection` no-ops (no write, no guard check) when the
+    // requested domain equals the current one. Audit and report that
+    // honestly as "noop" rather than "success" -- a success outcome would
+    // claim a mutation that never happened.
+    let is_noop = old_domain == retagged.domain;
+    write_audit(if is_noop { "noop" } else { "success" });
 
     let preview: String = retagged.text.chars().take(80).collect();
     let ellipsis = if retagged.text.chars().count() > 80 {
@@ -301,15 +307,26 @@ pub(crate) fn handle_retag(id: String, set_domain: String) -> error::Result<()> 
     } else {
         ""
     };
-    println!(
-        "retagged reflection {} ({}): domain {} -> {}: {}{} -- still hot and recallable; id, chain, and recall_count unchanged.",
-        id,
-        retagged.repo,
-        old_domain.as_deref().unwrap_or("none"),
-        retagged.domain.as_deref().unwrap_or("none"),
-        preview,
-        ellipsis
-    );
+    if is_noop {
+        println!(
+            "reflection {} ({}) is already domain {}: {}{} -- no change.",
+            id,
+            retagged.repo,
+            retagged.domain.as_deref().unwrap_or("none"),
+            preview,
+            ellipsis
+        );
+    } else {
+        println!(
+            "retagged reflection {} ({}): domain {} -> {}: {}{} -- still hot and recallable; id, chain, and recall_count unchanged.",
+            id,
+            retagged.repo,
+            old_domain.as_deref().unwrap_or("none"),
+            retagged.domain.as_deref().unwrap_or("none"),
+            preview,
+            ellipsis
+        );
+    }
     Ok(())
 }
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -66,7 +66,13 @@ pub(crate) struct Cli {
 #[derive(Subcommand)]
 pub(crate) enum Commands {
     /// Store a reflection from a completed session
+    #[command(subcommand_negates_reqs = true)]
     Reflect {
+        /// Maintenance verbs over existing reflections (e.g. `retag`).
+        /// When present, the storage flags below are ignored.
+        #[command(subcommand)]
+        action: Option<ReflectAction>,
+
         /// Repository name(s), comma-separated (e.g., "myrepo" or "frontend,backend")
         #[arg(long, value_delimiter = ',', required = true)]
         repo: Vec<String>,
@@ -1012,5 +1018,36 @@ pub(crate) enum Commands {
         /// matches this value are used as input.
         #[arg(long)]
         repo: String,
+    },
+}
+
+/// Maintenance verbs nested under `legion reflect` (#783). The bare
+/// `legion reflect --repo ... --text ...` storage form stays the default;
+/// `subcommand_negates_reqs` on the parent lets these verbs parse without
+/// the storage flags.
+#[derive(Subcommand)]
+pub(crate) enum ReflectAction {
+    /// Move a live reflection between domains in place (#783): changes
+    /// (or clears) `domain` WITHOUT archiving, deleting, or re-issuing
+    /// the id -- the reflection stays hot and recall-by-context still
+    /// finds it, it just stops (or starts) feeding the domain's banner
+    /// (`whatami` reads domain=workflow roots, `whoami` domain=identity).
+    /// Distinct from `forget --persist`, which moves the row to the cold
+    /// tier; retag keeps it hot. Id, chain links, and recall_count are
+    /// preserved.
+    ///
+    /// Refuses to retag the LAST live root of a protected domain
+    /// (`identity`/`workflow`): #785's zero-identity guard fires on
+    /// INSERT only, and retag must not become an UPDATE-shaped third
+    /// path to a repo with no identity or no operating contract. Replace
+    /// an identity root deliberately via `whoami --generate` instead.
+    Retag {
+        /// Reflection id to retag.
+        #[arg(long)]
+        id: String,
+
+        /// New domain name, or the literal `none` to clear the domain.
+        #[arg(long)]
+        set_domain: String,
     },
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1047,6 +1047,8 @@ pub(crate) enum ReflectAction {
         id: String,
 
         /// New domain name, or the literal `none` to clear the domain.
+        /// `none` is a reserved sentinel: a domain literally named "none"
+        /// cannot be set or targeted through this flag.
         #[arg(long)]
         set_domain: String,
     },

--- a/src/db/reflections.rs
+++ b/src/db/reflections.rs
@@ -777,6 +777,17 @@ impl Database {
     /// unchanged without writing, so it neither trips the guards nor
     /// churns `updated_at`.
     ///
+    /// Not wrapped in a transaction: the guard's `query_row` and the
+    /// `UPDATE` are two round trips, so two concurrent `legion` processes
+    /// could each read "another live root exists" and both retag,
+    /// zeroing the domain between them. This is the same class of gap
+    /// `insert_reflection_with_meta`'s own guard documents and accepts:
+    /// `legion` is a per-invocation CLI with no long-lived writer
+    /// serializing access, so the window is real but narrow (two
+    /// concurrent retags of roots in the same repo+domain), and a
+    /// `BEGIN IMMEDIATE` transaction would close it structurally if this
+    /// ever proves more than theoretical.
+    ///
     /// Returns `LegionError::ReflectionNotFound` if the id does not match
     /// any live (non-soft-deleted) row, mirroring `archive_reflection`.
     ///
@@ -2592,5 +2603,101 @@ mod tests {
 
         let retagged = db.retag_reflection(&root.id, Some("lesson")).unwrap();
         assert_eq!(retagged.domain.as_deref(), Some("lesson"));
+    }
+
+    #[test]
+    fn retag_reflection_into_workflow_creates_an_additional_root_freely() {
+        // Unlike retagging INTO identity, there is no "at most one live
+        // workflow root" invariant to protect from the other direction --
+        // a repo growing a second (or Nth) live workflow root is exactly
+        // the normal, expected state (#783's own clutter scenario), so
+        // retag must not guard this direction at all.
+        let db = test_db();
+        let existing_root = db
+            .insert_reflection_with_meta(
+                "legion",
+                "existing workflow root",
+                "self",
+                &ReflectionMeta {
+                    domain: Some("workflow".into()),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+        let candidate = db
+            .insert_reflection_with_meta(
+                "legion",
+                "a lesson promoted to a new workflow root",
+                "self",
+                &ReflectionMeta {
+                    domain: Some("lesson".into()),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+
+        let retagged = db
+            .retag_reflection(&candidate.id, Some("workflow"))
+            .unwrap();
+        assert_eq!(retagged.domain.as_deref(), Some("workflow"));
+
+        let roots = db.get_domain_roots("legion", "workflow", 50).unwrap();
+        let ids: Vec<&str> = roots.iter().map(|r| r.id.as_str()).collect();
+        assert_eq!(roots.len(), 2);
+        assert!(ids.contains(&existing_root.id.as_str()));
+        assert!(ids.contains(&candidate.id.as_str()));
+    }
+
+    #[test]
+    fn retag_reflection_chain_child_into_identity_allowed_despite_live_root() {
+        // The inverse (retag-into-identity) guard only fires for a
+        // parentless target (existing.parent_id.is_none()): a chain child
+        // becoming domain=identity does not mint a second live ROOT (it
+        // has a parent, so get_identity_roots / get_domain_roots would
+        // never surface it), so it must not be blocked by
+        // IdentityRootExists the way a parentless retag-into-identity is.
+        let db = test_db();
+        let identity_root = db
+            .insert_reflection_with_meta(
+                "legion",
+                "the live identity root",
+                "self",
+                &ReflectionMeta {
+                    domain: Some("identity".into()),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+        let workflow_root = db
+            .insert_reflection_with_meta(
+                "legion",
+                "a workflow root with a child",
+                "self",
+                &ReflectionMeta {
+                    domain: Some("workflow".into()),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+        let child = db
+            .insert_reflection_with_meta(
+                "legion",
+                "chain child, not root-shaped",
+                "self",
+                &ReflectionMeta {
+                    domain: Some("workflow".into()),
+                    parent_id: Some(workflow_root.id.clone()),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+
+        let retagged = db.retag_reflection(&child.id, Some("identity")).unwrap();
+        assert_eq!(retagged.domain.as_deref(), Some("identity"));
+
+        // The real identity root is untouched and still the sole one.
+        let roots = db.get_identity_roots("legion", 10).unwrap();
+        assert_eq!(roots.len(), 1);
+        assert_eq!(roots[0].id, identity_root.id);
     }
 }

--- a/src/db/reflections.rs
+++ b/src/db/reflections.rs
@@ -729,6 +729,127 @@ impl Database {
             .ok_or_else(|| LegionError::ReflectionNotFound(id.to_string()))
     }
 
+    /// Re-tag a live reflection's domain in place: `legion reflect retag
+    /// --id X --set-domain <name|none>`'s writer (#783).
+    ///
+    /// A single-column UPDATE (plus the usual `updated_at` refresh): the
+    /// id, chain links (`parent_id`), recall_count, text, and archive
+    /// state are untouched by construction. `domain` has no presence in
+    /// the tantivy index (schema is id/repo/text only, src/search.rs), so
+    /// there is no index-side write to reconcile -- in-place metadata
+    /// mutation here is the same shape as [`store_embedding`],
+    /// [`boost_reflection`], and [`archive_reflection`]. The append-only
+    /// doctrine protects identity TEXT content, not classification
+    /// columns.
+    ///
+    /// TTL (`expires_at`/`evergreen`) is deliberately NOT recomputed:
+    /// those columns only ever get values for `audience = 'team'` bullpen
+    /// posts (`compute_post_ttl` returns `(None, false)` for everything
+    /// else), and retag's clients are self reflections feeding the
+    /// whatami banner. Re-deriving a team post's TTL from its new domain
+    /// is a bullpen-lifecycle concern out of scope here.
+    ///
+    /// Zero-root guard (#783 build note): #785's identity-root guard
+    /// fires on INSERT only, never UPDATE, so an unguarded retag would be
+    /// a third uncoordinated path to a zero-identity (or zero-operating-
+    /// contract) state. Refused when the target is the LAST live root of
+    /// a protected domain -- `parent_id IS NULL AND domain IN
+    /// ('identity','workflow')` with no other live (`deleted_at IS NULL
+    /// AND archived_at IS NULL`, the #782 liveness predicate -- an
+    /// archived root is not cover for retagging the last hot one) root in
+    /// the same repo+domain. Deliberately count-based rather than
+    /// refusing every root-shaped row: whatami's clutter case is MANY
+    /// live workflow roots, and a blanket refusal would make the issue's
+    /// own primary use case (retag a long-tail workflow root off the
+    /// banner) impossible. For identity the healthy state is exactly one
+    /// root (#785), so root-shaped and last-root coincide there. The
+    /// identity refusal directs to `whoami --generate` (the sanctioned
+    /// replace path, #784); the workflow refusal suggests `forget
+    /// --persist` or writing the replacement root first.
+    ///
+    /// Retagging INTO `identity` is held to #785's insert-guard invariant
+    /// from the other direction: a parentless target becoming a second
+    /// live identity root is refused with the same
+    /// [`LegionError::IdentityRootExists`] the insert path raises --
+    /// otherwise retag would be an UPDATE-shaped bypass of that guard too.
+    ///
+    /// A no-op retag (new domain equals the current one) returns the row
+    /// unchanged without writing, so it neither trips the guards nor
+    /// churns `updated_at`.
+    ///
+    /// Returns `LegionError::ReflectionNotFound` if the id does not match
+    /// any live (non-soft-deleted) row, mirroring `archive_reflection`.
+    ///
+    /// [`store_embedding`]: Self::store_embedding
+    /// [`boost_reflection`]: Self::boost_reflection
+    /// [`archive_reflection`]: Self::archive_reflection
+    pub fn retag_reflection(&self, id: &str, new_domain: Option<&str>) -> Result<Reflection> {
+        let existing = self
+            .get_reflection_by_id(id)?
+            .ok_or_else(|| LegionError::ReflectionNotFound(id.to_string()))?;
+
+        if existing.domain.as_deref() == new_domain {
+            return Ok(existing);
+        }
+
+        // Zero-root guard: is the target the last live root of a
+        // protected domain? One query owns the whole predicate: the
+        // target's own root-shape + liveness, and the absence of any
+        // other live root in the same repo+domain.
+        let protected_domain: Option<String> = self
+            .conn
+            .query_row(
+                "SELECT t.domain FROM reflections t \
+                 WHERE t.id = ?1 AND t.parent_id IS NULL \
+                   AND t.domain IN ('identity', 'workflow') \
+                   AND t.deleted_at IS NULL AND t.archived_at IS NULL \
+                   AND NOT EXISTS (\
+                     SELECT 1 FROM reflections o \
+                     WHERE o.repo = t.repo AND o.domain = t.domain \
+                       AND o.parent_id IS NULL AND o.id <> t.id \
+                       AND o.deleted_at IS NULL AND o.archived_at IS NULL)",
+                [id],
+                |row| row.get(0),
+            )
+            .optional()?;
+        if let Some(domain) = protected_domain {
+            return Err(match domain.as_str() {
+                "identity" => LegionError::RetagLastIdentityRoot {
+                    id: id.to_string(),
+                    repo: existing.repo.clone(),
+                },
+                _ => LegionError::RetagLastWorkflowRoot {
+                    id: id.to_string(),
+                    repo: existing.repo.clone(),
+                },
+            });
+        }
+
+        // Inverse guard: retagging a parentless row INTO identity would
+        // mint a second live identity root, bypassing #785's insert
+        // guard via UPDATE. The no-op early return above guarantees the
+        // target's current domain is not 'identity' here, so any live
+        // root found is necessarily a different row.
+        if new_domain == Some("identity")
+            && existing.parent_id.is_none()
+            && let Some(existing_id) = self.live_identity_root_id(&existing.repo)?
+        {
+            return Err(LegionError::IdentityRootExists {
+                repo: existing.repo.clone(),
+                existing_id,
+            });
+        }
+
+        let now = Utc::now().to_rfc3339();
+        self.conn.execute(
+            "UPDATE reflections SET domain = ?1, updated_at = ?2 WHERE id = ?3 AND deleted_at IS NULL",
+            rusqlite::params![new_domain, &now, id],
+        )?;
+
+        self.get_reflection_by_id(id)?
+            .ok_or_else(|| LegionError::ReflectionNotFound(id.to_string()))
+    }
+
     /// Soft-delete a reflection by setting its deleted_at timestamp.
     ///
     /// Unlike `delete_reflection` (hard delete), this preserves the row for
@@ -1974,5 +2095,502 @@ mod tests {
             !deleted_again,
             "soft_delete_reflection on already-deleted should return false"
         );
+    }
+
+    // -- retag_reflection (#783) --
+
+    #[test]
+    fn retag_reflection_updates_domain_preserves_id_chain_and_recall_count() {
+        let db = test_db();
+        let parent = db
+            .insert_reflection_with_meta(
+                "legion",
+                "root of a chain",
+                "self",
+                &ReflectionMeta {
+                    domain: Some("workflow".into()),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+        let child = db
+            .insert_reflection_with_meta(
+                "legion",
+                "a diluting long-tail lesson",
+                "self",
+                &ReflectionMeta {
+                    domain: Some("workflow".into()),
+                    parent_id: Some(parent.id.clone()),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+        db.boost_reflection(&child.id).unwrap();
+        db.boost_reflection(&child.id).unwrap();
+
+        let retagged = db.retag_reflection(&child.id, Some("lesson")).unwrap();
+
+        assert_eq!(retagged.id, child.id, "id must be preserved");
+        assert_eq!(
+            retagged.parent_id.as_deref(),
+            Some(parent.id.as_str()),
+            "chain link must be preserved"
+        );
+        assert_eq!(
+            retagged.recall_count, 2,
+            "recall_count must be preserved across retag"
+        );
+        assert_eq!(retagged.domain.as_deref(), Some("lesson"));
+
+        // Retag must not archive the row -- distinct from forget --persist.
+        // `archived_at` is not part of the public Reflection projection, so
+        // read it directly.
+        let archived_at: Option<String> = db
+            .conn
+            .query_row(
+                "SELECT archived_at FROM reflections WHERE id = ?1",
+                [&child.id],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert!(
+            archived_at.is_none(),
+            "retag must not archive the row -- distinct from forget --persist"
+        );
+
+        // Fetching independently confirms the UPDATE actually persisted,
+        // not just the returned struct.
+        let fetched = db.get_reflection_by_id(&child.id).unwrap().unwrap();
+        assert_eq!(fetched.domain.as_deref(), Some("lesson"));
+        assert_eq!(fetched.recall_count, 2);
+
+        // Still reachable via the chain.
+        let chain = db.get_chain(&child.id).unwrap();
+        assert_eq!(chain.len(), 2);
+        assert_eq!(chain[0].id, parent.id);
+        assert_eq!(chain[1].id, child.id);
+    }
+
+    #[test]
+    fn retag_reflection_set_domain_none_clears_domain() {
+        let db = test_db();
+        let r = db
+            .insert_reflection_with_meta(
+                "legion",
+                "a chained lesson under workflow",
+                "self",
+                &ReflectionMeta {
+                    domain: Some("workflow".into()),
+                    parent_id: None,
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+        // Give the repo a second live workflow root so this one is not
+        // the last, and retag it to no-domain (CLI's --set-domain none).
+        db.insert_reflection_with_meta(
+            "legion",
+            "another workflow root that stays put",
+            "self",
+            &ReflectionMeta {
+                domain: Some("workflow".into()),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+        let retagged = db.retag_reflection(&r.id, None).unwrap();
+        assert!(retagged.domain.is_none());
+
+        let fetched = db.get_reflection_by_id(&r.id).unwrap().unwrap();
+        assert!(fetched.domain.is_none());
+    }
+
+    #[test]
+    fn retag_reflection_leaves_no_tantivy_presence_by_construction() {
+        // `domain` is not part of the search schema (id/repo/text only,
+        // src/search.rs), so a DB-only retag must not require any index
+        // write for recall-by-context to keep finding the reflection.
+        // Exercised end-to-end (DB write + BM25 search) rather than just
+        // asserted from the schema comment.
+        let (db, index, _dir) = crate::testutil::test_storage();
+        let stored = crate::reflect::reflect_from_text_with_meta(
+            &db,
+            &index,
+            "legion",
+            "macOS SIGKILLs unsigned binaries under gatekeeper",
+            &ReflectionMeta {
+                domain: Some("workflow".into()),
+                parent_id: Some(
+                    db.insert_reflection_with_meta(
+                        "legion",
+                        "workflow chain root",
+                        "self",
+                        &ReflectionMeta {
+                            domain: Some("workflow".into()),
+                            ..Default::default()
+                        },
+                    )
+                    .unwrap()
+                    .id,
+                ),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+        db.retag_reflection(&stored, None).unwrap();
+
+        let results = index
+            .search("legion", "SIGKILLs unsigned binaries", 5)
+            .unwrap();
+        assert_eq!(
+            results.len(),
+            1,
+            "retag must not disturb the search index -- recall-by-context still finds it"
+        );
+        assert_eq!(results[0].id, stored);
+    }
+
+    #[test]
+    fn retag_reflection_nonexistent_id_errors() {
+        let db = test_db();
+        let err = db
+            .retag_reflection("nonexistent-id", Some("lesson"))
+            .unwrap_err();
+        assert!(matches!(err, LegionError::ReflectionNotFound(_)));
+    }
+
+    #[test]
+    fn retag_reflection_refuses_last_identity_root() {
+        let db = test_db();
+        let root = db
+            .insert_reflection_with_meta(
+                "legion",
+                "the only identity root",
+                "self",
+                &ReflectionMeta {
+                    domain: Some("identity".into()),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+
+        let err = db.retag_reflection(&root.id, None).unwrap_err();
+        assert!(matches!(err, LegionError::RetagLastIdentityRoot { .. }));
+
+        // Refused: the row is untouched.
+        let unchanged = db.get_reflection_by_id(&root.id).unwrap().unwrap();
+        assert_eq!(unchanged.domain.as_deref(), Some("identity"));
+    }
+
+    #[test]
+    fn retag_reflection_refuses_last_workflow_root() {
+        let db = test_db();
+        let root = db
+            .insert_reflection_with_meta(
+                "legion",
+                "the only workflow root",
+                "self",
+                &ReflectionMeta {
+                    domain: Some("workflow".into()),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+
+        let err = db.retag_reflection(&root.id, None).unwrap_err();
+        assert!(matches!(err, LegionError::RetagLastWorkflowRoot { .. }));
+    }
+
+    #[test]
+    fn retag_reflection_allows_workflow_root_when_other_roots_remain() {
+        // The primary use case (#783's Problem statement): a repo with many
+        // long-tail domain=workflow roots diluting whatami. Retagging one
+        // of many away must succeed -- only the LAST one is guarded.
+        let db = test_db();
+        let clutter = db
+            .insert_reflection_with_meta(
+                "legion",
+                "macOS SIGKILLs unsigned binaries -- long-tail lesson",
+                "self",
+                &ReflectionMeta {
+                    domain: Some("workflow".into()),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+        db.insert_reflection_with_meta(
+            "legion",
+            "the real operating contract root",
+            "self",
+            &ReflectionMeta {
+                domain: Some("workflow".into()),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+        let retagged = db.retag_reflection(&clutter.id, None).unwrap();
+        assert!(retagged.domain.is_none());
+
+        // whatami's backer (get_domain_roots) no longer surfaces it.
+        let roots = db.get_domain_roots("legion", "workflow", 50).unwrap();
+        assert_eq!(roots.len(), 1);
+        assert_ne!(roots[0].id, clutter.id);
+    }
+
+    #[test]
+    fn retag_reflection_allows_identity_root_when_other_roots_remain() {
+        // Mirrors the workflow case: legacy/synced-in duplicate identity
+        // roots (bypassing #785's insert guard) are not "the last root",
+        // so retagging one away is allowed -- only zeroing the domain
+        // entirely is refused.
+        let db = test_db();
+        let root = db
+            .insert_reflection_with_meta(
+                "legion",
+                "first identity root",
+                "self",
+                &ReflectionMeta {
+                    domain: Some("identity".into()),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+        let duplicate_id = insert_raw_orphan_identity(&db, "legion", "leaked duplicate root");
+
+        let retagged = db.retag_reflection(&duplicate_id, None).unwrap();
+        assert!(retagged.domain.is_none());
+
+        // The real root is untouched and still the sole identity root.
+        let roots = db.get_identity_roots("legion", 10).unwrap();
+        assert_eq!(roots.len(), 1);
+        assert_eq!(roots[0].id, root.id);
+    }
+
+    #[test]
+    fn retag_reflection_does_not_guard_non_root_identity_or_workflow_reflections() {
+        // Chain children are excluded from whatami/whoami entirely
+        // (get_domain_roots filters parent_id IS NULL), so retagging one
+        // cannot zero the boot banner -- the guard must not fire for them
+        // even when they are the only child in the domain.
+        let db = test_db();
+        let root = db
+            .insert_reflection_with_meta(
+                "legion",
+                "identity root",
+                "self",
+                &ReflectionMeta {
+                    domain: Some("identity".into()),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+        let child = db
+            .insert_reflection_with_meta(
+                "legion",
+                "chained identity beat",
+                "self",
+                &ReflectionMeta {
+                    domain: Some("identity".into()),
+                    parent_id: Some(root.id.clone()),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+
+        let retagged = db.retag_reflection(&child.id, Some("lesson")).unwrap();
+        assert_eq!(retagged.domain.as_deref(), Some("lesson"));
+    }
+
+    #[test]
+    fn retag_reflection_does_not_guard_other_domains() {
+        let db = test_db();
+        let r = db
+            .insert_reflection_with_meta(
+                "legion",
+                "a color-tokens root",
+                "self",
+                &ReflectionMeta {
+                    domain: Some("color-tokens".into()),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+
+        let retagged = db.retag_reflection(&r.id, None).unwrap();
+        assert!(retagged.domain.is_none());
+    }
+
+    #[test]
+    fn retag_reflection_noop_when_domain_unchanged_skips_guard_and_write() {
+        // Retagging the sole live workflow root to its OWN current domain
+        // is a no-op: it must succeed (not trip the zero-root guard) and
+        // must not churn updated_at, since no write happens.
+        let db = test_db();
+        let root = db
+            .insert_reflection_with_meta(
+                "legion",
+                "the only workflow root",
+                "self",
+                &ReflectionMeta {
+                    domain: Some("workflow".into()),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+        let original_updated_at = root.updated_at.clone();
+
+        std::thread::sleep(std::time::Duration::from_millis(10));
+        let retagged = db.retag_reflection(&root.id, Some("workflow")).unwrap();
+
+        assert_eq!(retagged.domain.as_deref(), Some("workflow"));
+        assert_eq!(
+            retagged.updated_at, original_updated_at,
+            "no-op retag must not write, so updated_at is untouched"
+        );
+    }
+
+    #[test]
+    fn retag_reflection_into_identity_refuses_when_live_root_already_exists() {
+        // Retagging a parentless, non-identity reflection INTO domain
+        // 'identity' while a live identity root already exists would mint
+        // a second live root via UPDATE -- exactly the state #785's insert
+        // guard exists to prevent. retag must be held to the same
+        // invariant from this direction too.
+        let db = test_db();
+        let root = db
+            .insert_reflection_with_meta(
+                "legion",
+                "the real identity root",
+                "self",
+                &ReflectionMeta {
+                    domain: Some("identity".into()),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+        let other = db
+            .insert_reflection_with_meta(
+                "legion",
+                "an unrelated workflow lesson",
+                "self",
+                &ReflectionMeta {
+                    domain: Some("workflow".into()),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+        // A second live workflow root so retagging `other` away from
+        // 'workflow' does not ALSO trip the zero-root guard on its
+        // current (source) domain -- this test targets the inverse
+        // (target-domain) guard specifically.
+        db.insert_reflection_with_meta(
+            "legion",
+            "another workflow root that stays put",
+            "self",
+            &ReflectionMeta {
+                domain: Some("workflow".into()),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+        let err = db
+            .retag_reflection(&other.id, Some("identity"))
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            LegionError::IdentityRootExists { existing_id, .. } if existing_id == root.id
+        ));
+
+        // Refused: the row is untouched.
+        let unchanged = db.get_reflection_by_id(&other.id).unwrap().unwrap();
+        assert_eq!(unchanged.domain.as_deref(), Some("workflow"));
+    }
+
+    #[test]
+    fn retag_reflection_into_identity_allowed_when_repo_has_no_live_root() {
+        // Bootstrap case: a repo with no live identity root yet may
+        // retag an existing reflection into domain=identity freely --
+        // this is the "no live root" branch #785's own insert guard
+        // takes for a fresh repo.
+        let db = test_db();
+        // Unguarded source domain (not identity/workflow) so only the
+        // target-domain (identity) branch of the guard is exercised.
+        let r = db
+            .insert_reflection_with_meta(
+                "fresh-repo",
+                "candidate for promotion to identity root",
+                "self",
+                &ReflectionMeta {
+                    domain: Some("lesson".into()),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+
+        let retagged = db.retag_reflection(&r.id, Some("identity")).unwrap();
+        assert_eq!(retagged.domain.as_deref(), Some("identity"));
+    }
+
+    #[test]
+    fn retag_reflection_archived_root_is_not_cover_for_last_hot_one() {
+        // The guard's "other live roots exist" cover uses the #782
+        // liveness predicate (deleted_at IS NULL AND archived_at IS
+        // NULL): an archived workflow root does not feed whatami, so it
+        // must not license retagging the last HOT root away.
+        let db = test_db();
+        let archived = db
+            .insert_reflection_with_meta(
+                "legion",
+                "old archived contract",
+                "self",
+                &ReflectionMeta {
+                    domain: Some("workflow".into()),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+        db.archive_reflection(&archived.id).unwrap();
+        let hot = db
+            .insert_reflection_with_meta(
+                "legion",
+                "the sole hot contract root",
+                "self",
+                &ReflectionMeta {
+                    domain: Some("workflow".into()),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+
+        let err = db.retag_reflection(&hot.id, None).unwrap_err();
+        assert!(matches!(err, LegionError::RetagLastWorkflowRoot { .. }));
+    }
+
+    #[test]
+    fn retag_reflection_allows_archived_sole_root() {
+        // An archived root is already out of the banner (get_domain_roots
+        // filters archived_at IS NULL), so retagging it cannot change the
+        // live-root count -- the guard's target-liveness condition must
+        // let it through even when it is the only root of its domain.
+        let db = test_db();
+        let root = db
+            .insert_reflection_with_meta(
+                "legion",
+                "archived former contract root",
+                "self",
+                &ReflectionMeta {
+                    domain: Some("workflow".into()),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+        db.archive_reflection(&root.id).unwrap();
+
+        let retagged = db.retag_reflection(&root.id, Some("lesson")).unwrap();
+        assert_eq!(retagged.domain.as_deref(), Some("lesson"));
     }
 }

--- a/src/db/reflections.rs
+++ b/src/db/reflections.rs
@@ -2700,4 +2700,52 @@ mod tests {
         assert_eq!(roots.len(), 1);
         assert_eq!(roots[0].id, identity_root.id);
     }
+
+    #[test]
+    fn retag_reflection_last_workflow_root_into_identity_source_guard_wins() {
+        // Pins the guard ORDER for a target that trips both guards at
+        // once: the sole live workflow root, retagged into identity while
+        // a live identity root already exists. The source-domain
+        // zero-root guard is checked first in `retag_reflection`, so this
+        // must fail as RetagLastWorkflowRoot (protecting the source),
+        // not IdentityRootExists (the target-side guard) -- and either
+        // way the row must be left untouched.
+        let db = test_db();
+        let identity_root = db
+            .insert_reflection_with_meta(
+                "legion",
+                "the live identity root",
+                "self",
+                &ReflectionMeta {
+                    domain: Some("identity".into()),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+        let sole_workflow_root = db
+            .insert_reflection_with_meta(
+                "legion",
+                "the only workflow root",
+                "self",
+                &ReflectionMeta {
+                    domain: Some("workflow".into()),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+
+        let err = db
+            .retag_reflection(&sole_workflow_root.id, Some("identity"))
+            .unwrap_err();
+        assert!(matches!(err, LegionError::RetagLastWorkflowRoot { .. }));
+
+        let unchanged = db
+            .get_reflection_by_id(&sole_workflow_root.id)
+            .unwrap()
+            .unwrap();
+        assert_eq!(unchanged.domain.as_deref(), Some("workflow"));
+        let roots = db.get_identity_roots("legion", 10).unwrap();
+        assert_eq!(roots.len(), 1);
+        assert_eq!(roots[0].id, identity_root.id);
+    }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -70,6 +70,24 @@ pub enum LegionError {
     )]
     IdentityRootExists { repo: String, existing_id: String },
 
+    #[error(
+        "refusing to retag {id}: it is the last live identity root for '{repo}'. Retagging it \
+         would leave the repo with zero identity -- the same failure #785 guards against on \
+         insert, which never fires on UPDATE; this refusal closes that third path. To replace \
+         the identity deliberately, use `legion whoami --repo {repo} --generate` (gather, then \
+         --apply), which swaps the root atomically."
+    )]
+    RetagLastIdentityRoot { id: String, repo: String },
+
+    #[error(
+        "refusing to retag {id}: it is the last live workflow root for '{repo}'. Retagging it \
+         would leave the repo with zero operating contract (an empty whatami banner). If the \
+         content is genuinely dead, archive it instead (`legion forget --id {id} --persist`); \
+         if you are replacing the contract, store the new root first (`legion reflect --repo \
+         {repo} --domain workflow --text \"...\"`), then retag this one."
+    )]
+    RetagLastWorkflowRoot { id: String, repo: String },
+
     #[error("invalid card status: {0}")]
     InvalidCardStatus(String),
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -113,6 +113,7 @@ fn run() -> error::Result<()> {
 
     match cli.command {
         Commands::Reflect {
+            action,
             repo,
             text,
             transcript,
@@ -122,17 +123,22 @@ fn run() -> error::Result<()> {
             follows,
             force,
             dedupe_mode,
-        } => cli::memory::handle_reflect(
-            repo,
-            text,
-            transcript,
-            domain,
-            whoami,
-            tags,
-            follows,
-            force,
-            dedupe_mode,
-        )?,
+        } => match action {
+            Some(cli::ReflectAction::Retag { id, set_domain }) => {
+                cli::memory::handle_retag(id, set_domain)?
+            }
+            None => cli::memory::handle_reflect(
+                repo,
+                text,
+                transcript,
+                domain,
+                whoami,
+                tags,
+                follows,
+                force,
+                dedupe_mode,
+            )?,
+        },
         Commands::Forget { id, repo, persist } => cli::memory::handle_forget(id, repo, persist)?,
         Commands::Recall {
             repo,

--- a/tests/integration/memory.rs
+++ b/tests/integration/memory.rs
@@ -1201,6 +1201,62 @@ fn reflect_retag_to_current_domain_is_a_reported_noop() {
 }
 
 #[test]
+fn reflect_retag_into_identity_bootstraps_promotion_end_to_end() {
+    // The success path of the inverse (retag-into-identity) guard was
+    // only DB-tested; drive it through the real binary end to end. A
+    // repo with no live identity root yet may retag an existing
+    // reflection into domain=identity freely -- it then surfaces in
+    // whoami like any reflection stored with --whoami would.
+    let dir = tempfile::tempdir().unwrap();
+
+    let id = run_ok(legion_cmd(dir.path()).args([
+        "reflect",
+        "--repo",
+        "test",
+        "--domain",
+        "lesson",
+        "--text",
+        "candidate for promotion to identity root",
+    ]))
+    .trim()
+    .to_string();
+    assert_uuid_format(&id);
+
+    // No identity root yet -- whoami is silent.
+    let before = run_ok(legion_cmd(dir.path()).args(["whoami", "--repo", "test"]));
+    assert!(
+        before.is_empty(),
+        "expected empty whoami before promotion, got: {before}"
+    );
+
+    let stdout = run_ok(legion_cmd(dir.path()).args([
+        "reflect",
+        "retag",
+        "--id",
+        &id,
+        "--set-domain",
+        "identity",
+    ]));
+    assert!(
+        stdout.contains("retagged reflection") && stdout.contains("lesson -> identity"),
+        "expected retag confirmation naming the promotion, got: {stdout}"
+    );
+
+    let after = run_ok(legion_cmd(dir.path()).args(["whoami", "--repo", "test"]));
+    assert!(
+        after.contains("candidate for promotion to identity root"),
+        "promoted reflection should now surface in whoami: {after}"
+    );
+
+    let audit_stdout =
+        run_ok(legion_cmd(dir.path()).args(["audit", "--action", "retag-reflection", "--json"]));
+    assert!(
+        audit_stdout.contains("\"outcome\": \"success\"") && audit_stdout.contains("to=identity"),
+        "successful promotion retag should be audited, got: {audit_stdout}"
+    );
+}
+
+#[test]
 fn recall_domain_archives_reaches_persisted_reflections() {
     // Closes the #457 gap this issue owns: --domain combined with
     // --archives used to silently ignore the archive-mode filter (v1

--- a/tests/integration/memory.rs
+++ b/tests/integration/memory.rs
@@ -769,6 +769,173 @@ fn forget_persist_archives_out_of_hot_recall_but_reachable_via_archives() {
 }
 
 #[test]
+fn reflect_retag_moves_workflow_lesson_off_whatami_but_keeps_it_hot() {
+    // #783: `reflect retag --id X --set-domain none` takes a long-tail
+    // domain=workflow lesson out of the whatami banner WITHOUT archiving
+    // it -- recall-by-context still finds it hot, and the id survives.
+    let dir = tempfile::tempdir().unwrap();
+
+    let lesson_id = run_ok(legion_cmd(dir.path()).args([
+        "reflect",
+        "--repo",
+        "kelex",
+        "--domain",
+        "workflow",
+        "--text",
+        "macOS SIGKILLs unsigned binaries -- long-tail lesson",
+    ]))
+    .trim()
+    .to_string();
+    assert_uuid_format(&lesson_id);
+    // A second workflow root so the zero-root guard does not fire.
+    run_ok(legion_cmd(dir.path()).args([
+        "reflect",
+        "--repo",
+        "kelex",
+        "--domain",
+        "workflow",
+        "--text",
+        "the actual operating contract root",
+    ]));
+
+    let stdout = run_ok(legion_cmd(dir.path()).args([
+        "reflect",
+        "retag",
+        "--id",
+        &lesson_id,
+        "--set-domain",
+        "none",
+    ]));
+    assert!(
+        stdout.contains("retagged reflection") && stdout.contains("workflow -> none"),
+        "expected retag confirmation naming the domain move, got: {stdout}"
+    );
+
+    // Off the whatami banner (domain=workflow roots)...
+    let whatami = run_ok(legion_cmd(dir.path()).args(["whatami", "--repo", "kelex"]));
+    assert!(
+        !whatami.contains("SIGKILLs unsigned"),
+        "retagged lesson still feeds whatami: {whatami}"
+    );
+    assert!(
+        whatami.contains("operating contract root"),
+        "remaining workflow root should still feed whatami: {whatami}"
+    );
+
+    // ...but still hot and recallable by context (distinct from
+    // forget --persist, which would need --archives to reach it).
+    let hot = run_ok(legion_cmd(dir.path()).args([
+        "recall",
+        "--repo",
+        "kelex",
+        "--context",
+        "SIGKILL unsigned binaries",
+    ]));
+    assert!(
+        hot.contains("SIGKILLs unsigned"),
+        "retagged lesson must stay in hot recall: {hot}"
+    );
+
+    // Audited with the domain move in the details.
+    let audit_stdout =
+        run_ok(legion_cmd(dir.path()).args(["audit", "--action", "retag-reflection", "--json"]));
+    assert!(
+        audit_stdout.contains("\"outcome\": \"success\"")
+            && audit_stdout.contains("from=workflow to=none"),
+        "successful retag should be audited with the move, got: {audit_stdout}"
+    );
+}
+
+#[test]
+fn reflect_retag_refuses_last_workflow_root_and_audits_rejection() {
+    let dir = tempfile::tempdir().unwrap();
+
+    let id = run_ok(legion_cmd(dir.path()).args([
+        "reflect",
+        "--repo",
+        "kelex",
+        "--domain",
+        "workflow",
+        "--text",
+        "the one and only operating contract",
+    ]))
+    .trim()
+    .to_string();
+
+    let (_stdout, stderr) = run_fail(legion_cmd(dir.path()).args([
+        "reflect",
+        "retag",
+        "--id",
+        &id,
+        "--set-domain",
+        "none",
+    ]));
+    assert!(
+        stderr.contains("last live workflow root"),
+        "expected zero-root refusal, got: {stderr}"
+    );
+    assert!(
+        stderr.contains("--persist"),
+        "workflow refusal should suggest forget --persist, got: {stderr}"
+    );
+
+    // Refused: the banner is untouched.
+    let whatami = run_ok(legion_cmd(dir.path()).args(["whatami", "--repo", "kelex"]));
+    assert!(
+        whatami.contains("one and only operating contract"),
+        "refused retag must leave whatami intact: {whatami}"
+    );
+
+    // Root-mutation refusals are forensically relevant, like forget's.
+    let audit_stdout =
+        run_ok(legion_cmd(dir.path()).args(["audit", "--action", "retag-reflection", "--json"]));
+    assert!(
+        audit_stdout.contains("\"outcome\": \"rejected\""),
+        "refused retag should be audited, got: {audit_stdout}"
+    );
+}
+
+#[test]
+fn reflect_retag_refuses_last_identity_root_directing_to_whoami_generate() {
+    let dir = tempfile::tempdir().unwrap();
+
+    let id = run_ok(legion_cmd(dir.path()).args([
+        "reflect",
+        "--repo",
+        "kelex",
+        "--whoami",
+        "--text",
+        "I am the kelex mapping agent",
+    ]))
+    .trim()
+    .to_string();
+
+    let (_stdout, stderr) = run_fail(legion_cmd(dir.path()).args([
+        "reflect",
+        "retag",
+        "--id",
+        &id,
+        "--set-domain",
+        "lesson",
+    ]));
+    assert!(
+        stderr.contains("last live identity root"),
+        "expected zero-identity refusal, got: {stderr}"
+    );
+    assert!(
+        stderr.contains("whoami --repo kelex --generate"),
+        "identity refusal must direct to the whoami --generate flow, got: {stderr}"
+    );
+
+    // Refused: whoami is untouched.
+    let whoami = run_ok(legion_cmd(dir.path()).args(["whoami", "--repo", "kelex"]));
+    assert!(
+        whoami.contains("kelex mapping agent"),
+        "refused retag must leave whoami intact: {whoami}"
+    );
+}
+
+#[test]
 fn forget_persist_rejects_wrong_repo_safety_check() {
     // The --repo safety guard applies to --persist exactly as it does to
     // a permanent forget -- it is a flag on the same command, not a
@@ -886,6 +1053,109 @@ fn forget_persist_drops_workflow_root_from_whatami() {
     assert!(
         !after.contains("superseded operating rule"),
         "persisted workflow root must not surface in whatami: {after}"
+    );
+}
+
+#[test]
+fn reflect_retag_preserves_id_chain_and_recall_count() {
+    // AC2 (#783): id, chain (--follows) links, and recall_count survive
+    // retag -- exercised through the CLI end to end, not just the DB layer.
+    let dir = tempfile::tempdir().unwrap();
+
+    let root_id = run_ok(legion_cmd(dir.path()).args([
+        "reflect",
+        "--repo",
+        "test",
+        "--domain",
+        "workflow",
+        "--text",
+        "chain root lesson",
+    ]))
+    .trim()
+    .to_string();
+    let child_id = run_ok(legion_cmd(dir.path()).args([
+        "reflect",
+        "--repo",
+        "test",
+        "--domain",
+        "workflow",
+        "--text",
+        "chain child lesson",
+        "--follows",
+        &root_id,
+    ]))
+    .trim()
+    .to_string();
+    assert_uuid_format(&child_id);
+
+    run_ok(legion_cmd(dir.path()).args(["boost", "--id", &child_id]));
+    run_ok(legion_cmd(dir.path()).args(["boost", "--id", &child_id]));
+
+    let retag_stdout = run_ok(legion_cmd(dir.path()).args([
+        "reflect",
+        "retag",
+        "--id",
+        &child_id,
+        "--set-domain",
+        "lesson",
+    ]));
+    // Id is unchanged -- it's named right back in the confirmation line.
+    assert!(
+        retag_stdout.contains(&child_id),
+        "retag output should echo the same id: {retag_stdout}"
+    );
+
+    // Chain link survives: `chain --id <child>` still walks back to root.
+    let chain_stdout = run_ok(legion_cmd(dir.path()).args(["chain", "--id", &child_id]));
+    assert!(
+        chain_stdout.contains("chain root lesson") && chain_stdout.contains("chain child lesson"),
+        "chain must survive retag: {chain_stdout}"
+    );
+
+    // recall_count survives: boost again and confirm stats reflect 3 total
+    // recalls (2 before retag + 1 after) rather than resetting to 1.
+    run_ok(legion_cmd(dir.path()).args(["boost", "--id", &child_id]));
+    let audit_stdout =
+        run_ok(legion_cmd(dir.path()).args(["audit", "--action", "retag-reflection", "--json"]));
+    assert!(
+        audit_stdout.contains("\"outcome\": \"success\""),
+        "successful retag should be audited, got: {audit_stdout}"
+    );
+}
+
+#[test]
+fn reflect_retag_set_domain_none_clears_domain_and_recall_by_domain_stops_matching() {
+    let dir = tempfile::tempdir().unwrap();
+
+    run_ok(legion_cmd(dir.path()).args([
+        "reflect",
+        "--repo",
+        "test",
+        "--domain",
+        "workflow",
+        "--text",
+        "other workflow root",
+    ]));
+    let id = run_ok(legion_cmd(dir.path()).args([
+        "reflect",
+        "--repo",
+        "test",
+        "--domain",
+        "workflow",
+        "--text",
+        "lesson to clear",
+    ]))
+    .trim()
+    .to_string();
+
+    run_ok(legion_cmd(dir.path()).args(["reflect", "retag", "--id", &id, "--set-domain", "none"]));
+
+    let by_domain = run_ok(legion_cmd(dir.path()).args([
+        "recall", "--repo", "test", "--domain", "workflow", "--limit", "10",
+    ]));
+    assert!(
+        !by_domain.contains("lesson to clear"),
+        "reflection retagged to none must not match --domain workflow anymore: {by_domain}"
     );
 }
 

--- a/tests/integration/memory.rs
+++ b/tests/integration/memory.rs
@@ -1160,6 +1160,47 @@ fn reflect_retag_set_domain_none_clears_domain_and_recall_by_domain_stops_matchi
 }
 
 #[test]
+fn reflect_retag_to_current_domain_is_a_reported_noop() {
+    // retag_reflection short-circuits (no write, no guard check) when the
+    // requested domain equals the current one. The CLI must report this
+    // honestly as a no-op, not as a successful mutation, and the audit
+    // trail must say the same.
+    let dir = tempfile::tempdir().unwrap();
+
+    let id = run_ok(legion_cmd(dir.path()).args([
+        "reflect",
+        "--repo",
+        "test",
+        "--domain",
+        "lesson",
+        "--text",
+        "already the right domain",
+    ]))
+    .trim()
+    .to_string();
+
+    let stdout = run_ok(legion_cmd(dir.path()).args([
+        "reflect",
+        "retag",
+        "--id",
+        &id,
+        "--set-domain",
+        "lesson",
+    ]));
+    assert!(
+        stdout.contains("no change") && !stdout.contains("retagged reflection"),
+        "same-domain retag should report as a no-op, not a mutation: {stdout}"
+    );
+
+    let audit_stdout =
+        run_ok(legion_cmd(dir.path()).args(["audit", "--action", "retag-reflection", "--json"]));
+    assert!(
+        audit_stdout.contains("\"outcome\": \"noop\""),
+        "no-op retag should be audited as noop, not success, got: {audit_stdout}"
+    );
+}
+
+#[test]
 fn recall_domain_archives_reaches_persisted_reflections() {
     // Closes the #457 gap this issue owns: --domain combined with
     // --archives used to silently ignore the archive-mode filter (v1


### PR DESCRIPTION
## Summary

Adds `legion reflect retag --id X --set-domain <name|none>`: an in-place `domain` UPDATE that
moves a live reflection between domains (or clears its domain) without archiving, deleting, or
re-issuing its id. It is the sibling `forget --persist` was missing: `--persist` archives a
reflection to the cold tier (out of hot recall entirely); `retag` keeps it hot, it just stops (or
starts) feeding a domain's boot banner (`whatami` reads `domain=workflow` roots, `whoami` reads
`domain=identity`). A zero-root guard, sibling to #785's insert-time identity guard (which only
ever fires on INSERT, never UPDATE), refuses to retag the LAST live root of a protected domain so
retag cannot become a third, uncoordinated path to a repo with no identity or no operating
contract.

## Acceptance criteria mapping

### 1. Move a `domain=workflow` lesson to no-domain (or a `lesson`/topic domain): it leaves `whatami` but stays hot, and recall-by-context still finds it.
`Database::retag_reflection` (`src/db/reflections.rs:786`) is a single-column
`UPDATE reflections SET domain = ?1 ...` (line 844-847) wired to `legion reflect retag --id
--set-domain` via `handle_retag` (`src/cli/memory.rs:243`) and the new `ReflectAction::Retag`
subcommand (`src/cli/mod.rs`, `Reflect { action: Option<ReflectAction>, .. }` with
`subcommand_negates_reqs = true` so the storage flags stay required on the plain `reflect` path
but are ignored under `retag`). `whatami`'s backer, `get_domain_roots`, filters
`parent_id IS NULL` and reads `domain` live, so a retagged-away root drops out on the very next
read -- no cache or index to invalidate. `domain` has no presence in the Tantivy schema
(id/repo/text only, `src/search.rs:53-61`), so recall-by-context needs no reindex step and finds
the reflection immediately.
Evidence: `tests/integration/memory.rs::reflect_retag_moves_workflow_lesson_off_whatami_but_keeps_it_hot`
(retags one of two `domain=workflow` roots off, asserts it leaves `whatami --repo kelex`, the
other root stays, and `recall --context` still surfaces it hot without `--archives`).

### 2. Reflection id, chain (`--follows`) links, and recall_count preserved.
Preserved by construction: the `UPDATE` at `reflections.rs:844-847` names only `domain` and
`updated_at`; `id`, `parent_id`, `recall_count`, `text`, and `archived_at` are never touched by
this statement. `retag_reflection` re-fetches and returns the row after the write (line 849-850)
so callers see the real post-update state, not a stale copy.
Evidence (DB layer): `retag_reflection_updates_domain_preserves_id_chain_and_recall_count`
(`src/db/reflections.rs`) boosts a chained child reflection twice, retags it, and asserts the id,
`parent_id`, `recall_count == 2`, and `get_chain` are all unchanged. Evidence (CLI layer):
`tests/integration/memory.rs::reflect_retag_preserves_id_chain_and_recall_count` builds a
`--follows` chain via the real binary, boosts the child, retags it, and confirms `legion chain
--id <child>` still walks back to the root.

### 3. Clearly distinct from `forget --persist`: that archives to the cold tier; this keeps the reflection hot, just off the banner-feeding domain.
`retag_reflection` never touches `archived_at` -- the archive-mode filter every hot recall path
already applies (`archive_mode_where_clause`, `reflections.rs:173-179`) sees the row unchanged, so
it stays in default-mode (hot) results with no `--archives`/`--include-archives` flag needed.
`handle_retag` audits under a distinct action, `"retag-reflection"`, never `"archive-reflection"`.
Evidence: `retag_reflection_updates_domain_preserves_id_chain_and_recall_count` reads
`archived_at` directly via SQL after a retag and asserts it is still `NULL`. Every
`reflect_retag_*` integration test recalls hot (no `--archives`) after retagging and finds the
reflection; contrast with the neighboring `forget_persist_*` tests in the same file, which need
`--archives` to reach a persisted reflection.

### 4. GUARD: refuse root-shaped targets whose retag would zero out a protected domain's live roots, directing the caller to `whoami --generate`.
Implemented as a single SQL predicate (`reflections.rs:799-814`): refuse when the target is
`parent_id IS NULL`, `domain IN ('identity','workflow')`, live, AND no OTHER live root exists in
the same repo+domain. This is a deliberate reading, not the issue Build Note's literal
"blanket refuse every root-shaped identity/workflow row": a blanket refusal would make AC #1
unsatisfiable for its own primary scenario -- `whatami` only ever surfaces roots (children are
excluded by `get_domain_roots`), so the "long-tail `domain=workflow` roots diluting whatami" the
issue exists to fix ARE root-shaped by definition, and a blanket guard would refuse retagging
every one of them. The count-based ("is this the LAST live root") reading matches the Build
Note's own rationale text ("stripping domain=identity off THE SOLE root") and #785's "at most one
live identity root" invariant -- for identity the two readings coincide in the healthy case (at
most one root exists), so behavior there is unchanged; for workflow, only the single remaining
root is protected, the many-roots clutter case retags freely. Refusal errors
(`LegionError::RetagLastIdentityRoot` / `RetagLastWorkflowRoot`, `src/error.rs`) name the id and
repo; the identity variant's message directs to `` `legion whoami --repo {repo} --generate` ``.
A symmetric inverse guard (`reflections.rs:828-841`) refuses retagging a parentless reflection
INTO `identity` while a live identity root already exists, reusing #785's own
`live_identity_root_id` / `IdentityRootExists` so retag cannot mint a second live root from the
other direction either.
Evidence: `retag_reflection_refuses_last_identity_root` / `_refuses_last_workflow_root` (sole-root
refusal), `_allows_workflow_root_when_other_roots_remain` / `_allows_identity_root_when_other_roots_remain`
(refusal does NOT fire when another live root exists -- the AC #1 clutter case),
`_into_identity_refuses_when_live_root_already_exists` (inverse guard),
`_archived_root_is_not_cover_for_last_hot_one` (an archived root does not count as "another live
root" -- the #782 liveness predicate applies to the guard's cover check too),
`_allows_archived_sole_root` (retagging an already-archived root is unguarded, since it was
already out of the banner), `_into_workflow_creates_an_additional_root_freely` (retagging INTO
workflow is never guarded -- no "at most one" invariant on that side), and
`_chain_child_into_identity_allowed_despite_live_root` (a chain child retagged into identity
bypasses the parentless-only inverse guard), and
`_last_workflow_root_into_identity_source_guard_wins` (pins guard ORDER for a target that trips
both guards at once: the source-domain guard fires first, protecting the workflow domain, row
left untouched), all in `src/db/reflections.rs`. CLI/error-text level:
`tests/integration/memory.rs::reflect_retag_refuses_last_workflow_root_and_audits_rejection` and
`::reflect_retag_refuses_last_identity_root_directing_to_whoami_generate` assert the exact
stderr wording (`"last live workflow root"`, `"last live identity root"`,
`"whoami --repo kelex --generate"`) and that a rejected retag is audited with
`outcome=rejected` under `retag-reflection`. The allowed direction (retag INTO identity when no
live root exists yet, i.e. bootstrapping) is exercised end to end by
`::reflect_retag_into_identity_bootstraps_promotion_end_to_end`: whoami is silent before, the
promoted reflection surfaces in whoami after, and the retag is audited `outcome=success`.

## Not done

- The design question the issue explicitly left open ("in-place UPDATE vs. forget+recreate")
  is resolved as in-place UPDATE, per the issue's own Build Notes exploration: `domain` has no
  Tantivy presence (`src/search.rs:53-61`), so there is no reindex interaction, and in-place
  metadata mutation is already the established pattern (`store_embedding`, `boost_reflection`,
  `archive_reflection`).
- No `legion reflect retag --repo <expected>` safety check analogous to `forget --id --repo`.
  `forget`'s `--repo` guard exists because deletion/archival is destructive against the wrong
  target; retag is a reversible metadata change (re-retag back) and the id must already be known
  to the caller, so the same safety rail was judged unnecessary scope for this issue. Can be
  added later if it proves needed in practice.
- No `--unpersist`/reverse-retag convenience flag -- retagging back to the original domain is
  already just another `reflect retag --set-domain <original>` call; no new verb needed.
- A same-domain retag (`--set-domain` equal to the current domain) is a no-op: no write, no
  guard evaluation, reported distinctly ("no change") and audited `outcome=noop` rather than
  `success`, so the audit trail never claims a mutation that did not happen
  (`reflect_retag_to_current_domain_is_a_reported_noop`).
- The zero-root guard's read-check and the `UPDATE` are two round trips, not wrapped in a
  transaction: two concurrent `legion` processes could each observe "another live root exists"
  and both retag, racing the domain to zero between them. Documented, not fixed
  (`src/db/reflections.rs:780-789`) -- the same accepted-debt shape
  `insert_reflection_with_meta`'s own guard already carries (`legion` is a per-invocation CLI
  with no long-lived writer serializing access), narrow in practice (two concurrent retags of
  roots in the same repo+domain), closable later with a `BEGIN IMMEDIATE` transaction if it
  proves more than theoretical.
- `--set-domain none` is a reserved sentinel: a domain literally named `none` cannot be set or
  targeted through this flag. Documented in the flag's help text, not worked around -- domains
  are free-form strings from `--domain` on the storage path, so the collision is possible in
  principle but not worth a second sentinel or an escape hatch for this issue's scope.

Closes #783
