### PR TITLE
fix(#812): pass TimeRange to search() at pre-#808-signature test call site

### DIFF
--- a/src/db/reflections.rs
+++ b/src/db/reflections.rs
@@ -2331,8 +2331,9 @@ mod tests {
 
         db.retag_reflection(&stored, None).unwrap();
 
+        let default_range = crate::timerange::TimeRange::default();
         let results = index
-            .search("legion", "SIGKILLs unsigned binaries", 5)
+            .search("legion", "SIGKILLs unsigned binaries", 5, &default_range)
             .unwrap();
         assert_eq!(
             results.len(),


### PR DESCRIPTION
## Summary

`cargo clippy --all-targets` and `cargo test --all-targets` were red on main: PR #809
added a retag-index test that called `Index::search(repo, query, limit)` with the
three-argument signature that predates PR #808's mandatory `&TimeRange` fourth
parameter -- a landing-order break between two PRs that were both correct against the
main they branched from. This PR adds the missing argument at the one crossed call
site and confirms via a full-suite sweep that no other call site was affected.

## Acceptance criteria mapping

### 1. Add the missing range argument (unbounded TimeRange::default()) at the failing call site; sweep for any OTHER call sites the two branches crossed on (cargo test --all-targets is the oracle).
`src/db/reflections.rs:2334-2336`, in
`retag_reflection_leaves_no_tantivy_presence_by_construction`, now builds
`let default_range = crate::timerange::TimeRange::default();` and passes
`&default_range` as the fourth argument to `index.search(...)`. This matches the exact
idiom already used at `reflections.rs:2077` and `reflections.rs:2125` for the same
unbounded-range case in the same file, rather than inventing a new pattern. I then ran
`cargo test --all-targets`, which compiles and runs every test binary in the crate
(unit tests in `src/main.rs` plus the `tests/integration/main.rs` binary) -- this is
the oracle the issue specifies, since any other #808/#809-crossed call site would fail
to compile under `--all-targets`. Result: 1634 lib-test passes + 352 integration-test
passes, 0 failures, confirming `reflections.rs:2335` was the only casualty.
Evidence: `cargo clippy --all-targets` originally failed with `E0061` at
`src/db/reflections.rs:2335` ("this method takes 4 arguments but 3 arguments were
supplied"); after the fix, `cargo test --all-targets` reports
`test result: ok. 1634 passed; 0 failed` (lib) and `test result: ok. 352 passed; 0
failed` (integration).

### 2. Full checks green: cargo test, clippy --all-targets -D warnings, fmt.
Ran all three gates locally after the fix, in the worktree at
`/Volumes/store/projects/runlegion/legion-812`. `cargo test --all-targets` is green as
detailed above. `cargo clippy --all-targets -- -D warnings` completes with `Finished
\`dev\` profile [unoptimized + debuginfo] target(s)` and zero warnings/errors.
`cargo fmt -- --check` produces no output (no diffs), i.e. the one-line diff is already
correctly formatted.
Evidence: three separate command runs, each exiting clean, immediately before staging
the commit (`5dea71e164eb2e76b9b6ed2db8b73aa83e9ac834`).

## Not done

The issue explicitly scopes the root-cause fix (adopting the #768 merge-queue for
multi-PR merge sessions, to prevent a fourth instance of this landing-order class)
to a separate, already-tracked effort -- this PR is only the heal for #812, per the
issue's own "Context" section. No other files were touched.

Closes #812
