### PR TITLE
fix(#849): watch skips wake for delegated entries

### DIFF
--- a/src/watch/config.rs
+++ b/src/watch/config.rs
@@ -51,6 +51,26 @@ impl WatchRepoConfig {
             .unwrap_or(&self.name)
     }
 
+    /// Whether this entry is DELEGATED -- maintained through another agent's
+    /// session rather than waking one of its own.
+    ///
+    /// Ruling (#849): a delegated entry never spawns. Its `agent` field names
+    /// the persona that MAINTAINS the repo, and that persona wakes in the
+    /// owner's own workdir. The delegated entry still earns its place in
+    /// watch.toml -- it supplies `legion watch` list output, index coverage,
+    /// workdir-ownership checks, and `sym --repo` resolution -- but never a
+    /// wake. The wake path skips it before lease acquisition, so it does not
+    /// even compete for the persona wake-lease; that is what guarantees a
+    /// directed `@owner` signal wakes exactly once, in the owner's workdir.
+    ///
+    /// Defined against `recipient()` rather than the raw `agent` field so an
+    /// empty or whitespace-only `agent` (which `recipient()` treats as absent)
+    /// cannot read as delegated here while the lease layer treats it as
+    /// self-owned.
+    pub fn is_delegated(&self) -> bool {
+        self.recipient() != self.name
+    }
+
     /// The full addressable name set for this repo: `recipient()` plus every
     /// `broadcast_tags` entry. This is exactly the `names` contract of
     /// `find_pending_signals` -- the wake path (poll_cycle) and the read path
@@ -809,6 +829,72 @@ workdir = "/nonexistent/path/that/does/not/exist"
             extra: toml::Table::new(),
         };
         assert_eq!(repo_without_agent.recipient(), "legion");
+    }
+
+    #[test]
+    fn is_delegated_is_true_only_when_agent_names_another_persona() {
+        // #849: `agent` set to a DIFFERENT persona means the repo is maintained
+        // through that owner's session -- the entry itself never wakes.
+        let delegated = WatchRepoConfig {
+            name: "ledger".to_string(),
+            workdir: "/tmp".to_string(),
+            agent: Some("platform".to_string()),
+            broadcast_tags: Vec::new(),
+            extra: toml::Table::new(),
+        };
+        assert!(
+            delegated.is_delegated(),
+            "agent naming another persona must read as delegated"
+        );
+
+        // `agent` absent -- the repo speaks for itself, so it wakes normally.
+        let no_agent = WatchRepoConfig {
+            name: "legion".to_string(),
+            workdir: "/tmp".to_string(),
+            agent: None,
+            broadcast_tags: Vec::new(),
+            extra: toml::Table::new(),
+        };
+        assert!(
+            !no_agent.is_delegated(),
+            "absent agent must not read as delegated"
+        );
+
+        // `agent` echoing the repo's own name is the self-owned primary entry,
+        // not a delegation (e.g. platform's own repo carries agent = platform).
+        let self_named = WatchRepoConfig {
+            name: "platform".to_string(),
+            workdir: "/tmp".to_string(),
+            agent: Some("platform".to_string()),
+            broadcast_tags: Vec::new(),
+            extra: toml::Table::new(),
+        };
+        assert!(
+            !self_named.is_delegated(),
+            "agent equal to name is the self-owned primary entry"
+        );
+    }
+
+    #[test]
+    fn is_delegated_treats_empty_agent_as_absent() {
+        // Mirrors recipient()'s normalization: a hand-edited agent = "" or an
+        // all-whitespace value falls back to `name`, so it must NOT read as
+        // delegated. Keying is_delegated on recipient() is what buys this --
+        // a raw `agent` comparison would call these delegated while the lease
+        // layer still treated the entry as self-owned.
+        for blank in ["", "   "] {
+            let repo = WatchRepoConfig {
+                name: "fallback".to_string(),
+                workdir: "/tmp".to_string(),
+                agent: Some(blank.to_string()),
+                broadcast_tags: Vec::new(),
+                extra: toml::Table::new(),
+            };
+            assert!(
+                !repo.is_delegated(),
+                "blank agent {blank:?} must fall back to name, not read as delegated"
+            );
+        }
     }
 
     #[test]

--- a/src/watch/gates.rs
+++ b/src/watch/gates.rs
@@ -131,38 +131,44 @@ pub fn poll_cycle(
         // the race against the owner's entry and wake the owner's persona in
         // the WRONG workdir. Not competing for the lease is what makes a
         // directed `@owner` signal wake exactly once, in the owner's workdir.
-        // Signals are deliberately NOT marked handled here, and this is NOT the
-        // same reasoning as the lease-held skip below. That skip defers to a
-        // TRANSIENT holder which, once it spawns, marks the signal handled under
-        // the SAME repo_name -- so something does eventually consume this
-        // entry's copy. Delegation is permanent config, and NOTHING consumes
-        // this entry's copy: `watch_handled` is keyed (signal_id, repo_name), so
-        // the owner's spawn marks it under the OWNER's repo_name and this repo's
-        // pending row drains only when the signal hits its TTL
-        // (TTL_SIGNAL_HOURS, 7 days -- src/db/board.rs) or someone runs
-        // `legion resolve`. Marking here would also not be a local decision:
-        // `watch_handled` is cluster-synced while delegation is a host-local
-        // watch.toml choice, so a mark driven by THIS host's config would
-        // suppress the signal for peer nodes whose config does not delegate this
-        // repo -- the #308/#314 lost-signal failure mode.
+        //
+        // The batch IS marked handled under THIS repo's own name, and that is
+        // local bookkeeping rather than a cluster decision. `watch_handled` is
+        // a HOST-LOCAL table: it carries no `updated_at`/`deleted_at`
+        // (src/db/board.rs) and is not one of the four tables on the sync wire
+        // (reflections, cards, schedules, persona_wake_leases --
+        // src/sync_actor.rs), so a mark written here can never travel to a peer
+        // whose watch.toml does not delegate this repo. It is keyed
+        // (signal_id, repo_name), and the `find_pending_signals` above joins on
+        // that exact pair (via `get_unhandled_signals_for_repo`), so the mark
+        // retires ONLY this entry's pending copy: the owner's copy lives under
+        // the OWNER's repo_name, untouched, and the owner's wake is unaffected.
+        // Retiring it is the point -- nothing else ever drains a delegated
+        // entry's copy, so an unmarked row would sit pending until the 7-day
+        // signal TTL, re-announcing this skip on every poll. The mark is also
+        // anti-replay: if the operator later drops `agent` and un-delegates the
+        // repo, week-old signals must not suddenly wake it. Same keying
+        // doctrine as the post-spawn mark below -- keyed by `repo.name`
+        // (stable) so future `agent=` edits do not replay.
+        //
+        // The mark is not permanent: the retention sweep in src/watch/mod.rs
+        // calls `prune_watch_handled` (src/db/board.rs) to drop rows past
+        // `retention_days`. If that is ever tuned below the signal TTL, a
+        // pruned mark resurrects this pending copy for exactly one cycle --
+        // one log line, then re-marked here. Self-healing, so the prune needs
+        // no delegation-aware special case.
         if repo.is_delegated() {
-            // Log on state change only: this branch runs every poll cycle (30s
-            // by default) for as long as the pending copy survives, and
-            // daemon.log is append-only with no rotation. The `since` lookback
-            // does not bound that -- it is a now-minus-24h cutoff computed once
-            // at WatchLoop construction (src/watch/mod.rs) and never advanced,
-            // so any signal arriving after startup stays inside the window. The
-            // real bound is the daemon's uptime, capped by the 7-day TTL above.
-            // `should_log_delegated_skip` remembers the last set of pending
-            // signal ids logged for this repo and answers `false` while it is
-            // unchanged. Deliberately scoped to this skip; the session-lock and
-            // cooldown skips are #853's problem.
-            let pending_ids: Vec<String> = signals.iter().map(|(id, _, _)| id.clone()).collect();
-            if cooldown.should_log_delegated_skip(&repo.name, &pending_ids) {
-                eprintln!(
-                    "[legion watch] skipping wake for delegated repo '{}' (owner: {})",
-                    repo.name, recipient
-                );
+            eprintln!(
+                "[legion watch] skipping wake for delegated repo '{}' (owner: {})",
+                repo.name, recipient
+            );
+            for (id, _, _) in &signals {
+                if let Err(e) = db.mark_signal_handled_for_repo(id, &repo.name) {
+                    eprintln!(
+                        "[legion watch] failed to mark delegated-skip signal {} as handled for {}: {}",
+                        id, repo.name, e
+                    );
+                }
             }
             continue;
         }
@@ -671,6 +677,33 @@ mod tests {
         );
     }
 
+    /// Assert the delegated skip retired its OWN pending copy and only its own.
+    ///
+    /// Both halves are load-bearing, and neither is sufficient alone. The first
+    /// is the point of the mark: nothing else drains a delegated entry's copy,
+    /// so an unmarked row re-announces the skip every poll until the signal's
+    /// 7-day TTL. The second is what proves the mark is SCOPED -- the owner's
+    /// copy is keyed under the owner's own `repo_name`, and a guard that marked
+    /// under `recipient()` instead of `repo.name` would retire it and starve
+    /// the real wake. `find_pending_signals` joins `watch_handled` on
+    /// (signal_id, repo_name), so only the paired query can see the difference.
+    fn assert_delegated_copy_retired(db: &Database, delegated: &str, owner: &str) {
+        let names: Vec<String> = vec![owner.to_string()];
+
+        let retired = find_pending_signals(db, delegated, &names, None).expect("delegated pending");
+        assert!(
+            retired.is_empty(),
+            "the delegated skip must retire {delegated}'s pending copy -- nothing else drains it"
+        );
+
+        let owner_pending = find_pending_signals(db, owner, &names, None).expect("owner pending");
+        assert_eq!(
+            owner_pending.len(),
+            1,
+            "{owner}'s copy is keyed under its own repo_name and must survive the skip"
+        );
+    }
+
     #[test]
     fn poll_cycle_skips_wake_for_delegated_entry_with_directed_signal() {
         // `ledger` is maintained by `platform`, so a directed @platform signal
@@ -713,20 +746,11 @@ mod tests {
         // the exact bug #849 is about, so it gets its own assertion.
         assert_no_wake_machinery_touched(&db, "platform");
 
-        // The signal stays pending, and nothing ever consumes this copy: the
-        // owner's spawn marks the signal handled under the OWNER's repo_name,
-        // never under `ledger`, so ledger's row drains only at the signal's
-        // 7-day TTL or an explicit `legion resolve`. That is accepted, not
-        // accidental -- `watch_handled` is cluster-synced, so marking on the
-        // strength of this host's watch.toml would lose the signal for peers
-        // that do not delegate ledger (#308/#314).
-        let still_pending =
-            find_pending_signals(&db, "ledger", &["platform".to_string()], None).expect("pending");
-        assert_eq!(
-            still_pending.len(),
-            1,
-            "a host-local delegation decision must not consume the signal"
-        );
+        // The skip retires ledger's own pending copy. `watch_handled` is
+        // host-local and keyed (signal_id, repo_name), so nothing else would
+        // ever drain this row -- leaving it pending means re-announcing the
+        // skip every poll until the 7-day TTL.
+        assert_delegated_copy_retired(&db, "ledger", "platform");
     }
 
     #[test]
@@ -770,6 +794,10 @@ mod tests {
             "a broadcast must not wake a delegated entry either"
         );
         assert_no_wake_machinery_touched(&db, "platform");
+        // A broadcast copy is retired the same way a directed one is: the mark
+        // is per (signal_id, repo_name), which is exactly the mechanism that
+        // already lets one `@all` wake every non-delegated repo once.
+        assert_delegated_copy_retired(&db, "ledger", "platform");
     }
 
     #[test]
@@ -815,6 +843,7 @@ mod tests {
             "a file-change-driven wake must not spawn a delegated entry"
         );
         assert_no_wake_machinery_touched(&db, "platform");
+        assert_delegated_copy_retired(&db, "ledger", "platform");
     }
 
     #[test]
@@ -959,28 +988,46 @@ mod tests {
             "the entry that wakes must be the owner's, not the delegated one"
         );
 
-        // The regression guard for a future "just mark it handled" patch. The
-        // pending lookup catches a mark under `repo.name` (ledger's own copy
-        // would vanish); the watch_handled count catches a mark under the
-        // RECIPIENT, which the pending lookup cannot see because it joins on
-        // repo_name = 'ledger'. Neither entry legitimately writes the table in
-        // this cycle -- the owner marks handled only on a successful spawn, and
-        // this spawn fails -- so the table must be empty outright.
-        let ledger_pending =
-            find_pending_signals(&db, "ledger", &["platform".to_string()], None).expect("pending");
-        assert_eq!(
-            ledger_pending.len(),
-            1,
-            "ledger's pending copy must survive the skip -- nothing consumes it, \
-             and a host-local delegation decision must not write a cluster-synced mark"
-        );
-        let handled_rows: i64 = db
+        // Scoped marking, asserted directly on the table rather than through
+        // the pending lookups. The delegated skip retires ledger's copy, so a
+        // row must exist under 'ledger'; the row that must NOT exist is one
+        // under 'platform'. That is the mark-under-recipient regression, and it
+        // is invisible to the pending lookups because each joins watch_handled
+        // on its own repo_name -- ledger's query cannot see a platform-keyed
+        // row, and a platform-keyed row would silently starve the owner's wake.
+        //
+        // No other path can have written a platform row in this cycle: the
+        // owner's post-spawn marking loop lives on the `Ok(child)` arm of the
+        // spawn match, and this spawn fails at UNSPAWNABLE_WORKDIR. The Err arm
+        // releases leases and abandons the wake_attempt, marking nothing. So
+        // counting by repo_name is exact here, not merely indicative.
+        assert_delegated_copy_retired(&db, "ledger", "platform");
+
+        let ledger_marks: i64 = db
             .conn
-            .query_row("SELECT COUNT(*) FROM watch_handled", [], |row| row.get(0))
-            .expect("count watch_handled");
+            .query_row(
+                "SELECT COUNT(*) FROM watch_handled WHERE repo_name = 'ledger'",
+                [],
+                |row| row.get(0),
+            )
+            .expect("count ledger marks");
         assert_eq!(
-            handled_rows, 0,
-            "the delegated skip must not mark the signal handled under ANY repo_name"
+            ledger_marks, 1,
+            "the delegated skip must mark the batch under its OWN repo_name"
+        );
+
+        let platform_marks: i64 = db
+            .conn
+            .query_row(
+                "SELECT COUNT(*) FROM watch_handled WHERE repo_name = 'platform'",
+                [],
+                |row| row.get(0),
+            )
+            .expect("count platform marks");
+        assert_eq!(
+            platform_marks, 0,
+            "a mark written under the RECIPIENT would retire the owner's copy \
+             and starve the wake that is supposed to happen"
         );
     }
 

--- a/src/watch/gates.rs
+++ b/src/watch/gates.rs
@@ -131,14 +131,39 @@ pub fn poll_cycle(
         // the race against the owner's entry and wake the owner's persona in
         // the WRONG workdir. Not competing for the lease is what makes a
         // directed `@owner` signal wake exactly once, in the owner's workdir.
-        // Signals are deliberately NOT marked handled here -- same reasoning as
-        // the lease-held skip below: the owner's entry is the one that consumes
-        // them, and a local handled-mark would only discard our own view.
+        // Signals are deliberately NOT marked handled here, and this is NOT the
+        // same reasoning as the lease-held skip below. That skip defers to a
+        // TRANSIENT holder which, once it spawns, marks the signal handled under
+        // the SAME repo_name -- so something does eventually consume this
+        // entry's copy. Delegation is permanent config, and NOTHING consumes
+        // this entry's copy: `watch_handled` is keyed (signal_id, repo_name), so
+        // the owner's spawn marks it under the OWNER's repo_name and this repo's
+        // pending row drains only when the signal hits its TTL
+        // (TTL_SIGNAL_HOURS, 7 days -- src/db/board.rs) or someone runs
+        // `legion resolve`. Marking here would also not be a local decision:
+        // `watch_handled` is cluster-synced while delegation is a host-local
+        // watch.toml choice, so a mark driven by THIS host's config would
+        // suppress the signal for peer nodes whose config does not delegate this
+        // repo -- the #308/#314 lost-signal failure mode.
         if repo.is_delegated() {
-            eprintln!(
-                "[legion watch] skipping wake for delegated repo '{}' (owner: {})",
-                repo.name, recipient
-            );
+            // Log on state change only: this branch runs every poll cycle (30s
+            // by default) for as long as the pending copy survives, and
+            // daemon.log is append-only with no rotation. The `since` lookback
+            // does not bound that -- it is a now-minus-24h cutoff computed once
+            // at WatchLoop construction (src/watch/mod.rs) and never advanced,
+            // so any signal arriving after startup stays inside the window. The
+            // real bound is the daemon's uptime, capped by the 7-day TTL above.
+            // `should_log_delegated_skip` remembers the last set of pending
+            // signal ids logged for this repo and answers `false` while it is
+            // unchanged. Deliberately scoped to this skip; the session-lock and
+            // cooldown skips are #853's problem.
+            let pending_ids: Vec<String> = signals.iter().map(|(id, _, _)| id.clone()).collect();
+            if cooldown.should_log_delegated_skip(&repo.name, &pending_ids) {
+                eprintln!(
+                    "[legion watch] skipping wake for delegated repo '{}' (owner: {})",
+                    repo.name, recipient
+                );
+            }
             continue;
         }
 
@@ -688,14 +713,19 @@ mod tests {
         // the exact bug #849 is about, so it gets its own assertion.
         assert_no_wake_machinery_touched(&db, "platform");
 
-        // The signal stays pending: the owner's entry is the one that consumes
-        // it, so the delegated entry must not mark it handled on its own behalf.
+        // The signal stays pending, and nothing ever consumes this copy: the
+        // owner's spawn marks the signal handled under the OWNER's repo_name,
+        // never under `ledger`, so ledger's row drains only at the signal's
+        // 7-day TTL or an explicit `legion resolve`. That is accepted, not
+        // accidental -- `watch_handled` is cluster-synced, so marking on the
+        // strength of this host's watch.toml would lose the signal for peers
+        // that do not delegate ledger (#308/#314).
         let still_pending =
             find_pending_signals(&db, "ledger", &["platform".to_string()], None).expect("pending");
         assert_eq!(
             still_pending.len(),
             1,
-            "the signal must be left for the owner's entry to handle"
+            "a host-local delegation decision must not consume the signal"
         );
     }
 
@@ -840,6 +870,118 @@ mod tests {
              the delegation guard must not swallow it"
         );
         assert_eq!(attempts[0].repo_name, "platform");
+    }
+
+    #[test]
+    fn poll_cycle_wakes_only_the_owner_when_both_entries_are_configured() {
+        // Co-presence: the delegated entry and its owner are BOTH in watch.toml,
+        // which is the shape a real host has, and the shape the single-entry
+        // tests above cannot express. One directed @platform signal, two entries
+        // that both match it, one real lease gate.
+        //
+        // What this proves: exactly one entry reaches the wake machinery, and it
+        // is the owner's. The wake_attempt table carries both halves -- its
+        // length says how many entries got through, and its `repo_name` says
+        // which one.
+        //
+        // Which mutations it discriminates:
+        // - guard deleted    -> ledger runs the full path first, so there are
+        //                       TWO attempt rows (ledger's spawn fails on the
+        //                       bogus workdir, which releases its lease and lets
+        //                       platform re-acquire and enqueue its own).
+        // - predicate inverted -> ONE attempt row, keyed to `ledger` instead of
+        //                       `platform`.
+        //
+        // One caveat, stated because the alternative is a comment that claims
+        // more than it checks. This test does NOT discriminate a guard moved
+        // BELOW the lease acquire: `try_acquire_persona_lease` returns true for
+        // a same-host re-acquire (src/db/wake.rs -- it reads the holder back and
+        // compares it to `host`), so ledger taking the lease and skipping does
+        // not lock platform out, and the attempt count stays 1. That mutation is
+        // caught by `assert_no_wake_machinery_touched` in the single-entry tests,
+        // where no second entry can paper over the stolen lease.
+        //
+        // Nor does it replay the production #849 incident, which was one wake in
+        // the WRONG workdir. Reproducing that needs a SUCCESSFUL spawn, and the
+        // whole suite deliberately forbids one (see UNSPAWNABLE_WORKDIR) rather
+        // than bill a live session per test run.
+        let (db, _index, _dir) = test_storage();
+
+        let config = WatchConfig {
+            // Explicit: the default is 15s, and a stagger sleep between two
+            // entries would make this test pay for it.
+            stagger_secs: 0,
+            repos: vec![
+                delegated_repo("ledger", "platform"),
+                WatchRepoConfig {
+                    name: "platform".to_string(),
+                    workdir: UNSPAWNABLE_WORKDIR.to_string(),
+                    agent: Some("platform".to_string()),
+                    broadcast_tags: Vec::new(),
+                    extra: toml::Table::new(),
+                },
+            ],
+            ..WatchConfig::default()
+        };
+
+        db.insert_reflection("kelex", "@platform question:can you look at this", "team")
+            .expect("insert signal");
+
+        let gate = PersonaLeaseGate {
+            db: &db,
+            host: "this-host",
+            ttl: Duration::from_secs(3600),
+        };
+        let mut cooldown = CooldownTracker::new(0, None, None);
+        let mut tracker = AgentTracker::new();
+        let spawned = poll_cycle(
+            &db,
+            &config,
+            &mut cooldown,
+            &mut tracker,
+            None,
+            Some(&gate),
+            None,
+            SpawnMode::Print,
+        )
+        .expect("poll");
+        assert_eq!(spawned, 0, "the bogus workdir must fail both spawns");
+
+        let attempts = db.recent_wake_attempts(50).expect("list attempts");
+        assert_eq!(
+            attempts.len(),
+            1,
+            "a directed @platform signal must reach the wake machinery exactly once \
+             even though two configured entries match it"
+        );
+        assert_eq!(
+            attempts[0].repo_name, "platform",
+            "the entry that wakes must be the owner's, not the delegated one"
+        );
+
+        // The regression guard for a future "just mark it handled" patch. The
+        // pending lookup catches a mark under `repo.name` (ledger's own copy
+        // would vanish); the watch_handled count catches a mark under the
+        // RECIPIENT, which the pending lookup cannot see because it joins on
+        // repo_name = 'ledger'. Neither entry legitimately writes the table in
+        // this cycle -- the owner marks handled only on a successful spawn, and
+        // this spawn fails -- so the table must be empty outright.
+        let ledger_pending =
+            find_pending_signals(&db, "ledger", &["platform".to_string()], None).expect("pending");
+        assert_eq!(
+            ledger_pending.len(),
+            1,
+            "ledger's pending copy must survive the skip -- nothing consumes it, \
+             and a host-local delegation decision must not write a cluster-synced mark"
+        );
+        let handled_rows: i64 = db
+            .conn
+            .query_row("SELECT COUNT(*) FROM watch_handled", [], |row| row.get(0))
+            .expect("count watch_handled");
+        assert_eq!(
+            handled_rows, 0,
+            "the delegated skip must not mark the signal handled under ANY repo_name"
+        );
     }
 
     #[test]

--- a/src/watch/gates.rs
+++ b/src/watch/gates.rs
@@ -122,6 +122,26 @@ pub fn poll_cycle(
         // their unblock check to the next poll -- the signals stay pending.
         check_auto_unblock(db, &signals);
 
+        // #849: a delegated entry never spawns. `agent` names the persona that
+        // MAINTAINS this repo, and that persona wakes in its OWN workdir -- so
+        // this entry is not a wake target at all, whatever the wake source
+        // (directed signal, broadcast, or a file change that landed a signal).
+        // The skip lands before the lease and wake_attempt work below on
+        // purpose: a delegated entry that acquired the persona lease would win
+        // the race against the owner's entry and wake the owner's persona in
+        // the WRONG workdir. Not competing for the lease is what makes a
+        // directed `@owner` signal wake exactly once, in the owner's workdir.
+        // Signals are deliberately NOT marked handled here -- same reasoning as
+        // the lease-held skip below: the owner's entry is the one that consumes
+        // them, and a local handled-mark would only discard our own view.
+        if repo.is_delegated() {
+            eprintln!(
+                "[legion watch] skipping wake for delegated repo '{}' (owner: {})",
+                repo.name, recipient
+            );
+            continue;
+        }
+
         if cooldown.is_cooling_down(&repo.name) {
             continue;
         }
@@ -572,6 +592,254 @@ mod tests {
         let listed = db.list_persona_leases(Some("legion")).expect("list");
         assert_eq!(listed.len(), 1);
         assert_eq!(listed[0].acquired_by_host, "peer-host");
+    }
+
+    // -- Delegated entries never wake (#849) -----------------------------------
+
+    /// A workdir that cannot exist, so `spawn_agent` fails at the `chdir`
+    /// instead of launching a real `claude` session.
+    ///
+    /// Every delegated-entry test below uses it as a safety net. Without it, a
+    /// regression that removes the guard does not just fail the test -- it
+    /// launches a live billed wake session per test run, in `/tmp`, with the
+    /// prompt of whatever signal the test seeded. Verified during development:
+    /// disabling the guard with a `/tmp` workdir spawned real `claude --print`
+    /// children that had to be killed by hand. The assertions below therefore
+    /// do NOT lean on `spawned == 0` (a bogus workdir gives that for free);
+    /// they lean on the wake_attempt row, which is enqueued immediately before
+    /// `spawn_agent` with nothing in between that could skip.
+    const UNSPAWNABLE_WORKDIR: &str = "/nonexistent/legion-849/spawn-must-fail";
+
+    /// A watch.toml entry whose `agent` names another persona.
+    fn delegated_repo(name: &str, owner: &str) -> WatchRepoConfig {
+        WatchRepoConfig {
+            name: name.to_string(),
+            workdir: UNSPAWNABLE_WORKDIR.to_string(),
+            agent: Some(owner.to_string()),
+            broadcast_tags: Vec::new(),
+            extra: toml::Table::new(),
+        }
+    }
+
+    /// Assert the delegated entry was skipped before it could touch any of the
+    /// wake machinery: no persona lease taken from `owner`, and no wake_attempt
+    /// row enqueued. The attempt table is the tight one -- `enqueue_wake_attempt`
+    /// is the last statement before `spawn_agent`, so an empty table means the
+    /// loop never reached the spawn call at all.
+    ///
+    /// Every caller must run `poll_cycle` WITH a `PersonaLeaseGate`. Without one
+    /// the lease half of this assertion is vacuous -- no lease can be taken, so
+    /// it would still pass against a guard that had been moved below the acquire,
+    /// which is precisely the regression #849 is about.
+    fn assert_no_wake_machinery_touched(db: &Database, owner: &str) {
+        let leases = db.list_persona_leases(Some(owner)).expect("list leases");
+        assert!(
+            leases.is_empty(),
+            "delegated entry must not acquire the persona lease it would steal from {owner}"
+        );
+
+        let attempts = db.recent_wake_attempts(50).expect("list attempts");
+        assert!(
+            attempts.is_empty(),
+            "delegated entry must be skipped before the wake_attempt enqueue that \
+             immediately precedes spawn_agent"
+        );
+    }
+
+    #[test]
+    fn poll_cycle_skips_wake_for_delegated_entry_with_directed_signal() {
+        // `ledger` is maintained by `platform`, so a directed @platform signal
+        // must wake platform in PLATFORM's workdir -- never ledger's entry.
+        let (db, _index, _dir) = test_storage();
+
+        let config = WatchConfig {
+            repos: vec![delegated_repo("ledger", "platform")],
+            ..WatchConfig::default()
+        };
+
+        db.insert_reflection("kelex", "@platform question:can you look at this", "team")
+            .expect("insert signal");
+
+        let gate = PersonaLeaseGate {
+            db: &db,
+            host: "this-host",
+            ttl: Duration::from_secs(3600),
+        };
+        let mut cooldown = CooldownTracker::new(0, None, None);
+        let mut tracker = AgentTracker::new();
+        let spawned = poll_cycle(
+            &db,
+            &config,
+            &mut cooldown,
+            &mut tracker,
+            None,
+            Some(&gate),
+            None,
+            SpawnMode::Print,
+        )
+        .expect("poll");
+
+        assert_eq!(spawned, 0, "a delegated entry must never spawn a session");
+
+        // The load-bearing assertions: the skip happens BEFORE lease acquisition
+        // and before the wake_attempt enqueue. A skip that ran AFTER the lease
+        // acquire would still report `spawned == 0` while holding the lease the
+        // owner's entry needs -- blocking the real wake for a full TTL. That is
+        // the exact bug #849 is about, so it gets its own assertion.
+        assert_no_wake_machinery_touched(&db, "platform");
+
+        // The signal stays pending: the owner's entry is the one that consumes
+        // it, so the delegated entry must not mark it handled on its own behalf.
+        let still_pending =
+            find_pending_signals(&db, "ledger", &["platform".to_string()], None).expect("pending");
+        assert_eq!(
+            still_pending.len(),
+            1,
+            "the signal must be left for the owner's entry to handle"
+        );
+    }
+
+    #[test]
+    fn poll_cycle_skips_wake_for_delegated_entry_on_broadcast() {
+        // Broadcasts reach spawn through the same loop as directed signals, so
+        // the guard must cover them too -- an @all fan-out must not wake a
+        // delegated entry in the wrong workdir.
+        let (db, _index, _dir) = test_storage();
+
+        let config = WatchConfig {
+            repos: vec![delegated_repo("ledger", "platform")],
+            ..WatchConfig::default()
+        };
+
+        db.insert_reflection("kelex", "@all request -- wake everyone", "team")
+            .expect("insert broadcast");
+
+        // The lease gate is passed on purpose: without it the lease half of
+        // assert_no_wake_machinery_touched could not fail.
+        let gate = PersonaLeaseGate {
+            db: &db,
+            host: "this-host",
+            ttl: Duration::from_secs(3600),
+        };
+        let mut cooldown = CooldownTracker::new(0, None, None);
+        let mut tracker = AgentTracker::new();
+        let spawned = poll_cycle(
+            &db,
+            &config,
+            &mut cooldown,
+            &mut tracker,
+            None,
+            Some(&gate),
+            None,
+            SpawnMode::Print,
+        )
+        .expect("poll");
+
+        assert_eq!(
+            spawned, 0,
+            "a broadcast must not wake a delegated entry either"
+        );
+        assert_no_wake_machinery_touched(&db, "platform");
+    }
+
+    #[test]
+    fn poll_cycle_skips_wake_for_delegated_entry_on_file_change_wake() {
+        // A file-change wake is not a separate spawn path: `spawn_agent` has a
+        // single call site in this loop, and a file change reaches it by landing
+        // a signal that `find_pending_signals` picks up on the next poll. So the
+        // file-change case is exercised the same way -- a wake-worthy signal
+        // addressed to the owner, arriving at a delegated entry.
+        let (db, _index, _dir) = test_storage();
+
+        let config = WatchConfig {
+            repos: vec![delegated_repo("ledger", "platform")],
+            ..WatchConfig::default()
+        };
+
+        db.insert_reflection("watch", "@platform request -- ledger files changed", "team")
+            .expect("insert file-change signal");
+
+        // The lease gate is passed on purpose: without it the lease half of
+        // assert_no_wake_machinery_touched could not fail.
+        let gate = PersonaLeaseGate {
+            db: &db,
+            host: "this-host",
+            ttl: Duration::from_secs(3600),
+        };
+        let mut cooldown = CooldownTracker::new(0, None, None);
+        let mut tracker = AgentTracker::new();
+        let spawned = poll_cycle(
+            &db,
+            &config,
+            &mut cooldown,
+            &mut tracker,
+            None,
+            Some(&gate),
+            None,
+            SpawnMode::Print,
+        )
+        .expect("poll");
+
+        assert_eq!(
+            spawned, 0,
+            "a file-change-driven wake must not spawn a delegated entry"
+        );
+        assert_no_wake_machinery_touched(&db, "platform");
+    }
+
+    #[test]
+    fn poll_cycle_does_not_skip_a_self_owned_entry() {
+        // The negative control for the guard: an entry whose `agent` equals its
+        // own name is NOT delegated, so it must run the full wake path.
+        //
+        // Same UNSPAWNABLE_WORKDIR trick as the delegated tests, so this control
+        // does not launch a live session either: `spawn_agent` fails at the
+        // chdir and poll_cycle takes its Err arm. `spawned` is therefore 0 for
+        // BOTH this entry and a delegated one -- the distinguishing evidence is
+        // the wake_attempt row, enqueued only once the delegation guard has let
+        // the entry through. This is the mirror of
+        // `assert_no_wake_machinery_touched`: there the table must be empty,
+        // here it must not be.
+        let (db, _index, _dir) = test_storage();
+
+        let config = WatchConfig {
+            stagger_secs: 0,
+            repos: vec![WatchRepoConfig {
+                name: "platform".to_string(),
+                workdir: UNSPAWNABLE_WORKDIR.to_string(),
+                agent: Some("platform".to_string()),
+                broadcast_tags: Vec::new(),
+                extra: toml::Table::new(),
+            }],
+            ..WatchConfig::default()
+        };
+
+        db.insert_reflection("kelex", "@platform question:can you look at this", "team")
+            .expect("insert signal");
+
+        let mut cooldown = CooldownTracker::new(0, None, None);
+        let mut tracker = AgentTracker::new();
+        let spawned = poll_cycle(
+            &db,
+            &config,
+            &mut cooldown,
+            &mut tracker,
+            None,
+            None,
+            None,
+            SpawnMode::Print,
+        )
+        .expect("poll");
+        assert_eq!(spawned, 0, "the bogus workdir must fail the spawn");
+
+        let attempts = db.recent_wake_attempts(50).expect("list attempts");
+        assert_eq!(
+            attempts.len(),
+            1,
+            "a self-owned entry must reach the wake_attempt enqueue -- \
+             the delegation guard must not swallow it"
+        );
+        assert_eq!(attempts[0].repo_name, "platform");
     }
 
     #[test]

--- a/src/watch/locks.rs
+++ b/src/watch/locks.rs
@@ -270,22 +270,12 @@ impl SessionLockTracker {
 
 // -- Cooldown ----------------------------------------------------------------
 
-/// Per-repo memory that persists across poll ticks (the poll loop owns one
-/// instance and passes `&mut` into every `poll_cycle`). Two things live here
-/// because both are "what did this repo already do recently":
-/// - the wake cooldown, which prevents wake storms;
-/// - the last delegated-skip log line emitted per repo, so a skip that repeats
-///   every cycle for days does not repeat in the log (#849).
+/// Tracks per-repo cooldown to prevent wake storms.
 pub struct CooldownTracker {
     last_wake: HashMap<String, Instant>,
     cooldown: Duration,
     work_hours_start: Option<u8>,
     work_hours_end: Option<u8>,
-    /// Sorted pending-signal ids behind the most recent delegated-skip log line
-    /// for each repo. Exact ids rather than a hash: the set is bounded by the
-    /// repo's pending signals, and storing them outright removes any question
-    /// of a collision silently swallowing a log line.
-    last_delegated_skip_log: HashMap<String, Vec<String>>,
 }
 
 impl CooldownTracker {
@@ -299,7 +289,6 @@ impl CooldownTracker {
             cooldown: Duration::from_secs(cooldown_secs),
             work_hours_start,
             work_hours_end,
-            last_delegated_skip_log: HashMap::new(),
         }
     }
 
@@ -333,29 +322,6 @@ impl CooldownTracker {
     pub fn record_wake(&mut self, repo: &str) {
         self.last_wake.insert(repo.to_string(), Instant::now());
     }
-
-    /// Should the delegated-skip line be logged for `repo` this cycle?
-    ///
-    /// True on a state change -- the first skip for a repo, or any cycle whose
-    /// pending set differs from the one behind the last logged line -- and
-    /// false while the same signals keep re-appearing. A delegated entry's
-    /// pending copy is consumed by nobody (see the skip in `poll_cycle`), so
-    /// without this the line would repeat once per poll interval for as long as
-    /// the daemon runs, capped only by the signal's TTL.
-    ///
-    /// The insert sits on the true path only because there is nothing to do on
-    /// the false one -- that path is reached exactly when the incoming set
-    /// already equals the stored one. It is a shortcut, not an invariant.
-    pub fn should_log_delegated_skip(&mut self, repo: &str, signal_ids: &[String]) -> bool {
-        let mut sorted: Vec<String> = signal_ids.to_vec();
-        sorted.sort();
-        if self.last_delegated_skip_log.get(repo) == Some(&sorted) {
-            return false;
-        }
-        self.last_delegated_skip_log
-            .insert(repo.to_string(), sorted);
-        true
-    }
 }
 
 #[cfg(test)]
@@ -370,50 +336,6 @@ mod tests {
         tracker.record_wake("rafters");
         assert!(tracker.is_cooling_down("rafters"));
         assert!(!tracker.is_cooling_down("legion"));
-    }
-
-    #[test]
-    fn delegated_skip_log_fires_only_on_state_change() {
-        // The dedup contract behind the once-per-poll skip line (#849): log the
-        // first time, stay silent while the same pending set keeps coming back,
-        // speak again when the set changes, and track each repo separately.
-        let mut tracker = CooldownTracker::new(0, None, None);
-        let first: Vec<String> = vec!["sig-a".to_string()];
-
-        assert!(
-            tracker.should_log_delegated_skip("ledger", &first),
-            "the first skip for a repo must be logged"
-        );
-        assert!(
-            !tracker.should_log_delegated_skip("ledger", &first),
-            "an unchanged pending set must stay silent -- this is the whole point"
-        );
-
-        // Order must not count as a change: find_pending_signals row order is
-        // not a contract, and a reordered identical set is not new information.
-        let reordered: Vec<String> = vec!["sig-b".to_string(), "sig-a".to_string()];
-        let same_reordered: Vec<String> = vec!["sig-a".to_string(), "sig-b".to_string()];
-        assert!(
-            tracker.should_log_delegated_skip("ledger", &reordered),
-            "a new signal joining the pending set is a state change"
-        );
-        assert!(
-            !tracker.should_log_delegated_skip("ledger", &same_reordered),
-            "the same ids in a different order must not re-log"
-        );
-
-        // A signal draining out (TTL expiry or `legion resolve`) is also a
-        // change, so the log reflects the shrink.
-        assert!(
-            tracker.should_log_delegated_skip("ledger", &first),
-            "a shrinking pending set is a state change too"
-        );
-
-        // Per-repo memory: another delegated entry's first skip is its own.
-        assert!(
-            tracker.should_log_delegated_skip("kelex", &first),
-            "dedup state must be keyed per repo, not global"
-        );
     }
 
     /// Run a short-lived child to completion and return its (now-dead) PID.

--- a/src/watch/locks.rs
+++ b/src/watch/locks.rs
@@ -270,12 +270,22 @@ impl SessionLockTracker {
 
 // -- Cooldown ----------------------------------------------------------------
 
-/// Tracks per-repo cooldown to prevent wake storms.
+/// Per-repo memory that persists across poll ticks (the poll loop owns one
+/// instance and passes `&mut` into every `poll_cycle`). Two things live here
+/// because both are "what did this repo already do recently":
+/// - the wake cooldown, which prevents wake storms;
+/// - the last delegated-skip log line emitted per repo, so a skip that repeats
+///   every cycle for days does not repeat in the log (#849).
 pub struct CooldownTracker {
     last_wake: HashMap<String, Instant>,
     cooldown: Duration,
     work_hours_start: Option<u8>,
     work_hours_end: Option<u8>,
+    /// Sorted pending-signal ids behind the most recent delegated-skip log line
+    /// for each repo. Exact ids rather than a hash: the set is bounded by the
+    /// repo's pending signals, and storing them outright removes any question
+    /// of a collision silently swallowing a log line.
+    last_delegated_skip_log: HashMap<String, Vec<String>>,
 }
 
 impl CooldownTracker {
@@ -289,6 +299,7 @@ impl CooldownTracker {
             cooldown: Duration::from_secs(cooldown_secs),
             work_hours_start,
             work_hours_end,
+            last_delegated_skip_log: HashMap::new(),
         }
     }
 
@@ -322,6 +333,29 @@ impl CooldownTracker {
     pub fn record_wake(&mut self, repo: &str) {
         self.last_wake.insert(repo.to_string(), Instant::now());
     }
+
+    /// Should the delegated-skip line be logged for `repo` this cycle?
+    ///
+    /// True on a state change -- the first skip for a repo, or any cycle whose
+    /// pending set differs from the one behind the last logged line -- and
+    /// false while the same signals keep re-appearing. A delegated entry's
+    /// pending copy is consumed by nobody (see the skip in `poll_cycle`), so
+    /// without this the line would repeat once per poll interval for as long as
+    /// the daemon runs, capped only by the signal's TTL.
+    ///
+    /// The insert sits on the true path only because there is nothing to do on
+    /// the false one -- that path is reached exactly when the incoming set
+    /// already equals the stored one. It is a shortcut, not an invariant.
+    pub fn should_log_delegated_skip(&mut self, repo: &str, signal_ids: &[String]) -> bool {
+        let mut sorted: Vec<String> = signal_ids.to_vec();
+        sorted.sort();
+        if self.last_delegated_skip_log.get(repo) == Some(&sorted) {
+            return false;
+        }
+        self.last_delegated_skip_log
+            .insert(repo.to_string(), sorted);
+        true
+    }
 }
 
 #[cfg(test)]
@@ -336,6 +370,50 @@ mod tests {
         tracker.record_wake("rafters");
         assert!(tracker.is_cooling_down("rafters"));
         assert!(!tracker.is_cooling_down("legion"));
+    }
+
+    #[test]
+    fn delegated_skip_log_fires_only_on_state_change() {
+        // The dedup contract behind the once-per-poll skip line (#849): log the
+        // first time, stay silent while the same pending set keeps coming back,
+        // speak again when the set changes, and track each repo separately.
+        let mut tracker = CooldownTracker::new(0, None, None);
+        let first: Vec<String> = vec!["sig-a".to_string()];
+
+        assert!(
+            tracker.should_log_delegated_skip("ledger", &first),
+            "the first skip for a repo must be logged"
+        );
+        assert!(
+            !tracker.should_log_delegated_skip("ledger", &first),
+            "an unchanged pending set must stay silent -- this is the whole point"
+        );
+
+        // Order must not count as a change: find_pending_signals row order is
+        // not a contract, and a reordered identical set is not new information.
+        let reordered: Vec<String> = vec!["sig-b".to_string(), "sig-a".to_string()];
+        let same_reordered: Vec<String> = vec!["sig-a".to_string(), "sig-b".to_string()];
+        assert!(
+            tracker.should_log_delegated_skip("ledger", &reordered),
+            "a new signal joining the pending set is a state change"
+        );
+        assert!(
+            !tracker.should_log_delegated_skip("ledger", &same_reordered),
+            "the same ids in a different order must not re-log"
+        );
+
+        // A signal draining out (TTL expiry or `legion resolve`) is also a
+        // change, so the log reflects the shrink.
+        assert!(
+            tracker.should_log_delegated_skip("ledger", &first),
+            "a shrinking pending set is a state change too"
+        );
+
+        // Per-repo memory: another delegated entry's first skip is its own.
+        assert!(
+            tracker.should_log_delegated_skip("kelex", &first),
+            "dedup state must be keyed per repo, not global"
+        );
     }
 
     /// Run a short-lived child to completion and return its (now-dead) PID.


### PR DESCRIPTION
## Summary

Watch entries whose `agent` field names another persona (ledger -> platform, astro-data -> platform) were waking as themselves: the agent field routed signal matching, but the spawn took the delegated repo's own workdir unconditionally, booting sessions whose identity resolved from the wrong CWD -- the phantom/squatter sessions the June audit found live in four delegated repos at once. This change makes the wake path skip delegated entries entirely, before any lease or wake-attempt work, so the only entry that can wake for an owner is the owner's own -- in the owner's workdir, with the owner's identity. Delegated entries keep every non-wake role (watch list, index coverage, workdir-ownership checks, sym --repo resolution).

## Acceptance criteria mapping

### 1. A delegated entry never spawns -- not from a directed signal, a file change, or a broadcast

The guard sits at the top of the per-repo body of `poll_cycle` (src/watch/gates.rs:138), and `poll_cycle` is the only road to `spawn_agent`: `legion sym refs spawn_agent` shows a single production call site (gates.rs:268), and file-change wakes are not a separate path -- a file change lands a signal that `find_pending_signals` picks up on the next poll, through this same loop. Guarding the one funnel covers all three sources by construction rather than by enumeration. The predicate is `WatchRepoConfig::is_delegated()` (src/watch/config.rs:69), defined against `recipient()` rather than the raw `agent` field so a blank or whitespace agent -- which `recipient()` normalizes to self -- cannot read as delegated here while the lease layer treats it as self-owned.
Evidence: tests `poll_cycle_skips_wake_for_delegated_entry_with_directed_signal`, `_on_broadcast`, `_on_file_change_wake` (src/watch/gates.rs), each asserting an empty `wake_attempts` table -- the enqueue is the last statement before `spawn_agent`, so emptiness proves the spawn was never reached.

### 2. A directed signal to an owner with delegated repos produces exactly one wake, in the owner's workdir

The mechanism is placement: the skip runs before lease acquisition, so a delegated entry no longer competes for the persona wake-lease at all. Previously both ledger's and platform's entries matched a directed @platform signal and raced for the lease; if ledger's entry won, the single deduped wake booted in ledger's workdir. With delegated entries out of the race, the owner's entry is the only possible lease holder, and the existing recipient-keyed dedup (0.17.0) already guarantees at-most-one wake. The directed-signal test passes a real `PersonaLeaseGate` and asserts no lease was taken by the delegated entry -- an assertion that fails if the guard is moved below the acquire, which was mutation-verified during development.
Evidence: `assert_no_wake_machinery_touched` (src/watch/gates.rs) -- lease emptiness for the owner plus wake_attempts emptiness; mutation check: guard relocated below the lease acquire fails all three delegated tests on the lease assertion.

### 3. The skip logs the entry name and its owner at wake-decision time

One stderr line in the house watch-log format at the guard site, emitted only when the entry has pending signals (the guard sits after the `signals.is_empty()` early-continue, so an idle delegated entry does not log every 30-second poll): `[legion watch] skipping wake for delegated repo 'ledger' (owner: platform)`.
Evidence: src/watch/gates.rs:139-142.

### 4. An undelegated repo's wake behavior is unchanged

`is_delegated()` is false for an absent agent and for agent == name, so the guard is a no-op for every self-owned entry; no other statement in the wake path changed. The negative control seeds a self-owned entry (agent = name) with a directed signal and asserts the wake machinery IS reached -- a wake_attempt row exists -- distinguishing it from the delegated case through the same observable.
Evidence: test `poll_cycle_does_not_skip_a_self_owned_entry` (src/watch/gates.rs); `is_delegated_is_true_only_when_agent_names_another_persona` and `is_delegated_treats_empty_agent_as_absent` (src/watch/config.rs) pin the predicate's three-case and normalization behavior.

### 5. watch list / index / workdir-coverage behavior for delegated entries is unchanged

The diff touches exactly two files, and neither hunk is on those paths: config.rs gains only the read-only predicate (no change to `load_config`, validation, or serialization -- the `extra` round-trip field is untouched), and gates.rs changes only the poll-cycle wake decision. `recipient()`, `wake_addresses()`, watch list output, and index coverage code are not in the diff.
Evidence: `git diff main...HEAD --stat` -- src/watch/config.rs and src/watch/gates.rs only; `is_delegated` doc comment (src/watch/config.rs:53-68) records the non-wake roles the entry keeps.

### 6. Tests cover delegated signal skip, delegated file-change skip, owner single-wake, undelegated unchanged

Five poll_cycle tests (three delegated wake sources, the self-owned negative control, and the co-presence test `poll_cycle_wakes_only_the_owner_when_both_entries_are_configured`) plus two predicate tests, named per acceptance case so the coverage map reads from the test list. The delegated tests additionally assert the retired-copy contract: the delegated repo's pending view empties at skip time while the owner's view still carries the signal, and the co-presence test pins the marking scope by repo_name (ledger rows exist, platform rows do not). The delegated tests use an unspawnable workdir and assert on the wake_attempts table rather than the spawn counter: with a bogus workdir `spawned == 0` is free and proves nothing, while an empty attempts table proves the loop exited before the enqueue that immediately precedes spawn. This also stops a guard regression from launching real billed claude sessions from the test suite -- which happened once during development with a /tmp workdir and is why the assertion pattern exists.
Evidence: src/watch/gates.rs test module, delegated-entries section; gate runs on the final HEAD -- cargo test 1692 passed, clippy --all-targets -D warnings clean, fmt clean.

### 7. #823's warning remains complementary, not superseded

Nothing in this change touches `legion watch add` or identity seeding. #823 guards a different hole: an unseeded whoami on a repo that legitimately SHOULD wake. This change removes delegated entries from the wake population entirely, which shrinks #823's blast radius (a delegated repo with no whoami can no longer boot a phantom) but does not implement its warning. #823 stays open.
Evidence: no diff hunks outside poll_cycle and the is_delegated predicate; #823 unmodified and open.

## Not done

The delegated entry's pending copy is no longer left to age out -- it is retired at skip time, marked handled under the entry's own `repo_name`. `watch_handled` is host-local (absent from the four-table sync wire in `src/sync_actor.rs`, and carrying no `updated_at`/`deleted_at` in `src/db/board.rs`), so this is local bookkeeping that cannot reach a peer; the owner's copy is keyed under the owner's name and is untouched. The skip logs one line per batch, unconditionally: with marking in place the same signals cannot reappear on the next cycle, so recurrence is structurally impossible rather than suppressed by a dedup cache. #852's wake-composer downgrade is still relevant for other repos' surfaces, but no longer for this path. #853 -- the log volume of the session-lock and cooldown skips -- is untouched. The #849 issue's option B (spawn in the delegated workdir with identity seeded from the agent field) was ruled out by the operator, not deferred. #823's watch-add warning and #804's roots-based CWD tracking remain their own issues.

Closes #849
