### PR TITLE
feat(#816): kanban defer -- card-level scheduled wake

### DIFF
--- a/src/cli/kanban.rs
+++ b/src/cli/kanban.rs
@@ -110,12 +110,16 @@ pub(crate) enum KanbanAction {
         json: bool,
 
         /// Show all cards, including Backlog and terminal (Done/Cancelled)
-        #[arg(long, conflicts_with = "backlog")]
+        #[arg(long, conflicts_with_all = ["backlog", "deferred"])]
         all: bool,
 
         /// Show only the raw Backlog (the unconsented inbox)
-        #[arg(long)]
+        #[arg(long, conflicts_with = "deferred")]
         backlog: bool,
+
+        /// Show only Deferred cards (put off until a future wake_at, #816)
+        #[arg(long)]
+        deferred: bool,
     },
 
     /// Accept a pending card (move to in-progress)
@@ -169,6 +173,39 @@ pub(crate) enum KanbanAction {
     /// once its attempt is no longer live -- but available for an agent
     /// that wants to resume the work itself before that sweep runs.
     Undelegate {
+        /// Card ID
+        #[arg(long)]
+        id: String,
+    },
+
+    /// Defer a card to a future time (#816): put it off until `--until`,
+    /// excluding it from the Stop in-progress gate and the active
+    /// (WorkingSet) listing until then. Legal from Accepted or Pending;
+    /// re-defer (updating `--until`) is legal from Deferred itself.
+    /// `tick_health` wakes the owner and reverts the card automatically
+    /// once `--until` passes; `legion kanban undefer` does the same
+    /// manually, ahead of schedule.
+    Defer {
+        /// Card ID
+        #[arg(long)]
+        id: String,
+
+        /// When to wake: `YYYY-MM-DD`, `<N>d`, `<N>w`, or `today`, reusing
+        /// #786's `TimeRange` token shapes applied FORWARD from now (not
+        /// the backward-from-today direction `--since`/`--until` use
+        /// elsewhere). Must resolve to a future time -- a past or
+        /// same-instant result is refused, naming the parsed value.
+        #[arg(long)]
+        until: String,
+    },
+
+    /// Manually wake a deferred card early (returns to whichever status it
+    /// was deferred from -- Accepted or Pending).
+    ///
+    /// Normally unnecessary -- `tick_health` auto-reverts a deferred card
+    /// once `wake_at` passes -- but available for an agent or operator that
+    /// wants the work back before then.
+    Undefer {
         /// Card ID
         #[arg(long)]
         id: String,
@@ -818,17 +855,23 @@ pub(crate) fn handle(action: KanbanAction) -> error::Result<()> {
             json,
             all,
             backlog,
+            deferred,
         } => {
             let direction = if from {
                 kanban::Direction::Outbound
             } else {
                 kanban::Direction::Inbound
             };
-            // Default to the working set; --all and --backlog widen/redirect.
+            // Default to the working set; --all, --backlog, and --deferred
+            // widen/redirect. Deferred is its own scope (#816) -- excluded
+            // from WorkingSet, consciously visible here rather than folded
+            // into --all/--backlog.
             let scope = if all {
                 kanban::CardScope::All
             } else if backlog {
                 kanban::CardScope::Backlog
+            } else if deferred {
+                kanban::CardScope::Deferred
             } else {
                 kanban::CardScope::WorkingSet
             };
@@ -874,6 +917,22 @@ pub(crate) fn handle(action: KanbanAction) -> error::Result<()> {
         }
         KanbanAction::Undelegate { id } => {
             kanban::undelegate_card(&database, &id, None)?;
+            println!("{id}");
+        }
+        KanbanAction::Defer { id, until } => {
+            let wake_at = crate::timerange::parse_point_in_time(&until)?;
+            let now = chrono::Utc::now().to_rfc3339();
+            if wake_at <= now {
+                return Err(error::LegionError::DeferWakeAtInPast {
+                    input: until,
+                    wake_at,
+                });
+            }
+            kanban::defer_card(&database, &id, &wake_at, None)?;
+            println!("{id}");
+        }
+        KanbanAction::Undefer { id } => {
+            kanban::undefer_card(&database, &id, None)?;
             println!("{id}");
         }
         KanbanAction::DelegatedNeedsAttention { repo, json } => {

--- a/src/cli/kanban.rs
+++ b/src/cli/kanban.rs
@@ -185,6 +185,13 @@ pub(crate) enum KanbanAction {
     /// `tick_health` wakes the owner and reverts the card automatically
     /// once `--until` passes; `legion kanban undefer` does the same
     /// manually, ahead of schedule.
+    ///
+    /// Liveness caveat (same limitation as `legion kanban delegate`, #778):
+    /// the auto-wake only fires while `legion watch` (standalone or the
+    /// daemon) is running for this card's repo. If no watch process is
+    /// alive when `--until` passes, the card stays Deferred past its wake
+    /// time until one starts and runs a health tick -- use `legion kanban
+    /// undefer` to wake it manually if that matters before then.
     Defer {
         /// Card ID
         #[arg(long)]

--- a/src/cli/verify.rs
+++ b/src/cli/verify.rs
@@ -1219,6 +1219,8 @@ mod tests {
             solution: None,
             acceptance: acceptance.map(str::to_string),
             document_id: doc_id.map(str::to_string),
+            wake_at: None,
+            pre_defer_status: None,
         }
     }
 

--- a/src/db/kanban.rs
+++ b/src/db/kanban.rs
@@ -114,6 +114,27 @@ pub(super) fn migrate(conn: &Connection) -> Result<()> {
              ON tasks(document_id) WHERE document_id IS NOT NULL;",
         )?;
     }
+
+    // Migration 17: kanban defer -- card-level scheduled wake (#816).
+    // `wake_at` (RFC3339, matching `created_at`'s format) is the time the
+    // deferred card wakes; `pre_defer_status` is the status the card was in
+    // immediately before deferring, so the revert target (Accepted or
+    // Pending -- Defer is legal from either) is data-dependent, not fixed
+    // by the state machine alone. Both TEXT NULL; only set while a card is
+    // Deferred, cleared on revert.
+    if !Database::has_column(conn, "tasks", "wake_at")? {
+        conn.execute_batch("ALTER TABLE tasks ADD COLUMN wake_at TEXT;")?;
+    }
+    if !Database::has_column(conn, "tasks", "pre_defer_status")? {
+        conn.execute_batch("ALTER TABLE tasks ADD COLUMN pre_defer_status TEXT;")?;
+    }
+    // Partial index: `tick_health`'s sweep polls "deferred cards due now"
+    // every health tick (src/watch/mod.rs), so this predicate runs
+    // constantly on every board regardless of how many cards are deferred.
+    conn.execute_batch(
+        "CREATE INDEX IF NOT EXISTS idx_tasks_deferred_wake_at \
+         ON tasks(wake_at) WHERE status = 'deferred';",
+    )?;
     Ok(())
 }
 
@@ -302,12 +323,12 @@ impl Database {
     ///  3  text           11  source_type      19 solution
     ///  4  context        12  sort_order       20 acceptance
     ///  5  priority       13  created_at       21 document_id
-    ///  6  status         14  updated_at
-    ///  7  note           15  assigned_at
+    ///  6  status         14  updated_at       22 wake_at
+    ///  7  note           15  assigned_at      23 pre_defer_status
     const CARD_COLUMNS: &'static str = "id, from_repo, to_repo, text, context, priority, status, note, \
          labels, parent_card_id, source_url, source_type, sort_order, \
          created_at, updated_at, assigned_at, started_at, completed_at, \
-         problem, solution, acceptance, document_id";
+         problem, solution, acceptance, document_id, wake_at, pre_defer_status";
 
     /// SQL fragment for consistent priority ordering across all card queries.
     const PRIORITY_ORDER: &'static str = "CASE priority WHEN 'critical' THEN 0 WHEN 'high' THEN 1 \
@@ -398,13 +419,18 @@ impl Database {
         scope: crate::kanban::CardScope,
     ) -> Result<Vec<crate::kanban::Card>> {
         // Status predicate for the requested slice of the board. WorkingSet is the
-        // default consumer view (active work); Backlog is the raw inbox; All keeps
-        // every non-deleted row. Status literals match CardStatus::Display.
+        // default consumer view (active work); Backlog is the raw inbox; Deferred
+        // is the consciously-separate "put off until later" bucket (#816 -- a
+        // deferred card must be visible somewhere, never silently uncounted, so
+        // it gets its own scope rather than folding into WorkingSet or vanishing
+        // between Backlog and All); All keeps every non-deleted row. Status
+        // literals match CardStatus::Display.
         let status_filter = match scope {
             crate::kanban::CardScope::WorkingSet => {
-                " AND status NOT IN ('backlog', 'done', 'cancelled')"
+                " AND status NOT IN ('backlog', 'done', 'cancelled', 'deferred')"
             }
             crate::kanban::CardScope::Backlog => " AND status = 'backlog'",
+            crate::kanban::CardScope::Deferred => " AND status = 'deferred'",
             crate::kanban::CardScope::All => "",
         };
         let sql = match direction {
@@ -493,6 +519,61 @@ impl Database {
             .map_err(LegionError::Database)
     }
 
+    /// Get every `Deferred` card whose `wake_at` has passed (#816): the
+    /// scheduled-wake sweep target for `tick_health`. Scans every repo (no
+    /// `repo` filter), the same "one watch daemon can service many boards"
+    /// reasoning `get_delegated_cards` documents for its own sweep use.
+    pub fn get_deferred_cards_due(&self, now: &str) -> Result<Vec<crate::kanban::Card>> {
+        let sql = format!(
+            "SELECT {} FROM tasks \
+             WHERE status = 'deferred' AND wake_at IS NOT NULL AND wake_at <= ?1 \
+             AND deleted_at IS NULL \
+             ORDER BY {}, sort_order ASC, created_at ASC",
+            Self::CARD_COLUMNS,
+            Self::PRIORITY_ORDER
+        );
+        let mut stmt = self.conn.prepare(&sql)?;
+        let rows = stmt.query_map([now], crate::kanban::map_card_row)?;
+        rows.collect::<std::result::Result<Vec<_>, _>>()
+            .map_err(LegionError::Database)
+    }
+
+    /// Stamp `wake_at`/`pre_defer_status` on a card entering (or
+    /// re-entering) `Deferred` (#816). Called by `kanban::defer_card` right
+    /// after the status transition commits, mirroring how `delegate_card`
+    /// links the wake_attempts row after `transition_card` succeeds.
+    pub fn set_card_defer_fields(
+        &self,
+        id: &str,
+        wake_at: &str,
+        pre_defer_status: &str,
+    ) -> Result<()> {
+        let rows = self.conn.execute(
+            "UPDATE tasks SET wake_at = ?1, pre_defer_status = ?2 WHERE id = ?3 AND deleted_at IS NULL",
+            rusqlite::params![wake_at, pre_defer_status, id],
+        )?;
+        if rows == 0 {
+            return Err(LegionError::CardNotFound(id.to_string()));
+        }
+        Ok(())
+    }
+
+    /// Clear `wake_at`/`pre_defer_status` on a card leaving `Deferred`
+    /// (#816). Called by `kanban::undefer_card` (both the manual CLI path
+    /// and `tick_health`'s auto-wake sweep) so a resolved defer never
+    /// leaves a stale wake_at behind -- mirroring
+    /// `clear_wake_attempt_card`'s role for `undelegate_card`.
+    pub fn clear_card_defer_fields(&self, id: &str) -> Result<()> {
+        let rows = self.conn.execute(
+            "UPDATE tasks SET wake_at = NULL, pre_defer_status = NULL WHERE id = ?1 AND deleted_at IS NULL",
+            [id],
+        )?;
+        if rows == 0 {
+            return Err(LegionError::CardNotFound(id.to_string()));
+        }
+        Ok(())
+    }
+
     /// Atomically pick the next pending card for a repo and accept it.
     ///
     /// Selects highest priority, then lowest sort_order, then oldest.
@@ -579,6 +660,10 @@ impl Database {
             CardStatus::NeedsInput => None,
             CardStatus::Blocked => None,
             CardStatus::Delegated => None,
+            // Deferred carries no spec meaning either -- the bound document
+            // (if any) stays exactly where the pre-defer status left it;
+            // deferring and later waking do not move the spec's own status.
+            CardStatus::Deferred => None,
         }
     }
 
@@ -1403,6 +1488,7 @@ mod tests {
         assert!(Database::requirement_status_for_card_status(CardStatus::NeedsInput).is_none());
         assert!(Database::requirement_status_for_card_status(CardStatus::Blocked).is_none());
         assert!(Database::requirement_status_for_card_status(CardStatus::Delegated).is_none());
+        assert!(Database::requirement_status_for_card_status(CardStatus::Deferred).is_none());
     }
 
     // -- get_delegated_cards (#778) -------------------------------------------
@@ -1484,6 +1570,172 @@ mod tests {
 
         let all = db.get_delegated_cards(None).unwrap();
         assert_eq!(all.len(), 2, "None scans every repo");
+    }
+
+    // -- kanban defer (#816) --------------------------------------------------
+
+    #[test]
+    fn migration_wake_at_and_pre_defer_status_columns_are_idempotent_on_reopen() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("test_defer_idempotent.db");
+
+        let db1 = Database::open(&db_path).expect("first open");
+        let id = insert_test_card(&db1);
+        let card = db1.get_card_by_id(&id).expect("get").expect("exists");
+        assert!(card.wake_at.is_none());
+        assert!(card.pre_defer_status.is_none());
+        drop(db1);
+
+        // Second open must not fail even though both columns already exist.
+        let db2 = Database::open(&db_path).expect("second open must not fail");
+        let card2 = db2.get_card_by_id(&id).expect("get").expect("exists");
+        assert!(card2.wake_at.is_none());
+    }
+
+    #[test]
+    fn set_and_clear_card_defer_fields_round_trip() {
+        let db = test_db();
+        let id = insert_test_card(&db);
+
+        db.set_card_defer_fields(&id, "2099-01-01T00:00:00+00:00", "accepted")
+            .expect("set defer fields");
+        let card = db.get_card_by_id(&id).expect("get").expect("exists");
+        assert_eq!(card.wake_at.as_deref(), Some("2099-01-01T00:00:00+00:00"));
+        assert_eq!(card.pre_defer_status.as_deref(), Some("accepted"));
+
+        db.clear_card_defer_fields(&id).expect("clear defer fields");
+        let card = db.get_card_by_id(&id).expect("get").expect("exists");
+        assert!(card.wake_at.is_none());
+        assert!(card.pre_defer_status.is_none());
+    }
+
+    #[test]
+    fn set_card_defer_fields_reports_not_found() {
+        let db = test_db();
+        let err = db
+            .set_card_defer_fields("nonexistent-id", "2099-01-01T00:00:00+00:00", "accepted")
+            .unwrap_err();
+        assert!(matches!(err, LegionError::CardNotFound(_)));
+    }
+
+    #[test]
+    fn get_deferred_cards_due_only_returns_deferred_with_past_wake_at() {
+        let db = test_db();
+
+        // Due: deferred, wake_at in the past.
+        let due_id = db
+            .insert_card(
+                "legion",
+                "legion",
+                "due for wake",
+                None,
+                crate::kanban::Priority::Med,
+                None,
+                None,
+                None,
+                None,
+                None,
+                crate::kanban::CardStatus::Deferred,
+            )
+            .unwrap();
+        db.set_card_defer_fields(&due_id, "2020-01-01T00:00:00+00:00", "accepted")
+            .unwrap();
+
+        // Not due: deferred, wake_at in the future.
+        let future_id = db
+            .insert_card(
+                "legion",
+                "legion",
+                "not due yet",
+                None,
+                crate::kanban::Priority::Med,
+                None,
+                None,
+                None,
+                None,
+                None,
+                crate::kanban::CardStatus::Deferred,
+            )
+            .unwrap();
+        db.set_card_defer_fields(&future_id, "2099-01-01T00:00:00+00:00", "accepted")
+            .unwrap();
+
+        // Not deferred at all -- must never appear regardless of wake_at.
+        db.insert_card(
+            "legion",
+            "legion",
+            "plain accepted card",
+            None,
+            crate::kanban::Priority::Med,
+            None,
+            None,
+            None,
+            None,
+            None,
+            crate::kanban::CardStatus::Accepted,
+        )
+        .unwrap();
+
+        let now = chrono::Utc::now().to_rfc3339();
+        let due = db.get_deferred_cards_due(&now).unwrap();
+        assert_eq!(due.len(), 1);
+        assert_eq!(due[0].id, due_id);
+    }
+
+    #[test]
+    fn get_cards_working_set_excludes_deferred() {
+        let db = test_db();
+        let deferred_id = db
+            .insert_card(
+                "legion",
+                "legion",
+                "deferred card",
+                None,
+                crate::kanban::Priority::Med,
+                None,
+                None,
+                None,
+                None,
+                None,
+                crate::kanban::CardStatus::Deferred,
+            )
+            .unwrap();
+        db.insert_card(
+            "legion",
+            "legion",
+            "accepted card",
+            None,
+            crate::kanban::Priority::Med,
+            None,
+            None,
+            None,
+            None,
+            None,
+            crate::kanban::CardStatus::Accepted,
+        )
+        .unwrap();
+
+        let working_set = db
+            .get_cards(
+                "legion",
+                crate::kanban::Direction::Inbound,
+                crate::kanban::CardScope::WorkingSet,
+            )
+            .unwrap();
+        assert_eq!(working_set.len(), 1, "WorkingSet must exclude Deferred");
+        assert!(working_set.iter().all(|c| c.id != deferred_id));
+
+        // But it must still be visible via the dedicated Deferred scope --
+        // never silently uncounted (#798's lesson applied to a new status).
+        let deferred_scope = db
+            .get_cards(
+                "legion",
+                crate::kanban::Direction::Inbound,
+                crate::kanban::CardScope::Deferred,
+            )
+            .unwrap();
+        assert_eq!(deferred_scope.len(), 1);
+        assert_eq!(deferred_scope[0].id, deferred_id);
     }
 
     /// Transactional sync: transitioning a bound card to "done" updates BOTH

--- a/src/db/kanban.rs
+++ b/src/db/kanban.rs
@@ -538,19 +538,36 @@ impl Database {
             .map_err(LegionError::Database)
     }
 
-    /// Stamp `wake_at`/`pre_defer_status` on a card entering (or
-    /// re-entering) `Deferred` (#816). Called by `kanban::defer_card` right
-    /// after the status transition commits, mirroring how `delegate_card`
-    /// links the wake_attempts row after `transition_card` succeeds.
-    pub fn set_card_defer_fields(
+    /// Atomically transition a card to `Deferred` and stamp `wake_at`/
+    /// `pre_defer_status` (#816 review fix, HIGH): the previous shape called
+    /// `transition_card_status_with_sync` and a separate field-stamp as two
+    /// writes. A crash (or a `set_card_defer_fields`-style error) between
+    /// them left a `Deferred` card with `wake_at = NULL` -- and
+    /// `get_deferred_cards_due`'s `wake_at IS NOT NULL` filter permanently
+    /// excludes such a row from the sweep, unlike `Delegated`'s equivalent
+    /// partial-failure window (`get_delegated_cards` has no link-presence
+    /// filter, so it stays reapable either way). A single `UPDATE` statement
+    /// is atomic by construction (SQLite commits or rolls back one
+    /// statement as a unit even outside an explicit transaction), so this
+    /// closes the gap without needing `unchecked_transaction`.
+    ///
+    /// `kanban::defer_card` is the only caller; it does not sync a bound
+    /// document the way `transition_card_status_with_sync` does for other
+    /// transitions, because `requirement_status_for_card_status` maps
+    /// `Deferred` to `None` (deferring carries no spec meaning).
+    pub fn set_card_deferred(
         &self,
         id: &str,
+        note: Option<&str>,
         wake_at: &str,
         pre_defer_status: &str,
     ) -> Result<()> {
+        let now = chrono::Utc::now().to_rfc3339();
         let rows = self.conn.execute(
-            "UPDATE tasks SET wake_at = ?1, pre_defer_status = ?2 WHERE id = ?3 AND deleted_at IS NULL",
-            rusqlite::params![wake_at, pre_defer_status, id],
+            "UPDATE tasks SET status = 'deferred', note = COALESCE(?1, note), \
+             wake_at = ?2, pre_defer_status = ?3, updated_at = ?4 \
+             WHERE id = ?5 AND deleted_at IS NULL",
+            rusqlite::params![note, wake_at, pre_defer_status, now, id],
         )?;
         if rows == 0 {
             return Err(LegionError::CardNotFound(id.to_string()));
@@ -1593,13 +1610,14 @@ mod tests {
     }
 
     #[test]
-    fn set_and_clear_card_defer_fields_round_trip() {
+    fn set_card_deferred_and_clear_defer_fields_round_trip() {
         let db = test_db();
         let id = insert_test_card(&db);
 
-        db.set_card_defer_fields(&id, "2099-01-01T00:00:00+00:00", "accepted")
-            .expect("set defer fields");
+        db.set_card_deferred(&id, None, "2099-01-01T00:00:00+00:00", "accepted")
+            .expect("set deferred");
         let card = db.get_card_by_id(&id).expect("get").expect("exists");
+        assert_eq!(card.status.to_string(), "deferred");
         assert_eq!(card.wake_at.as_deref(), Some("2099-01-01T00:00:00+00:00"));
         assert_eq!(card.pre_defer_status.as_deref(), Some("accepted"));
 
@@ -1610,10 +1628,27 @@ mod tests {
     }
 
     #[test]
-    fn set_card_defer_fields_reports_not_found() {
+    fn set_card_deferred_sets_note_and_reports_not_found() {
         let db = test_db();
+        let id = insert_test_card(&db);
+
+        db.set_card_deferred(
+            &id,
+            Some("deferred for now"),
+            "2099-01-01T00:00:00+00:00",
+            "accepted",
+        )
+        .expect("set deferred with note");
+        let card = db.get_card_by_id(&id).expect("get").expect("exists");
+        assert_eq!(card.note.as_deref(), Some("deferred for now"));
+
         let err = db
-            .set_card_defer_fields("nonexistent-id", "2099-01-01T00:00:00+00:00", "accepted")
+            .set_card_deferred(
+                "nonexistent-id",
+                None,
+                "2099-01-01T00:00:00+00:00",
+                "accepted",
+            )
             .unwrap_err();
         assert!(matches!(err, LegionError::CardNotFound(_)));
     }
@@ -1638,7 +1673,7 @@ mod tests {
                 crate::kanban::CardStatus::Deferred,
             )
             .unwrap();
-        db.set_card_defer_fields(&due_id, "2020-01-01T00:00:00+00:00", "accepted")
+        db.set_card_deferred(&due_id, None, "2020-01-01T00:00:00+00:00", "accepted")
             .unwrap();
 
         // Not due: deferred, wake_at in the future.
@@ -1657,7 +1692,7 @@ mod tests {
                 crate::kanban::CardStatus::Deferred,
             )
             .unwrap();
-        db.set_card_defer_fields(&future_id, "2099-01-01T00:00:00+00:00", "accepted")
+        db.set_card_deferred(&future_id, None, "2099-01-01T00:00:00+00:00", "accepted")
             .unwrap();
 
         // Not deferred at all -- must never appear regardless of wake_at.

--- a/src/error.rs
+++ b/src/error.rs
@@ -262,6 +262,13 @@ pub enum LegionError {
     /// unparsed date.
     #[error("unparseable date '{input}' -- accepted: YYYY-MM-DD, <N>d, <N>w, today, yesterday")]
     InvalidDateFilter { input: String },
+
+    /// `legion kanban defer --until <input>` parsed to a time that is not
+    /// after now (#816). Names both the raw input and the resolved wake_at
+    /// so a stale absolute date or a same-day `today` is diagnosable from
+    /// the error alone.
+    #[error("cannot defer: '{input}' resolved to {wake_at}, which is not in the future")]
+    DeferWakeAtInPast { input: String, wake_at: String },
 }
 
 pub type Result<T> = std::result::Result<T, LegionError>;
@@ -435,5 +442,17 @@ mod tests {
             stderr: "! [rejected]".to_string(),
         };
         assert!(err.to_string().contains("! [rejected]"));
+    }
+
+    #[test]
+    fn defer_wake_at_in_past_display() {
+        let err = LegionError::DeferWakeAtInPast {
+            input: "yesterday".to_string(),
+            wake_at: "2026-07-01T00:00:00+00:00".to_string(),
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("yesterday"));
+        assert!(msg.contains("2026-07-01T00:00:00+00:00"));
+        assert!(msg.contains("not in the future"));
     }
 }

--- a/src/kanban/format.rs
+++ b/src/kanban/format.rs
@@ -84,10 +84,19 @@ pub fn format_card_list(cards: &[Card], repo: &str, direction: Direction) -> Str
             .as_deref()
             .map(|u| format!(" <{}>", u))
             .unwrap_or_default();
+        // #816 review (MED): a deferred card's wake_at must be visible in
+        // the same list output that shows every other card -- the #798
+        // lesson (a status detail that only lives in `view`/`--json` is
+        // half-visible) applied to the new field, not just the new status.
+        let wake_part = c
+            .wake_at
+            .as_deref()
+            .map(|w| format!(" [wakes:{}]", crate::db::format_date(w)))
+            .unwrap_or_default();
         let date = crate::db::format_date(&c.created_at);
         output.push_str(&format!(
-            "- [{}] {}{}{} ({}, {}{}) {}\n",
-            c.status, c.text, prio, source_part, peer, date, note_part, c.id
+            "- [{}] {}{}{}{} ({}, {}{}) {}\n",
+            c.status, c.text, prio, source_part, wake_part, peer, date, note_part, c.id
         ));
 
         if let Some(summary) = crate::card_parse::card_summary(
@@ -118,6 +127,8 @@ pub struct CardSummary {
     pub updated_at: String,
     pub labels: Vec<String>,
     pub source_url: Option<String>,
+    /// Scheduled wake time (#816), present only while `status == deferred`.
+    pub wake_at: Option<String>,
 }
 
 /// Derive a display title from the card text field.
@@ -154,6 +165,12 @@ pub fn format_card_view(card: &Card) -> String {
     ));
     out.push_str(&format!("Created: {}\n", card.created_at));
     out.push_str(&format!("Updated: {}\n", card.updated_at));
+
+    // #816 review (MED): visible in `view` alongside every other status
+    // detail, not only reachable through `--json`.
+    if let Some(ref wake_at) = card.wake_at {
+        out.push_str(&format!("Wake at: {}\n", wake_at));
+    }
 
     if let Some(ref labels) = card.labels
         && !labels.is_empty()
@@ -212,6 +229,7 @@ pub fn format_card_list_json(cards: &[Card]) -> crate::error::Result<String> {
             updated_at: card.updated_at.clone(),
             labels: labels_to_vec(card.labels.as_deref()),
             source_url: card.source_url.clone(),
+            wake_at: card.wake_at.clone(),
         };
         out.push_str(&serde_json::to_string(&summary)?);
         out.push('\n');
@@ -470,6 +488,153 @@ mod tests {
         assert!(output.contains("## Context"), "context section present");
         assert!(output.contains("raw context text"));
         assert!(!output.contains("## Problem"), "no problem section");
+    }
+
+    // -- wake_at visibility (#816 review, MED: a deferred card's wake time
+    // must be visible in list/view output, not only reachable via
+    // view --json's full-struct serialization) --------------------------
+
+    #[test]
+    fn format_card_view_shows_wake_at_when_deferred() {
+        let (db, _index, _dir) = test_storage();
+
+        let id = create_card(
+            &db,
+            "sean",
+            "kelex",
+            "defer me",
+            None,
+            Priority::Med,
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+        .expect("create");
+        transition_card(&db, &id, Action::Assign, None).expect("assign");
+        transition_card(&db, &id, Action::Accept, None).expect("accept");
+        let card = defer_card(&db, &id, "2099-01-01T00:00:00+00:00", None).expect("defer");
+
+        let output = format_card_view(&card);
+        assert!(
+            output.contains("Wake at: 2099-01-01T00:00:00+00:00"),
+            "expected wake_at in view output, got: {output}"
+        );
+    }
+
+    #[test]
+    fn format_card_view_omits_wake_at_when_not_deferred() {
+        let (db, _index, _dir) = test_storage();
+
+        let id = create_card(
+            &db,
+            "sean",
+            "kelex",
+            "never deferred",
+            None,
+            Priority::Med,
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+        .expect("create");
+        let card = db.get_card_by_id(&id).expect("get").expect("exists");
+
+        let output = format_card_view(&card);
+        assert!(!output.contains("Wake at:"), "got: {output}");
+    }
+
+    #[test]
+    fn format_card_list_shows_wake_at_when_deferred() {
+        let (db, _index, _dir) = test_storage();
+
+        let id = create_card(
+            &db,
+            "sean",
+            "kelex",
+            "defer me too",
+            None,
+            Priority::Med,
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+        .expect("create");
+        transition_card(&db, &id, Action::Assign, None).expect("assign");
+        transition_card(&db, &id, Action::Accept, None).expect("accept");
+        defer_card(&db, &id, "2099-06-15T00:00:00+00:00", None).expect("defer");
+
+        let cards = list_cards(&db, "kelex", Direction::Inbound, CardScope::Deferred)
+            .expect("list deferred");
+        let output = format_card_list(&cards, "kelex", Direction::Inbound);
+        assert!(
+            output.contains("[wakes:2099-06-15]"),
+            "expected date-only wake marker in list output, got: {output}"
+        );
+    }
+
+    #[test]
+    fn format_card_list_json_includes_wake_at() {
+        let (db, _index, _dir) = test_storage();
+
+        let id = create_card(
+            &db,
+            "sean",
+            "kelex",
+            "json defer",
+            None,
+            Priority::Med,
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+        .expect("create");
+        transition_card(&db, &id, Action::Assign, None).expect("assign");
+        transition_card(&db, &id, Action::Accept, None).expect("accept");
+        defer_card(&db, &id, "2099-03-03T00:00:00+00:00", None).expect("defer");
+
+        let cards = list_cards(&db, "kelex", Direction::Inbound, CardScope::Deferred)
+            .expect("list deferred");
+        let output = format_card_list_json(&cards).expect("json");
+        let line = output.lines().next().expect("has output");
+        let parsed: serde_json::Value = serde_json::from_str(line).expect("valid JSON");
+        assert_eq!(
+            parsed["wake_at"].as_str(),
+            Some("2099-03-03T00:00:00+00:00")
+        );
+    }
+
+    #[test]
+    fn format_card_list_json_wake_at_is_null_when_not_deferred() {
+        let (db, _index, _dir) = test_storage();
+
+        create_card(
+            &db,
+            "sean",
+            "kelex",
+            "not deferred",
+            None,
+            Priority::Med,
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+        .expect("create");
+
+        let cards = list_cards(&db, "kelex", Direction::Inbound, CardScope::All).expect("list");
+        let output = format_card_list_json(&cards).expect("json");
+        let line = output.lines().next().expect("has output");
+        let parsed: serde_json::Value = serde_json::from_str(line).expect("valid JSON");
+        assert!(parsed["wake_at"].is_null());
     }
 
     #[test]

--- a/src/kanban/format.rs
+++ b/src/kanban/format.rs
@@ -294,6 +294,8 @@ mod tests {
             solution: None,
             acceptance: None,
             document_id: None,
+            wake_at: None,
+            pre_defer_status: None,
         };
         let output = format_work_card(&card);
         assert!(output.contains("Priority: high"));
@@ -335,6 +337,8 @@ mod tests {
             solution: None,
             acceptance: None,
             document_id: None,
+            wake_at: None,
+            pre_defer_status: None,
         };
         let output = format_work_card(&card);
         assert!(output.contains("minimal card"));
@@ -368,6 +372,8 @@ mod tests {
             solution: None,
             acceptance: ac.map(str::to_string),
             document_id: None,
+            wake_at: None,
+            pre_defer_status: None,
         };
 
         // An Accepted card with AC becomes the goal, listing its criteria.
@@ -416,6 +422,8 @@ mod tests {
             solution: Some("Fix them".to_string()),
             acceptance: Some("Tests pass\nClipy clean".to_string()),
             document_id: None,
+            wake_at: None,
+            pre_defer_status: None,
         };
         let output = format_card_view(&card);
         assert!(output.contains("Test Card"), "title derived correctly");
@@ -455,6 +463,8 @@ mod tests {
             solution: None,
             acceptance: None,
             document_id: None,
+            wake_at: None,
+            pre_defer_status: None,
         };
         let output = format_card_view(&card);
         assert!(output.contains("## Context"), "context section present");
@@ -487,6 +497,8 @@ mod tests {
             solution: None,
             acceptance: None,
             document_id: None,
+            wake_at: None,
+            pre_defer_status: None,
         };
         let json = format_card_json(&card).expect("json");
         let parsed: serde_json::Value = serde_json::from_str(&json).expect("parse");

--- a/src/kanban/mod.rs
+++ b/src/kanban/mod.rs
@@ -390,6 +390,13 @@ pub fn undelegate_card(db: &Database, id: &str, note: Option<&str>) -> Result<Ca
 /// the existing stored value is kept, not overwritten with `"deferred"`:
 /// a chain of `defer` calls must always revert to the ORIGINAL pre-defer
 /// status, never to the deferred state itself.
+///
+/// The status transition and the `wake_at`/`pre_defer_status` stamp write
+/// together via `Database::set_card_deferred` (#816 review fix, HIGH): an
+/// earlier version wrote them as two separate steps, so a crash between
+/// them could leave a `Deferred` card with `wake_at = NULL` --
+/// permanently un-reapable, since `get_deferred_cards_due` requires
+/// `wake_at IS NOT NULL`.
 pub fn defer_card(db: &Database, id: &str, wake_at: &str, note: Option<&str>) -> Result<Card> {
     let card = db
         .get_card_by_id(id)?
@@ -409,8 +416,7 @@ pub fn defer_card(db: &Database, id: &str, wake_at: &str, note: Option<&str>) ->
         card.status.to_string()
     };
 
-    transition_card(db, id, Action::Defer, note)?;
-    db.set_card_defer_fields(id, wake_at, &pre_defer_status)?;
+    db.set_card_deferred(id, note, wake_at, &pre_defer_status)?;
     db.get_card_by_id(id)?
         .ok_or_else(|| LegionError::CardNotFound(id.to_string()))
 }
@@ -432,6 +438,15 @@ pub fn defer_card(db: &Database, id: &str, wake_at: &str, note: Option<&str>) ->
 /// revert target is computed or on clearing the link (the #679 "one
 /// predicate, not one per call site" lesson, mirrored from
 /// `undelegate_card`).
+///
+/// A `Deferred` card with no stored `pre_defer_status` is a hard error, not
+/// a silent guess (#816 review fix, MED): an earlier version fell back to
+/// `"accepted"`, which disagreed with `defer_card`'s own integrity check
+/// (the same corruption is an error there) and would silently mis-revert a
+/// card actually deferred from `Pending`. `defer_card` now writes
+/// `wake_at`/`pre_defer_status` atomically with the status transition, so
+/// this case should be unreachable in practice; erroring here keeps that an
+/// enforced invariant rather than an assumption.
 pub fn undefer_card(db: &Database, id: &str, note: Option<&str>) -> Result<Card> {
     let card = db
         .get_card_by_id(id)?
@@ -440,7 +455,11 @@ pub fn undefer_card(db: &Database, id: &str, note: Option<&str>) -> Result<Card>
     // Validates the action is legal from the card's current status.
     transition(card.status, Action::Undefer)?;
 
-    let pre_defer_status = card.pre_defer_status.as_deref().unwrap_or("accepted");
+    let pre_defer_status = card.pre_defer_status.as_deref().ok_or_else(|| {
+        LegionError::WorkSource(format!(
+            "card '{id}' is Deferred but has no stored pre_defer_status -- data integrity error"
+        ))
+    })?;
     let target = CardStatus::from_str(pre_defer_status)?;
 
     db.transition_card_status_with_sync(
@@ -1180,6 +1199,33 @@ mod tests {
 
         let err = undefer_card(&db, &id, None).expect_err("undefer on non-deferred must refuse");
         assert!(matches!(err, LegionError::InvalidCardTransition { .. }));
+    }
+
+    /// Review regression (#816, MED): `undefer_card` must hard-error on a
+    /// `Deferred` card with no stored `pre_defer_status`, not silently
+    /// guess `"accepted"`. `defer_card`'s atomic `set_card_deferred` write
+    /// makes this state unreachable through normal defer/undefer traffic,
+    /// so it is constructed here via `force_move_card` (the FSM-bypassing
+    /// admin path) the same way `defer_card`'s own integrity check is
+    /// exercised: both sibling functions must treat the same corruption
+    /// the same way, symmetrically, per the review finding.
+    #[test]
+    fn undefer_card_refuses_when_pre_defer_status_is_missing() {
+        let (db, _index, _dir) = test_storage();
+
+        let id = create_and_assign(&db, "kelex", "legion", "corrupted defer", Priority::Med);
+        transition_card(&db, &id, Action::Accept, None).expect("accept");
+        // Bypass the FSM to land in Deferred with no wake_at/pre_defer_status
+        // stamped -- the exact corruption defer_card's atomic write prevents
+        // in practice, reproduced here to prove undefer_card refuses it.
+        force_move(&db, &id, CardStatus::Deferred, None).expect("force move to deferred");
+
+        let err = undefer_card(&db, &id, None)
+            .expect_err("undefer on a Deferred card with no pre_defer_status must refuse");
+        assert!(
+            matches!(err, LegionError::WorkSource(_)),
+            "expected a data-integrity WorkSource error, got: {err:?}"
+        );
     }
 
     #[test]

--- a/src/kanban/mod.rs
+++ b/src/kanban/mod.rs
@@ -43,6 +43,14 @@ pub struct Card {
     /// `verification.acceptance` block overrides `tasks.acceptance` as the
     /// source of acceptance criteria for `legion verify`.
     pub document_id: Option<String>,
+    /// Scheduled wake time (RFC3339), set while `status == Deferred` (#816).
+    /// `None` for a card that has never been deferred or has since woken.
+    pub wake_at: Option<String>,
+    /// The status this card was in immediately before deferring (#816):
+    /// `Defer` is legal from both `Accepted` and `Pending`, so the revert
+    /// target on wake is data-dependent and stored here rather than fixed
+    /// by the state machine. `None` outside of `Deferred`.
+    pub pre_defer_status: Option<String>,
 }
 
 /// Per-agent workload summary for the dashboard agent strip.
@@ -87,6 +95,8 @@ pub fn map_card_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<Card> {
         solution: row.get(19)?,
         acceptance: row.get(20)?,
         document_id: row.get(21)?,
+        wake_at: row.get(22)?,
+        pre_defer_status: row.get(23)?,
     })
 }
 
@@ -102,12 +112,17 @@ pub enum Direction {
 /// Which slice of the board to return when listing cards.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum CardScope {
-    /// Active work only: Pending, Accepted, NeedsInput, InReview, Blocked.
-    /// Excludes Backlog (pre-consensus) and terminal (Done, Cancelled). This is
-    /// the default for `kanban list` and the SessionStart "Current work" banner.
+    /// Active work only: Pending, Accepted, NeedsInput, InReview, Blocked,
+    /// Delegated. Excludes Backlog (pre-consensus), Deferred (consciously
+    /// put off, #816), and terminal (Done, Cancelled). This is the default
+    /// for `kanban list` and the SessionStart "Current work" banner.
     WorkingSet,
     /// The raw, unconsented inbox: Backlog cards only.
     Backlog,
+    /// Cards deliberately put off until a future time (#816): the dedicated
+    /// visibility bucket for `Deferred`, since it is excluded from
+    /// `WorkingSet` and must never be silently uncounted (the #798 lesson).
+    Deferred,
     /// Everything non-deleted, regardless of status.
     All,
 }
@@ -359,6 +374,86 @@ pub fn undelegate_card(db: &Database, id: &str, note: Option<&str>) -> Result<Ca
     let card = transition_card(db, id, Action::Undelegate, note)?;
     db.clear_wake_attempt_card(id)?;
     Ok(card)
+}
+
+/// Defer a card to a future `wake_at` (#816).
+///
+/// Legal from `Accepted` or `Pending` (validated by `transition`), and
+/// legal as a re-defer from `Deferred` itself (updates `wake_at` in place).
+/// `wake_at` must already be validated as a future RFC3339 timestamp by the
+/// caller (the CLI layer parses `--until` and refuses a past time before
+/// this is ever reached; see `LegionError::DeferWakeAtInPast`).
+///
+/// `pre_defer_status` -- the revert target `undefer_card` and the
+/// `tick_health` sweep will use -- is captured from the card's CURRENT
+/// status on first defer. On re-defer (current status already `Deferred`)
+/// the existing stored value is kept, not overwritten with `"deferred"`:
+/// a chain of `defer` calls must always revert to the ORIGINAL pre-defer
+/// status, never to the deferred state itself.
+pub fn defer_card(db: &Database, id: &str, wake_at: &str, note: Option<&str>) -> Result<Card> {
+    let card = db
+        .get_card_by_id(id)?
+        .ok_or_else(|| LegionError::CardNotFound(id.to_string()))?;
+
+    // Validates the action is legal from the card's current status (errors
+    // for anything other than Accepted/Pending/Deferred).
+    transition(card.status, Action::Defer)?;
+
+    let pre_defer_status: String = if card.status == CardStatus::Deferred {
+        card.pre_defer_status.clone().ok_or_else(|| {
+            LegionError::WorkSource(format!(
+                "card '{id}' is Deferred but has no stored pre_defer_status -- data integrity error"
+            ))
+        })?
+    } else {
+        card.status.to_string()
+    };
+
+    transition_card(db, id, Action::Defer, note)?;
+    db.set_card_defer_fields(id, wake_at, &pre_defer_status)?;
+    db.get_card_by_id(id)?
+        .ok_or_else(|| LegionError::CardNotFound(id.to_string()))
+}
+
+/// Undefer a card (#816): the inverse of `defer_card`. Reverts `Deferred`
+/// to whichever status the card was deferred FROM -- `Accepted` or
+/// `Pending`, read from the card's own `pre_defer_status` -- and clears
+/// both defer fields so a resolved defer never leaves a stale `wake_at`
+/// behind (mirroring `undelegate_card`'s `clear_wake_attempt_card` call).
+///
+/// The pure `transition` function only knows a single (conservative)
+/// target for `(Deferred, Undefer)`; the real target is data-dependent (see
+/// `kanban::state`'s doc comment on that match arm), so this function reads
+/// `pre_defer_status` directly rather than trusting `transition`'s return
+/// value for the write.
+///
+/// Used by both the manual `legion kanban undefer` CLI path and
+/// `tick_health`'s auto-wake sweep, so the two can never diverge on how the
+/// revert target is computed or on clearing the link (the #679 "one
+/// predicate, not one per call site" lesson, mirrored from
+/// `undelegate_card`).
+pub fn undefer_card(db: &Database, id: &str, note: Option<&str>) -> Result<Card> {
+    let card = db
+        .get_card_by_id(id)?
+        .ok_or_else(|| LegionError::CardNotFound(id.to_string()))?;
+
+    // Validates the action is legal from the card's current status.
+    transition(card.status, Action::Undefer)?;
+
+    let pre_defer_status = card.pre_defer_status.as_deref().unwrap_or("accepted");
+    let target = CardStatus::from_str(pre_defer_status)?;
+
+    db.transition_card_status_with_sync(
+        id,
+        &target.to_string(),
+        note,
+        timestamp_for_action(&Action::Undefer),
+        card.document_id.as_deref(),
+        Some(&card.status.to_string()),
+    )?;
+    db.clear_card_defer_fields(id)?;
+    db.get_card_by_id(id)?
+        .ok_or_else(|| LegionError::CardNotFound(id.to_string()))
 }
 
 /// Bind a document to a card (manual path; spec-gen uses the atomic insert).
@@ -984,6 +1079,120 @@ mod tests {
                 .expect("liveness check"),
             "the live delegation to b must read as live, unaffected by a's terminal outcome"
         );
+    }
+
+    // -- defer_card / undefer_card (#816) -------------------------------------
+
+    #[test]
+    fn defer_card_from_accepted_stores_wake_at_and_pre_defer_status() {
+        let (db, _index, _dir) = test_storage();
+
+        let id = create_and_assign(&db, "kelex", "legion", "defer me", Priority::Med);
+        transition_card(&db, &id, Action::Accept, None).expect("accept");
+
+        let card = defer_card(&db, &id, "2099-01-01T00:00:00+00:00", None).expect("defer");
+        assert_eq!(card.status, CardStatus::Deferred);
+        assert_eq!(card.wake_at.as_deref(), Some("2099-01-01T00:00:00+00:00"));
+        assert_eq!(card.pre_defer_status.as_deref(), Some("accepted"));
+    }
+
+    #[test]
+    fn defer_card_from_pending_stores_pending_as_pre_defer_status() {
+        let (db, _index, _dir) = test_storage();
+
+        // create_and_assign leaves the card Pending (not yet Accepted).
+        let id = create_and_assign(&db, "kelex", "legion", "defer while ready", Priority::Med);
+
+        let card = defer_card(&db, &id, "2099-01-01T00:00:00+00:00", None).expect("defer");
+        assert_eq!(card.status, CardStatus::Deferred);
+        assert_eq!(
+            card.pre_defer_status.as_deref(),
+            Some("pending"),
+            "a card deferred from Pending must revert to Pending, not Accepted"
+        );
+    }
+
+    #[test]
+    fn defer_card_refuses_from_needs_input() {
+        let (db, _index, _dir) = test_storage();
+
+        let id = create_and_assign(&db, "kelex", "legion", "not deferrable", Priority::Med);
+        transition_card(&db, &id, Action::Accept, None).expect("accept");
+        transition_card(&db, &id, Action::NeedInput, None).expect("need-input");
+
+        let err = defer_card(&db, &id, "2099-01-01T00:00:00+00:00", None)
+            .expect_err("defer from needs-input must be refused");
+        assert!(matches!(err, LegionError::InvalidCardTransition { .. }));
+    }
+
+    #[test]
+    fn redefer_updates_wake_at_and_keeps_original_pre_defer_status() {
+        let (db, _index, _dir) = test_storage();
+
+        let id = create_and_assign(&db, "kelex", "legion", "redefer me", Priority::Med);
+        transition_card(&db, &id, Action::Accept, None).expect("accept");
+        defer_card(&db, &id, "2099-01-01T00:00:00+00:00", None).expect("first defer");
+
+        // Re-defer with a later wake_at -- must stay Deferred, update
+        // wake_at, and keep pre_defer_status as the ORIGINAL "accepted",
+        // not overwrite it with "deferred".
+        let card = defer_card(&db, &id, "2100-06-01T00:00:00+00:00", None).expect("second defer");
+        assert_eq!(card.status, CardStatus::Deferred);
+        assert_eq!(card.wake_at.as_deref(), Some("2100-06-01T00:00:00+00:00"));
+        assert_eq!(card.pre_defer_status.as_deref(), Some("accepted"));
+    }
+
+    #[test]
+    fn undefer_card_reverts_to_accepted_and_clears_defer_fields() {
+        let (db, _index, _dir) = test_storage();
+
+        let id = create_and_assign(&db, "kelex", "legion", "undefer me", Priority::Med);
+        transition_card(&db, &id, Action::Accept, None).expect("accept");
+        defer_card(&db, &id, "2099-01-01T00:00:00+00:00", None).expect("defer");
+
+        let card = undefer_card(&db, &id, None).expect("undefer");
+        assert_eq!(card.status, CardStatus::Accepted);
+        assert!(card.wake_at.is_none());
+        assert!(card.pre_defer_status.is_none());
+    }
+
+    #[test]
+    fn undefer_card_reverts_to_pending_when_deferred_from_pending() {
+        let (db, _index, _dir) = test_storage();
+
+        let id = create_and_assign(&db, "kelex", "legion", "undefer to pending", Priority::Med);
+        defer_card(&db, &id, "2099-01-01T00:00:00+00:00", None).expect("defer from pending");
+
+        let card = undefer_card(&db, &id, None).expect("undefer");
+        assert_eq!(
+            card.status,
+            CardStatus::Pending,
+            "must revert to Pending, the status it was deferred from"
+        );
+    }
+
+    #[test]
+    fn undefer_card_refuses_when_not_deferred() {
+        let (db, _index, _dir) = test_storage();
+
+        let id = create_and_assign(&db, "kelex", "legion", "not deferred", Priority::Med);
+        transition_card(&db, &id, Action::Accept, None).expect("accept");
+
+        let err = undefer_card(&db, &id, None).expect_err("undefer on non-deferred must refuse");
+        assert!(matches!(err, LegionError::InvalidCardTransition { .. }));
+    }
+
+    #[test]
+    fn defer_card_refuses_from_done() {
+        let (db, _index, _dir) = test_storage();
+
+        let id = create_and_assign(&db, "kelex", "legion", "already done", Priority::Med);
+        transition_card(&db, &id, Action::Accept, None).expect("accept");
+        transition_card(&db, &id, Action::Done, None).expect("done");
+
+        let err = defer_card(&db, &id, "2099-01-01T00:00:00+00:00", None)
+            .expect_err("defer on a Done card must be refused");
+        assert!(matches!(err, LegionError::InvalidCardTransition { .. }));
     }
 
     #[test]

--- a/src/kanban/state.rs
+++ b/src/kanban/state.rs
@@ -28,6 +28,16 @@ pub enum CardStatus {
     /// dark. Named for the stance ("running elsewhere"), not "awaiting"
     /// (a snooze button that primes dormancy -- see reflection 019e98f4).
     Delegated,
+    /// Deliberately put off until a future time (#816). Reachable from
+    /// `Accepted` or `Pending` -- unlike `Delegated`, the revert target on
+    /// wake is data-dependent (whichever of the two the card was in before
+    /// deferring), stored on the card as `pre_defer_status` rather than
+    /// fixed in this enum. `tick_health`'s sweep (mirroring #778's
+    /// delegated-reaper site) reverts the card and wakes its owner once
+    /// `wake_at` passes; `legion kanban undefer` does the same manually.
+    /// Excluded from `CardScope::WorkingSet` and the Stop in-progress gate
+    /// -- deferred work is consciously not "in progress right now."
+    Deferred,
     Done,
     Cancelled,
 }
@@ -42,6 +52,7 @@ impl fmt::Display for CardStatus {
             Self::InReview => write!(f, "in-review"),
             Self::Blocked => write!(f, "blocked"),
             Self::Delegated => write!(f, "delegated"),
+            Self::Deferred => write!(f, "deferred"),
             Self::Done => write!(f, "done"),
             Self::Cancelled => write!(f, "cancelled"),
         }
@@ -60,6 +71,7 @@ impl FromStr for CardStatus {
             "in-review" => Ok(Self::InReview),
             "blocked" => Ok(Self::Blocked),
             "delegated" => Ok(Self::Delegated),
+            "deferred" => Ok(Self::Deferred),
             "done" => Ok(Self::Done),
             "cancelled" => Ok(Self::Cancelled),
             other => Err(LegionError::InvalidCardStatus(other.to_string())),
@@ -78,6 +90,7 @@ impl CardStatus {
             Self::InReview => "In Review",
             Self::Blocked => "Blocked",
             Self::Delegated => "Delegated",
+            Self::Deferred => "Deferred",
             Self::Done => "Done",
             Self::Cancelled => "Cancelled",
         }
@@ -174,6 +187,17 @@ pub enum Action {
     /// card itself) or programmatically by `tick_health`'s auto-revert sweep
     /// when the delegated attempt is no longer live.
     Undelegate,
+    /// accepted | pending -> deferred (#816). Also legal from `Deferred`
+    /// itself (re-defer: updates `wake_at`, keeps the original
+    /// `pre_defer_status`). Refused from every other status, including
+    /// `Done`/`Cancelled`.
+    Defer,
+    /// deferred -> (accepted | pending), whichever the card was in before
+    /// deferring. Fired either manually (`legion kanban undefer`) or
+    /// programmatically by `tick_health`'s sweep once `wake_at` passes. The
+    /// concrete target is data-dependent (stored `pre_defer_status`), not
+    /// fixed by this action alone -- see `kanban::undefer_card`.
+    Undefer,
     /// needs-input | in-review -> accepted
     Resume,
     /// accepted | in-review -> done
@@ -197,6 +221,20 @@ pub fn transition(current: CardStatus, action: Action) -> Result<CardStatus> {
         (CardStatus::Blocked, Action::Unblock) => CardStatus::Accepted,
         (CardStatus::Accepted, Action::Delegate) => CardStatus::Delegated,
         (CardStatus::Delegated, Action::Undelegate) => CardStatus::Accepted,
+        (CardStatus::Accepted, Action::Defer) => CardStatus::Deferred,
+        (CardStatus::Pending, Action::Defer) => CardStatus::Deferred,
+        // Re-defer: legal from Deferred itself so `kanban::defer_card` can
+        // update `wake_at` in place without an intervening undefer.
+        (CardStatus::Deferred, Action::Defer) => CardStatus::Deferred,
+        // The concrete revert target is data-dependent (Accepted or Pending,
+        // whichever the card was deferred FROM) and lives in the card's
+        // stored `pre_defer_status`, which this pure (status, action)
+        // function has no access to. `Accepted` here is only the FSM
+        // legality answer for "is Undefer legal from Deferred" -- callers
+        // (`kanban::undefer_card`, the tick_health sweep) use this solely as
+        // a gate and independently read `pre_defer_status` for the actual
+        // write target. See `kanban::undefer_card`'s doc comment.
+        (CardStatus::Deferred, Action::Undefer) => CardStatus::Accepted,
         (CardStatus::NeedsInput, Action::Resume) => CardStatus::Accepted,
         // Verify (#520) runs after review and can find an unprovable criterion;
         // routing the card from InReview to NeedsInput lets a human adjudicate
@@ -232,6 +270,7 @@ mod tests {
             CardStatus::InReview,
             CardStatus::Blocked,
             CardStatus::Delegated,
+            CardStatus::Deferred,
             CardStatus::Done,
             CardStatus::Cancelled,
         ] {
@@ -247,6 +286,7 @@ mod tests {
         assert_eq!(CardStatus::Accepted.label(), "In Progress");
         assert_eq!(CardStatus::NeedsInput.label(), "Needs Input");
         assert_eq!(CardStatus::Delegated.label(), "Delegated");
+        assert_eq!(CardStatus::Deferred.label(), "Deferred");
     }
 
     // --- State machine tests ---
@@ -310,6 +350,7 @@ mod tests {
             CardStatus::InReview,
             CardStatus::Blocked,
             CardStatus::Delegated,
+            CardStatus::Deferred,
             CardStatus::Done,
             CardStatus::Cancelled,
         ] {
@@ -330,6 +371,7 @@ mod tests {
             CardStatus::NeedsInput,
             CardStatus::InReview,
             CardStatus::Blocked,
+            CardStatus::Deferred,
             CardStatus::Done,
             CardStatus::Cancelled,
         ] {
@@ -344,6 +386,78 @@ mod tests {
     #[test]
     fn cancel_from_delegated() {
         let result = transition(CardStatus::Delegated, Action::Cancel);
+        assert_eq!(result.expect("cancel"), CardStatus::Cancelled);
+    }
+
+    // --- Deferred state (#816) ---
+
+    #[test]
+    fn defer_from_accepted() {
+        let result = transition(CardStatus::Accepted, Action::Defer);
+        assert_eq!(result.expect("defer"), CardStatus::Deferred);
+    }
+
+    #[test]
+    fn defer_from_pending() {
+        let result = transition(CardStatus::Pending, Action::Defer);
+        assert_eq!(result.expect("defer"), CardStatus::Deferred);
+    }
+
+    #[test]
+    fn redefer_from_deferred_is_legal() {
+        let result = transition(CardStatus::Deferred, Action::Defer);
+        assert_eq!(result.expect("re-defer"), CardStatus::Deferred);
+    }
+
+    #[test]
+    fn undefer_from_deferred_is_legal() {
+        // The FSM-level answer is Accepted; the concrete revert target
+        // (Accepted vs Pending) is resolved by `kanban::undefer_card` from
+        // the card's stored `pre_defer_status`, not by this pure function.
+        let result = transition(CardStatus::Deferred, Action::Undefer);
+        assert_eq!(result.expect("undefer"), CardStatus::Accepted);
+    }
+
+    #[test]
+    fn cannot_defer_from_non_accepted_non_pending_states() {
+        for status in [
+            CardStatus::Backlog,
+            CardStatus::NeedsInput,
+            CardStatus::InReview,
+            CardStatus::Blocked,
+            CardStatus::Delegated,
+            CardStatus::Done,
+            CardStatus::Cancelled,
+        ] {
+            let result = transition(status, Action::Defer);
+            assert!(result.is_err(), "defer should be rejected from {status:?}");
+        }
+    }
+
+    #[test]
+    fn cannot_undefer_from_non_deferred_states() {
+        for status in [
+            CardStatus::Backlog,
+            CardStatus::Pending,
+            CardStatus::Accepted,
+            CardStatus::NeedsInput,
+            CardStatus::InReview,
+            CardStatus::Blocked,
+            CardStatus::Delegated,
+            CardStatus::Done,
+            CardStatus::Cancelled,
+        ] {
+            let result = transition(status, Action::Undefer);
+            assert!(
+                result.is_err(),
+                "undefer should be rejected from {status:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn cancel_from_deferred() {
+        let result = transition(CardStatus::Deferred, Action::Cancel);
         assert_eq!(result.expect("cancel"), CardStatus::Cancelled);
     }
 
@@ -381,6 +495,7 @@ mod tests {
             CardStatus::InReview,
             CardStatus::Blocked,
             CardStatus::Delegated,
+            CardStatus::Deferred,
         ] {
             let result = transition(status, Action::Cancel);
             assert_eq!(result.expect("cancel"), CardStatus::Cancelled);

--- a/src/timerange.rs
+++ b/src/timerange.rs
@@ -167,6 +167,48 @@ fn day_start_utc(date: Date) -> Result<String> {
     ))
 }
 
+/// Parse a single forward-looking point in time for scheduling callers
+/// (`legion kanban defer --until`, #816), reusing the same token shapes as
+/// [`parse_date`]'s grammar (`YYYY-MM-DD`, `<N>d`, `<N>w`, `today`) but
+/// applying the relative forms FORWARD (`checked_add`) instead of backward.
+///
+/// This is deliberately a sibling of `parse_date`, not a shared call into
+/// it: `parse_date` filters `created_at` on historical records, so its
+/// relative forms subtract from today (`<N>d` = N days ago). A defer target
+/// is inherently forward-looking -- reusing `parse_date` verbatim would
+/// silently compute `--until 3d` as three days in the past. `yesterday` is
+/// deliberately not accepted here (nonsensical for a future wake time); the
+/// literal absolute/relative token shapes are otherwise identical so the
+/// grammar itself is never invented twice.
+///
+/// Returns the UTC RFC3339 timestamp for local midnight of the resolved
+/// date (day granularity only, matching `TimeRange`'s own precision --
+/// callers needing minute-level scheduling are out of scope for #816).
+/// Callers are responsible for rejecting a resolved time that has already
+/// passed (e.g. `today`, always local midnight, is always in the past by
+/// the time this returns) -- this function only parses the grammar.
+pub fn parse_point_in_time(input: &str) -> Result<String> {
+    let trimmed = input.trim();
+    let invalid = || LegionError::InvalidDateFilter {
+        input: input.to_string(),
+    };
+    let today = || Zoned::now().date();
+
+    let date: Date = if trimmed == "today" {
+        today()
+    } else if let Some(digits) = trimmed.strip_suffix('d') {
+        let n: i64 = digits.parse().map_err(|_| invalid())?;
+        today().checked_add(n.days()).map_err(|_| invalid())?
+    } else if let Some(digits) = trimmed.strip_suffix('w') {
+        let n: i64 = digits.parse().map_err(|_| invalid())?;
+        today().checked_add(n.weeks()).map_err(|_| invalid())?
+    } else {
+        trimmed.parse::<Date>().map_err(|_| invalid())?
+    };
+
+    day_start_utc(date)
+}
+
 /// Parse one `--since`/`--until`/`--on` value against the accepted
 /// grammar: `YYYY-MM-DD`, `<N>d`, `<N>w`, `today`, `yesterday`.
 fn parse_date(input: &str) -> Result<Date> {
@@ -312,5 +354,58 @@ mod tests {
         let clause = TimeRange::sql_clause(3);
         assert!(clause.contains("?3 IS NULL OR created_at >= ?3"));
         assert!(clause.contains("?4 IS NULL OR created_at < ?4"));
+    }
+
+    // --- parse_point_in_time (#816) ---
+
+    #[test]
+    fn point_in_time_parses_absolute_date() {
+        let ts = parse_point_in_time("2099-01-01").expect("parse");
+        assert!(ts.starts_with("2099-01-01") || ts.starts_with("2098-12-31"));
+    }
+
+    #[test]
+    fn point_in_time_relative_days_is_forward_not_backward() {
+        // <N>d must resolve to N days from now, not N days ago -- the
+        // opposite direction of TimeRange::parse's own `<N>d`.
+        let today = Zoned::now().date();
+        let forward = parse_point_in_time("3d").expect("parse");
+        let expected = day_start_utc(today.checked_add(3.days()).unwrap()).unwrap();
+        assert_eq!(forward, expected);
+
+        let backward_would_be = day_start_utc(today.checked_sub(3.days()).unwrap()).unwrap();
+        assert_ne!(
+            forward, backward_would_be,
+            "3d must not resolve backward like TimeRange::parse's <N>d does"
+        );
+    }
+
+    #[test]
+    fn point_in_time_relative_weeks_is_forward() {
+        let today = Zoned::now().date();
+        let forward = parse_point_in_time("2w").expect("parse");
+        let expected = day_start_utc(today.checked_add(2.weeks()).unwrap()).unwrap();
+        assert_eq!(forward, expected);
+    }
+
+    #[test]
+    fn point_in_time_today_resolves_to_local_midnight() {
+        let today = Zoned::now().date();
+        let ts = parse_point_in_time("today").expect("parse");
+        assert_eq!(ts, day_start_utc(today).unwrap());
+    }
+
+    #[test]
+    fn point_in_time_rejects_yesterday() {
+        // Not part of the forward grammar -- nonsensical for a future wake time.
+        let err = parse_point_in_time("yesterday").unwrap_err();
+        assert!(matches!(err, LegionError::InvalidDateFilter { .. }));
+    }
+
+    #[test]
+    fn point_in_time_rejects_garbage() {
+        let err = parse_point_in_time("not-a-date").unwrap_err();
+        assert!(matches!(err, LegionError::InvalidDateFilter { .. }));
+        assert!(err.to_string().contains("not-a-date"));
     }
 }

--- a/src/watch/mod.rs
+++ b/src/watch/mod.rs
@@ -540,6 +540,17 @@ fn reap_delegated_cards(db: &Database, log_prefix: &str) {
 /// An error from the DB scan, a single card's revert, or a single card's
 /// wake signal is logged and swallowed; the health tick must never abort
 /// over one bad row.
+///
+/// Liveness caveat (same honest limitation `#778`'s delegated reaper
+/// carries, review-requested for this sweep too): this only fires while
+/// `legion watch` (standalone or the daemon) is actually running for the
+/// repo -- `tick_health` is this function's only caller. A card deferred
+/// while no watch process is alive for its repo sits in `Deferred` past its
+/// `wake_at` until one starts and runs a health tick; nothing else polls
+/// for due wakes. Unlike `Delegated`, there is no `stop.sh` backstop for
+/// this gap -- Deferred does not block Stop by design, so a late wake is a
+/// missed page, not a stuck agent. `legion kanban undefer` is the manual
+/// escape hatch if an operator notices a card overdue.
 fn reap_deferred_cards(db: &Database, host: &str, log_prefix: &str) {
     let now = chrono::Utc::now().to_rfc3339();
     let due = match db.get_deferred_cards_due(&now) {

--- a/src/watch/mod.rs
+++ b/src/watch/mod.rs
@@ -262,6 +262,8 @@ impl WatchLoop {
         // reap-before-mutate, the same ordering lesson #679's own reaper
         // finalization fix (f45e7e5) encoded for lease release vs heartbeat.
         reap_delegated_cards(&self.db, self.log_prefix);
+        // #816: wake deferred cards whose wake_at has passed.
+        reap_deferred_cards(&self.db, &self.host, self.log_prefix);
         if let Err(e) = self.db.heartbeat_persona_leases(&self.host, self.lease_ttl) {
             eprintln!("{} lease heartbeat error: {e}", self.log_prefix);
         }
@@ -508,6 +510,78 @@ fn reap_delegated_cards(db: &Database, log_prefix: &str) {
         ) {
             eprintln!(
                 "{log_prefix} delegated reaper: failed to revert card {}: {e}",
+                card.id
+            );
+        }
+    }
+}
+
+/// Wake `Deferred` cards whose `wake_at` has passed (#816): reverts each to
+/// its pre-defer status via `kanban::undefer_card` (the SAME function the
+/// manual `legion kanban undefer` CLI path uses -- one revert function, not
+/// one per call site, mirroring the #679 lesson the delegated reaper above
+/// already applies via `undelegate_card`) and posts a wake-worthy `routing`
+/// signal naming the card to its owner (`to_repo`).
+///
+/// The signal is authored as `host`, not a repo name: the recipient-side
+/// self-address filter (`get_unhandled_signals_for_repo`'s `r.repo !=
+/// ?repo_param`) drops a signal whose author equals its own repo, and
+/// legion's own kanban board routinely has `to_repo == "legion"` -- an
+/// author fixed to a real repo name (e.g. "legion") would silently never
+/// wake that repo's own deferred cards. A machine hostname lives in a
+/// different namespace from project repo names, so it cannot collide with
+/// a legitimate `to_repo`. The signal is inserted directly via
+/// `insert_reflection_with_meta` (no search index) rather than through
+/// `board::post_from_text_with_meta` -- `WatchLoop` carries no `SearchIndex`
+/// handle, and the wake mechanism itself reads directly from the
+/// `reflections` table, not the search index (mirrors `QuotaPanicGate::
+/// check_and_post`'s identical unindexed system post).
+///
+/// An error from the DB scan, a single card's revert, or a single card's
+/// wake signal is logged and swallowed; the health tick must never abort
+/// over one bad row.
+fn reap_deferred_cards(db: &Database, host: &str, log_prefix: &str) {
+    let now = chrono::Utc::now().to_rfc3339();
+    let due = match db.get_deferred_cards_due(&now) {
+        Ok(v) => v,
+        Err(e) => {
+            eprintln!("{log_prefix} deferred reaper: scan error: {e}");
+            return;
+        }
+    };
+
+    for card in due {
+        let reverted =
+            match crate::kanban::undefer_card(db, &card.id, Some("auto-woken: wake_at reached")) {
+                Ok(c) => c,
+                Err(e) => {
+                    eprintln!(
+                        "{log_prefix} deferred reaper: failed to revert card {}: {e}",
+                        card.id
+                    );
+                    continue;
+                }
+            };
+
+        eprintln!(
+            "{log_prefix} deferred reaper: card {} (repo {}) wake_at reached -- reverted to {}",
+            card.id, card.to_repo, reverted.status
+        );
+
+        let summary = crate::card_parse::truncate_chars(&card.text, 100);
+        let note = format!(
+            "card {} \"{summary}\" is back in {}",
+            card.id, reverted.status
+        );
+        let text = crate::signal::format_signal(&card.to_repo, "routing", None, Some(&note), &[]);
+        if let Err(e) = db.insert_reflection_with_meta(
+            host,
+            &text,
+            "team",
+            &crate::db::ReflectionMeta::default(),
+        ) {
+            eprintln!(
+                "{log_prefix} deferred reaper: wake signal failed for card {}: {e}",
                 card.id
             );
         }
@@ -1267,6 +1341,151 @@ mod tests {
             card.status,
             crate::kanban::CardStatus::Accepted,
             "an in-flight attempt with no daemon heartbeat is still not verifiably live"
+        );
+    }
+
+    // -- deferred-card reaper (#816) -------------------------------------------
+
+    fn insert_deferred_card(db: &Database, repo: &str, text: &str, wake_at: &str) -> String {
+        let id = db
+            .insert_card(
+                "kelex",
+                repo,
+                text,
+                None,
+                crate::kanban::Priority::Med,
+                None,
+                None,
+                None,
+                None,
+                None,
+                crate::kanban::CardStatus::Deferred,
+            )
+            .expect("insert deferred card");
+        db.set_card_defer_fields(&id, wake_at, "accepted")
+            .expect("set defer fields");
+        id
+    }
+
+    #[test]
+    fn reap_deferred_cards_reverts_and_wakes_when_due() {
+        let (db, _index, _dir) = test_storage();
+        let card_id =
+            insert_deferred_card(&db, "test-repo", "past due", "2020-01-01T00:00:00+00:00");
+
+        reap_deferred_cards(&db, "test-host", "[test]");
+
+        let card = db
+            .get_card_by_id(&card_id)
+            .expect("get")
+            .expect("card exists");
+        assert_eq!(
+            card.status,
+            crate::kanban::CardStatus::Accepted,
+            "a due deferred card must revert to its pre-defer status"
+        );
+        assert!(card.wake_at.is_none(), "wake_at must be cleared on revert");
+        assert!(
+            card.pre_defer_status.is_none(),
+            "pre_defer_status must be cleared on revert"
+        );
+
+        let pending = find_pending_signals(&db, "test-repo", &["test-repo".to_string()], None)
+            .expect("find pending");
+        assert_eq!(
+            pending.len(),
+            1,
+            "the card's owner must have a pending wake signal"
+        );
+        assert!(
+            pending[0].1.contains(&card_id),
+            "the wake signal must name the card: {}",
+            pending[0].1
+        );
+    }
+
+    #[test]
+    fn reap_deferred_cards_leaves_future_wake_at_alone() {
+        let (db, _index, _dir) = test_storage();
+        let card_id =
+            insert_deferred_card(&db, "test-repo", "not due yet", "2099-01-01T00:00:00+00:00");
+
+        reap_deferred_cards(&db, "test-host", "[test]");
+
+        let card = db
+            .get_card_by_id(&card_id)
+            .expect("get")
+            .expect("card exists");
+        assert_eq!(
+            card.status,
+            crate::kanban::CardStatus::Deferred,
+            "a not-yet-due deferred card must be left alone"
+        );
+
+        let pending = find_pending_signals(&db, "test-repo", &["test-repo".to_string()], None)
+            .expect("find pending");
+        assert!(
+            pending.is_empty(),
+            "no wake signal should be sent before wake_at"
+        );
+    }
+
+    /// The wake signal's author must never collide with the recipient
+    /// (`to_repo`), since `find_pending_signals`/`get_unhandled_signals_for_repo`
+    /// drop any signal whose author equals the repo being polled -- and
+    /// legion's own board routinely has `to_repo == "legion"`. Using the
+    /// deferred card's OWN `to_repo` as the author (the bug a naive fixed
+    /// `"legion"` sender would reproduce) would silently swallow the wake;
+    /// this test pins that the chosen author (the watch host) never does.
+    #[test]
+    fn reap_deferred_cards_wakes_owner_even_when_to_repo_is_legion() {
+        let (db, _index, _dir) = test_storage();
+        let card_id =
+            insert_deferred_card(&db, "legion", "dogfood defer", "2020-01-01T00:00:00+00:00");
+
+        reap_deferred_cards(&db, "test-host", "[test]");
+
+        let pending = find_pending_signals(&db, "legion", &["legion".to_string()], None)
+            .expect("find pending");
+        assert_eq!(
+            pending.len(),
+            1,
+            "a deferred card owned by 'legion' must still wake its owner; got: {pending:?}"
+        );
+        assert!(pending[0].1.contains(&card_id));
+    }
+
+    /// Full `tick_health` integration: a deferred card with a past wake_at
+    /// is reverted and its owner woken by a single tick, not just by
+    /// calling `reap_deferred_cards` directly. Proves the sweep is actually
+    /// wired into the health tick, not just unit-testable in isolation.
+    #[test]
+    fn watch_loop_tick_health_wakes_due_deferred_card() {
+        let (db, _index, _dir) = test_storage();
+        let card_id = insert_deferred_card(
+            &db,
+            "test-repo",
+            "tick wakes me",
+            "2020-01-01T00:00:00+00:00",
+        );
+
+        let mut state = test_watch_loop(db, "[legion test]");
+        state.tick_health();
+
+        let card = state
+            .db
+            .get_card_by_id(&card_id)
+            .expect("get")
+            .expect("card exists");
+        assert_eq!(card.status, crate::kanban::CardStatus::Accepted);
+
+        let pending =
+            find_pending_signals(&state.db, "test-repo", &["test-repo".to_string()], None)
+                .expect("find pending");
+        assert_eq!(
+            pending.len(),
+            1,
+            "tick_health must wake the deferred card's owner"
         );
     }
 }

--- a/src/watch/mod.rs
+++ b/src/watch/mod.rs
@@ -1373,8 +1373,8 @@ mod tests {
                 crate::kanban::CardStatus::Deferred,
             )
             .expect("insert deferred card");
-        db.set_card_defer_fields(&id, wake_at, "accepted")
-            .expect("set defer fields");
+        db.set_card_deferred(&id, None, wake_at, "accepted")
+            .expect("set deferred");
         id
     }
 

--- a/tests/integration/kanban.rs
+++ b/tests/integration/kanban.rs
@@ -661,3 +661,167 @@ fn kanban_reconcile_dry_run_on_empty_db_is_quiet_success() {
         "expected shipped-pending empty-state line, got: {stdout}"
     );
 }
+
+// --- kanban defer / undefer (#816) ---
+
+#[test]
+fn kanban_defer_excludes_card_from_working_set_but_keeps_it_visible() {
+    let dir = tempfile::tempdir().unwrap();
+
+    let id = run_ok(legion_cmd(dir.path()).args([
+        "kanban", "create", "--from", "sean", "--to", "kelex", "--text", "defer me",
+    ]))
+    .trim()
+    .to_string();
+    run_ok(legion_cmd(dir.path()).args(["kanban", "assign", "--id", &id, "--to", "kelex"]));
+    run_ok(legion_cmd(dir.path()).args(["kanban", "accept", "--id", &id]));
+
+    run_ok(legion_cmd(dir.path()).args(["kanban", "defer", "--id", &id, "--until", "2099-01-01"]));
+
+    // Bare (WorkingSet) list must no longer show the deferred card.
+    let stdout = run_ok(legion_cmd(dir.path()).args(["kanban", "list", "--repo", "kelex"]));
+    assert!(
+        !stdout.contains("defer me"),
+        "WorkingSet must exclude a Deferred card, got: {stdout}"
+    );
+
+    // But --deferred must still show it -- never silently uncounted (#798's
+    // lesson applied to the new status).
+    let stdout =
+        run_ok(legion_cmd(dir.path()).args(["kanban", "list", "--repo", "kelex", "--deferred"]));
+    assert!(
+        stdout.contains("defer me"),
+        "--deferred must show the deferred card, got: {stdout}"
+    );
+
+    // And --all must include it too.
+    let stdout =
+        run_ok(legion_cmd(dir.path()).args(["kanban", "list", "--repo", "kelex", "--all"]));
+    assert!(stdout.contains("defer me"));
+}
+
+#[test]
+fn kanban_defer_refuses_past_until() {
+    let dir = tempfile::tempdir().unwrap();
+
+    let id = run_ok(legion_cmd(dir.path()).args([
+        "kanban",
+        "create",
+        "--from",
+        "sean",
+        "--to",
+        "kelex",
+        "--text",
+        "cannot defer to the past",
+    ]))
+    .trim()
+    .to_string();
+    run_ok(legion_cmd(dir.path()).args(["kanban", "assign", "--id", &id, "--to", "kelex"]));
+    run_ok(legion_cmd(dir.path()).args(["kanban", "accept", "--id", &id]));
+
+    let (_stdout, stderr) = run_fail(legion_cmd(dir.path()).args([
+        "kanban",
+        "defer",
+        "--id",
+        &id,
+        "--until",
+        "2020-01-01",
+    ]));
+    assert!(
+        stderr.contains("not in the future"),
+        "expected the past-wake_at refusal naming the parsed value, got: {stderr}"
+    );
+}
+
+#[test]
+fn kanban_defer_refuses_unparseable_until() {
+    let dir = tempfile::tempdir().unwrap();
+
+    let id = run_ok(legion_cmd(dir.path()).args([
+        "kanban",
+        "create",
+        "--from",
+        "sean",
+        "--to",
+        "kelex",
+        "--text",
+        "bad grammar",
+    ]))
+    .trim()
+    .to_string();
+    run_ok(legion_cmd(dir.path()).args(["kanban", "assign", "--id", &id, "--to", "kelex"]));
+    run_ok(legion_cmd(dir.path()).args(["kanban", "accept", "--id", &id]));
+
+    let (_stdout, stderr) = run_fail(legion_cmd(dir.path()).args([
+        "kanban",
+        "defer",
+        "--id",
+        &id,
+        "--until",
+        "not-a-date",
+    ]));
+    assert!(
+        stderr.contains("unparseable date"),
+        "expected InvalidDateFilter guidance, got: {stderr}"
+    );
+}
+
+#[test]
+fn kanban_undefer_reverts_card_to_working_set() {
+    let dir = tempfile::tempdir().unwrap();
+
+    let id = run_ok(legion_cmd(dir.path()).args([
+        "kanban",
+        "create",
+        "--from",
+        "sean",
+        "--to",
+        "kelex",
+        "--text",
+        "wake me up early",
+    ]))
+    .trim()
+    .to_string();
+    run_ok(legion_cmd(dir.path()).args(["kanban", "assign", "--id", &id, "--to", "kelex"]));
+    run_ok(legion_cmd(dir.path()).args(["kanban", "accept", "--id", &id]));
+    run_ok(legion_cmd(dir.path()).args(["kanban", "defer", "--id", &id, "--until", "2099-01-01"]));
+
+    run_ok(legion_cmd(dir.path()).args(["kanban", "undefer", "--id", &id]));
+
+    let stdout = run_ok(legion_cmd(dir.path()).args(["kanban", "list", "--repo", "kelex"]));
+    assert!(
+        stdout.contains("wake me up early"),
+        "WorkingSet must show the card again after undefer, got: {stdout}"
+    );
+    assert!(stdout.contains("[accepted]"), "got: {stdout}");
+}
+
+#[test]
+fn kanban_defer_refuses_from_needs_input() {
+    let dir = tempfile::tempdir().unwrap();
+
+    let id = run_ok(legion_cmd(dir.path()).args([
+        "kanban",
+        "create",
+        "--from",
+        "sean",
+        "--to",
+        "kelex",
+        "--text",
+        "not deferrable",
+    ]))
+    .trim()
+    .to_string();
+    run_ok(legion_cmd(dir.path()).args(["kanban", "assign", "--id", &id, "--to", "kelex"]));
+    run_ok(legion_cmd(dir.path()).args(["kanban", "accept", "--id", &id]));
+    run_ok(legion_cmd(dir.path()).args(["kanban", "need-input", "--id", &id]));
+
+    run_fail(legion_cmd(dir.path()).args([
+        "kanban",
+        "defer",
+        "--id",
+        &id,
+        "--until",
+        "2099-01-01",
+    ]));
+}

--- a/tests/integration/kanban.rs
+++ b/tests/integration/kanban.rs
@@ -686,18 +686,32 @@ fn kanban_defer_excludes_card_from_working_set_but_keeps_it_visible() {
     );
 
     // But --deferred must still show it -- never silently uncounted (#798's
-    // lesson applied to the new status).
+    // lesson applied to the new status) -- AND its wake_at must be visible
+    // right there in list output, not only reachable via `view`/`--json`
+    // (review MED: a deferred card whose wake time is invisible is
+    // half-visible).
     let stdout =
         run_ok(legion_cmd(dir.path()).args(["kanban", "list", "--repo", "kelex", "--deferred"]));
     assert!(
         stdout.contains("defer me"),
         "--deferred must show the deferred card, got: {stdout}"
     );
+    assert!(
+        stdout.contains("[wakes:2099-01-01]"),
+        "list output must show the wake_at date, got: {stdout}"
+    );
 
     // And --all must include it too.
     let stdout =
         run_ok(legion_cmd(dir.path()).args(["kanban", "list", "--repo", "kelex", "--all"]));
     assert!(stdout.contains("defer me"));
+
+    // `kanban view` must also surface it.
+    let stdout = run_ok(legion_cmd(dir.path()).args(["kanban", "view", "--id", &id]));
+    assert!(
+        stdout.contains("Wake at:"),
+        "kanban view must show Wake at:, got: {stdout}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Adds card-level scheduled defer: `legion kanban defer --id <id> --until <when>` moves an
Accepted or Pending card into a new `Deferred` status, excluded from the Stop in-progress
gate and the default `WorkingSet` listing, and `tick_health` (the `#778` sweep site)
automatically reverts the card and wakes its owner once `--until` passes. Built entirely
from precedented parts: the `Delegated` state-machine/reaper shape (`#778`), `#786`'s
`TimeRange` date grammar, and the `has_column`-guarded migration pattern.

**Update 1:** a second commit (`7684bbc`) addresses the two MED findings from the first
review pass (gate `019f6d88`): the `reap_deferred_cards` sweep and `legion kanban defer`'s
CLI help now document the watch-liveness caveat explicitly (auto-wake only fires while
`legion watch` is running for the repo, same honest limitation `#778` already carries, with
no `stop.sh` backstop since `Deferred` doesn't block Stop by design), and `wake_at` is now
visible in `kanban list`, `kanban view`, and `list --json` output, not only `view --json`
(the `#798` lesson applied to the new field).

**Update 2:** a third commit (`ce8e1ac`) addresses a HIGH and a MED finding from the
pre-push review. HIGH: `defer_card` wrote the status transition and `wake_at`/
`pre_defer_status` as two separate DB calls -- a crash between them left a `Deferred` card
with `wake_at = NULL`, permanently un-reapable since `get_deferred_cards_due` requires
`wake_at IS NOT NULL`. Fixed by folding both into one atomic `UPDATE` (`Database::
set_card_deferred`). MED: `undefer_card` silently fell back to `"accepted"` when
`pre_defer_status` was missing, disagreeing with `defer_card`'s own hard error on the same
corruption; both now error symmetrically.

## Acceptance criteria mapping

### 1. All tests pass; simplify + review + verify per pipeline
`cargo test --bin legion` (1665 passed, 0 failed), `cargo clippy --all-targets -- -D
warnings` (clean), `cargo fmt -- --check` (clean), and `cargo test --test integration`
(357 passed, 0 failed) all run clean on this branch's HEAD. The `legion-simplify` gate is
recorded clean for this commit (gate id `019f6d77-2573-7381-9747-8c8bc0a70c48`, 10 file
entries, 0 findings). Review and verify are the remaining pipeline stages this PR hands
off to.
Evidence: `cargo test --bin legion` -> "1665 passed; 0 failed"; `cargo test --test
integration` -> "357 passed; 0 failed"; `legion quality-gate check --skill legion-simplify`
-> "articulation accepted ... result 'clean'".

### 2. A deferred card does not block Stop, survives daemon restart, and its owner receives the wake signal when wake_at passes (integration test with a short wake_at + tick invocation)
Three sub-claims:
- **Does not block Stop**: `stop.sh`'s in-progress gate reads `kanban list --json`
  (default `CardScope::WorkingSet`) and jq-filters `status == "accepted"`. `Deferred` is
  now excluded from `WorkingSet`'s SQL predicate (`src/db/kanban.rs`'s `status_filter`
  match, `NOT IN ('backlog', 'done', 'cancelled', 'deferred')`), so a deferred card never
  even reaches the gate's input, let alone matches `accepted`. No `stop.sh` change was
  needed -- verified, not just asserted, by
  `get_cards_working_set_excludes_deferred` (`src/db/kanban.rs`) and
  `kanban_defer_excludes_card_from_working_set_but_keeps_it_visible`
  (`tests/integration/kanban.rs`).
- **Survives daemon restart**: `wake_at`/`pre_defer_status` are persisted as `TEXT`
  columns on the `tasks` table (migration 17, `src/db/kanban.rs`), not held in
  `WatchLoop`'s in-memory state. `reap_deferred_cards` re-queries
  `get_deferred_cards_due` fresh on every `tick_health` call, so a process restart loses
  nothing -- the next tick after restart picks the row up exactly as it would have before.
  `migration_wake_at_and_pre_defer_status_columns_are_idempotent_on_reopen`
  (`src/db/kanban.rs`) pins that a fresh `Database::open` on the same file reads the
  persisted defer state back correctly.
- **Owner receives the wake signal**: `reap_deferred_cards` (`src/watch/mod.rs`) posts a
  wake-worthy `routing` signal addressed `@<to_repo>` once a card is due. The AC's own
  parenthetical -- "integration test with a short wake_at + tick invocation" -- is
  `watch_loop_tick_health_wakes_due_deferred_card` (`src/watch/mod.rs`), which seeds a
  Deferred card with a past `wake_at` directly in the DB (the CLI grammar is day-granular,
  so a sub-day "short" wake_at can only be set this way, not driven through `--until`),
  calls `state.tick_health()` once, and asserts both the card reverted to `Accepted` and
  `find_pending_signals` returns exactly one pending signal for the owning repo.
Evidence: `src/db/kanban.rs::get_cards_working_set_excludes_deferred`,
`tests/integration/kanban.rs::kanban_defer_excludes_card_from_working_set_but_keeps_it_visible`,
`src/db/kanban.rs::migration_wake_at_and_pre_defer_status_columns_are_idempotent_on_reopen`,
`src/watch/mod.rs::watch_loop_tick_health_wakes_due_deferred_card`.

## Not done

- **Recurring defers**: explicitly out of scope per the issue (cron/schedule territory).
- **Deferred-work dashboards**: explicitly out of scope per the issue (`#697` wont-do
  stands).
- **`get_agent_workloads` / `get_active_tasks_for_repo` Deferred bucketing**: these two
  status-based SQL lists are the exact surfaces `#798` (still open) already flags for the
  *Delegated* status making the same silent-drop mistake. I did not extend that fix to
  cover `Deferred` -- it is out of the file locations this card named, and folding it in
  would blur the boundary with `#798`'s own scope. `Deferred` cards do get a first-class,
  non-silent visibility surface via the new `CardScope::Deferred` / `legion kanban list
  --deferred`, which is the mechanism `#816`'s requirements actually named.
- **`pre_defer_status` as an additional migration column**: the issue's File Locations
  line names only "`wake_at` ALTER". A second column, `pre_defer_status`, was added
  (also `has_column`-guarded) because `Defer` is legal from both `Accepted` and `Pending`
  (an explicit requirement), so the revert target is data-dependent and cannot be a fixed
  enum-level constant the way `Delegated`'s single revert-to-`Accepted` target is.

**Addendum, `#805` incident data (commit-protocol tree-hash mismatch):** not part of this
feature's scope, but recorded here since the orchestrator asked for it and this is fresh
reproduction data for the open `#805` investigation. Sequence: staged
exactly the 10 feature files, ran `git write-tree` (recorded `c7700c9499785bd3b43e89c42860da827ca2c126`),
ran `git commit`. The pre-commit hook printed a normal "PASS ... Ship it" simplify review
and the commit succeeded, but `git show -s --format=%T HEAD` returned
`bb4ecb705db20c4a49f97953300cce1fa1c879c9` -- a mismatch. Diagnosis: the landed commit's
tree was byte-for-byte the concurrent `0.22.0` -> `0.23.0` release cut's file set
(`Cargo.toml`/`Cargo.lock`/`plugin/.claude-plugin/plugin.json`/`.claude-plugin/marketplace.json`/
`plugin/CHANGELOG.md`), carrying my commit message but none of my staged content. No
reflog entry recorded the intermediate state -- the reflog showed only the eventual
(wrong) commit, not a trace of the race itself. `git status` afterward showed my 10 files
still present as unstaged working-tree modifications (nothing was lost), alongside the
five release files as unstaged reverts of the just-committed state -- consistent with a
second, independent `git add`/`git commit` (the real release process, confirmed
separately to have landed cleanly on `origin/main` as `2e285a8`) executing concurrently
against the same on-disk index/HEAD this worktree's commit was reading and writing at
the same wall-clock moment. Recovery was a plain `git reset origin/main` (mixed) followed
by re-checking out the five release files from `origin/main` and re-committing my staged
10; the tree-hash assertion matched cleanly on the second attempt with no further gap
observed.

Closes #816
