### PR TITLE
feat(#828): redirect gh to the exact legion command, not a menu

### DIFF
--- a/plugin/hooks/no-gh.sh
+++ b/plugin/hooks/no-gh.sh
@@ -25,16 +25,119 @@ TRIMMED="${COMMAND#"${COMMAND%%[![:space:]]*}"}"
 FIRST_TOKEN="${TRIMMED%%[[:space:]]*}"
 FIRST_BIN="${FIRST_TOKEN##*/}"
 
-if [ "$FIRST_BIN" = "gh" ]; then
-  emit_deny "Do not use gh directly. Use legion commands instead:
-- legion issue create --repo <name> --title '...' --body '...'
-- legion issue list --repo <name>
-- legion pr create --repo <name> --title '...'
-- legion pr list --repo <name>
-- legion pr review --repo <name> --number <n> --approve
-- legion pr merge --repo <name> --number <n>
-- legion comment --repo <name> --number <n> --body '...'
-- legion audit
-
-These commands go through the work source plugin and are tracked in the audit log. Absolute-path invocations (e.g. /opt/homebrew/bin/gh) are also blocked -- legion sees through the path."
+if [ "$FIRST_BIN" != "gh" ]; then
+  exit 0
 fi
+
+# --- Translate, do not enumerate ---------------------------------------------
+#
+# This deny message is the only place the legion work-source surface gets
+# named to an agent mid-task, and it used to print a fixed list of 8 verbs
+# against a surface of roughly 40 -- with every READ verb missing
+# (pr view, pr checks, pr comments, pr reviews, issue view). Those are
+# exactly what an agent reaches for when reacting to review feedback or
+# checking CI, so the list was thinnest precisely where it was most needed.
+#
+# `pre-bash-grep.sh` already established the better pattern: resolve the
+# agent's actual query and hand back the specific answer instead of a
+# catalog. An exact redirect also cannot drift into partiality the way an
+# enumeration does -- a new legion verb does not silently make this message
+# wrong.
+#
+# Parsing is argv-style, whole-token comparisons only. See the
+# pre-whoami-rewrite scar (019e2a5a): a greedy regex over a command string
+# matches content inside --body/--title values.
+
+read -r -a GH_TOKENS <<<"$TRIMMED"
+
+GROUP=""
+VERB=""
+NUMBER=""
+for ((gi = 1; gi < ${#GH_TOKENS[@]}; gi++)); do
+  TOK="${GH_TOKENS[$gi]}"
+  case "$TOK" in
+    -*) continue ;;
+  esac
+  if [ -z "$GROUP" ]; then
+    GROUP="$TOK"
+  elif [ -z "$VERB" ]; then
+    VERB="$TOK"
+  elif [ -z "$NUMBER" ]; then
+    case "$TOK" in
+      *[!0-9]*) : ;;
+      *) NUMBER="$TOK" ;;
+    esac
+  fi
+done
+
+# `--number <n>` when the agent used the flag form rather than a positional.
+if [ -z "$NUMBER" ]; then
+  for ((gi = 1; gi < ${#GH_TOKENS[@]}; gi++)); do
+    if [ "${GH_TOKENS[$gi]}" = "--number" ] && [ $((gi + 1)) -lt "${#GH_TOKENS[@]}" ]; then
+      NUMBER="${GH_TOKENS[$((gi + 1))]}"
+      break
+    fi
+  done
+fi
+
+NUM_ARG="--number ${NUMBER:-<n>}"
+
+case "$GROUP $VERB" in
+  "pr view")     SUGGESTION="legion pr view --repo ${REPO} ${NUM_ARG}" ;;
+  "pr diff")     SUGGESTION="legion pr view --repo ${REPO} ${NUM_ARG}" ;;
+  "pr checks")   SUGGESTION="legion pr checks --repo ${REPO} ${NUM_ARG}" ;;
+  "pr list")     SUGGESTION="legion pr list --repo ${REPO}" ;;
+  "pr create")   SUGGESTION="legion pr create --repo ${REPO} --title '...' --closes <issue>" ;;
+  "pr merge")    SUGGESTION="legion pr merge --repo ${REPO} ${NUM_ARG}" ;;
+  "pr close")    SUGGESTION="legion pr close --repo ${REPO} ${NUM_ARG}" ;;
+  "pr edit")     SUGGESTION="legion pr edit --repo ${REPO} ${NUM_ARG} --title '...'" ;;
+  "pr review")   SUGGESTION="legion pr review --repo ${REPO} ${NUM_ARG} --approve" ;;
+  "pr comment")  SUGGESTION="legion comment --repo ${REPO} ${NUM_ARG} --body '...'" ;;
+  "pr comments") SUGGESTION="legion pr comments --repo ${REPO} ${NUM_ARG}" ;;
+  "issue view")    SUGGESTION="legion issue view --repo ${REPO} ${NUM_ARG}" ;;
+  "issue list")    SUGGESTION="legion issue list --repo ${REPO}" ;;
+  "issue create")  SUGGESTION="legion issue create --repo ${REPO} --title '...' --body '...'" ;;
+  "issue close")   SUGGESTION="legion issue close --repo ${REPO} ${NUM_ARG}" ;;
+  "issue reopen")  SUGGESTION="legion issue reopen --repo ${REPO} ${NUM_ARG}" ;;
+  "issue edit")    SUGGESTION="legion issue edit --repo ${REPO} ${NUM_ARG} --title '...'" ;;
+  "issue comment") SUGGESTION="legion comment --repo ${REPO} ${NUM_ARG} --body '...'" ;;
+  "run list" | "run view" | "run watch")
+    # CI status lives on the PR in legion's model, not on the run.
+    SUGGESTION="legion pr checks --repo ${REPO} ${NUM_ARG}"
+    ;;
+  *)
+    SUGGESTION=""
+    ;;
+esac
+
+if [ -n "$SUGGESTION" ]; then
+  emit_deny "Use legion, not gh:
+
+    ${SUGGESTION}
+
+Work-source actions go through legion so they land in the audit log (\`legion audit\`). Absolute-path invocations are blocked too -- legion resolves the binary by basename.
+
+Fill in any \`...\` placeholder; \`legion ${GROUP} --help\` lists the rest of the surface, which is wider than this message shows."
+  exit 0
+fi
+
+# No mapping. Point at the group help rather than inventing a translation
+# -- a fabricated command is worse than an honest "look here", because the
+# agent will run it and read the error as legion being broken.
+#
+# The pointer is deliberately to the GROUP help, never a leaf subcommand's
+# help: a leaf documents its own options and hides its siblings, which is
+# the one confusion this surface reproducibly causes (an agent that ran
+# `legion pr list --help` concluded `legion pr checks` did not exist).
+HELP_HINT="legion --help"
+case "$GROUP" in
+  pr | issue | run) HELP_HINT="legion ${GROUP/run/pr} --help" ;;
+esac
+
+emit_deny "Do not use gh directly -- work-source actions go through legion so they land in the audit log.
+
+There is no direct legion equivalent for \`gh ${GROUP} ${VERB}\`. Run:
+
+    ${HELP_HINT}
+
+to see the surface (it is wider than you may expect -- \`legion pr\` alone covers view, checks, comments, reviews, edit, review, merge and close). Ask the group's help, not a single subcommand's: a leaf \`--help\` documents its own flags and hides its siblings."

--- a/plugin/hooks/test-no-gh.sh
+++ b/plugin/hooks/test-no-gh.sh
@@ -58,4 +58,42 @@ echo "==> uncovered repo passes through"
 out=$(printf '%s' '{"tool_input":{"command":"gh pr merge 1"},"cwd":"/tmp/uncovered-repo","session_id":"test"}' | bash "$HOOK")
 assert_empty "gh allowed in a repo legion does not cover" "$out"
 
+
+# --- #828: exact redirect instead of a fixed menu ----------------------------
+
+assert_suggests() {
+  local desc="$1" cmd="$2" needle="$3"
+  assert_contains "$desc" "$(run_hook "$cmd")" "$needle"
+}
+
+echo "==> translates the verb the agent actually typed"
+assert_suggests "pr view"     '"gh pr view 42"'     'legion pr view --repo legion-test --number 42'
+assert_suggests "pr checks"   '"gh pr checks 42"'   'legion pr checks --repo legion-test --number 42'
+assert_suggests "pr comments" '"gh pr comments 42"' 'legion pr comments --repo legion-test --number 42'
+assert_suggests "pr merge"    '"gh pr merge 123"'   'legion pr merge --repo legion-test --number 123'
+assert_suggests "pr list"     '"gh pr list"'        'legion pr list --repo legion-test'
+assert_suggests "issue view"  '"gh issue view 7"'   'legion issue view --repo legion-test --number 7'
+assert_suggests "issue list"  '"gh issue list"'     'legion issue list --repo legion-test'
+
+echo "==> maps verbs whose legion name differs"
+assert_suggests "pr comment -> legion comment" '"gh pr comment 42 --body x"' 'legion comment --repo legion-test --number 42'
+assert_suggests "run list -> pr checks"        '"gh run list"'               'legion pr checks --repo legion-test'
+assert_suggests "pr diff -> pr view"           '"gh pr diff 42"'             'legion pr view --repo legion-test --number 42'
+
+echo "==> reads the number from the --number flag form too"
+assert_suggests "flag-form number" '"gh pr view --number 99"' '--number 99'
+
+echo "==> no number given leaves a visible placeholder, not a wrong number"
+assert_suggests "placeholder when absent" '"gh pr view"' '--number <n>'
+
+echo "==> unmapped shapes point at group help and invent nothing"
+assert_suggests "gh api falls back"   '"gh api /repos/x/y"' 'legion --help'
+assert_suggests "unknown pr verb"     '"gh pr sync"'        'legion pr --help'
+out_api=$(run_hook '"gh api /repos/x/y"')
+assert_not_contains "no fabricated translation for gh api" "$out_api" 'legion api'
+
+echo "==> the old fixed menu is gone"
+out_view=$(run_hook '"gh pr view 42"')
+assert_not_contains "does not print the 8-verb catalog" "$out_view" 'legion pr review --repo <name>'
+
 finish_tests


### PR DESCRIPTION
## Summary

The `no-gh` deny message is the only place legion's work-source surface gets named to an agent
mid-task, and it printed a fixed list of 8 verbs against a surface of roughly 40 -- with every
READ verb missing: `pr view`, `pr checks`, `pr comments`, `pr reviews`, `issue view`. Those are
exactly what an agent reaches for when reacting to review feedback or checking CI, so the list
was thinnest precisely where it was most needed.

`gh pr view 42` now denies with `legion pr view --repo <r> --number 42`, and nothing else.

Closes #828.

## Acceptance criteria mapping

### All tests pass

`cargo test` green (357 passed, 0 failed, 2 ignored -- no Rust on this branch), `shellcheck`
clean on both modified files, `bash -n` clean. The harness went from 11 assertions to 30: the
existing detection and absolute-path cases were left untouched and still pass, which is what
confirms the hardening survived a full rewrite of the deny body.

Evidence: `bash plugin/hooks/test-no-gh.sh` -> `30 passed, 0 failed`.

### Simplify pass completed

Gate `019fb509` against commit `992fbc9`, result clean, provenance `validated`, two file
entries. The articulation argues the structural calls rather than asserting them: why
`case "$GROUP $VERB"` on a joined string beats nested cases, why the two argv scans are separate
passes rather than one merged loop, and why nineteen one-line `case` arms are what a lookup
table should look like rather than something to parametrise.

Evidence: `legion quality-gate list --branch fix/828-gh-redirect` -> `legion-simplify`,
`validated`, commit `992fbc9`.

### Review pass completed and issues fixed

`bash -n` caught a stray `done` where the flag-form number scan should have closed with `fi` --
the file parsed as a syntax error and every rewrite assertion returned empty until it was traced.
Fixed before commit. The review also drove the two negative assertions, which are the
load-bearing ones in the new suite: one fails if a future arm invents a command like
`legion api`, the other fails if anyone reinstates the old catalog alongside the redirect.

Evidence: `plugin/hooks/test-no-gh.sh` -- "no fabricated translation for gh api" and "does not
print the 8-verb catalog".

### PR created and linked to this issue

Opened via `legion pr create --repo legion --closes 828`, gated on clean simplify and pr-write
rows for HEAD, pushed via `legion push`.

Evidence: `legion audit --action push` row for `fix/828-gh-redirect`.

## Why deny-and-redirect rather than rewrite

`legion` implements a SUBSET of `gh` with different ergonomics -- `gh pr list --state all` has no
legion equivalent. A translator would have to drop that flag silently, and an agent that asks
for all PRs and receives open ones has no signal anything was dropped. That is strictly worse
than an honest refusal.

`git push` -> `legion push` (#827) is the opposite case: near-lossless, so it rewrites. The two
issues deliberately use different mechanisms for that reason, and the distinction is recorded in
both so a later pass does not "harmonise" them.

## Unmapped shapes invent nothing

`gh api`, or any verb with no legion equivalent, denies with a pointer to the group help. A
fabricated command is worse than "look here", because the agent runs it and reads the failure as
legion being broken.

The pointer goes to the GROUP help, never a leaf subcommand's. That is the one confusion this
surface reproducibly causes: a probe agent that ran `legion pr list --help` concluded
`legion pr checks` did not exist -- for a command named exactly that. A leaf `--help` documents
its own flags and hides its siblings.

## Not done

- **The three dead `Bash(gh ...)` allow entries are not removed here.** `Bash(gh run:*)`,
  `Bash(gh pr view:*)` and `Bash(gh pr list:*)` sit in the operator's `settings.json`; verified
  the hook deny overrides `permissions.allow`, so they are inert, but they are the operator's
  file to edit. Documented in the issue.
- **No rewrite via `updatedInput`** -- argued above.
- **No new legion verbs.** This maps what exists; `gh pr diff` points at `legion pr view`
  because that is the closest real surface, not because a diff verb was added.

## Scope honesty

Five probe agents were run against this surface. Four found the legion commands unprompted by
walking `legion --help` -> `legion <group> --help`, including one that was handed the old 8-verb
list first and went up to `legion pr --help` anyway. No probe was ever blocked from a capability
that exists. This is a quality fix on a real design defect, not a fix for a demonstrated outage
-- prioritise accordingly.