### PR TITLE
feat(#837): point script-shaped searches at sym

### DIFF
--- a/plugin/hooks/_legion-prequery.sh
+++ b/plugin/hooks/_legion-prequery.sh
@@ -137,6 +137,62 @@ legion_prequery_extract_pattern() {
   done
 }
 
+# legion_prequery_script_primitive TEXT -- echo the search SHAPE a script
+# is reaching for (#837), or empty when it is not doing a search.
+#
+#   tree    -- directory walk / listing      -> legion sym tree
+#   file    -- filename or glob matching     -> legion sym etc find-file
+#   content -- text search inside files      -> legion sym etc find-content
+#
+# Why this exists: every other enforcement point classifies by the leading
+# binary, and no first-token rule can catch `python tree.py` -- you cannot
+# tell what a script does from its invocation. Observed 2026-07-31: the
+# rafters agent wrote a Python script for a directory tree against an index
+# that had been rebuilt 42 seconds earlier.
+#
+# Detection is heuristic and deliberately biased toward MISSING rather than
+# over-firing. The consumer injects, never denies, so a false positive
+# costs one paragraph and a false negative costs only today's behaviour.
+# Order matters: `tree` is checked first because a walk usually also
+# contains a filename test, and the walk is the more specific signal.
+legion_prequery_script_primitive() {
+  local text="$1"
+
+  case "$text" in
+    *os.walk*|*os.scandir*|*os.listdir*|*readdirSync*|*fs.readdir*|*.rglob\(*|*walkdir*)
+      echo tree; return ;;
+  esac
+  case "$text" in
+    *fnmatch*|*glob.glob*|*.glob\(*|*endswith\(*|*path.match*)
+      echo file; return ;;
+  esac
+  case "$text" in
+    *re.search*|*re.findall*|*re.compile*|*.includes\(*|*subprocess*grep*)
+      echo content; return ;;
+  esac
+}
+
+# legion_prequery_script_interpreter CMD -- echo the interpreter name when
+# a Bash command leads with one, empty otherwise. Resolved by basename so
+# an absolute path is caught, matching no-gh.sh.
+legion_prequery_script_interpreter() {
+  local cmd="$1"
+  local trimmed="${cmd#"${cmd%%[![:space:]]*}"}"
+  local toks=()
+  IFS=' ' read -ra toks <<<"$trimmed"
+  [ "${#toks[@]}" -ge 1 ] || return 0
+
+  local first="${toks[0]##*/}"
+  case "$first" in
+    python|python3|node|bun|deno|ruby|perl) echo "$first"; return ;;
+    # Runner wrappers: the interpreter is the second token.
+    uv|pnpm|npx|yarn)
+      [ "${#toks[@]}" -ge 2 ] && echo "$first ${toks[1]}"
+      return
+      ;;
+  esac
+}
+
 # legion_prequery_is_symbol PATTERN -- exit 0 if pattern looks like a bare
 # symbol identifier (CamelCase or snake_case, length > 2, no regex
 # metachars). Exit 1 otherwise.

--- a/plugin/hooks/hooks.json
+++ b/plugin/hooks/hooks.json
@@ -151,6 +151,11 @@
             "type": "command",
             "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/pre-bash-grep.sh",
             "timeout": 6
+          },
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/pre-script-search.sh",
+            "timeout": 5
           }
         ]
       },
@@ -171,6 +176,11 @@
             "type": "command",
             "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/no-local-memory.sh",
             "timeout": 5
+          },
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/pre-script-search.sh",
+            "timeout": 5
           }
         ]
       },
@@ -180,6 +190,11 @@
           {
             "type": "command",
             "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/no-local-memory.sh",
+            "timeout": 5
+          },
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/pre-script-search.sh",
             "timeout": 5
           }
         ]

--- a/plugin/hooks/pre-script-search.sh
+++ b/plugin/hooks/pre-script-search.sh
@@ -1,0 +1,136 @@
+#!/bin/bash
+# Legion PreToolUse hook (#837): when an agent reaches for a SCRIPT to do
+# what sym already answers, point at the sym command -- at the moment it
+# reaches, not after.
+#
+# Observed 2026-07-31: the rafters agent wrote a Python script to get a
+# directory tree. `legion sym tree --repo rafters` answers that directly,
+# rafters is legion-covered, and its index had been rebuilt 42 seconds
+# earlier. The capability was live and adjacent; nothing connected the
+# agent to it.
+#
+# Why no existing hook catches this: every other enforcement point
+# classifies by the command's LEADING BINARY (grep|rg|ag|ack|find|fd, plus
+# the git shapes from #829). `python tree.py` leads with `python`, and no
+# first-token rule can ever catch it -- you cannot tell what a script does
+# from its invocation. Writing the script only meets no-local-memory.sh.
+#
+# So this hook watches two moments instead of one:
+#
+#   Write/Edit -- the content being written carries a search primitive.
+#                 This is the EARLIER and more useful catch: the nudge
+#                 lands before the script exists.
+#   Bash       -- an interpreter with inline `-c` / `-e` code carrying a
+#                 search primitive.
+#
+# INJECT, NEVER DENY. A script that walks a tree may also do real work,
+# and refusing real work to prevent a redundant listing is a worse trade
+# than a missed nudge. Same posture #829 took for `git log --grep`: never
+# refuse a query the sanctioned surface cannot fully serve. Detection is
+# heuristic; the cost of a false positive is one injected paragraph.
+#
+# Every detection also writes a telemetry row. This class is currently a
+# structural blind spot in `etc-summary` (#713) -- the primary metric for
+# whether the sanctioned surface answers what agents actually ask -- and a
+# metric that cannot see script-shaped searches reads their absence as
+# success.
+#
+# Skip via LEGION_SKIP_SCRIPT_SEARCH=1.
+
+set -u
+
+if [ "${LEGION_SKIP_SCRIPT_SEARCH:-}" = "1" ]; then
+  exit 0
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+  exit 0
+fi
+
+# shellcheck source=lib/prelude.sh
+source "${CLAUDE_PLUGIN_ROOT:-}/hooks/lib/prelude.sh" 2>/dev/null || exit 0
+
+legion_hook_parse || exit 0
+
+if [ -z "$CWD" ] || [ -z "$REPO" ]; then
+  exit 0
+fi
+
+# shellcheck source=_legion-prequery.sh
+source "${CLAUDE_PLUGIN_ROOT}/hooks/_legion-prequery.sh" 2>/dev/null || exit 0
+
+legion_hook_covered || exit 0
+
+# Pointing at sym in a repo with no index is advice the agent cannot take.
+legion_indexed "$SESSION_ID" "$REPO" || exit 0
+
+# --- Gather the text to inspect, per tool ------------------------------------
+
+SUBJECT=""
+ORIGIN=""
+
+case "$TOOL" in
+  Bash)
+    COMMAND=$(legion_hook_field '.tool_input.command')
+    [ -n "$COMMAND" ] || exit 0
+    INTERP=$(legion_prequery_script_interpreter "$COMMAND")
+    [ -n "$INTERP" ] || exit 0
+    # Only inline code is inspectable. `python tree.py` carries no clue
+    # about what the script does, and reading arbitrary script files at
+    # hook time is slow and unbounded -- the Write-side trigger covers
+    # the authorship moment for those instead.
+    case "$COMMAND" in
+      *\ -c\ *|*\ -e\ *) SUBJECT="$COMMAND" ;;
+      *) exit 0 ;;
+    esac
+    ORIGIN="inline ${INTERP}"
+    ;;
+  Write)
+    SUBJECT=$(legion_hook_field '.tool_input.content')
+    ORIGIN="a script you are writing"
+    ;;
+  Edit)
+    SUBJECT=$(legion_hook_field '.tool_input.new_string')
+    ORIGIN="a script you are editing"
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+
+[ -n "$SUBJECT" ] || exit 0
+
+SHAPE=$(legion_prequery_script_primitive "$SUBJECT")
+[ -n "$SHAPE" ] || exit 0
+
+# --- One command per shape, never a menu (#828's lesson) ---------------------
+
+case "$SHAPE" in
+  tree)
+    SUGGESTION="legion sym tree --repo ${REPO}"
+    WHAT="a directory walk"
+    ;;
+  file)
+    SUGGESTION="legion sym etc find-file '<name-or-glob>' --repo ${REPO}"
+    WHAT="a filename or glob match"
+    ;;
+  content)
+    SUGGESTION="legion sym etc find-content '<pattern>' --repo ${REPO}"
+    WHAT="a text search inside files"
+    ;;
+esac
+
+legion_prequery_record_bypass \
+  "$REPO" "$SESSION_ID" "$TOOL" "script:${SHAPE}" \
+  "script-shaped search (${ORIGIN})" "false" "false"
+
+emit_allow "## legion sym answers this without the script
+
+That looks like ${WHAT} in ${ORIGIN}. \`${REPO}\` is indexed, so:
+
+    ${SUGGESTION}
+
+returns it directly -- no file to write, no walk to run, no output to page through.
+
+Not blocking you: a script that searches may also do real work this cannot replace, and if that is the case here, carry on. But if the search IS the point, sym already has the answer indexed. \`legion sym --help\` covers def/refs/impl/hover for symbols; \`legion sym etc\` covers content, filenames, and structure." \
+  "legion sym covers this shape"

--- a/plugin/hooks/test-pre-script-search.sh
+++ b/plugin/hooks/test-pre-script-search.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+# Test runner for the pre-script-search PreToolUse hook (#837).
+#
+# The observed case: an agent writes a Python script to walk a directory
+# tree in a covered, indexed repo where `legion sym tree` already answers.
+# No first-token rule can catch that, so this hook watches the content
+# being written and the inline code being run.
+#
+# Two properties matter more than coverage breadth here:
+#   1. It INJECTS, never denies. Denying real work to prevent a redundant
+#      listing is the worse trade.
+#   2. It does not over-fire. A script that merely mentions a path, or
+#      does structured editing, must pass through untouched.
+#
+#   bash plugin/hooks/test-pre-script-search.sh
+
+set -u
+
+# shellcheck source=tests/testutil.sh
+source "$(dirname "${BASH_SOURCE[0]}")/tests/testutil.sh"
+
+make_plugin_root pre-script-search.sh
+
+export FAKE_WATCH="legion-test	/tmp/legion-test"
+# The hook refuses to point at sym in an unindexed repo -- that would be
+# advice the agent cannot take -- so the covered fixture must also report
+# an index.
+export FAKE_INDEX_JSON='[{"repo":"legion-test","lang":"rust","size_bytes":100,"updated_at":"2026-01-01T00:00:00Z"}]'
+
+HOOK="$CLAUDE_PLUGIN_ROOT/hooks/pre-script-search.sh"
+
+run_write() {
+  jq -n --arg c "$1" '{tool_name:"Write",tool_input:{content:$c},cwd:"/tmp/legion-test",session_id:"test"}' | bash "$HOOK"
+}
+run_bash() {
+  jq -n --arg c "$1" '{tool_name:"Bash",tool_input:{command:$c},cwd:"/tmp/legion-test",session_id:"test"}' | bash "$HOOK"
+}
+
+echo "==> the observed rafters case: a script that walks a tree"
+out=$(run_write 'import os
+for root, dirs, files in os.walk("."):
+    print(root)')
+assert_contains "suggests sym tree" "$out" 'legion sym tree --repo legion-test'
+assert_contains "injects rather than denies" "$out" '"permissionDecision": "allow"'
+assert_not_contains "never denies" "$out" '"permissionDecision": "deny"'
+
+echo "==> routes each shape to ONE command, not a menu"
+assert_contains "rglob -> tree" "$(run_write 'Path(".").rglob("*.rs")')" 'legion sym tree'
+assert_contains "readdirSync -> tree" "$(run_write 'fs.readdirSync(dir)')" 'legion sym tree'
+assert_contains "fnmatch -> find-file" "$(run_write 'import fnmatch
+fnmatch.filter(names, "*.rs")')" 'find-file'
+assert_contains "re.search -> find-content" "$(run_write 'import re
+re.search(pat, text)')" 'find-content'
+assert_not_contains "tree answer does not also list find-content" \
+  "$(run_write 'import os
+os.walk(".")')" 'find-content'
+
+echo "==> inline interpreter code on Bash"
+assert_contains "python -c walk" "$(run_bash 'python3 -c "import os; os.walk(\".\")"')" 'legion sym tree'
+assert_contains "node -e readdir" "$(run_bash 'node -e "fs.readdirSync(\".\")"')" 'legion sym tree'
+assert_contains "absolute-path interpreter" "$(run_bash '/usr/bin/python3 -c "import os; os.walk(\".\")"')" 'legion sym tree'
+
+echo "==> does NOT over-fire"
+assert_empty "ordinary script passes" "$(run_write 'def add(a, b):
+    return a + b')"
+assert_empty "structured json edit passes" "$(run_write 'import json
+d = json.load(open("f.json"))
+json.dump(d, open("f.json", "w"))')"
+assert_empty "script named by path, no inline code" "$(run_bash 'python3 tree.py')"
+assert_empty "interpreter with no search primitive" "$(run_bash 'python3 -c "print(1 + 1)"')"
+assert_empty "non-interpreter bash passes" "$(run_bash 'ls -la')"
+assert_empty "cargo build passes" "$(run_bash 'cargo build --release')"
+
+echo "==> gates"
+out_unc=$(jq -n '{tool_name:"Write",tool_input:{content:"import os\nos.walk(\".\")"},cwd:"/tmp/not-a-legion-repo",session_id:"test"}' | bash "$HOOK")
+assert_empty "uncovered repo passes through" "$out_unc"
+assert_empty "skip switch honoured" "$(LEGION_SKIP_SCRIPT_SEARCH=1 run_write 'import os
+os.walk(".")')"
+
+finish_tests


### PR DESCRIPTION
## Summary

The rafters agent wrote a Python script to get a directory tree. `legion sym tree --repo
rafters` answers that directly, rafters is legion-covered, and its index had been rebuilt 42
seconds earlier. The capability was live and adjacent, and nothing connected the agent to it.

No existing enforcement point can catch this, and none ever could: they all classify by the
command's leading binary, and `python tree.py` leads with `python`. You cannot tell what a
script does from its invocation.

Closes #837.

## Acceptance criteria mapping

### Writing a script containing os.walk injects the sym tree redirect, allow not deny

The Write-side trigger inspects `tool_input.content` and emits `permissionDecision: "allow"`
with `additionalContext` naming `legion sym tree --repo <r>`. The deny path does not exist in
this hook at all -- there is no `emit_deny` call in the file.

Evidence: `plugin/hooks/test-pre-script-search.sh`, "the observed rafters case" group --
asserts the suggestion appears, asserts `"permissionDecision": "allow"`, and asserts
`"permissionDecision": "deny"` never appears.

### python -c with an inline walk primitive injects the same redirect

The Bash arm resolves the interpreter by basename (so `/usr/bin/python3` is caught) and
inspects the command only when it carries `-c` or `-e`. A script invoked by path is
deliberately not opened -- see "Not done".

Evidence: the "inline interpreter code on Bash" group -- `python3 -c`, `node -e`, and an
absolute-path interpreter, all three asserting `legion sym tree`.

### Content-search and filename-match primitives route to find-content and find-file

Three shapes, one command each. Order of detection is load-bearing: a directory walk usually
also contains a filename test, so `tree` is checked first, which is what stops `os.walk` being
classified as `file`.

Evidence: "routes each shape to ONE command, not a menu" -- `rglob`/`readdirSync` to tree,
`fnmatch` to find-file, `re.search` to find-content, plus an assertion that the tree answer
does NOT also list find-content.

### Ordinary scripts pass through, and an uncovered or unindexed repo passes through

Six pass-through assertions. The load-bearing one is structured JSON editing: a script that
opens and rewrites a JSON file touches `open(` and `json.load` and must not be flagged --
that is precisely what an over-broad matcher would catch. The hook also refuses to fire in an
unindexed repo, since pointing at sym where there is no index is advice the agent cannot take.

Evidence: the "does NOT over-fire" and "gates" groups -- ordinary function, structured JSON
edit, script-by-path, interpreter with no primitive, non-interpreter bash, `cargo build`,
uncovered repo, skip switch.

### Every detection writes a telemetry row

`legion_prequery_record_bypass` is called before the injection, with pattern `script:<shape>`
and a reason naming the origin. This class is currently a structural blind spot: no hook fires,
so no row exists, and `etc-summary` (#713) reads the absence as success.

Evidence: the `legion_prequery_record_bypass` call in `plugin/hooks/pre-script-search.sh`,
immediately above `emit_allow`.

### PR created and linked to this issue

Opened via `legion pr create --repo legion --closes 837`, gated on clean simplify and pr-write
rows for HEAD, pushed via `legion push`.

Evidence: `legion audit --action push` row for `feat/837-script-search`.

## Why inject and never deny

A script that searches may also do real work this cannot replace. Refusing real work to prevent
a redundant directory listing is the worse trade, and detection here is heuristic by nature --
a false positive costs one injected paragraph, while a false deny costs the agent its task.
This is the same posture #829 took for `git log --grep`: never refuse a query the sanctioned
surface cannot fully serve.

## Why one hook across three tools

Bash, Write and Edit share everything after subject extraction. Three near-identical hooks
differing only in which JSON field they read is exactly the duplication the simplify gate
exists to catch, so the `case "$TOOL"` block extracts `(subject, origin)` and the rest is
tool-agnostic.

## Not done

- **A script invoked by path (`python tree.py`) is not inspected.** Reading arbitrary script
  files at hook time is slow and unbounded. The Write-side trigger catches those scripts at
  authorship, which is the earlier and more useful moment anyway.
- **No blocking or denying of any interpreter invocation**, argued above.
- **No extension of sym itself.** This routes to what already exists.
- **No re-baselining of historical #704 metrics.** The blind spot stops growing; the past
  undercount is not recoverable.
- **Detection stays heuristic.** No attempt at parsing or executing script content to decide
  what it really does -- that is unbounded, and the injection posture makes precision cheap to
  be wrong about.

## Note on the acceptance criteria

This issue's `## Done When` section carries outcome conditions rather than the four process
checkboxes the template currently produces, so the card synced with 6 real criteria and the
mapping above certifies behaviour instead of process. That is the shape the template fix is
about; this issue demonstrates it rather than waiting on it.