### PR TITLE
feat(#827): route git push through legion push so every push is audited

### DIFF
--- a/plugin/hooks/hooks.json
+++ b/plugin/hooks/hooks.json
@@ -151,6 +151,11 @@
             "type": "command",
             "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/pre-bash-grep.sh",
             "timeout": 6
+          },
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/no-git-push.sh",
+            "timeout": 5
           }
         ]
       },

--- a/plugin/hooks/lib/emit.sh
+++ b/plugin/hooks/lib/emit.sh
@@ -62,6 +62,33 @@ emit_deny() {
   fi
 }
 
+# emit_rewrite CMD CTX [REASON] -- PreToolUse: allow the call but REPLACE
+# the tool's command with CMD via updatedInput (#827).
+#
+# The rewrite is only honest when the translation is LOSSLESS. A caller
+# that would have to drop a flag the target command cannot express must
+# emit_deny instead -- silently running something the agent did not ask
+# for is worse than refusing, because the agent reads the result as the
+# answer to its original question.
+#
+# CTX is mandatory rather than optional on purpose: a silent rewrite
+# teaches nothing, so the agent re-derives the same wrong habit next
+# session. Announcing the translation costs one line and the surface
+# gets learned.
+emit_rewrite() {
+  local cmd="$1" ctx="$2"
+  local reason="${3:-legion rewrote this to its audited equivalent}"
+  jq -n --arg cmd "$cmd" --arg ctx "$ctx" --arg reason "$reason" '{
+    "hookSpecificOutput": {
+      "hookEventName": "PreToolUse",
+      "permissionDecision": "allow",
+      "permissionDecisionReason": $reason,
+      "updatedInput": { "command": $cmd },
+      "additionalContext": $ctx
+    }
+  }'
+}
+
 # emit_block REASON -- top-level decision:block. The documented refusal
 # shape for Stop events (hard gate with the harness 8-block cap as its
 # backstop). Do NOT use for PreToolUse -- that dialect is deprecated

--- a/plugin/hooks/no-git-push.sh
+++ b/plugin/hooks/no-git-push.sh
@@ -1,0 +1,176 @@
+#!/bin/bash
+# Legion PreToolUse hook (#827): route `git push` through `legion push`.
+#
+# `legion push` (#791) exists so the push-from-own-checkout doctrine is
+# enforced by the tool rather than by agent discipline: the pre-push hook
+# reviews the CWD's checked-out branch, not the ref being pushed, so a
+# push issued from the wrong checkout silently reviews the wrong diff.
+# It also refuses main/master, refuses force, and audit-logs every attempt
+# with branch, resolved checkout, and head SHA.
+#
+# Adoption of that command was itself left to agent discipline. Nothing
+# intercepted a raw `git push`, which writes no audit row at all, so the
+# audit trail was only as complete as every agent remembering. This hook
+# closes that: the sanctioned path becomes the one that happens.
+#
+# Three outcomes:
+#
+#   1. REWRITE -- the push is expressible as `legion push`. Replace the
+#      command via updatedInput and announce the translation.
+#   2. DENY    -- the command carries semantics `legion push` cannot
+#      express (force, refspec, delete, tags, mirror, prune). Refuse and
+#      name the flag. Rewriting would silently drop it and run something
+#      the agent did not ask for.
+#   3. PASS    -- not a git push, repo not legion-covered, or any
+#      dependency missing. Fail open; a PreToolUse hook that fails closed
+#      can wedge every session.
+#
+# No recursion guard is needed: hooks fire on the AGENT's Bash tool calls,
+# not on child processes, so `legion push`'s own internal `git push` never
+# re-enters here. That is precisely why this is a hook and not a PATH shim
+# or a symlink -- legion is itself a git consumer, and a shim would recurse.
+#
+# Parsing is argv-style by deliberate choice. `pre-whoami-rewrite.sh` was
+# retired after its greedy `sed` matched the LAST `--repo` in a command,
+# so an agent writing `--repo` inside `--text` content shifted the
+# extracted value to garbage and the hook silently allowed a bad rewrite.
+# Iterate tokens, compare whole words, never regex across the string.
+#
+# Skip via LEGION_SKIP_GIT_PUSH=1.
+
+set -u
+
+if [ "${LEGION_SKIP_GIT_PUSH:-}" = "1" ]; then
+  exit 0
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+  exit 0
+fi
+
+# shellcheck source=lib/prelude.sh
+source "${CLAUDE_PLUGIN_ROOT:-}/hooks/lib/prelude.sh" 2>/dev/null || exit 0
+# shellcheck source=lib/emit.sh
+source "${CLAUDE_PLUGIN_ROOT:-}/hooks/lib/emit.sh" 2>/dev/null || exit 0
+
+legion_hook_parse || exit 0
+
+COMMAND=$(legion_hook_field '.tool_input.command')
+
+if [ -z "$CWD" ] || [ "$TOOL" != "Bash" ] || [ -z "$COMMAND" ] || [ -z "$REPO" ]; then
+  exit 0
+fi
+
+# Universal gate: skip repos legion does not cover (#353).
+legion_hook_covered || exit 0
+
+# --- Detect `git push` -------------------------------------------------------
+#
+# Tokenise on whitespace. The first token's BASENAME must be `git` so an
+# absolute-path invocation (/opt/homebrew/bin/git) resolves the same way,
+# matching the hardening in no-gh.sh. The next non-flag token must be
+# `push`; `git -C /path push` and `git --no-pager push` are real shapes.
+
+read -r -a TOKENS <<<"$COMMAND"
+[ "${#TOKENS[@]}" -ge 2 ] || exit 0
+
+FIRST_BIN="${TOKENS[0]##*/}"
+[ "$FIRST_BIN" = "git" ] || exit 0
+
+# Walk past git's own global options to find the subcommand. Options that
+# take a value (-C, -c, --git-dir, --work-tree, --namespace) consume the
+# next token too.
+SUBCOMMAND=""
+IDX=1
+while [ "$IDX" -lt "${#TOKENS[@]}" ]; do
+  TOK="${TOKENS[$IDX]}"
+  case "$TOK" in
+    -C | -c | --git-dir | --work-tree | --namespace)
+      IDX=$((IDX + 2))
+      continue
+      ;;
+    -*)
+      IDX=$((IDX + 1))
+      continue
+      ;;
+    *)
+      SUBCOMMAND="$TOK"
+      break
+      ;;
+  esac
+done
+
+[ "$SUBCOMMAND" = "push" ] || exit 0
+
+# --- Classify the push -------------------------------------------------------
+#
+# Anything `legion push` cannot express is a DENY, never a silent drop.
+# `legion push` has no force path by design (#791), takes no refspec, and
+# pushes exactly one branch from the checkout that has it.
+
+BLOCKING_FLAG=""
+EXPLICIT_BRANCH=""
+POSITIONALS=()
+
+IDX=$((IDX + 1))
+while [ "$IDX" -lt "${#TOKENS[@]}" ]; do
+  TOK="${TOKENS[$IDX]}"
+  case "$TOK" in
+    -f | --force | --force-with-lease | --force-if-includes | --force-with-lease=*)
+      BLOCKING_FLAG="$TOK"
+      break
+      ;;
+    -d | --delete | --mirror | --tags | --prune | --all)
+      BLOCKING_FLAG="$TOK"
+      break
+      ;;
+    *:*)
+      # A refspec (src:dst) retargets the remote ref. `legion push` takes
+      # a branch name, not a refspec, so this cannot round-trip.
+      BLOCKING_FLAG="$TOK (refspec)"
+      break
+      ;;
+    -*)
+      # Benign flags legion push either implies or does not need:
+      # -u/--set-upstream (always set), -q/-v, --progress.
+      ;;
+    *)
+      POSITIONALS+=("$TOK")
+      ;;
+  esac
+  IDX=$((IDX + 1))
+done
+
+REPO_ARG="$REPO"
+
+if [ -n "$BLOCKING_FLAG" ]; then
+  emit_deny "Refusing \`git push\` -- and this one cannot be translated.
+
+\`${BLOCKING_FLAG}\` has no equivalent on \`legion push\`, which by design has no force path, takes no refspec, and pushes exactly one branch from the checkout that has it (#791). Rewriting the command for you would silently drop that flag and run something you did not ask for.
+
+If you want a plain push of this branch:
+    legion push --repo ${REPO_ARG}
+
+If you reached for force because the branch diverged: an already-pushed branch cannot be rebased under this doctrine. Merge origin/main INTO the branch and re-run the gates on the new HEAD. If that is not workable, close the PR and recreate from a fresh branch -- never a force bypass."
+  exit 0
+fi
+
+# POSITIONALS are [remote] [branch] in the common `git push origin foo`
+# shape. Take the branch only when both are present; a bare `git push` or
+# `git push origin` lets `legion push` default to the CWD's branch, which
+# is the behaviour we want anyway.
+if [ "${#POSITIONALS[@]}" -ge 2 ]; then
+  EXPLICIT_BRANCH="${POSITIONALS[1]}"
+fi
+
+REWRITTEN="legion push --repo ${REPO_ARG}"
+if [ -n "$EXPLICIT_BRANCH" ]; then
+  REWRITTEN="${REWRITTEN} --branch ${EXPLICIT_BRANCH}"
+fi
+
+emit_rewrite "$REWRITTEN" "Translated your \`git push\` to \`${REWRITTEN}\`.
+
+This is the audited push path (#791). It resolves the checkout that actually has the branch and pushes from there -- the pre-push hook reviews the CWD's checked-out branch, not the ref being pushed, so pushing from the wrong checkout silently reviews the wrong diff. It also refuses main/master and writes an audit row carrying the branch, the resolved checkout, and the head SHA.
+
+That audit row is what binds a gate-verified commit to the artifact that actually reached origin. A raw \`git push\` writes none, so reach for \`legion push\` directly next time rather than relying on this translation." \
+  "routed through legion push for the audit trail (#827)"

--- a/plugin/hooks/test-no-git-push.sh
+++ b/plugin/hooks/test-no-git-push.sh
@@ -1,0 +1,112 @@
+#!/bin/bash
+# Test runner for the no-git-push PreToolUse hook (#827).
+#
+# Covers the three outcomes: REWRITE (translation is lossless), DENY (the
+# command carries semantics `legion push` cannot express, so dropping them
+# silently would run something the agent did not ask for), and PASS
+# (not a git push, or the repo is not legion-covered).
+#
+#   bash plugin/hooks/test-no-git-push.sh
+
+set -u
+
+# shellcheck source=tests/testutil.sh
+source "$(dirname "${BASH_SOURCE[0]}")/tests/testutil.sh"
+
+make_plugin_root no-git-push.sh
+
+export FAKE_WATCH="legion-test	/tmp/legion-test"
+
+HOOK="$CLAUDE_PLUGIN_ROOT/hooks/no-git-push.sh"
+
+run_hook() {
+  local cmd="$1"
+  # tool_name is load-bearing: the hook gates on it being Bash, matching
+  # pre-bash-grep.sh. A real PreToolUse payload always carries it.
+  printf '%s' "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":${cmd}},\"cwd\":\"/tmp/legion-test\",\"session_id\":\"test\"}" | bash "$HOOK"
+}
+
+assert_rewritten() {
+  local desc="$1" cmd="$2"
+  assert_contains "$desc" "$(run_hook "$cmd")" '"updatedInput"'
+}
+
+assert_denied() {
+  local desc="$1" cmd="$2"
+  assert_contains "$desc" "$(run_hook "$cmd")" '"permissionDecision": "deny"'
+}
+
+assert_passthrough() {
+  local desc="$1" cmd="$2"
+  local out
+  out="$(run_hook "$cmd")"
+  assert_not_contains "$desc (no rewrite)" "$out" '"updatedInput"'
+  assert_not_contains "$desc (no deny)" "$out" '"permissionDecision": "deny"'
+}
+
+echo "==> rewrites plain pushes"
+assert_rewritten "bare git push"            '"git push"'
+assert_rewritten "push with remote"         '"git push origin"'
+assert_rewritten "push remote + branch"     '"git push origin feat/x"'
+assert_rewritten "push with -u"             '"git push -u origin feat/x"'
+assert_rewritten "push with --set-upstream" '"git push --set-upstream origin feat/x"'
+
+echo "==> resolves the binary by basename, like no-gh.sh"
+assert_rewritten "absolute path git"   '"/opt/homebrew/bin/git push"'
+assert_rewritten "leading whitespace"  '"   git push"'
+assert_rewritten "global -C before subcommand" '"git -C /tmp/legion-test push"'
+assert_rewritten "global --no-pager"   '"git --no-pager push"'
+
+echo "==> carries an explicit branch into --branch"
+assert_contains "branch threaded through" \
+  "$(run_hook '"git push origin feat/x"')" '--branch feat/x'
+
+echo "==> bare push omits --branch so legion push defaults to CWD"
+assert_not_contains "no spurious --branch" \
+  "$(run_hook '"git push"')" '--branch'
+
+echo "==> denies what legion push cannot express"
+assert_denied "force"             '"git push --force"'
+assert_denied "force short"       '"git push -f origin feat/x"'
+assert_denied "force-with-lease"  '"git push --force-with-lease"'
+assert_denied "force-if-includes" '"git push --force-if-includes"'
+assert_denied "delete"            '"git push --delete origin feat/x"'
+assert_denied "delete short"      '"git push -d origin feat/x"'
+assert_denied "tags"              '"git push --tags"'
+assert_denied "mirror"            '"git push --mirror"'
+assert_denied "prune"             '"git push --prune"'
+assert_denied "all"               '"git push --all"'
+assert_denied "refspec retarget"  '"git push origin feat/x:main"'
+
+echo "==> deny names the offending flag rather than refusing generically"
+assert_contains "names the flag" \
+  "$(run_hook '"git push --force-with-lease"')" 'force-with-lease'
+
+echo "==> a denied force push does NOT carry a rewrite"
+assert_not_contains "force is never silently translated" \
+  "$(run_hook '"git push --force"')" '"updatedInput"'
+
+echo "==> passes through non-push git and non-git commands"
+assert_passthrough "git status"    '"git status"'
+assert_passthrough "git commit"    '"git commit -m x"'
+assert_passthrough "git pushed-ish subcommand" '"git push-fake"'
+assert_passthrough "not git at all" '"echo git push"'
+assert_passthrough "legion push itself" '"legion push --repo legion"'
+
+echo "==> announces the translation instead of rewriting silently"
+assert_contains "additionalContext present" \
+  "$(run_hook '"git push"')" '"additionalContext"'
+
+echo "==> skips uncovered repos"
+# Coverage is memoized per (session, repo), so clearing FAKE_WATCH after the
+# covered cases above would still hit the warm cache entry. Use a cwd whose
+# basename is absent from FAKE_WATCH instead -- a different repo, a different
+# cache key, genuinely uncovered.
+uncovered_out=$(printf '%s' '{"tool_name":"Bash","tool_input":{"command":"git push"},"cwd":"/tmp/not-a-legion-repo","session_id":"test"}' | bash "$HOOK")
+assert_not_contains "repo not legion-covered (no rewrite)" "$uncovered_out" '"updatedInput"'
+assert_not_contains "repo not legion-covered (no deny)" "$uncovered_out" '"permissionDecision": "deny"'
+
+echo "==> honours the skip switch"
+LEGION_SKIP_GIT_PUSH=1 assert_passthrough "LEGION_SKIP_GIT_PUSH=1" '"git push"'
+
+finish_tests

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -880,9 +880,12 @@ pub(crate) enum Commands {
         /// Filter by action type. Known verbs:
         /// create-issue, close-issue, reopen-issue, edit-issue,
         /// create-pr, close-pr, review, merge, comment,
-        /// delete-card, update-card.
+        /// delete-card, update-card, push.
         /// Filter is an exact string match; additional verbs
         /// introduced by future subcommands work automatically.
+        /// `push` was written by `legion push` from #791 onward but was
+        /// missing from this list, so anyone auditing by the documented
+        /// verbs never looked for the rows that were already there.
         #[arg(long)]
         action: Option<String>,
 


### PR DESCRIPTION
## Summary

`legion push` (#791) exists so the push-from-own-checkout doctrine is enforced by the tool
rather than by agent discipline. Adoption of that command was itself left to agent discipline:
nothing intercepted a raw `git push`, which writes no audit row at all, so the audit trail was
only ever as complete as every agent remembering to use the right command.

This adds a PreToolUse hook that rewrites plain `git push` into `legion push`, and refuses --
rather than silently rewriting -- anything `legion push` cannot express.

Closes #827.

## Acceptance criteria mapping

### All tests pass

`cargo test` green (357 passed, 0 failed, 2 ignored), `cargo clippy --all-targets -- -D
warnings` clean, `cargo fmt -- --check` clean, `shellcheck` clean on the new hook, the new test
harness, and the modified `lib/emit.sh`. The hook harness itself is 39 assertions covering all
three outcomes plus binary-resolution, branch threading, skip switch, and uncovered-repo
passthrough.

Evidence: `bash plugin/hooks/test-no-git-push.sh` -> `39 passed, 0 failed`.

### Simplify pass completed

Gate `019fb4f9` against commit `9f32fb0`, result clean, provenance `validated`, five file
entries. The articulation argues the two structural calls rather than asserting them: why the
two `while` loops are not the copy-paste they resemble (different termination conditions -- one
consumes option-value pairs to find the subcommand, the other classifies argv), and why
`emit_rewrite` is a new function instead of an optional argument on `emit_allow` (an optional
argument that silently decides whether the agent's command gets replaced is a far worse seam
than one named function).

Evidence: `legion quality-gate list --branch feat/827-git-push-hook` -> `legion-simplify`,
`validated`, commit `9f32fb0`.

### Review pass completed and issues fixed

Two real defects surfaced during the test-writing pass and were fixed before commit rather than
after merge. The test payload initially omitted `tool_name`, which the hook correctly gates on
(matching `pre-bash-grep.sh`) -- every rewrite assertion failed silently with empty output until
that was traced. The uncovered-repo assertion passed for the wrong reason at first: coverage is
memoized per (session, repo), so clearing `FAKE_WATCH` after the covered cases still hit a warm
cache entry; it now uses a genuinely different repo path.

Evidence: `plugin/hooks/test-no-git-push.sh` -- the `tool_name` comment in `run_hook`, and the
inlined uncovered-repo payload using cwd `/tmp/not-a-legion-repo`.

### PR created and linked to this issue

Opened via `legion pr create --repo legion --closes 827`, gated on clean simplify and pr-write
rows for HEAD, and pushed via `legion push` -- the command this PR makes automatic.

Evidence: `legion audit --action push` row for `feat/827-git-push-hook`.

## Why rewrite here and not for `gh`

The rewrite is only honest when the translation is lossless. `git push` -> `legion push` is:
`--branch` defaults to the CWD's checked-out branch, `-u`/`--set-upstream` is implied because
legion push always sets upstream, and `--repo` is derivable. `gh` is a different case -- legion
implements a subset with different ergonomics, so a translator would have to drop flags
silently, and an agent that asks for all PRs and receives open ones has no signal that anything
was dropped. #828 handles `gh` with an exact deny-side redirect instead, deliberately.

That principle is enforced here rather than left to convention: force in any spelling, refspecs,
`--delete`, `--tags`, `--mirror`, `--prune`, and `--all` all DENY and name the offending flag.

## Why a hook and not a symlink

`legion push` shells out to `git push` internally, so a PATH shim or symlink would recurse.
Hooks fire on the agent's Bash tool calls, not on child processes, so the internal call never
re-enters. This is the direct answer to "can we do it like the 1Password SSH agent" -- the
symlink shape specifically does not work here because legion is itself a git consumer.

## Not done

- **The operator's `permissions.ask` rule on `Bash(git push:*)` is untouched.** That is the
  operator's call and the hook is correct with or without it.
- **No change to `legion push`'s own semantics.** It already refuses main/master, has no force
  path, and audit-logs every attempt. This only makes it the path that gets taken.
- **No `gh` redirect** (#828) and **no `git grep` detection** (#829) -- separate issues, separate
  files, and in `gh`'s case a deliberately different mechanism.
- **No backfill of the unaudited branches.** `wf_2b4b2905` left five branches on origin with no
  push row; those SHAs are recoverable from git today but the attestation of when and from which
  checkout is not, and inventing one would defeat the point of an audit trail.

## Evidence for the gap this closes

Workflow batch `wf_2b4b2905` produced seven branches (`feat/787`, `761`, `776`, `772`, `785`,
`778`, `788`). All seven are on origin; only `776` and `778` have push audit rows. That batch
straddled #791 shipping, so it is most likely a transition artifact rather than an ongoing leak
-- the two later batches (`wf_36951cc3`, `wf_5bda7df7`) are 7/7 audited. But they are clean
because the agents chose correctly, which is exactly the reliance `legion push --help` says the
command exists to remove.