### PR TITLE
chore(#814): add merge_group trigger to CI -- merge-queue bootstrap

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
   # Run on every PR regardless of base branch so stacked PRs (whose base
   # is a sibling feat/* branch, not main) still gate on CI before merge.
   pull_request:
+  # Required by the GitHub merge queue (enabled 2026-07-16): queued PRs
+  # trigger CI via merge_group, not pull_request -- without this event
+  # every queued PR stalls with no checks reporting. See #814.
+  merge_group:
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
## Summary

Adds the `merge_group` event to ci.yml so the merge queue (enabled by the operator today) can run required checks on queued PRs. One trigger, four lines, no job changes.

## Acceptance criteria mapping

### 1. merge_group added to the on: block alongside push/pull_request
Done at ci.yml:12-13 with a comment (lines 8-11) stating why the trigger exists and citing #814.
Evidence: the diff is 4 insertions, 0 deletions, all inside the `on:` block.

### 2. No other workflow changes
release.yml untouched (tag-triggered, the queue never routes it); ci.yml jobs, permissions, and steps byte-identical.
Evidence: `git diff origin/main...HEAD --stat` shows exactly one file, +4/-0.

### 3. Bootstrap note honored
This PR is itself the first through the queue. merge_group workflows resolve from the merge-group commit, which contains this PR's tree -- so the trigger exists in the exact commit the queue tests, and the queue self-bootstraps. If GitHub's evaluation surprises us and the queue stalls anyway, the pre-agreed fallback is a one-time operator bypass-merge of this single PR, after which every subsequent queued PR has the trigger on main.
Evidence: ci.yml:12 (`merge_group:`) is in this PR's tree at head 767a17c, and merge-group commits are constructed from the PR's merge result (observable at queue time: the CI run for this PR's merge group will list `merge_group` as its triggering event in the run metadata).

## Not done

- No merge_group filters: the queue constructs synthetic branches; filtering them recreates the stall.
- No fleet rollout: each repo adopts the same one-liner before its own ruleset lands; this PR is the template, not the sweep.

Closes #814
