### PR TITLE
fix(#830): prefix legion skill invocations after CC 2.1.216

### DIFF
--- a/.github/ISSUE_TEMPLATE/implementation-task.md
+++ b/.github/ISSUE_TEMPLATE/implementation-task.md
@@ -41,8 +41,8 @@ assignees: ''
 Each step is mandatory. Do not skip steps or combine them.
 
 1. **Build** -- Implement the feature. Write tests alongside code. Run `cargo test`, `cargo clippy -- -D warnings`, `cargo fmt -- --check`. All must pass.
-2. **Simplify** -- Run `/simplify` on all changed files. Accept structural improvements, flatten unnecessary abstractions, remove dead code.
-3. **Review** -- Run `/review-pr` which launches parallel review agents (code review, silent failure hunter, type design analysis). Do not create the PR yet.
+2. **Simplify** -- Run `/legion:legion-simplify` on all changed files. Accept structural improvements, flatten unnecessary abstractions, remove dead code. This records the `legion-simplify` gate that `legion pr create` requires; the harness `/simplify` skill is a different tool and records no gate.
+3. **Review** -- Run `/legion:legion-review`, which fans out parallel review dimensions (spec-vs-diff, correctness, quality, security) and adversarially verifies each finding. Do not create the PR yet.
 4. **Fix** -- Address every issue the review found. Re-run tests after fixes.
 5. **PR** -- Create the PR. Reference this issue number.
 

--- a/docs/site/architecture.md
+++ b/docs/site/architecture.md
@@ -755,10 +755,14 @@ Only a dangling `document_id` -- the bound document does not exist -- is a hard 
 
 The full quality pipeline for a branch is:
 
-1. `/legion-simplify` -- review for code quality (duplication, unnecessary abstraction, stringly-typed state). Records a `legion-simplify` gate via `legion quality-gate record`.
-2. `/legion-pr-write` -- compose the PR body mapping each acceptance criterion to the change that satisfies it, with evidence. Validates the body is non-empty and non-boilerplate via `legion pr write-check`. Records a `legion-pr-write` gate.
-3. `/legion-review` -- parallel dimension review (spec, correctness, quality, security) with adversarial refutation of HIGH/MED findings. Records a `legion-review` gate.
-4. `/legion-verify` -- per-criterion verdict (pass/fail/uncertain + evidence). Records a `legion-verify:<card>` gate.
+1. `/legion:legion-simplify` -- review for code quality (duplication, unnecessary abstraction, stringly-typed state). Records a `legion-simplify` gate via `legion quality-gate record`.
+2. `/legion:legion-pr-write` -- compose the PR body mapping each acceptance criterion to the change that satisfies it, with evidence. Validates the body is non-empty and non-boilerplate via `legion pr write-check`. Records a `legion-pr-write` gate.
+3. `/legion:legion-review` -- parallel dimension review (spec, correctness, quality, security) with adversarial refutation of HIGH/MED findings. Records a `legion-review` gate.
+4. `/legion:legion-verify` -- per-criterion verdict (pass/fail/uncertain + evidence). Records a `legion-verify:<card>` gate.
+
+The skill names carry the `legion:` plugin prefix. Claude Code 2.1.216 fixed plugin skills
+with a `name:` frontmatter field losing that prefix; the bare forms no longer resolve. The
+gate keys recorded in the database (`legion-simplify` and friends, above) are unaffected.
 
 ### PR create gate requirements
 

--- a/docs/site/llms-full.txt
+++ b/docs/site/llms-full.txt
@@ -1537,27 +1537,27 @@ PLUGIN SKILLS
         doctrine. Order: recall -> consult -> then grep/glob/read.
         Allowed tools: Bash, Read.
 
-    legion-simplify     User-invocable (/legion-simplify).
+    legion-simplify     User-invocable (/legion:legion-simplify).
         Reviews the branch diff for duplicate logic, needless abstraction, and
         stringly-typed state. Emits structured JSON findings and records the
         simplify gate via `legion quality-gate record` that `legion pr create`
         requires. Run on every feature branch before the PR.
 
-    legion-pr-write     (v0.16.2) User-invocable (/legion-pr-write).
+    legion-pr-write     (v0.16.2) User-invocable (/legion:legion-pr-write).
         Composes the PR body as an articulation-as-verification forcing function:
         map each acceptance criterion to the change satisfying it with evidence;
         state what was deliberately not done; validate with
         `legion pr write-check`. Records a clean legion-pr-write gate on success.
-        Run after /legion-simplify, before review.
+        Run after /legion:legion-simplify, before review.
 
-    legion-review       (v0.17.2) User-invocable (/legion-review).
+    legion-review       (v0.17.2) User-invocable (/legion:legion-review).
         The review gate between pr-write and verify. Orchestrates parallel
         dimension agents (spec, correctness, quality, security) over the
         legion-review agent, adversarially refutes every HIGH/MED finding
         before it is reported, and records a HEAD-keyed legion-review quality
         gate via `legion quality-gate record`.
 
-    legion-verify       (v0.16.2) User-invocable (/legion-verify).
+    legion-verify       (v0.16.2) User-invocable (/legion:legion-verify).
         Final gate before Done: reads acceptance criteria plus diff plus test
         output, emits one pass/fail/uncertain verdict per criterion with cited
         evidence, recorded via `legion verify`. Run after review, before Done.

--- a/plugin/skills/legion-pr-write/SKILL.md
+++ b/plugin/skills/legion-pr-write/SKILL.md
@@ -7,7 +7,7 @@ description: |
   mapping makes you re-read your own diff as a reader and catch what you talked past while
   coding. Validate the body with `legion pr write-check`, which refuses an empty or
   boilerplate mapping and records the gate `legion pr create` requires. Run this after
-  `/legion-simplify`, before review.
+  `/legion:legion-simplify`, before review.
 version: 1.0.0
 user-invocable: true
 allowed-tools: Bash, Read, Write

--- a/plugin/skills/legion-review/SKILL.md
+++ b/plugin/skills/legion-review/SKILL.md
@@ -6,7 +6,7 @@ description: |
   security), adversarially verifies every HIGH/MED finding before reporting it, and records
   the result via `legion quality-gate record --skill legion-review` so downstream gates can
   require a clean review on HEAD. Run after `legion pr create`, before team sign-off and
-  /legion-verify.
+  /legion:legion-verify.
 version: 1.0.0
 user-invocable: true
 allowed-tools: Bash, Read, Task
@@ -112,9 +112,9 @@ no code is written or fixed by this skill -- the fix loop belongs to the impleme
 
 ## Relationship to the other gates
 
-- `/legion-simplify` reviews the diff's structure before the PR exists; this skill reviews
-  the PR against its spec after it exists.
+- `/legion:legion-simplify` reviews the diff's structure before the PR exists; this skill
+  reviews the PR against its spec after it exists.
 - `legion pr write-check` validates the implementer's own claim mapping; this skill validates
   the claims themselves against the diff, independently.
-- `/legion-verify` is the per-criterion evidence gate before Done; run it after this review
-  is clean and fixes (if any) have landed.
+- `/legion:legion-verify` is the per-criterion evidence gate before Done; run it after this
+  review is clean and fixes (if any) have landed.

--- a/src/cli/pr.rs
+++ b/src/cli/pr.rs
@@ -417,9 +417,14 @@ pub(crate) fn handle(action: PrAction) -> error::Result<()> {
                 // articulated criterion-to-work mapping the verify gate later
                 // audits). Each is recorded by its own skill on the current
                 // commit, so a post-gate commit invalidates them (re-run).
+                // The first element is the quality-gate DB key written by
+                // `legion quality-gate record --skill` and read by
+                // `get_quality_gate`; it must stay bare. Only the second --
+                // the invocation hint printed to the agent -- carries the
+                // `legion:` plugin prefix that Claude Code 2.1.216 restored.
                 for (skill, run_hint) in [
-                    ("legion-simplify", "/legion-simplify"),
-                    ("legion-pr-write", "/legion-pr-write"),
+                    ("legion-simplify", "/legion:legion-simplify"),
+                    ("legion-pr-write", "/legion:legion-pr-write"),
                 ] {
                     match database.get_quality_gate(&commit_hash, skill)? {
                         None => {

--- a/tests/integration/worksource_pr.rs
+++ b/tests/integration/worksource_pr.rs
@@ -1075,13 +1075,22 @@ fn pr_create_refuses_without_quality_gate() {
         "--title",
         "My PR",
     ]));
+    // The gate KEY stays bare -- it is the `quality_gates.skill` value written by
+    // `legion quality-gate record` and read by `get_quality_gate`.
     assert!(
-        stderr.contains("no clean legion-simplify gate") || stderr.contains("legion-simplify"),
-        "error should mention legion-simplify gate, got: {stderr}"
+        stderr.contains("no clean legion-simplify gate"),
+        "error should name the bare gate key, got: {stderr}"
+    );
+    // The invocation HINT carries the `legion:` plugin prefix. Claude Code 2.1.216
+    // restored the prefix on plugin skills declaring `name:` frontmatter, so the bare
+    // form no longer resolves and must not regress back into the hint.
+    assert!(
+        stderr.contains("/legion:legion-simplify"),
+        "error should guide toward the prefixed skill invocation, got: {stderr}"
     );
     assert!(
-        stderr.contains("/legion-simplify") || stderr.contains("legion-simplify"),
-        "error should guide toward the skill, got: {stderr}"
+        !stderr.contains("Run /legion-simplify"),
+        "run hint must not use the bare skill name, which no longer resolves: {stderr}"
     );
 }
 


### PR DESCRIPTION
## What this does

Claude Code 2.1.216 fixed a bug where plugin skills declaring a `name:` frontmatter field lost
their plugin prefix. All five legion skills declare `name:`, so on upgrade they moved from bare
(`legion-simplify`) to prefixed (`legion:legion-simplify`) with no error and no deprecation.
Nothing in the repo moved with them, so every prose instruction telling an agent to invoke a
legion skill named a form that no longer resolves.

The load-bearing instance was the runtime remediation string in `legion pr create`: an agent
blocked by a missing gate was told to run a command that does not exist, at precisely the moment
it was stuck and least able to recover.

Closes #830.

## Acceptance criteria mapping

### All tests pass

`cargo test` is green at 357 passed, 0 failed, 2 ignored. `cargo clippy --all-targets -- -D
warnings` and `cargo fmt -- --check` are both clean. The suite that matters here is
`worksource_pr` at 78 passing, because it captures real stderr from the built binary rather
than asserting against a constant -- so its passing is direct evidence that `legion pr create`
now emits the prefixed hint at runtime, not merely that a string literal changed in the source.

Evidence: `cargo test` -> `test result: ok. 357 passed; 0 failed; 2 ignored`.

### Simplify pass completed

Gate `019fb4e1` recorded against commit `d529352a`, result clean, provenance `validated`, seven
file entries covering all seven changed files with no gaps. The articulation is not a rubber
stamp -- the `src/cli/pr.rs` entry argues *against* a stringly-typed-state finding that would
be defensible in the abstract (a `GateSkill` enum separating DB key from display string), on
the grounds that it buys indirection rather than extensibility for two literals consumed at a
single call site, and records that the risk is handled by the explanatory comment and the new
negative test assertion instead.

Evidence: `legion quality-gate list --branch fix/830-skill-prefix` -> skill `legion-simplify`,
provenance `validated`, commit `d529352a`.

### Review pass completed and issues fixed

Reviewed against the categories the simplify gate enumerates, written down per file rather than
asserted. Two review outcomes changed the diff rather than blessing it. First,
`docs/site/architecture.md` gained an explanatory paragraph, because each of its four pipeline
lines carries both an invocation and a backticked gate name that look identical, and a later
reader "fixing" the apparent inconsistency would break `get_quality_gate` for every historical
row. Second, `tests/integration/worksource_pr.rs` gained a third, negative assertion rather
than having its two existing ones merely updated, because the old assertion's `||` branch meant
it never constrained the behaviour it appeared to guard.

Evidence: `docs/site/architecture.md` lines 762-765 (new paragraph);
`tests/integration/worksource_pr.rs` lines 1090-1093 (negative assertion).

### PR created and linked to this issue

Opened via `legion pr create --repo legion --closes 830`, which refuses to open unless both the
simplify and pr-write gates are clean on HEAD. That is the same gate path whose run hints this
PR repairs, so opening the PR exercises the change end to end: the command that would have
printed a dead command name is the command that had to succeed to create this PR.

Evidence: the `legion audit --action create-pr` row for this branch, and the PR link on #830.

## The invariant this change had to respect

`src/cli/pr.rs` iterates `(gate_key, run_hint)` pairs. The first element is the
`quality_gates.skill` value written by `legion quality-gate record --skill` and read by
`get_quality_gate(&commit_hash, skill)`. It stays bare. Only the second, the string printed to
a blocked agent, takes the `legion:` prefix. A blanket find-and-replace across this repo would
have invalidated every gate row ever recorded. Verified after the fact: the gate row for this
branch reports skill `legion-simplify`, not `legion:legion-simplify`.

## A second defect fixed in the same lines

`.github/ISSUE_TEMPLATE/implementation-task.md` was independently wrong in a way that trapped
implementers. Step 3 named `/review-pr`, which resolves to nothing at all. Step 2 named
`/simplify`, which resolves to the *harness* simplify skill rather than legion's, and therefore
records no `legion-simplify` gate. An agent that followed the template faithfully recorded
nothing and was then refused by `legion pr create`, with no indication that the template it
obeyed was the cause. Step 2 now says so explicitly.

This is folded in rather than split out because it is the same failure on the same lines;
splitting would have left the template half-corrected.

## Not done

- **Did not touch gate keys, `quality-gate record --skill` values, or `get_quality_gate`
  lookups.** Out of scope by design and the primary hazard of this change.
- **Did not remove `name:` from skill frontmatter to revert the prefix.** The prefixed form is
  what the harness resolves; the documentation is what was stale.
- **Did not update `plugin/CHANGELOG.md` occurrences.** Those are historical record. A changelog
  entry describing what an agent was told in 2026-04 should keep saying what it said.
- **Did not fix the acceptance-criteria parsing defect this PR ran into.** The card for this
  issue carries four process criteria (tests pass / simplify done / review done / PR created)
  because `card_parse` reads the checkbox list under `## Done When` and the template puts the
  substantive condition beneath it as a bold sentence. That is a real defect and it is why the
  mapping above certifies process rather than outcome, but it governs every future issue and is
  unscoped pending an operator decision.

## Verification

- `legion sym etc find-content '/legion-(simplify|verify|review|pr-write)' --repo legion` returns
  no remaining bare *invocations*; surviving hits are file paths (`plugin/skills/legion-simplify/SKILL.md`),
  CHANGELOG history, and the new negative assertion.
- The rewritten test asserts three propositions where the old code asserted one: the bare key is
  present, the prefixed hint is present, and `Run /legion-simplify` is absent. The old assertion
  was `contains("/legion-simplify") || contains("legion-simplify")`, whose second branch matches
  either form and therefore stayed green through this rename in both directions. It never guarded
  the behaviour it appeared to guard.