### PR TITLE
fix(#829): detect searches spelled as git subcommands

### DIFF
--- a/plugin/hooks/_legion-prequery.sh
+++ b/plugin/hooks/_legion-prequery.sh
@@ -48,16 +48,136 @@ fi
 
 # legion_prequery_bash_binary CMD -- echo the leading search binary name
 # (grep|rg|ag|ack|find|fd) on match, empty on miss.
+#
+# Also recognizes SEARCHES SPELLED AS GIT SUBCOMMANDS (#829). Both
+# enforcement points -- the operator's permissions.deny and this hook --
+# historically matched on the FIRST token only, so `git grep` slipped past
+# both: the first token is `git`, which is in neither list. Verified live
+# on 2026-07-30, `git grep`, `git ls-files`, `git log -S` and
+# `git log --grep` all returned results with the full stack active.
+#
+# The measurement consequence is the worse half: a bypass row is only
+# written when a hook FIRES and the agent escapes via the sentinel. This
+# never fired, so those searches were not merely unblocked, they were
+# uncounted -- and `etc-summary` (#713) is the primary success metric for
+# the sym-etc epic (#704).
+#
+# Multi-word labels ("git grep") are returned deliberately: they read
+# correctly in the redirect messages and callers already quote the value.
 legion_prequery_bash_binary() {
   local cmd="$1"
   local trimmed="${cmd#"${cmd%%[![:space:]]*}"}"
   case "$trimmed" in
-    grep\ *|grep) echo grep ;;
-    rg\ *|rg)     echo rg ;;
-    ag\ *|ag)     echo ag ;;
-    ack\ *|ack)   echo ack ;;
-    find\ *|find) echo find ;;
-    fd\ *|fd)     echo fd ;;
+    grep\ *|grep) echo grep; return ;;
+    rg\ *|rg)     echo rg;   return ;;
+    ag\ *|ag)     echo ag;   return ;;
+    ack\ *|ack)   echo ack;  return ;;
+    find\ *|find) echo find; return ;;
+    fd\ *|fd)     echo fd;   return ;;
+  esac
+
+  # Git-spelled searches. Resolve the binary by basename so an absolute
+  # path invocation is caught too, matching no-gh.sh's hardening.
+  local toks=()
+  IFS=' ' read -ra toks <<<"$trimmed"
+  [ "${#toks[@]}" -ge 2 ] || return 0
+  [ "${toks[0]##*/}" = "git" ] || return 0
+
+  # Walk git's own global options to reach the subcommand. Options taking
+  # a value consume the following token.
+  local i=1 sub=""
+  while [ "$i" -lt "${#toks[@]}" ]; do
+    case "${toks[$i]}" in
+      -C|-c|--git-dir|--work-tree|--namespace) i=$((i + 2)) ;;
+      -*) i=$((i + 1)) ;;
+      *) sub="${toks[$i]}"; break ;;
+    esac
+  done
+
+  case "$sub" in
+    grep)     echo "git grep" ;;
+    ls-files) echo "git ls-files" ;;
+    log)
+      # `git log` is a search ONLY with a content or message predicate.
+      # Every other shape (--oneline, -p, a bare range) is ordinary
+      # history reading and must pass through untouched.
+      local t
+      for t in "${toks[@]}"; do
+        case "$t" in
+          -S|-S*) echo "git log -S"; return ;;
+          -G|-G*) echo "git log -G"; return ;;
+          --grep|--grep=*) echo "git log --grep"; return ;;
+        esac
+      done
+      ;;
+  esac
+}
+
+# legion_prequery_is_git_shape BINARY -- true when BINARY is one of the
+# git-spelled search labels. Callers use this to skip the argv-position
+# assumptions that hold for single-token binaries.
+legion_prequery_is_git_shape() {
+  case "$1" in
+    "git grep"|"git ls-files"|"git log -S"|"git log -G"|"git log --grep") return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# legion_prequery_git_pattern CMD BINARY -- echo the search term for a
+# git-spelled search. Separate from the general extractor because the
+# pattern's argv position differs per shape: a positional after the
+# subcommand for grep/ls-files, a flag VALUE for the log predicates
+# (attached `-Sfoo` and detached `-S foo` both occur).
+legion_prequery_git_pattern() {
+  local cmd="$1" binary="$2"
+  local head="${cmd%%|*}"
+  head="${head%%>*}"; head="${head%%<*}"; head="${head%%;*}"; head="${head%%&&*}"
+
+  local toks=()
+  IFS=' ' read -ra toks <<<"$head"
+
+  local i t
+  case "$binary" in
+    "git log -S"|"git log -G"|"git log --grep")
+      local flag="${binary##* }"
+      for ((i = 0; i < ${#toks[@]}; i++)); do
+        t="${toks[$i]}"
+        case "$t" in
+          "$flag")
+            # Detached value: the next token.
+            [ $((i + 1)) -lt "${#toks[@]}" ] && printf '%s\n' "${toks[$((i + 1))]//\"/}"
+            return
+            ;;
+          "$flag"=*)
+            printf '%s\n' "${t#*=}" | tr -d '"'
+            return
+            ;;
+          "$flag"*)
+            # Attached value: -Sfoo.
+            printf '%s\n' "${t#"$flag"}" | tr -d '"'
+            return
+            ;;
+        esac
+      done
+      ;;
+    *)
+      # git grep / git ls-files: first non-flag token after the
+      # subcommand. `--` and pathspecs after it are not the pattern.
+      local seen_sub=0
+      local subword="${binary##* }"
+      for ((i = 1; i < ${#toks[@]}; i++)); do
+        t="${toks[$i]}"
+        if [ "$seen_sub" -eq 0 ]; then
+          [ "$t" = "$subword" ] && seen_sub=1
+          continue
+        fi
+        case "$t" in
+          --) return ;;
+          -*) continue ;;
+          *) printf '%s\n' "${t//\"/}"; return ;;
+        esac
+      done
+      ;;
   esac
 }
 

--- a/plugin/hooks/pre-bash-grep.sh
+++ b/plugin/hooks/pre-bash-grep.sh
@@ -66,9 +66,29 @@ if [ -z "$BINARY" ]; then
 fi
 
 # Extract the pattern. Empty extraction means we couldn't isolate one;
-# pass through rather than guessing.
-PATTERN=$(legion_prequery_extract_pattern "$COMMAND" "$BINARY")
+# pass through rather than guessing. Git-spelled searches (#829) put the
+# pattern in a different argv position per shape, so they use their own
+# extractor.
+if legion_prequery_is_git_shape "$BINARY"; then
+  PATTERN=$(legion_prequery_git_pattern "$COMMAND" "$BINARY")
+else
+  PATTERN=$(legion_prequery_extract_pattern "$COMMAND" "$BINARY")
+fi
 if [ -z "$PATTERN" ]; then
+  exit 0
+fi
+
+# `git log --grep` searches COMMIT MESSAGES, which sym does not index.
+# Recognizing it matters -- an unrecognized shape is invisible to the
+# bypass telemetry that grades whether the sanctioned surface answers
+# what agents actually ask (#713/#704). But blocking it, or redirecting
+# it to a sym command that structurally cannot serve it, is the exact
+# failure this ladder exists to avoid: refusing a query the sanctioned
+# surface has no answer for. Record the shape, then pass through.
+if [ "$BINARY" = "git log --grep" ]; then
+  legion_prequery_record_bypass \
+    "$REPO" "$SESSION_ID" "Bash" "$PATTERN" "git-log-grep: commit messages are not sym-indexed" \
+    "false" "false"
   exit 0
 fi
 

--- a/plugin/hooks/test-pre-bash-grep.sh
+++ b/plugin/hooks/test-pre-bash-grep.sh
@@ -161,4 +161,61 @@ echo "==> LEGION_REPO precedence: env overrides basename(cwd)"
 out=$(echo '{"cwd":"/tmp/legion","tool_name":"Bash","tool_input":{"command":"grep -r Symbol src/"},"session_id":"repo-env-t"}' | LEGION_REPO=uncovered-elsewhere bash "$HOOK")
 assert_empty "LEGION_REPO redirects the coverage gate" "$out"
 
+
+# --- #829: searches spelled as git subcommands ------------------------------
+#
+# Both enforcement points matched on the first token only, so `git grep`
+# and friends slipped past unblocked AND uncounted. These assert the
+# detector now names each shape, and that ordinary `git log` still passes.
+
+echo "==> detects git-spelled searches"
+assert_eq "git grep detected" \
+  "$(legion_prequery_bash_binary 'git grep -n foo -- src')" "git grep"
+assert_eq "git ls-files detected" \
+  "$(legion_prequery_bash_binary 'git ls-files "*.rs"')" "git ls-files"
+assert_eq "git log -S detected" \
+  "$(legion_prequery_bash_binary 'git log -S find_plugin --oneline')" "git log -S"
+assert_eq "git log -G detected" \
+  "$(legion_prequery_bash_binary 'git log -G regex_thing')" "git log -G"
+assert_eq "git log --grep detected" \
+  "$(legion_prequery_bash_binary 'git log --grep worksource')" "git log --grep"
+
+echo "==> resolves git by basename and past global options"
+assert_eq "absolute path git" \
+  "$(legion_prequery_bash_binary '/opt/homebrew/bin/git grep foo')" "git grep"
+assert_eq "global -C before subcommand" \
+  "$(legion_prequery_bash_binary 'git -C /tmp/x grep foo')" "git grep"
+assert_eq "global --no-pager" \
+  "$(legion_prequery_bash_binary 'git --no-pager grep foo')" "git grep"
+
+echo "==> ordinary git log is not a search"
+assert_eq "git log --oneline passes" \
+  "$(legion_prequery_bash_binary 'git log --oneline')" ""
+assert_eq "git log -p passes" \
+  "$(legion_prequery_bash_binary 'git log -p HEAD~3')" ""
+assert_eq "bare git log passes" \
+  "$(legion_prequery_bash_binary 'git log')" ""
+assert_eq "git status passes" \
+  "$(legion_prequery_bash_binary 'git status')" ""
+assert_eq "git commit passes" \
+  "$(legion_prequery_bash_binary 'git commit -m grep')" ""
+
+echo "==> extracts the pattern from each git shape"
+assert_eq "git grep positional" \
+  "$(legion_prequery_git_pattern 'git grep -n find_plugin -- src' 'git grep')" "find_plugin"
+assert_eq "git ls-files glob" \
+  "$(legion_prequery_git_pattern 'git ls-files *.rs' 'git ls-files')" "*.rs"
+assert_eq "git log -S detached value" \
+  "$(legion_prequery_git_pattern 'git log -S find_plugin' 'git log -S')" "find_plugin"
+assert_eq "git log -S attached value" \
+  "$(legion_prequery_git_pattern 'git log -Sfind_plugin' 'git log -S')" "find_plugin"
+assert_eq "git log --grep equals form" \
+  "$(legion_prequery_git_pattern 'git log --grep=worksource' 'git log --grep')" "worksource"
+assert_eq "git log --grep detached form" \
+  "$(legion_prequery_git_pattern 'git log --grep worksource' 'git log --grep')" "worksource"
+
+echo "==> git shapes are classified as such"
+legion_prequery_is_git_shape "git grep" && echo "  PASS: git grep is a git shape" || echo "  FAIL: git grep is a git shape"
+legion_prequery_is_git_shape "grep" && echo "  FAIL: plain grep misclassified" || echo "  PASS: plain grep is not a git shape"
+
 finish_tests


### PR DESCRIPTION
## Summary

Both search-enforcement points matched on the first token only. `permissions.deny` lists
`grep`/`rg`/`find`/`fd`/`ag`/`ack`; `pre-bash-grep.sh` basenames the first token and compares
against the same set. For `git grep foo` the first token is `git`, so neither fired.

Verified live with the full stack active: `git grep -n`, `git ls-files`, `git log -S` and
`git log --grep` all returned real results. Two are additionally pre-approved, since
`Bash(git log:*)` sits in the operator's allow list.

Closes #829.

## Acceptance criteria mapping

### All tests pass

`cargo test` green (357 passed, 0 failed, 2 ignored -- no Rust changed on this branch), and
`shellcheck` clean on all three modified shell files. The prequery harness gained 22 assertions
across four groups: detection per shape, binary resolution by basename and past git global
options, the negative set, and pattern extraction for both attached and detached flag values.

Evidence: `bash plugin/hooks/test-pre-bash-grep.sh` -> `69 passed, 0 failed`.

### Simplify pass completed

Gate `019fb502` against commit `baa01b2`, result clean, provenance `validated`, three file
entries. The articulation argues the two structural calls: why the git-global-option walk is
NOT extracted into a helper shared with `no-git-push.sh` (different files, different sourcing
contracts -- the coupling would cost more than six duplicated lines), and why
`legion_prequery_git_pattern` is a separate function rather than another branch in
`legion_prequery_extract_pattern` (the existing extractor's `local i=1` skip assumes a
single-token binary; threading a variable skip through it would make an already subtle function
worse for a shape it was not designed for).

Evidence: `legion quality-gate list --branch fix/829-git-search` -> `legion-simplify`,
`validated`, commit `baa01b2`.

### Review pass completed and issues fixed

Reviewed for over-matching, which is this change's real failure mode -- a detector that is too
eager breaks ordinary history reading. `git log` is classified as a search ONLY when it carries
`-S`, `-G`, or `--grep`; `--oneline`, `-p`, and a bare range pass through untouched, each with
its own assertion. `git commit -m grep` is asserted specifically because it is what a naive
substring check over the whole command would wrongly catch.

Evidence: the "ordinary git log is not a search" group in
`plugin/hooks/test-pre-bash-grep.sh`, five assertions including `git status` and
`git commit -m grep`.

### PR created and linked to this issue

Opened via `legion pr create --repo legion --closes 829`, gated on clean simplify and pr-write
rows for HEAD, pushed via `legion push`.

Evidence: `legion audit --action push` row for `fix/829-git-search`.

## The measurement half, which is worse than the hole

A bypass row is written only when a hook FIRES and the agent escapes via the sentinel. These
searches never fired the hook, so they were not merely unblocked -- they were **uncounted**.
`legion telemetry summary --since 24h` showed no trace of four searches run minutes earlier.

`etc-summary` is documented as "the PRIMARY sym-etc epic (#704) metric," and bypass volume feeds
the uncertainty engine (#354). Both have been measuring a subset and reporting it as the whole.
This does not recover the historical undercount; it stops it growing.

## `git log --grep` is recognized but never redirected

Commit messages are not sym-indexed. Recognizing the shape matters, because an unrecognized
shape is invisible to the very telemetry this issue is about. But blocking it, or redirecting it
to a sym command that structurally cannot serve it, is precisely the failure the three-state
ladder exists to avoid: refusing a query the sanctioned surface has no answer for. It records
its shape and passes through, with `had_sym_hits=false` accurately reflecting that no sym probe
ran, because there is nothing to probe.

## Not done

- **No `permissions.deny` edit.** `Bash(git grep:*)` and `Bash(git ls-files:*)` are documented
  in the issue for the operator to apply. `git log` deliberately gets no deny rule at all -- it
  is load-bearing for ordinary work, so its search forms are hook-side only.
- **No commit-message indexing in sym.** That would make `git log --grep` redirectable rather
  than merely recorded, but it is a design question about what sym indexes, not a hole to plug.
- **No re-baselining of historical #704 metrics.** The undercount is not retroactively
  recoverable.
- **No shared git-subcommand parser with `no-git-push.sh` (#827).** Deliberate, argued in the
  simplify articulation.