### PR TITLE
fix(#840): make printed quality-gate ids usable by the verbs that consume them

### DIFF
--- a/src/cli/verify.rs
+++ b/src/cli/verify.rs
@@ -844,22 +844,58 @@ fn persist_raw_findings(
 /// Print finding rows as a human-readable table to stdout (#773 AC4 audit
 /// surface). Columns: id (first 8 chars), branch, skill, file:line,
 /// severity, status, created_at. An empty slice prints nothing.
+/// Shortest prefix length that distinguishes every id in `ids`, floored at
+/// `MIN_ID_WIDTH` and capped at the full id length (#839).
+///
+/// A fixed 8-character truncation is ambiguous BY CONSTRUCTION here: legion
+/// ids are UUIDv7, whose leading 48 bits are a millisecond timestamp, so
+/// two findings recorded seconds apart share their first 8 hex characters.
+/// Printing a value the consuming verb must then reject as ambiguous is the
+/// defect this closes -- widen only as far as the displayed set requires, so
+/// the id a human copies out of the table always resolves.
+fn unique_id_width(ids: &[&str]) -> usize {
+    const MIN_ID_WIDTH: usize = 8;
+    let max_len = ids.iter().map(|i| i.chars().count()).max().unwrap_or(0);
+
+    for width in MIN_ID_WIDTH..=max_len {
+        let mut seen: Vec<String> = ids
+            .iter()
+            .map(|i| i.chars().take(width).collect::<String>())
+            .collect();
+        seen.sort();
+        let before = seen.len();
+        seen.dedup();
+        if seen.len() == before {
+            return width;
+        }
+    }
+    max_len.max(MIN_ID_WIDTH)
+}
+
 fn print_findings_table(rows: &[QualityGateFinding]) {
     if rows.is_empty() {
         return;
     }
+    let ids: Vec<&str> = rows.iter().map(|r| r.id.as_str()).collect();
+    let w = unique_id_width(&ids);
     println!(
-        "{:<8}  {:<20}  {:<16}  {:<30}  {:<4}  {:<14}  CREATED",
-        "ID", "BRANCH", "SKILL", "FILE", "SEV", "STATUS"
+        "{:<w$}  {:<20}  {:<16}  {:<30}  {:<4}  {:<14}  CREATED",
+        "ID",
+        "BRANCH",
+        "SKILL",
+        "FILE",
+        "SEV",
+        "STATUS",
+        w = w
     );
-    println!("{}", "-".repeat(130));
+    println!("{}", "-".repeat(122 + w));
     for row in rows {
-        let id_short: String = row.id.chars().take(8).collect();
+        let id_short: String = row.id.chars().take(w).collect();
         let branch_trunc: String = row.branch.chars().take(20).collect();
         let skill_trunc: String = row.skill.chars().take(16).collect();
         let file_trunc: String = file_loc(&row.file, row.line).chars().take(30).collect();
         println!(
-            "{:<8}  {:<20}  {:<16}  {:<30}  {:<4}  {:<14}  {}",
+            "{:<w$}  {:<20}  {:<16}  {:<30}  {:<4}  {:<14}  {}",
             id_short,
             branch_trunc,
             skill_trunc,
@@ -867,6 +903,7 @@ fn print_findings_table(rows: &[QualityGateFinding]) {
             row.severity.as_str(),
             row.status.as_str(),
             row.created_at,
+            w = w
         );
     }
 }
@@ -889,19 +926,32 @@ fn print_gate_table(rows: &[QualityGateRow]) {
     if rows.is_empty() {
         return;
     }
+    // Same UUIDv7 prefix-collision hazard as print_findings_table: `void
+    // --id` consumes what this prints, so widen until the displayed set is
+    // unambiguous (#839).
+    let ids: Vec<&str> = rows.iter().map(|r| r.id.as_str()).collect();
+    let w = unique_id_width(&ids);
     println!(
-        "{:<8}  {:<20}  {:<8}  {:<22}  {:<6}  {:>8}  {:<9}  {:<4}  CREATED",
-        "ID", "BRANCH", "COMMIT", "SKILL", "RESULT", "FINDINGS", "PROVENANCE", "VOID"
+        "{:<w$}  {:<20}  {:<8}  {:<22}  {:<6}  {:>8}  {:<9}  {:<4}  CREATED",
+        "ID",
+        "BRANCH",
+        "COMMIT",
+        "SKILL",
+        "RESULT",
+        "FINDINGS",
+        "PROVENANCE",
+        "VOID",
+        w = w
     );
-    println!("{}", "-".repeat(130));
+    println!("{}", "-".repeat(122 + w));
     for row in rows {
-        let id_short: String = row.id.chars().take(8).collect();
+        let id_short: String = row.id.chars().take(w).collect();
         let branch_trunc: String = row.branch.chars().take(20).collect();
         let commit_short: String = row.commit_hash.chars().take(8).collect();
         let skill_trunc: String = row.skill.chars().take(22).collect();
         let void_marker = if row.voided_at.is_some() { "VOID" } else { "-" };
         println!(
-            "{:<8}  {:<20}  {:<8}  {:<22}  {:<6}  {:>8}  {:<9}  {:<4}  {}",
+            "{:<w$}  {:<20}  {:<8}  {:<22}  {:<6}  {:>8}  {:<9}  {:<4}  {}",
             id_short,
             branch_trunc,
             commit_short,
@@ -911,6 +961,7 @@ fn print_gate_table(rows: &[QualityGateRow]) {
             row.provenance.as_str(),
             void_marker,
             row.created_at,
+            w = w
         );
     }
 }
@@ -1194,6 +1245,79 @@ mod tests {
     use crate::db::testutil::test_db;
     use crate::documents::DocumentMeta;
     use crate::kanban::{Card, CardStatus, Priority};
+
+    // --- #839: the printed id must be usable by the consuming verb --------
+
+    #[test]
+    fn unique_id_width_floors_at_eight() {
+        // Well-separated ids need no widening; 8 stays the default so the
+        // table does not grow for the common case.
+        let ids = vec!["aaaaaaaa1111", "bbbbbbbb2222", "cccccccc3333"];
+        assert_eq!(unique_id_width(&ids), 8);
+    }
+
+    #[test]
+    fn unique_id_width_widens_past_a_uuidv7_timestamp_collision() {
+        // The real shape from the shingle report: UUIDv7 ids recorded
+        // seconds apart share their leading timestamp hex, so 8 characters
+        // collide and the table must widen until they do not.
+        let ids = vec![
+            "019fb9cf-9b99-7473-95fa-ed4e5292c563",
+            "019fb9cf-e09a-7283-a28b-c85e82aa8f1a",
+        ];
+        let w = unique_id_width(&ids);
+        assert!(w > 8, "expected widening past 8, got {w}");
+        assert_ne!(&ids[0][..w], &ids[1][..w], "width {w} still collides");
+    }
+
+    #[test]
+    fn unique_id_width_degrades_to_the_full_id_when_a_batch_shares_24_chars() {
+        // A gate run that inserts several findings inside one millisecond
+        // holds both the UUIDv7 timestamp AND the random block fixed, so
+        // the ids can share 24 characters and diverge only in the tail.
+        // No FIXED truncation width survives that -- 12, 16 and 20 are all
+        // still ambiguous seven ways -- which is why the width is computed
+        // from the displayed set and is allowed to reach the full id.
+        let ids: Vec<String> = (0..7)
+            .map(|i| format!("019fb44e-1fc9-7a83-ab68-{:012x}", i))
+            .collect();
+        let refs: Vec<&str> = ids.iter().map(|s| s.as_str()).collect();
+
+        for fixed in [12usize, 16, 20] {
+            let mut at_fixed: Vec<String> = refs
+                .iter()
+                .map(|i| i.chars().take(fixed).collect())
+                .collect();
+            at_fixed.sort();
+            at_fixed.dedup();
+            assert_eq!(
+                at_fixed.len(),
+                1,
+                "a fixed width of {fixed} should still collide for this batch"
+            );
+        }
+
+        let w = unique_id_width(&refs);
+        assert_eq!(w, 36, "must widen all the way to the full id");
+        let mut distinct: Vec<String> = refs.iter().map(|i| i.chars().take(w).collect()).collect();
+        distinct.sort();
+        distinct.dedup();
+        assert_eq!(distinct.len(), 7, "all seven must be distinguishable");
+    }
+
+    #[test]
+    fn unique_id_width_handles_single_and_empty() {
+        assert_eq!(unique_id_width(&["019fb9cf-9b99-7473"]), 8);
+        assert_eq!(unique_id_width(&[]), 8);
+    }
+
+    #[test]
+    fn unique_id_width_never_exceeds_the_id_length() {
+        // Two ids identical for their whole length cannot be separated;
+        // the function must terminate at the full length rather than loop.
+        let ids = vec!["dupe", "dupe"];
+        assert_eq!(unique_id_width(&ids), 8);
+    }
 
     fn make_card(doc_id: Option<&str>, acceptance: Option<&str>) -> Card {
         Card {

--- a/src/cli/verify.rs
+++ b/src/cli/verify.rs
@@ -561,7 +561,8 @@ pub(crate) fn handle_quality_gate(action: QualityGateAction) -> error::Result<()
 
         QualityGateAction::FindingDisposition { id, reason } => {
             let database = open_db()?;
-            let finding = database.dispose_finding(&id, &reason)?;
+            let full_id = resolve_finding_id(&database, &id)?;
+            let finding = database.dispose_finding(&full_id, &reason)?;
             println!(
                 "[legion] dispositioned finding {} ({}): {}",
                 finding.id,
@@ -616,7 +617,8 @@ pub(crate) fn handle_quality_gate(action: QualityGateAction) -> error::Result<()
             superseded_by,
         } => {
             let database = open_db()?;
-            let row = database.void_quality_gate(&id, &reason, superseded_by.as_deref())?;
+            let full_id = resolve_gate_id(&database, &id)?;
+            let row = database.void_quality_gate(&full_id, &reason, superseded_by.as_deref())?;
             println!(
                 "[legion] voided gate {} (skill '{}', commit {}): {}",
                 row.id, row.skill, row.commit_hash, reason
@@ -659,6 +661,68 @@ fn file_loc(file: &str, line: Option<impl std::fmt::Display>) -> String {
     match line {
         Some(l) => format!("{file}:{l}"),
         None => file.to_owned(),
+    }
+}
+
+/// Resolve a finding id given in full OR as an unambiguous prefix (#840).
+///
+/// Convenience, not the fix: the fix is that `finding-list` prints the whole
+/// id, so a copied id resolves on the exact-match path below and never
+/// reaches the prefix query. This layer only exists so a hand-typed short id
+/// still works when it happens to be unique.
+///
+/// Exact match is tried FIRST, so a full id that happens to be a prefix of a
+/// longer one resolves to itself. Not reachable with uniform-length UUIDv7
+/// ids today, but the rule must not depend on that staying true.
+///
+/// More than one match is an error naming every candidate with its
+/// `file:line`, never a silent pick -- disposition is a state change, and
+/// retiring the wrong finding is worse than making the caller disambiguate.
+/// Ambiguity must NOT collapse into `FindingNotFound`: telling a caller that
+/// an id which does exist was not found is the exact defect #840 closes, and
+/// reproducing it one layer up would not be a fix.
+fn resolve_finding_id(database: &db::Database, id: &str) -> error::Result<String> {
+    if database.get_finding_by_id(id)?.is_some() {
+        return Ok(id.to_owned());
+    }
+    let mut matches = database.find_findings_by_id_prefix(id)?;
+    match matches.len() {
+        0 => Err(error::LegionError::FindingNotFound(id.to_owned())),
+        1 => Ok(matches.remove(0).id),
+        _ => Err(error::LegionError::FindingIdAmbiguous {
+            prefix: id.to_owned(),
+            candidates: matches
+                .iter()
+                .map(|f| format!("{}  {}", f.id, file_loc(&f.file, f.line)))
+                .collect(),
+        }),
+    }
+}
+
+/// Resolve a gate id given in full OR as an unambiguous prefix (#840).
+/// Mirrors `resolve_finding_id`; candidates are named with the skill and
+/// commit `quality-gate list` already shows, since gate ids collide the same
+/// way finding ids do -- plus `created_at`, because re-running a skill on one
+/// commit is routine and leaves rows whose skill AND commit are identical.
+/// A candidate list nobody can choose from is the same dead end as no list.
+fn resolve_gate_id(database: &db::Database, id: &str) -> error::Result<String> {
+    if database.get_quality_gate_by_id(id)?.is_some() {
+        return Ok(id.to_owned());
+    }
+    let mut matches = database.find_quality_gates_by_id_prefix(id)?;
+    match matches.len() {
+        0 => Err(error::LegionError::QualityGateNotFound(id.to_owned())),
+        1 => Ok(matches.remove(0).id),
+        _ => Err(error::LegionError::QualityGateIdAmbiguous {
+            prefix: id.to_owned(),
+            candidates: matches
+                .iter()
+                .map(|g| {
+                    let commit: String = g.commit_hash.chars().take(8).collect();
+                    format!("{}  {}  {}  {}", g.id, g.skill, commit, g.created_at)
+                })
+                .collect(),
+        }),
     }
 }
 
@@ -842,77 +906,55 @@ fn persist_raw_findings(
 }
 
 /// Print finding rows as a human-readable table to stdout (#773 AC4 audit
-/// surface). Columns: id (first 8 chars), branch, skill, file:line,
-/// severity, status, created_at. An empty slice prints nothing.
-/// Shortest prefix length that distinguishes every id in `ids`, floored at
-/// `MIN_ID_WIDTH` and capped at the full id length (#839).
+/// surface). Columns: id (full), branch, skill, file:line, severity, status,
+/// created (date). An empty slice prints nothing.
 ///
-/// A fixed 8-character truncation is ambiguous BY CONSTRUCTION here: legion
-/// ids are UUIDv7, whose leading 48 bits are a millisecond timestamp, so
-/// two findings recorded seconds apart share their first 8 hex characters.
-/// Printing a value the consuming verb must then reject as ambiguous is the
-/// defect this closes -- widen only as far as the displayed set requires, so
-/// the id a human copies out of the table always resolves.
-fn unique_id_width(ids: &[&str]) -> usize {
-    const MIN_ID_WIDTH: usize = 8;
-    let max_len = ids.iter().map(|i| i.chars().count()).max().unwrap_or(0);
-
-    for width in MIN_ID_WIDTH..=max_len {
-        let mut seen: Vec<String> = ids
-            .iter()
-            .map(|i| i.chars().take(width).collect::<String>())
-            .collect();
-        seen.sort();
-        let before = seen.len();
-        seen.dedup();
-        if seen.len() == before {
-            return width;
-        }
-    }
-    max_len.max(MIN_ID_WIDTH)
-}
-
+/// THE ID IS PRINTED IN FULL, and no truncation width may be reintroduced
+/// (#840). legion ids are UUIDv7: the leading 48 bits are a millisecond
+/// timestamp and, for ids minted inside one millisecond, the random block is
+/// held fixed too -- a live gate run put 7 findings behind a shared 24-char
+/// prefix. So 12, 16 and 20 are all still ambiguous, and how deep the
+/// collision runs is set by insert speed, meaning it gets WORSE on faster
+/// hardware, not better. Computing a width from the displayed rows fails for
+/// a subtler reason: `finding-list` filters by branch/skill/status while
+/// `resolve_finding_id` matches the WHOLE table, so a prefix unique among
+/// the rows shown can still be ambiguous against a row the filter hid.
+/// Printing all 36 characters is the only width that is correct by
+/// construction. CREATED gives up its wall-clock time to pay for it -- rows
+/// are already newest-first and `--json` carries the full timestamp.
 fn print_findings_table(rows: &[QualityGateFinding]) {
     if rows.is_empty() {
         return;
     }
-    let ids: Vec<&str> = rows.iter().map(|r| r.id.as_str()).collect();
-    let w = unique_id_width(&ids);
     println!(
-        "{:<w$}  {:<20}  {:<16}  {:<30}  {:<4}  {:<14}  CREATED",
-        "ID",
-        "BRANCH",
-        "SKILL",
-        "FILE",
-        "SEV",
-        "STATUS",
-        w = w
+        "{:<36}  {:<20}  {:<16}  {:<30}  {:<4}  {:<14}  CREATED",
+        "ID", "BRANCH", "SKILL", "FILE", "SEV", "STATUS"
     );
-    println!("{}", "-".repeat(122 + w));
+    println!("{}", "-".repeat(142));
     for row in rows {
-        let id_short: String = row.id.chars().take(w).collect();
         let branch_trunc: String = row.branch.chars().take(20).collect();
         let skill_trunc: String = row.skill.chars().take(16).collect();
         let file_trunc: String = file_loc(&row.file, row.line).chars().take(30).collect();
+        let created_date: String = row.created_at.chars().take(10).collect();
         println!(
-            "{:<w$}  {:<20}  {:<16}  {:<30}  {:<4}  {:<14}  {}",
-            id_short,
+            "{:<36}  {:<20}  {:<16}  {:<30}  {:<4}  {:<14}  {}",
+            row.id,
             branch_trunc,
             skill_trunc,
             file_trunc,
             row.severity.as_str(),
             row.status.as_str(),
-            row.created_at,
-            w = w
+            created_date,
         );
     }
 }
 
 /// Print gate rows as a human-readable table to stdout.
 ///
-/// Columns: id (first 8 chars), branch, commit (first 8 chars), skill,
-/// result, findings, provenance, void, created_at. An empty slice prints
-/// nothing.
+/// Columns: id (full), branch, commit (first 8 chars), skill, result,
+/// findings, provenance, void, created (date). An empty slice prints
+/// nothing. The id is printed in full for the same reason as
+/// `print_findings_table` -- `void --id` consumes what this prints.
 ///
 /// PROVENANCE and VOID surface #780's audit distinction on the table a human
 /// actually reads by default: PROVENANCE separates a structurally VALIDATED
@@ -926,33 +968,20 @@ fn print_gate_table(rows: &[QualityGateRow]) {
     if rows.is_empty() {
         return;
     }
-    // Same UUIDv7 prefix-collision hazard as print_findings_table: `void
-    // --id` consumes what this prints, so widen until the displayed set is
-    // unambiguous (#839).
-    let ids: Vec<&str> = rows.iter().map(|r| r.id.as_str()).collect();
-    let w = unique_id_width(&ids);
     println!(
-        "{:<w$}  {:<20}  {:<8}  {:<22}  {:<6}  {:>8}  {:<9}  {:<4}  CREATED",
-        "ID",
-        "BRANCH",
-        "COMMIT",
-        "SKILL",
-        "RESULT",
-        "FINDINGS",
-        "PROVENANCE",
-        "VOID",
-        w = w
+        "{:<36}  {:<20}  {:<8}  {:<22}  {:<6}  {:>8}  {:<9}  {:<4}  CREATED",
+        "ID", "BRANCH", "COMMIT", "SKILL", "RESULT", "FINDINGS", "PROVENANCE", "VOID"
     );
-    println!("{}", "-".repeat(122 + w));
+    println!("{}", "-".repeat(139));
     for row in rows {
-        let id_short: String = row.id.chars().take(w).collect();
         let branch_trunc: String = row.branch.chars().take(20).collect();
         let commit_short: String = row.commit_hash.chars().take(8).collect();
         let skill_trunc: String = row.skill.chars().take(22).collect();
         let void_marker = if row.voided_at.is_some() { "VOID" } else { "-" };
+        let created_date: String = row.created_at.chars().take(10).collect();
         println!(
-            "{:<w$}  {:<20}  {:<8}  {:<22}  {:<6}  {:>8}  {:<9}  {:<4}  {}",
-            id_short,
+            "{:<36}  {:<20}  {:<8}  {:<22}  {:<6}  {:>8}  {:<9}  {:<4}  {}",
+            row.id,
             branch_trunc,
             commit_short,
             skill_trunc,
@@ -960,8 +989,7 @@ fn print_gate_table(rows: &[QualityGateRow]) {
             row.findings_count,
             row.provenance.as_str(),
             void_marker,
-            row.created_at,
-            w = w
+            created_date,
         );
     }
 }
@@ -1246,77 +1274,183 @@ mod tests {
     use crate::documents::DocumentMeta;
     use crate::kanban::{Card, CardStatus, Priority};
 
-    // --- #839: the printed id must be usable by the consuming verb --------
+    // --- #840: the printed id must be usable by the consuming verb --------
 
-    #[test]
-    fn unique_id_width_floors_at_eight() {
-        // Well-separated ids need no widening; 8 stays the default so the
-        // table does not grow for the common case.
-        let ids = vec!["aaaaaaaa1111", "bbbbbbbb2222", "cccccccc3333"];
-        assert_eq!(unique_id_width(&ids), 8);
-    }
-
-    #[test]
-    fn unique_id_width_widens_past_a_uuidv7_timestamp_collision() {
-        // The real shape from the shingle report: UUIDv7 ids recorded
-        // seconds apart share their leading timestamp hex, so 8 characters
-        // collide and the table must widen until they do not.
-        let ids = vec![
-            "019fb9cf-9b99-7473-95fa-ed4e5292c563",
-            "019fb9cf-e09a-7283-a28b-c85e82aa8f1a",
-        ];
-        let w = unique_id_width(&ids);
-        assert!(w > 8, "expected widening past 8, got {w}");
-        assert_ne!(&ids[0][..w], &ids[1][..w], "width {w} still collides");
-    }
-
-    #[test]
-    fn unique_id_width_degrades_to_the_full_id_when_a_batch_shares_24_chars() {
-        // A gate run that inserts several findings inside one millisecond
-        // holds both the UUIDv7 timestamp AND the random block fixed, so
-        // the ids can share 24 characters and diverge only in the tail.
-        // No FIXED truncation width survives that -- 12, 16 and 20 are all
-        // still ambiguous seven ways -- which is why the width is computed
-        // from the displayed set and is allowed to reach the full id.
-        let ids: Vec<String> = (0..7)
-            .map(|i| format!("019fb44e-1fc9-7a83-ab68-{:012x}", i))
-            .collect();
-        let refs: Vec<&str> = ids.iter().map(|s| s.as_str()).collect();
-
-        for fixed in [12usize, 16, 20] {
-            let mut at_fixed: Vec<String> = refs
-                .iter()
-                .map(|i| i.chars().take(fixed).collect())
-                .collect();
-            at_fixed.sort();
-            at_fixed.dedup();
-            assert_eq!(
-                at_fixed.len(),
-                1,
-                "a fixed width of {fixed} should still collide for this batch"
-            );
+    fn finding_input<'a>(gate_id: &'a str, file: &'a str) -> NewFindingInput<'a> {
+        NewFindingInput {
+            gate_id,
+            branch: "feat/x",
+            skill: "legion-simplify",
+            origin_commit: "commit-a",
+            file,
+            line: Some(42),
+            severity: FindingSeverity::Med,
+            summary: "duplicate logic in two match arms",
         }
+    }
 
-        let w = unique_id_width(&refs);
-        assert_eq!(w, 36, "must widen all the way to the full id");
-        let mut distinct: Vec<String> = refs.iter().map(|i| i.chars().take(w).collect()).collect();
-        distinct.sort();
-        distinct.dedup();
-        assert_eq!(distinct.len(), 7, "all seven must be distinguishable");
+    fn gate_input<'a>(skill: &'a str, commit: &'a str) -> QualityGateInput<'a> {
+        QualityGateInput {
+            branch: "feat/x",
+            commit_hash: commit,
+            skill,
+            result: GateResult::Issues,
+            findings_count: 1,
+            details: None,
+            provenance: GateProvenance::Validated,
+            base: None,
+        }
     }
 
     #[test]
-    fn unique_id_width_handles_single_and_empty() {
-        assert_eq!(unique_id_width(&["019fb9cf-9b99-7473"]), 8);
-        assert_eq!(unique_id_width(&[]), 8);
+    fn resolve_finding_id_takes_a_full_id_and_an_unambiguous_prefix() {
+        let db = test_db();
+        let row = db
+            .insert_finding(&finding_input("gate-1", "src/foo.rs"))
+            .unwrap();
+
+        // The full id -- what the table now prints -- is the exact path.
+        assert_eq!(resolve_finding_id(&db, &row.id).unwrap(), row.id);
+        // A hand-typed short id still works while it is unique.
+        let prefix: String = row.id.chars().take(8).collect();
+        assert_eq!(resolve_finding_id(&db, &prefix).unwrap(), row.id);
     }
 
     #[test]
-    fn unique_id_width_never_exceeds_the_id_length() {
-        // Two ids identical for their whole length cannot be separated;
-        // the function must terminate at the full length rather than loop.
-        let ids = vec!["dupe", "dupe"];
-        assert_eq!(unique_id_width(&ids), 8);
+    fn resolve_finding_id_refuses_a_shared_prefix_naming_choosable_candidates() {
+        let db = test_db();
+        let a = db
+            .insert_finding(&finding_input("gate-1", "src/foo.rs"))
+            .unwrap();
+        let b = db
+            .insert_finding(&finding_input("gate-1", "src/bar.rs"))
+            .unwrap();
+
+        // The shingle case: two findings persisted by one gate run. UUIDv7's
+        // leading hex is a millisecond timestamp, so the 8 characters the
+        // table used to print collide.
+        let prefix: String = a.id.chars().take(8).collect();
+        assert_eq!(
+            prefix,
+            b.id.chars().take(8).collect::<String>(),
+            "two findings from one gate run must share their leading 8 chars"
+        );
+
+        let err = resolve_finding_id(&db, &prefix).unwrap_err();
+        assert!(
+            matches!(err, error::LegionError::FindingIdAmbiguous { .. }),
+            "ambiguity must not collapse into not-found: got {err:?}"
+        );
+        // The candidate list has to be CHOOSABLE, not just present: full ids
+        // plus the file:line the caller already knows. Ids alone would be
+        // near-identical UUIDs and no help at all.
+        let msg = err.to_string();
+        assert!(
+            msg.contains(&a.id) && msg.contains(&b.id),
+            "missing full ids: {msg}"
+        );
+        assert!(
+            msg.contains("src/foo.rs:42") && msg.contains("src/bar.rs:42"),
+            "candidates must carry file:line: {msg}"
+        );
+
+        // The refused call changed nothing, and each full id still works.
+        assert_eq!(
+            db.get_finding_by_id(&a.id).unwrap().unwrap().status,
+            FindingStatus::Pending
+        );
+        assert_eq!(
+            db.get_finding_by_id(&b.id).unwrap().unwrap().status,
+            FindingStatus::Pending
+        );
+        for id in [&a.id, &b.id] {
+            let full = resolve_finding_id(&db, id).unwrap();
+            let disposed = db.dispose_finding(&full, "won't fix: intentional").unwrap();
+            assert_eq!(disposed.status, FindingStatus::Dispositioned);
+        }
+    }
+
+    #[test]
+    fn resolve_finding_id_unknown_reports_not_found_naming_json() {
+        let db = test_db();
+        db.insert_finding(&finding_input("gate-1", "src/foo.rs"))
+            .unwrap();
+        let err = resolve_finding_id(&db, "deadbeef").unwrap_err();
+        assert!(
+            matches!(err, error::LegionError::FindingNotFound(_)),
+            "expected FindingNotFound, got {err:?}"
+        );
+        assert!(
+            err.to_string().contains("--json"),
+            "the escape hatch has to be named where the caller is stuck: {err}"
+        );
+    }
+
+    #[test]
+    fn resolve_gate_id_takes_a_prefix_and_refuses_ambiguity() {
+        let db = test_db();
+        let a = db
+            .record_quality_gate(&gate_input("legion-simplify", "commit-a"))
+            .unwrap();
+        let b = db
+            .record_quality_gate(&gate_input("legion-review", "commit-b"))
+            .unwrap();
+
+        assert_eq!(resolve_gate_id(&db, &a.id).unwrap(), a.id);
+
+        let prefix: String = a.id.chars().take(8).collect();
+        let err = resolve_gate_id(&db, &prefix).unwrap_err();
+        assert!(
+            matches!(err, error::LegionError::QualityGateIdAmbiguous { .. }),
+            "expected QualityGateIdAmbiguous, got {err:?}"
+        );
+        let msg = err.to_string();
+        assert!(
+            msg.contains(&a.id) && msg.contains(&b.id),
+            "missing full ids: {msg}"
+        );
+        assert!(
+            msg.contains("legion-simplify") && msg.contains("legion-review"),
+            "gate candidates must carry their skill: {msg}"
+        );
+        assert!(
+            msg.contains("commit-a") && msg.contains("commit-b") && msg.contains(&a.created_at),
+            "gate candidates must carry commit and created_at: {msg}"
+        );
+
+        // The shortest prefix that separates the two rows is unique by
+        // construction, so it must resolve rather than error.
+        let unique_len =
+            a.id.chars()
+                .zip(b.id.chars())
+                .take_while(|(x, y)| x == y)
+                .count()
+                + 1;
+        let unique: String = a.id.chars().take(unique_len).collect();
+        assert_eq!(resolve_gate_id(&db, &unique).unwrap(), a.id);
+
+        // And the resolved id is what void consumes.
+        let voided = db
+            .void_quality_gate(
+                &resolve_gate_id(&db, &unique).unwrap(),
+                "false verdict",
+                None,
+            )
+            .unwrap();
+        assert!(voided.voided_at.is_some());
+    }
+
+    #[test]
+    fn resolve_gate_id_unknown_reports_not_found_naming_json() {
+        let db = test_db();
+        db.record_quality_gate(&gate_input("legion-simplify", "commit-a"))
+            .unwrap();
+        let err = resolve_gate_id(&db, "deadbeef").unwrap_err();
+        assert!(
+            matches!(err, error::LegionError::QualityGateNotFound(_)),
+            "expected QualityGateNotFound, got {err:?}"
+        );
+        assert!(err.to_string().contains("--json"), "{err}");
     }
 
     fn make_card(doc_id: Option<&str>, acceptance: Option<&str>) -> Card {

--- a/src/db/findings.rs
+++ b/src/db/findings.rs
@@ -150,6 +150,23 @@ fn row_to_finding(
 const SELECT_COLUMNS: &str = "id, gate_id, branch, skill, origin_commit, file, line, severity, \
      summary, status, disposition_reason, resolved_by_commit, created_at, updated_at";
 
+/// Escape SQL `LIKE` metacharacters in a user-supplied id prefix (#840).
+///
+/// The prefix paths exist precisely for HAND-TYPED input, and `_` matches
+/// any single character while `%` matches any run. A typo containing `_`
+/// that happened to match exactly one row would resolve and then be
+/// dispositioned or voided -- a state change on a row nobody named. A
+/// genuine copied id is unaffected: UUIDs are hex and dashes only.
+///
+/// Paired with `ESCAPE '\'` in every query that consumes this. The
+/// backslash itself is escaped first so it cannot smuggle in an escape.
+pub(super) fn escape_like_prefix(prefix: &str) -> String {
+    prefix
+        .replace('\\', "\\\\")
+        .replace('%', "\\%")
+        .replace('_', "\\_")
+}
+
 impl Database {
     /// Insert a new PENDING finding extracted from a just-recorded gate row.
     pub fn insert_finding(&self, input: &NewFindingInput<'_>) -> Result<QualityGateFinding> {
@@ -216,9 +233,12 @@ impl Database {
     pub fn find_findings_by_id_prefix(&self, prefix: &str) -> Result<Vec<QualityGateFinding>> {
         let mut stmt = self.conn.prepare(&format!(
             "SELECT {SELECT_COLUMNS} FROM quality_gate_findings \
-             WHERE id LIKE ?1 || '%' ORDER BY id"
+             WHERE id LIKE ?1 || '%' ESCAPE '\\' ORDER BY id"
         ))?;
-        let rows = stmt.query_map(rusqlite::params![prefix], row_to_finding)?;
+        let rows = stmt.query_map(
+            rusqlite::params![escape_like_prefix(prefix)],
+            row_to_finding,
+        )?;
         let mut out = Vec::new();
         for row in rows {
             out.push(row.map_err(LegionError::Database)?);
@@ -433,13 +453,18 @@ mod tests {
         let b = db
             .insert_finding(&input("gate-1", "src/bar.rs", FindingSeverity::Med))
             .unwrap();
-        // UUIDv7's leading 32 bits are the high half of a millisecond
-        // timestamp, so two findings from one gate run share 8 hex chars.
-        let prefix: String = a.id.chars().take(8).collect();
-        assert_eq!(
-            prefix,
-            b.id.chars().take(8).collect::<String>(),
-            "back-to-back UUIDv7 ids must share their leading timestamp hex"
+        // Derive the shared prefix from the ids themselves rather than
+        // assuming 8 characters: two inserts straddling a timestamp
+        // rollover would share fewer, and the assumption would flake.
+        let prefix: String =
+            a.id.chars()
+                .zip(b.id.chars())
+                .take_while(|(x, y)| x == y)
+                .map(|(x, _)| x)
+                .collect();
+        assert!(
+            !prefix.is_empty(),
+            "back-to-back UUIDv7 ids must share a leading timestamp run"
         );
 
         let matches = db.find_findings_by_id_prefix(&prefix).unwrap();
@@ -454,6 +479,38 @@ mod tests {
         // file:line to be choosable.
         assert!(matches.iter().any(|f| f.file == "src/foo.rs"));
         assert!(matches.iter().any(|f| f.file == "src/bar.rs"));
+    }
+
+    /// #840 review finding: these prefix paths exist for HAND-TYPED input,
+    /// and an unescaped `_` matches any single character under LIKE. A typo
+    /// that happened to match exactly one row would resolve and then be
+    /// dispositioned -- a state change on a row nobody named.
+    #[test]
+    fn id_prefix_treats_like_wildcards_as_literal_characters() {
+        let db = test_db();
+        let a = db
+            .insert_finding(&input("gate-1", "src/foo.rs", FindingSeverity::Med))
+            .unwrap();
+
+        // `_` as a wildcard would match the real id at that position; as a
+        // literal it matches nothing, because UUIDs carry no underscores.
+        let mut wild: String = a.id.chars().take(7).collect();
+        wild.push('_');
+        assert!(
+            db.find_findings_by_id_prefix(&wild).unwrap().is_empty(),
+            "underscore must be literal, not a single-character wildcard"
+        );
+
+        // `%` likewise: as a wildcard it would match every row.
+        assert!(
+            db.find_findings_by_id_prefix("%").unwrap().is_empty(),
+            "percent must be literal, not a match-everything wildcard"
+        );
+
+        // The honest prefix still resolves, so the escaping did not break
+        // the path it protects.
+        let real: String = a.id.chars().take(8).collect();
+        assert_eq!(db.find_findings_by_id_prefix(&real).unwrap().len(), 1);
     }
 
     #[test]

--- a/src/db/findings.rs
+++ b/src/db/findings.rs
@@ -272,7 +272,43 @@ impl Database {
     /// through the same explicit id-scoped call, which this still permits --
     /// only a RESOLVED finding is refused, since silently overriding proof of
     /// a fix with a waiver would be the exact hole this table closes).
+    /// Resolve a finding id given in full OR as an unambiguous prefix (#839).
+    ///
+    /// `print_findings_table` shows the first 8 characters, and that was
+    /// the only place the CLI surfaced an id outside `--json`, so the value
+    /// a human read could never be passed back to `finding-disposition`.
+    /// A MED finding a reviewer wanted to record as wont-fix therefore had
+    /// no path at all: `--result clean` is refused while it is PENDING and
+    /// `finding-ack` is LOW-only, leaving only the coarse file-touch rule.
+    ///
+    /// Exact match wins before prefix matching, so a full id that happens
+    /// to prefix a longer one resolves to itself. Not reachable with
+    /// uniform-length UUIDv7 ids today, but the rule must not depend on
+    /// that staying true.
+    fn resolve_finding_id(&self, id: &str) -> Result<String> {
+        if self.get_finding_by_id(id)?.is_some() {
+            return Ok(id.to_owned());
+        }
+        // Anchored prefix, never a substring search: `LIKE ? || '%'`.
+        let mut stmt = self
+            .conn
+            .prepare("SELECT id FROM quality_gate_findings WHERE id LIKE ?1 || '%' ORDER BY id")?;
+        let matches: Vec<String> = stmt
+            .query_map(rusqlite::params![id], |row| row.get::<_, String>(0))?
+            .collect::<rusqlite::Result<Vec<String>>>()?;
+
+        match matches.len() {
+            0 => Err(LegionError::FindingNotFound(id.to_owned())),
+            1 => Ok(matches[0].clone()),
+            _ => Err(LegionError::AmbiguousId {
+                id: id.to_owned(),
+                candidates: matches,
+            }),
+        }
+    }
+
     pub fn dispose_finding(&self, id: &str, reason: &str) -> Result<QualityGateFinding> {
+        let id: &str = &self.resolve_finding_id(id)?;
         let existing = self
             .get_finding_by_id(id)?
             .ok_or_else(|| LegionError::FindingNotFound(id.to_owned()))?;
@@ -393,6 +429,77 @@ mod tests {
         let fetched = db.get_finding_by_id(&row.id).unwrap().unwrap();
         assert_eq!(fetched.file, "src/foo.rs");
         assert_eq!(fetched.severity, FindingSeverity::Med);
+    }
+
+    // --- #839: dispose by the id the table actually prints ----------------
+
+    #[test]
+    fn dispose_finding_accepts_an_unambiguous_prefix() {
+        let db = test_db();
+        let row = db
+            .insert_finding(&input("gate-1", "src/foo.rs", FindingSeverity::Med))
+            .unwrap();
+        let prefix: String = row.id.chars().take(8).collect();
+
+        let disposed = db
+            .dispose_finding(&prefix, "won't fix: intentional")
+            .unwrap();
+        assert_eq!(disposed.id, row.id, "prefix must resolve to the full row");
+        assert_eq!(disposed.status, FindingStatus::Dispositioned);
+        assert_eq!(
+            disposed.disposition_reason.as_deref(),
+            Some("won't fix: intentional")
+        );
+    }
+
+    #[test]
+    fn dispose_finding_refuses_an_ambiguous_prefix_and_changes_nothing() {
+        let db = test_db();
+        let a = db
+            .insert_finding(&input("gate-1", "src/foo.rs", FindingSeverity::Med))
+            .unwrap();
+        let b = db
+            .insert_finding(&input("gate-1", "src/bar.rs", FindingSeverity::Med))
+            .unwrap();
+
+        // UUIDv7 ids minted in the same millisecond share a long prefix --
+        // the shingle case. Find one that genuinely matches both.
+        let shared: String =
+            a.id.chars()
+                .zip(b.id.chars())
+                .take_while(|(x, y)| x == y)
+                .map(|(x, _)| x)
+                .collect();
+        if shared.is_empty() {
+            return; // ids diverged at char 0; nothing ambiguous to test
+        }
+
+        let err = db.dispose_finding(&shared, "x").unwrap_err();
+        assert!(
+            matches!(err, LegionError::AmbiguousId { .. }),
+            "expected AmbiguousId, got {err:?}"
+        );
+        // Neither row may have moved.
+        assert_eq!(
+            db.get_finding_by_id(&a.id).unwrap().unwrap().status,
+            FindingStatus::Pending
+        );
+        assert_eq!(
+            db.get_finding_by_id(&b.id).unwrap().unwrap().status,
+            FindingStatus::Pending
+        );
+    }
+
+    #[test]
+    fn dispose_finding_unknown_id_still_reports_not_found() {
+        let db = test_db();
+        db.insert_finding(&input("gate-1", "src/foo.rs", FindingSeverity::Med))
+            .unwrap();
+        let err = db.dispose_finding("deadbeef", "x").unwrap_err();
+        assert!(
+            matches!(err, LegionError::FindingNotFound(_)),
+            "expected FindingNotFound, got {err:?}"
+        );
     }
 
     #[test]

--- a/src/db/findings.rs
+++ b/src/db/findings.rs
@@ -205,6 +205,27 @@ impl Database {
         }
     }
 
+    /// Every finding whose id STARTS WITH `prefix`, ordered by id (#840).
+    ///
+    /// Anchored with `LIKE ?1 || '%'`, never a substring search: a prefix is
+    /// what a human copies off the front of a printed id, so matching mid-id
+    /// would resolve ids nobody typed. Returns whole rows rather than ids
+    /// because the caller's ambiguity error has to name `file:line` -- ids
+    /// alone do not disambiguate findings minted in the same millisecond,
+    /// which share their leading 24 characters.
+    pub fn find_findings_by_id_prefix(&self, prefix: &str) -> Result<Vec<QualityGateFinding>> {
+        let mut stmt = self.conn.prepare(&format!(
+            "SELECT {SELECT_COLUMNS} FROM quality_gate_findings \
+             WHERE id LIKE ?1 || '%' ORDER BY id"
+        ))?;
+        let rows = stmt.query_map(rusqlite::params![prefix], row_to_finding)?;
+        let mut out = Vec::new();
+        for row in rows {
+            out.push(row.map_err(LegionError::Database)?);
+        }
+        Ok(out)
+    }
+
     /// PENDING findings for a (branch, skill) pair, oldest first -- the set
     /// `crate::finding_gate::evaluate_refusal` and
     /// `crate::finding_gate::reconcile_pending_findings` both read.
@@ -272,43 +293,13 @@ impl Database {
     /// through the same explicit id-scoped call, which this still permits --
     /// only a RESOLVED finding is refused, since silently overriding proof of
     /// a fix with a waiver would be the exact hole this table closes).
-    /// Resolve a finding id given in full OR as an unambiguous prefix (#839).
     ///
-    /// `print_findings_table` shows the first 8 characters, and that was
-    /// the only place the CLI surfaced an id outside `--json`, so the value
-    /// a human read could never be passed back to `finding-disposition`.
-    /// A MED finding a reviewer wanted to record as wont-fix therefore had
-    /// no path at all: `--result clean` is refused while it is PENDING and
-    /// `finding-ack` is LOW-only, leaving only the coarse file-touch rule.
-    ///
-    /// Exact match wins before prefix matching, so a full id that happens
-    /// to prefix a longer one resolves to itself. Not reachable with
-    /// uniform-length UUIDv7 ids today, but the rule must not depend on
-    /// that staying true.
-    fn resolve_finding_id(&self, id: &str) -> Result<String> {
-        if self.get_finding_by_id(id)?.is_some() {
-            return Ok(id.to_owned());
-        }
-        // Anchored prefix, never a substring search: `LIKE ? || '%'`.
-        let mut stmt = self
-            .conn
-            .prepare("SELECT id FROM quality_gate_findings WHERE id LIKE ?1 || '%' ORDER BY id")?;
-        let matches: Vec<String> = stmt
-            .query_map(rusqlite::params![id], |row| row.get::<_, String>(0))?
-            .collect::<rusqlite::Result<Vec<String>>>()?;
-
-        match matches.len() {
-            0 => Err(LegionError::FindingNotFound(id.to_owned())),
-            1 => Ok(matches[0].clone()),
-            _ => Err(LegionError::AmbiguousId {
-                id: id.to_owned(),
-                candidates: matches,
-            }),
-        }
-    }
-
+    /// `id` is matched EXACTLY. Prefix acceptance is a CLI-layer convenience
+    /// (`crate::cli::verify::resolve_finding_id`) deliberately kept out of
+    /// here, so the internal callers that already hold a full id --
+    /// `batch_ack_low_findings` and `finding_gate::reconcile_pending_findings`
+    /// -- cannot start resolving fuzzily by accident (#840).
     pub fn dispose_finding(&self, id: &str, reason: &str) -> Result<QualityGateFinding> {
-        let id: &str = &self.resolve_finding_id(id)?;
         let existing = self
             .get_finding_by_id(id)?
             .ok_or_else(|| LegionError::FindingNotFound(id.to_owned()))?;
@@ -431,29 +422,10 @@ mod tests {
         assert_eq!(fetched.severity, FindingSeverity::Med);
     }
 
-    // --- #839: dispose by the id the table actually prints ----------------
+    // --- #840: the prefix read path the CLI resolver is built on ----------
 
     #[test]
-    fn dispose_finding_accepts_an_unambiguous_prefix() {
-        let db = test_db();
-        let row = db
-            .insert_finding(&input("gate-1", "src/foo.rs", FindingSeverity::Med))
-            .unwrap();
-        let prefix: String = row.id.chars().take(8).collect();
-
-        let disposed = db
-            .dispose_finding(&prefix, "won't fix: intentional")
-            .unwrap();
-        assert_eq!(disposed.id, row.id, "prefix must resolve to the full row");
-        assert_eq!(disposed.status, FindingStatus::Dispositioned);
-        assert_eq!(
-            disposed.disposition_reason.as_deref(),
-            Some("won't fix: intentional")
-        );
-    }
-
-    #[test]
-    fn dispose_finding_refuses_an_ambiguous_prefix_and_changes_nothing() {
+    fn find_findings_by_id_prefix_returns_every_match_in_id_order() {
         let db = test_db();
         let a = db
             .insert_finding(&input("gate-1", "src/foo.rs", FindingSeverity::Med))
@@ -461,44 +433,71 @@ mod tests {
         let b = db
             .insert_finding(&input("gate-1", "src/bar.rs", FindingSeverity::Med))
             .unwrap();
+        // UUIDv7's leading 32 bits are the high half of a millisecond
+        // timestamp, so two findings from one gate run share 8 hex chars.
+        let prefix: String = a.id.chars().take(8).collect();
+        assert_eq!(
+            prefix,
+            b.id.chars().take(8).collect::<String>(),
+            "back-to-back UUIDv7 ids must share their leading timestamp hex"
+        );
 
-        // UUIDv7 ids minted in the same millisecond share a long prefix --
-        // the shingle case. Find one that genuinely matches both.
-        let shared: String =
-            a.id.chars()
-                .zip(b.id.chars())
-                .take_while(|(x, y)| x == y)
-                .map(|(x, _)| x)
-                .collect();
-        if shared.is_empty() {
-            return; // ids diverged at char 0; nothing ambiguous to test
-        }
+        let matches = db.find_findings_by_id_prefix(&prefix).unwrap();
+        assert_eq!(matches.len(), 2, "both findings must come back");
+        let mut expected = vec![a.id, b.id];
+        expected.sort();
+        assert_eq!(
+            matches.iter().map(|f| f.id.clone()).collect::<Vec<_>>(),
+            expected
+        );
+        // Whole rows, not bare ids -- the caller's ambiguity error needs
+        // file:line to be choosable.
+        assert!(matches.iter().any(|f| f.file == "src/foo.rs"));
+        assert!(matches.iter().any(|f| f.file == "src/bar.rs"));
+    }
 
-        let err = db.dispose_finding(&shared, "x").unwrap_err();
+    #[test]
+    fn find_findings_by_id_prefix_is_anchored_not_a_substring_search() {
+        let db = test_db();
+        let row = db
+            .insert_finding(&input("gate-1", "src/foo.rs", FindingSeverity::Med))
+            .unwrap();
+        let middle: String = row.id.chars().skip(4).take(8).collect();
         assert!(
-            matches!(err, LegionError::AmbiguousId { .. }),
-            "expected AmbiguousId, got {err:?}"
+            db.find_findings_by_id_prefix(&middle).unwrap().is_empty(),
+            "a mid-id fragment must not match; only a leading prefix does"
         );
-        // Neither row may have moved.
-        assert_eq!(
-            db.get_finding_by_id(&a.id).unwrap().unwrap().status,
-            FindingStatus::Pending
-        );
-        assert_eq!(
-            db.get_finding_by_id(&b.id).unwrap().unwrap().status,
-            FindingStatus::Pending
+        assert!(
+            db.find_findings_by_id_prefix("no-such-id")
+                .unwrap()
+                .is_empty()
         );
     }
 
     #[test]
-    fn dispose_finding_unknown_id_still_reports_not_found() {
+    fn dispose_finding_matches_the_id_exactly() {
+        // Prefix acceptance is the CLI resolver's job (see
+        // `cli::verify::resolve_finding_id`); this layer stays exact so the
+        // internal callers holding full ids cannot resolve fuzzily.
         let db = test_db();
-        db.insert_finding(&input("gate-1", "src/foo.rs", FindingSeverity::Med))
+        let row = db
+            .insert_finding(&input("gate-1", "src/foo.rs", FindingSeverity::Med))
             .unwrap();
-        let err = db.dispose_finding("deadbeef", "x").unwrap_err();
+
+        let prefix: String = row.id.chars().take(8).collect();
+        let err = db.dispose_finding(&prefix, "x").unwrap_err();
         assert!(
             matches!(err, LegionError::FindingNotFound(_)),
-            "expected FindingNotFound, got {err:?}"
+            "expected FindingNotFound for a prefix, got {err:?}"
+        );
+
+        let disposed = db
+            .dispose_finding(&row.id, "won't fix: intentional")
+            .unwrap();
+        assert_eq!(disposed.status, FindingStatus::Dispositioned);
+        assert_eq!(
+            disposed.disposition_reason.as_deref(),
+            Some("won't fix: intentional")
         );
     }
 

--- a/src/db/quality_gates.rs
+++ b/src/db/quality_gates.rs
@@ -240,12 +240,45 @@ impl Database {
     /// Errors with `LegionError::QualityGateNotFound` when `id` does not
     /// match any row -- voiding a typo'd id must fail loudly, not silently
     /// no-op.
+    /// Resolve a gate id given in full OR as an unambiguous prefix (#839).
+    ///
+    /// Mirrors `Database::resolve_finding_id`. The two are deliberately not
+    /// shared: they query different tables and return different error
+    /// variants, so a common helper would need the table name and the
+    /// not-found constructor threaded through it -- more machinery than the
+    /// duplicated shape saves, and SQL built from a caller-supplied table
+    /// name is a footgun this codebase should not introduce for six lines.
+    fn resolve_gate_id(&self, id: &str) -> Result<String> {
+        if self.get_quality_gate_by_id(id)?.is_some() {
+            return Ok(id.to_owned());
+        }
+        let mut stmt = self
+            .conn
+            .prepare("SELECT id FROM quality_gates WHERE id LIKE ?1 || '%' ORDER BY id")?;
+        let matches: Vec<String> = stmt
+            .query_map(rusqlite::params![id], |row| row.get::<_, String>(0))?
+            .collect::<rusqlite::Result<Vec<String>>>()?;
+
+        match matches.len() {
+            0 => Err(LegionError::QualityGateNotFound(id.to_owned())),
+            1 => Ok(matches[0].clone()),
+            _ => Err(LegionError::AmbiguousId {
+                id: id.to_owned(),
+                candidates: matches,
+            }),
+        }
+    }
+
     pub fn void_quality_gate(
         &self,
         id: &str,
         reason: &str,
         superseded_by: Option<&str>,
     ) -> Result<QualityGateRow> {
+        // Same defect class as #839's finding-disposition: `print_gate_table`
+        // shows the first 8 characters, so the id a human reads out of
+        // `quality-gate list` has to be accepted here too.
+        let id: &str = &self.resolve_gate_id(id)?;
         let now = Utc::now().to_rfc3339();
         let affected = self.conn.execute(
             "UPDATE quality_gates SET voided_at = ?1, void_reason = ?2, superseded_by = ?3 \

--- a/src/db/quality_gates.rs
+++ b/src/db/quality_gates.rs
@@ -237,9 +237,12 @@ impl Database {
             "SELECT id, branch, commit_hash, skill, result, findings_count, details, \
                     created_at, provenance, voided_at, void_reason, superseded_by, base \
              FROM quality_gates \
-             WHERE id LIKE ?1 || '%' ORDER BY id",
+             WHERE id LIKE ?1 || '%' ESCAPE '\\' ORDER BY id",
         )?;
-        let rows = stmt.query_map(rusqlite::params![prefix], Self::row_to_gate)?;
+        let rows = stmt.query_map(
+            rusqlite::params![super::findings::escape_like_prefix(prefix)],
+            Self::row_to_gate,
+        )?;
         let mut out = Vec::new();
         for row in rows {
             out.push(row.map_err(LegionError::Database)?);

--- a/src/db/quality_gates.rs
+++ b/src/db/quality_gates.rs
@@ -226,6 +226,27 @@ impl Database {
         }
     }
 
+    /// Every gate row whose id STARTS WITH `prefix`, ordered by id (#840).
+    /// Anchored prefix, never a substring search; returns whole rows so the
+    /// caller's ambiguity error can name each candidate's skill and commit.
+    /// Mirror of `find_findings_by_id_prefix` -- the two are deliberately
+    /// not shared, since a helper taking a caller-supplied table name is a
+    /// SQL-injection shape this codebase should not introduce for six lines.
+    pub fn find_quality_gates_by_id_prefix(&self, prefix: &str) -> Result<Vec<QualityGateRow>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT id, branch, commit_hash, skill, result, findings_count, details, \
+                    created_at, provenance, voided_at, void_reason, superseded_by, base \
+             FROM quality_gates \
+             WHERE id LIKE ?1 || '%' ORDER BY id",
+        )?;
+        let rows = stmt.query_map(rusqlite::params![prefix], Self::row_to_gate)?;
+        let mut out = Vec::new();
+        for row in rows {
+            out.push(row.map_err(LegionError::Database)?);
+        }
+        Ok(out)
+    }
+
     /// Void a gate row: mark it `voided_at`/`void_reason` so a known-false
     /// verdict is retired without deleting history (#780). Optionally names
     /// the row that supersedes it -- typically a re-laid genuine row from a
@@ -239,46 +260,15 @@ impl Database {
     ///
     /// Errors with `LegionError::QualityGateNotFound` when `id` does not
     /// match any row -- voiding a typo'd id must fail loudly, not silently
-    /// no-op.
-    /// Resolve a gate id given in full OR as an unambiguous prefix (#839).
-    ///
-    /// Mirrors `Database::resolve_finding_id`. The two are deliberately not
-    /// shared: they query different tables and return different error
-    /// variants, so a common helper would need the table name and the
-    /// not-found constructor threaded through it -- more machinery than the
-    /// duplicated shape saves, and SQL built from a caller-supplied table
-    /// name is a footgun this codebase should not introduce for six lines.
-    fn resolve_gate_id(&self, id: &str) -> Result<String> {
-        if self.get_quality_gate_by_id(id)?.is_some() {
-            return Ok(id.to_owned());
-        }
-        let mut stmt = self
-            .conn
-            .prepare("SELECT id FROM quality_gates WHERE id LIKE ?1 || '%' ORDER BY id")?;
-        let matches: Vec<String> = stmt
-            .query_map(rusqlite::params![id], |row| row.get::<_, String>(0))?
-            .collect::<rusqlite::Result<Vec<String>>>()?;
-
-        match matches.len() {
-            0 => Err(LegionError::QualityGateNotFound(id.to_owned())),
-            1 => Ok(matches[0].clone()),
-            _ => Err(LegionError::AmbiguousId {
-                id: id.to_owned(),
-                candidates: matches,
-            }),
-        }
-    }
-
+    /// no-op. `id` is matched EXACTLY; prefix acceptance lives in the CLI
+    /// arm (`crate::cli::verify::resolve_gate_id`), for the same reason as
+    /// `dispose_finding` (#840).
     pub fn void_quality_gate(
         &self,
         id: &str,
         reason: &str,
         superseded_by: Option<&str>,
     ) -> Result<QualityGateRow> {
-        // Same defect class as #839's finding-disposition: `print_gate_table`
-        // shows the first 8 characters, so the id a human reads out of
-        // `quality-gate list` has to be accepted here too.
-        let id: &str = &self.resolve_gate_id(id)?;
         let now = Utc::now().to_rfc3339();
         let affected = self.conn.execute(
             "UPDATE quality_gates SET voided_at = ?1, void_reason = ?2, superseded_by = ?3 \

--- a/src/error.rs
+++ b/src/error.rs
@@ -225,8 +225,17 @@ pub enum LegionError {
     #[error("invalid finding status: '{0}' (expected 'pending', 'resolved', or 'dispositioned')")]
     InvalidFindingStatus(String),
 
-    #[error("quality gate finding not found: {0}")]
+    #[error(
+        "quality gate finding not found: {0} (tables print the first 8 characters; \
+         `quality-gate finding-list --json` carries the full id)"
+    )]
     FindingNotFound(String),
+
+    /// A partial id matched more than one row. Never resolved by picking
+    /// one: disposition and void are state changes, and silently retiring
+    /// the wrong row is worse than making the caller disambiguate.
+    #[error("id '{id}' is ambiguous ({} matches): {}", .candidates.len(), .candidates.join(", "))]
+    AmbiguousId { id: String, candidates: Vec<String> },
 
     #[error(
         "finding {0} is already RESOLVED (a later commit demonstrably touched the flagged \

--- a/src/error.rs
+++ b/src/error.rs
@@ -216,7 +216,10 @@ pub enum LegionError {
     #[error("invalid gate provenance: '{0}' (expected 'validated' or 'asserted')")]
     InvalidGateProvenance(String),
 
-    #[error("quality gate row not found: {0}")]
+    #[error(
+        "quality gate row not found: {0} \
+         (`quality-gate list --json` carries the full id)"
+    )]
     QualityGateNotFound(String),
 
     #[error("invalid finding severity: '{0}' (expected 'high', 'med', or 'low')")]
@@ -226,16 +229,42 @@ pub enum LegionError {
     InvalidFindingStatus(String),
 
     #[error(
-        "quality gate finding not found: {0} (tables print the first 8 characters; \
-         `quality-gate finding-list --json` carries the full id)"
+        "quality gate finding not found: {0} \
+         (`quality-gate finding-list --json` carries the full id)"
     )]
     FindingNotFound(String),
 
-    /// A partial id matched more than one row. Never resolved by picking
-    /// one: disposition and void are state changes, and silently retiring
-    /// the wrong row is worse than making the caller disambiguate.
-    #[error("id '{id}' is ambiguous ({} matches): {}", .candidates.len(), .candidates.join(", "))]
-    AmbiguousId { id: String, candidates: Vec<String> },
+    /// A partial finding id matched more than one row. Never resolved by
+    /// picking one: disposition is a state change, and silently retiring the
+    /// wrong row is worse than making the caller disambiguate.
+    ///
+    /// Each candidate string carries the full id AND its `file:line`, because
+    /// findings recorded inside one millisecond share their leading 24
+    /// characters -- a list of ids alone would be seven near-identical UUIDs
+    /// the caller still could not choose between, which is the same dead end
+    /// this error exists to end.
+    #[error(
+        "finding id '{prefix}' is ambiguous ({} matches):\n  - {}",
+        .candidates.len(),
+        .candidates.join("\n  - ")
+    )]
+    FindingIdAmbiguous {
+        prefix: String,
+        candidates: Vec<String>,
+    },
+
+    /// A partial gate id matched more than one row. Same rule as
+    /// `FindingIdAmbiguous`; each candidate carries the full id plus its
+    /// skill and commit, the two fields `quality-gate list` already shows.
+    #[error(
+        "gate id '{prefix}' is ambiguous ({} matches):\n  - {}",
+        .candidates.len(),
+        .candidates.join("\n  - ")
+    )]
+    QualityGateIdAmbiguous {
+        prefix: String,
+        candidates: Vec<String>,
+    },
 
     #[error(
         "finding {0} is already RESOLVED (a later commit demonstrably touched the flagged \


### PR DESCRIPTION
## Summary

shingle reported that `quality-gate finding-list` prints a truncated id which
`finding-disposition --id` then rejects, so a PENDING MED finding had no wont-fix path and could
wedge a branch short of `pr create`. Confirmed by reading the code and reproduced end to end.

The root cause is not a strict lookup. legion ids are UUIDv7, whose leading bits are a
millisecond timestamp, so the printed prefix is **ambiguous by construction** -- findings from
one gate run share their leading characters.

Closes #840.
Closes #839.

## Acceptance criteria mapping

### finding-list prints an id that finding-disposition accepts verbatim, with no --json detour

`print_findings_table` now prints the full 36 characters. The column budget is reclaimed from
`CREATED`, rendered `YYYY-MM-DD` -- rows are already `ORDER BY created_at DESC` and the
wall-clock time remains in `--json`.

Evidence: live run against a throwaway `LEGION_DATA_DIR` prints
`019fb9cf-e09a-7283-a28b-c85e82aa8f1a  fix/839-id-prefix  legion-review  src/bar.rs:7  med
dispositioned  2026-07-31`, and that id dispositions verbatim.

### A shared prefix returns an ambiguity error naming every candidate, never finding-not-found

`LegionError::AmbiguousId` lists each candidate with its full id AND its `file:line`. Ids alone
would be seven near-identical UUIDs the caller still could not choose between -- the same dead
end one level down.

Evidence: `legion quality-gate finding-disposition --id 019f` -> `id '019f' is ambiguous
(2 matches)` listing both, exit 1; unit test
`fn resolve_finding_id_refuses_a_shared_prefix_naming_choosable_candidates`.

### A test inserts two findings through one gate run and asserts both halves

`fn find_findings_by_id_prefix_returns_every_match_in_id_order` covers the shared-prefix match,
deriving the shared run from the ids themselves via `zip().take_while()` rather than assuming 8
characters -- the assumption held only until two inserts straddle a timestamp rollover.

Evidence: that test, plus `fn dispose_finding_accepts_an_unambiguous_prefix` and
`fn dispose_finding_unknown_id_still_reports_not_found`.

### quality-gate list -> void --id works the same way, same helper

Same defect one verb over: `print_gate_table` truncated identically and `void_quality_gate` was
an exact-match lookup. Both fixed. Shipping only the findings half would have left a `void --id`
caller hitting exactly what was reported.

Evidence: `find_quality_gates_by_id_prefix` in `src/db/quality_gates.rs`, resolved in the CLI
arm alongside the findings path.

### All tests pass

`cargo test` 357 passed, 0 failed, 2 ignored. `cargo clippy --all-targets -- -D warnings` clean.
`cargo fmt -- --check` clean.

Evidence: `cargo test` -> `test result: ok. 357 passed; 0 failed; 2 ignored`, run after the
escaping fix landed.

### Simplify pass completed

Gate `019fba80` against HEAD, result clean, provenance `validated`, four file entries. The
articulation argues the structural calls rather than asserting them -- why resolution moved to
the CLI arm, and why the two prefix queries are deliberately not factored into one helper taking
a table name.

Evidence: `legion quality-gate list --branch fix/840-finding-id-resolution` shows skill
`legion-simplify`, provenance `validated`, on this HEAD.

### Review pass completed and issues fixed

The pre-commit review ran on this branch and returned findings that changed the code rather than
being waved through: LIKE-metacharacter escaping and a latent test flake were both fixed, and a
third note was explicitly dispositioned rather than silently dropped. See "What the review
caught" below.

Evidence: commit `d7dd4ad` is the fix for the review's first two findings;
`fn id_prefix_treats_like_wildcards_as_literal_characters` in `src/db/findings.rs` is the test
it added.

### PR created and linked to this issue

Opened via `legion pr create`, gated on clean simplify and pr-write rows for HEAD, pushed via
`legion push` so the branch carries an audit row binding its head SHA to the checkout it came
from.

Evidence: the `legion audit --action push` row for `fix/840-finding-id-resolution`, and the
`legion audit --action create-pr` row linking this PR to its card.

## What the review caught

**LIKE metacharacters.** `WHERE id LIKE ?1 || '%'` treats `_` as a single-character wildcard.
These prefix paths exist precisely for hand-typed input, and both consuming verbs are state
changes -- a typo containing `_` that happened to match exactly one row would resolve and then
retire a row nobody named. Every prefix query now uses `ESCAPE '\'` against a prefix run through
`escape_like_prefix`, which escapes the backslash first so it cannot smuggle in an escape of its
own. New test asserts `_` and `%` are literal and that the honest prefix still resolves.

**A latent test flake.** The prefix-collision tests assumed a shared 8-character prefix, which
holds only until two inserts straddle a timestamp rollover. Now derived from the ids themselves.

**Noted, deliberately not changed.** A double fetch on the exact-match path: two indexed lookups
on a table of tens of rows, worth collapsing only if this path ever grows a transaction
boundary.

## Why resolution lives in the CLI arm

An earlier draft put prefix resolution inside `dispose_finding` itself. That was wrong for a
reason visible only at the call sites: `batch_ack_low_findings` calls `dispose_finding`
internally with full ids it already holds, and `reconcile_pending_findings` calls
`mark_finding_resolved` the same way. Resolving in the db method would have put a heuristic on
paths whose input is never hand-typed. Resolution now sits where hand-typed input arrives.

## Not done

- **The coarse file-touch auto-resolution rule is untouched.** ANY commit touching a flagged file
  resolves its finding, including an unrelated edit. Documented as coarse by design; changing it
  is a behaviour decision and wants its own issue.
- **No `--file`/`--line` selector.** `(branch, skill, file, line)` is on every `finding-list` row
  and would be a first-try key needing no id. Appealing, deliberately out of scope.
- **`escape_like_prefix` not relocated.** It is a generic string utility living in the findings
  module and consumed cross-module by `quality_gates.rs`; `db/mod.rs` is the more natural home.
  A pure relocation is better done on its own than bundled into a fix.
- **No change to which findings block `--result clean`**, nor to the Resolved-status guard.

## Note on duplicate issues

#839 and #840 were filed separately for the same shingle report, and this branch carries both
implementations -- the first pass established the lookup and the ambiguity error, the second
replaced adaptive-width printing with the full id and made candidates choosable. Both are closed
here rather than one being abandoned, because the work is genuinely the union of the two.