### PR TITLE
feat(#854): legion commit -- audited, signer-preflighted commit verb

### DIFF
--- a/src/cli/commit.rs
+++ b/src/cli/commit.rs
@@ -74,6 +74,10 @@ const EMOJI_RANGES: [(u32, u32); 5] = [
 /// on a dangling object reads as intentional rather than as corruption.
 const PROBE_MESSAGE: &str = "legion signer preflight (#854)";
 
+/// Trailer key every commit message must end with, including the colon.
+/// Matched case-insensitively -- see [`is_coauthor_trailer`].
+const COAUTHOR_KEY: &str = "co-authored-by:";
+
 /// Commit staged changes in the CWD's checkout, audited.
 ///
 /// Order is load-bearing: the signer preflight runs before message
@@ -469,15 +473,14 @@ fn validate_message(message: &str) -> error::Result<()> {
 
     let lines: Vec<&str> = message.lines().collect();
     if lines.iter().all(|l| l.trim().is_empty()) {
+        // Covers both a zero-line message and one that is nothing but
+        // whitespace, so the subject lookup below has no empty-vec case
+        // left to handle.
         return Err(error::LegionError::CommitRefused {
             reason: "commit message is empty".to_string(),
         });
     }
-    let Some(subject) = lines.first() else {
-        return Err(error::LegionError::CommitRefused {
-            reason: "commit message is empty".to_string(),
-        });
-    };
+    let subject: &str = lines.first().copied().unwrap_or("");
     if subject.trim().is_empty() {
         return Err(error::LegionError::CommitRefused {
             reason: "commit message starts with a blank line -- the first line is the subject"
@@ -555,7 +558,15 @@ fn validate_subject(subject: &str) -> error::Result<()> {
         return Err(refuse(&format!("unknown type '{commit_type}'")));
     }
     let Some(scope) = scope_with_paren.strip_suffix(')') else {
-        return Err(refuse("unclosed '(' in the scope"));
+        // Tell the two failures apart rather than blaming the paren for
+        // both: `feat(#854: x` really is unclosed, but `feat(#854) oops: x`
+        // closed it and then kept going, and reporting that as "unclosed"
+        // sends the caller looking for a bracket that is right there.
+        return Err(refuse(if scope_with_paren.contains(')') {
+            "unexpected text after '(<scope>)'"
+        } else {
+            "unclosed '(' in the scope"
+        }));
     };
     if scope.is_empty() {
         return Err(refuse("empty scope"));
@@ -598,9 +609,6 @@ fn is_coauthor_trailer(line: &str) -> bool {
     };
     !rest.trim().is_empty()
 }
-
-/// Trailer key, including the colon, matched case-insensitively.
-const COAUTHOR_KEY: &str = "co-authored-by:";
 
 /// Run `git commit -F <tempfile>` in `checkout` and return the new HEAD.
 ///
@@ -743,6 +751,20 @@ mod tests {
         let msg = "feat(#854): \n\nCo-Authored-By: Claude <x@y.invalid>\n";
         let reason = refusal_reason(validate_message(msg).unwrap_err());
         assert!(reason.contains("empty summary"), "got: {reason}");
+    }
+
+    #[test]
+    fn validate_subject_tells_an_unclosed_paren_from_trailing_text() {
+        // Both fail, but for opposite reasons, and a caller sent looking for
+        // a missing ')' that is right there loses the round trip.
+        let unclosed = refusal_reason(validate_subject("feat(#854: summary").unwrap_err());
+        assert!(unclosed.contains("unclosed '('"), "got: {unclosed}");
+
+        let trailing = refusal_reason(validate_subject("feat(#854) oops: summary").unwrap_err());
+        assert!(
+            trailing.contains("unexpected text after"),
+            "got: {trailing}"
+        );
     }
 
     #[test]

--- a/src/cli/commit.rs
+++ b/src/cli/commit.rs
@@ -19,8 +19,8 @@
 //!    `Co-Authored-By` trailer, and the no-emoji rule are checked before
 //!    the commit runs, so a violation costs a re-run instead of an amend.
 //! 3. **An audit row on every attempt**, refusals included, carrying the
-//!    resolved checkout, pre/post HEAD, card id, and the quality-gate state
-//!    of the commit being built on.
+//!    resolved checkout, pre/post HEAD, card id, whether the commit was
+//!    signed, and the quality-gate state of the commit being built on.
 //!
 //! The PreToolUse hook that rewrites plain `git commit` into this verb is
 //! deliberately NOT part of this change -- it is the second half of #854.

--- a/src/cli/commit.rs
+++ b/src/cli/commit.rs
@@ -37,11 +37,18 @@ use crate::{db, error};
 
 /// Commit types accepted in a subject line, derived from this repo's own
 /// history rather than from the Conventional Commits spec: these are the
-/// eight that appear across the last 600 subjects (`feat` and `fix` account
-/// for most of them; `perf` and `style` are rare but real). Types the repo
-/// has never used (`ci`, `build`, `revert`) are deliberately absent -- the
-/// rule encodes what the repo does, and widening it is a decision someone
-/// should make on purpose.
+/// eight that appear as type tokens across ALL of history -- 494 commits at
+/// the time of writing, so there is no window to have missed anything in
+/// (`feat` and `fix` account for most of them; `perf` and `style` are rare
+/// but real).
+///
+/// Three types are absent, for two different reasons. `build` and `revert`
+/// have never appeared as type tokens at all -- git's auto-generated
+/// `Revert "..."` subjects are not the conventional `revert` type and do not
+/// parse as one. `ci` HAS appeared, exactly once (bdd7dd8, 2026-04-28), and
+/// is excluded on purpose: one subject is an instance, not a convention, and
+/// this list encodes what the repo does. Widening it is a decision someone
+/// should make deliberately rather than inherit from a single 2026 commit.
 const COMMIT_TYPES: [&str; 8] = [
     "feat", "fix", "chore", "docs", "refactor", "test", "perf", "style",
 ];
@@ -99,6 +106,14 @@ pub(crate) fn handle_commit(
     let branch: String = current_branch(&checkout)?;
     let pre_sha: Option<String> = head_sha(&checkout)?;
 
+    // Read once, here, because this value is both consulted (it decides
+    // whether the preflight runs) and RECORDED. Recorded matters: whether a
+    // commit was signed is exactly what an audit trail gets asked about
+    // after the fact, and answering it later by re-reading the config would
+    // describe the config as it is then rather than as it was when the
+    // commit ran.
+    let signing: bool = signing_enabled(&checkout);
+
     // Opened before the commit (not after) so a DB-open failure fails fast
     // rather than masking the commit result behind a DB error once the
     // commit has already landed -- same ordering as `legion push`.
@@ -108,19 +123,26 @@ pub(crate) fn handle_commit(
     // the PRE-commit HEAD and read before the commit runs.
     let gates: serde_json::Value = gate_state(&database, pre_sha.as_deref());
 
-    let result: error::Result<String> = preflight_validate_and_commit(&checkout, &text);
+    let result: error::Result<Committed> = preflight_validate_and_commit(&checkout, &text, signing);
 
     // Every attempt leaves a row, refusals included. A refused commit is an
     // attempted mutation that the perimeter blocked, and that is exactly
     // the signal the audit trail exists to carry -- especially once the
     // deferred hook starts routing every plain `git commit` through here.
     // The error (if any) propagates AFTER the row is written.
+    //
+    // `outcome` tracks whether the COMMIT happened, nothing else. See
+    // [`Committed`]: a landed commit whose new HEAD would not read back is
+    // still a landed commit, and it records the read failure in
+    // `post_sha_error` rather than claiming the mutation never happened.
     let details = serde_json::json!({
         "checkout": checkout.display().to_string(),
         "pre_sha": pre_sha,
-        "post_sha": result.as_ref().ok(),
+        "post_sha": result.as_ref().ok().and_then(|c| c.post_sha.clone()),
+        "post_sha_error": result.as_ref().ok().and_then(|c| c.post_sha_error.clone()),
         "card_id": card,
         "gates": gates,
+        "signing": signing,
     })
     .to_string();
     audit(
@@ -137,21 +159,64 @@ pub(crate) fn handle_commit(
         },
     );
 
-    let post_sha = result?;
-    println!(
-        "committed {} on {branch} ({})",
-        short_sha(&post_sha),
-        checkout.display()
-    );
+    let committed: Committed = result?;
+    match committed.post_sha {
+        Some(sha) => println!(
+            "committed {} on {branch} ({})",
+            short_sha(&sha),
+            checkout.display()
+        ),
+        None => {
+            // Effectively unreachable -- git exited 0, so there is a HEAD --
+            // and deliberately not an error. The commit is on disk by the
+            // time we are here; exiting non-zero because we could not read
+            // back the sha would tell the caller their work did not land
+            // when it did, which is the worse of the two lies.
+            eprintln!(
+                "[legion] warning: {}",
+                committed
+                    .post_sha_error
+                    .as_deref()
+                    .unwrap_or("HEAD did not resolve after the commit")
+            );
+            println!(
+                "committed on {branch} ({}) -- the new HEAD could not be read back",
+                checkout.display()
+            );
+        }
+    }
     Ok(())
+}
+
+/// A commit that LANDED, and what could be learned about it afterwards.
+///
+/// Two fields rather than a `Result` because these are not alternatives in
+/// the sense the audit row cares about: both shapes mean the commit
+/// happened. Folding a failed post-commit `rev-parse` into the commit's own
+/// `Result` -- which is what this used to do -- recorded a landed commit as
+/// `outcome: failure`, the single worst thing an audit trail can say, since
+/// it denies a mutation that is already on disk. The read failure is worth
+/// recording; it is just not the same fact as "the commit failed".
+struct Committed {
+    /// The new HEAD, absent only if it could not be resolved after the fact.
+    post_sha: Option<String>,
+    /// Why `post_sha` is absent, carried into the audit row's details.
+    post_sha_error: Option<String>,
 }
 
 /// Preflight the signer, validate the message, then commit. Split out from
 /// [`handle_commit`] so every failure between "we know which checkout and
 /// branch" and "the commit landed" funnels through one `Result` the audit
 /// row can classify, instead of each refusal needing its own audit call.
-fn preflight_validate_and_commit(checkout: &Path, message: &str) -> error::Result<String> {
-    preflight_signer(checkout)?;
+///
+/// `signing` is passed in rather than read here so the value that gates the
+/// preflight and the value recorded on the audit row are the same read.
+fn preflight_validate_and_commit(
+    checkout: &Path,
+    message: &str,
+    signing: bool,
+) -> error::Result<Committed> {
+    preflight_signer(checkout, signing)?;
     validate_message(message)?;
     run_git_commit(checkout, message)
 }
@@ -311,10 +376,17 @@ fn gate_state(database: &db::Database, pre_sha: Option<&str>) -> serde_json::Val
 /// Fail once, by name, if commit signing is configured but the signer
 /// cannot sign right now.
 ///
-/// `commit.gpgsign` alone decides whether this runs; `gpg.format` only
-/// selects which program name appears in the error. The probe is `git
-/// commit-tree -S` against the tree we are about to commit, and the
-/// resulting oid is discarded.
+/// `commit.gpgsign` alone decides whether this runs -- the caller passes the
+/// answer in, since the audit row records it too; `gpg.format` only selects
+/// which program name appears in the error.
+///
+/// The probe is `git commit-tree -S` against HEAD's tree (the STAGED tree
+/// only on an unborn branch, where `HEAD^{tree}` does not resolve -- see
+/// [`probe_tree`]), and the resulting oid is discarded. Which tree it is
+/// does not matter: any valid tree exercises the same `sign_buffer` path,
+/// and the question being asked is whether the signer can sign at all, not
+/// what it would be signing. Using HEAD's tree simply avoids writing a new
+/// one when there is already a tree lying around to point at.
 ///
 /// Why `commit-tree` and not invoking the configured signer directly: the
 /// direct route means reimplementing git's key selection -- `user.signingkey`
@@ -334,8 +406,8 @@ fn gate_state(database: &db::Database, pre_sha: Option<&str>) -> serde_json::Val
 /// at all; you cannot ask a signer whether it can sign without asking it to
 /// sign. Invisible with a cached agent (the agent-driven case this verb is
 /// built for), a real per-commit tax otherwise.
-fn preflight_signer(checkout: &Path) -> error::Result<()> {
-    if !signing_enabled(checkout) {
+fn preflight_signer(checkout: &Path, signing: bool) -> error::Result<()> {
+    if !signing {
         return Ok(());
     }
     let program: String = signer_program(checkout);
@@ -345,11 +417,31 @@ fn preflight_signer(checkout: &Path) -> error::Result<()> {
 
 /// Run the probe. Split from [`preflight_signer`] so the config reads and
 /// the sign attempt stay separately readable.
+///
+/// The subprocess runs under `LC_ALL=C` with `LANGUAGE` cleared. Both this
+/// function's exit-code handling and [`signer_failure_detail`]'s prefix
+/// stripping read git's own English output, and git localizes that output:
+/// under `fr_FR` its diagnostics come back as `erreur:`, and every
+/// assumption made about the text quietly stops holding. Pinning the locale
+/// on the probe is what makes those assumptions true rather than lucky.
+///
+/// EXIT CODE, not text, decides which failure this is -- measured against
+/// git 2.54.0. git DIES with 128 when it never reaches the signer at all
+/// (unresolvable committer identity, a tree oid that will not parse) and
+/// exits 1 when the signer WAS invoked and failed. A 128 is therefore not a
+/// signing problem, and reporting it as one sends the operator to unlock an
+/// agent that was never the issue. The split is an implementation detail of
+/// git rather than a documented contract, so it is pinned by test
+/// (`commit_preflight_reports_a_git_refusal_as_a_refusal`), and any
+/// unrecognized code falls through to the signing arm -- degrading to the
+/// previous behaviour rather than to silence.
 fn probe_signer(checkout: &Path, tree: &str, program: &str) -> error::Result<()> {
     let output = Command::new("git")
         .arg("-C")
         .arg(checkout)
         .args(["commit-tree", "-S", "-m", PROBE_MESSAGE, tree])
+        .env("LC_ALL", "C")
+        .env("LANGUAGE", "")
         .stdin(Stdio::null())
         .output()
         .map_err(|e| {
@@ -358,9 +450,20 @@ fn probe_signer(checkout: &Path, tree: &str, program: &str) -> error::Result<()>
     if output.status.success() {
         return Ok(());
     }
+
+    let stderr: std::borrow::Cow<'_, str> = String::from_utf8_lossy(&output.stderr);
+    if output.status.code() == Some(128) {
+        return Err(error::LegionError::CommitRefused {
+            reason: format!(
+                "git refused to build the signer preflight object, so signing was never \
+                 attempted -- git said: {}",
+                stderr.trim()
+            ),
+        });
+    }
     Err(error::LegionError::CommitSigningUnavailable {
         program: program.to_string(),
-        detail: signer_failure_detail(&String::from_utf8_lossy(&output.stderr)),
+        detail: signer_failure_detail(&stderr),
     })
 }
 
@@ -468,28 +571,51 @@ fn probe_tree(checkout: &Path) -> error::Result<String> {
     Ok(String::from_utf8_lossy(&written.stdout).trim().to_string())
 }
 
-/// Pull the useful line out of a failed signing attempt's stderr.
+/// Everything a failed signing attempt said, minus the content-free lines.
+///
+/// Relays EVERY informative line rather than just the first, because the
+/// first is routinely the least useful one: a failing signer explains itself
+/// across several lines and the remedy tends to be the last of them (gpg
+/// answers "gpg failed to sign the data" and then, underneath, the keyid it
+/// could not find or the agent it could not reach). Taking line one throws
+/// away the part the operator needed and keeps the part they could have
+/// guessed.
 ///
 /// git relays the signer's own stderr behind a bare `error: ` prefix, so a
 /// signer that fails silently (a stub like `/usr/bin/false`, or an agent
 /// that exits without a message) leaves nothing but the prefix -- measured,
-/// not assumed: `/usr/bin/false` produces exactly `"error: \n"`. Stripping
-/// the prefix and falling back to a literal keeps the refusal from reading
-/// "signing unavailable (...):  -- unlock your signer and re-run" with a
-/// hole where the reason should be.
+/// not assumed: `/usr/bin/false` produces exactly `"error: \n"`. Dropping
+/// the lines that are only a prefix, and falling back to a literal when
+/// none survive, keeps the refusal from reading "signing unavailable
+/// (...):  -- ..." with a hole where the reason should be.
+///
+/// Only the prefixed lines are trimmed at the front; the rest keep their
+/// indentation, because signers indent the commands in their remediation
+/// hints and that indentation is what makes them copy-pasteable. Matching
+/// the English prefixes literally is safe because [`probe_signer`] pins the
+/// subprocess locale.
 fn signer_failure_detail(stderr: &str) -> String {
-    for line in stderr.lines() {
-        let trimmed = line.trim();
-        let stripped = trimmed
-            .strip_prefix("error:")
-            .or_else(|| trimmed.strip_prefix("fatal:"))
-            .unwrap_or(trimmed)
-            .trim();
-        if !stripped.is_empty() {
-            return stripped.to_string();
-        }
+    let kept: Vec<&str> = stderr
+        .lines()
+        .map(|line| {
+            let line = line.trim_end();
+            match line
+                .strip_prefix("error:")
+                .or_else(|| line.strip_prefix("fatal:"))
+            {
+                // A prefixed line is git's own framing, never indented
+                // content, so its leading space is noise.
+                Some(rest) => rest.trim_start(),
+                None => line,
+            }
+        })
+        .filter(|line| !line.trim().is_empty())
+        .collect();
+
+    if kept.is_empty() {
+        return "the signer exited non-zero without a message".to_string();
     }
-    "the signer exited non-zero without a message".to_string()
+    kept.join("\n")
 }
 
 /// Enforce this repo's commit-message conventions, refusing by name.
@@ -650,7 +776,12 @@ fn is_coauthor_trailer(line: &str) -> bool {
     !rest.trim().is_empty()
 }
 
-/// Run `git commit -F <tempfile>` in `checkout` and return the new HEAD.
+/// Run `git commit -F <tempfile>` in `checkout` and report what landed.
+///
+/// The returned `Err` means one thing only: the commit process itself
+/// failed. Reading the new HEAD back is a separate concern with a separate
+/// home on [`Committed`], because once git has exited 0 the commit exists
+/// whether or not anything downstream can describe it.
 ///
 /// `--cleanup=whitespace` is pinned on the command line rather than left to
 /// git's default for `-F`. The default IS `whitespace`, but an ambient
@@ -662,7 +793,7 @@ fn is_coauthor_trailer(line: &str) -> bool {
 ///
 /// No `-a`: only the staged index is committed, exactly as `git commit`
 /// would. Nothing here stages anything.
-fn run_git_commit(checkout: &Path, message: &str) -> error::Result<String> {
+fn run_git_commit(checkout: &Path, message: &str) -> error::Result<Committed> {
     // UUIDv7 name rather than a fixed one so two concurrent agents (the
     // situation 019fc46c is about) cannot overwrite each other's message
     // file between write and read.
@@ -678,10 +809,25 @@ fn run_git_commit(checkout: &Path, message: &str) -> error::Result<String> {
 
     outcome?;
 
-    head_sha(checkout)?.ok_or_else(|| {
-        error::LegionError::WorkSource(
-            "git commit reported success but HEAD does not resolve".to_string(),
-        )
+    // Past this line the commit has LANDED. Everything below describes it;
+    // nothing below may retract it.
+    Ok(match head_sha(checkout) {
+        Ok(Some(sha)) => Committed {
+            post_sha: Some(sha),
+            post_sha_error: None,
+        },
+        Ok(None) => Committed {
+            post_sha: None,
+            post_sha_error: Some(
+                "git commit reported success but HEAD does not resolve".to_string(),
+            ),
+        },
+        Err(e) => Committed {
+            post_sha: None,
+            post_sha_error: Some(format!(
+                "git commit reported success but HEAD could not be read: {e}"
+            )),
+        },
     })
 }
 
@@ -855,6 +1001,21 @@ mod tests {
     }
 
     #[test]
+    fn validate_message_reports_the_emoji_when_the_subject_is_also_wrong() {
+        // Two rules broken at once, and the order is load-bearing: the emoji
+        // scan is the only check that can fire on a line other than the
+        // subject, so if the subject check won here, a message whose real
+        // problem is a rocket in the body would send the caller to line one.
+        let msg = "wip: nope \n\nShipped \u{1F680}\n\nCo-Authored-By: C <x@y.invalid>\n";
+        let reason = refusal_reason(validate_message(msg).unwrap_err());
+        assert!(reason.contains("emoji"), "got: {reason}");
+        assert!(
+            !reason.contains("bad subject line"),
+            "the emoji must be reported first, got: {reason}"
+        );
+    }
+
+    #[test]
     fn find_emoji_ignores_ordinary_prose_and_punctuation() {
         // Every one of these appears in this repo's real commit bodies and
         // must not be mistaken for an emoji: em dash, curly quotes, arrows
@@ -931,9 +1092,32 @@ mod tests {
     }
 
     #[test]
-    fn signer_failure_detail_uses_the_first_informative_line() {
+    fn signer_failure_detail_keeps_every_informative_line() {
         let stderr = "error: \nerror: gpg failed to sign the data\nfatal: failed to write commit\n";
-        assert_eq!(signer_failure_detail(stderr), "gpg failed to sign the data");
+        let detail = signer_failure_detail(stderr);
+        // The first line is not the useful one, which is the whole reason
+        // this relays all of them instead of picking one.
+        assert!(
+            detail.contains("gpg failed to sign the data"),
+            "got: {detail}"
+        );
+        assert!(detail.contains("failed to write commit"), "got: {detail}");
+        // The content-free "error: " line is dropped, and git's own prefixes
+        // go with it -- the caller already knows this is an error.
+        assert!(!detail.contains("error:"), "got: {detail}");
+        assert!(!detail.contains("fatal:"), "got: {detail}");
+    }
+
+    #[test]
+    fn signer_failure_detail_preserves_indented_remediation() {
+        // A signer that tells the operator what to run indents the command,
+        // and that indentation is what makes it copy-pasteable. Only the
+        // prefixed lines get their leading space trimmed.
+        let stderr = "error: gpg failed to sign the data\nTry:\n  gpg --card-status\n";
+        assert_eq!(
+            signer_failure_detail(stderr),
+            "gpg failed to sign the data\nTry:\n  gpg --card-status"
+        );
     }
 
     /// Record a gate row so the three verdicts can be told apart.

--- a/src/cli/commit.rs
+++ b/src/cli/commit.rs
@@ -49,6 +49,10 @@ use crate::{db, error};
 /// is excluded on purpose: one subject is an instance, not a convention, and
 /// this list encodes what the repo does. Widening it is a decision someone
 /// should make deliberately rather than inherit from a single 2026 commit.
+/// One token outside the spec set completes the census: `release` appeared
+/// twice (4c44f5f and c9b357d, both 2026-06-18) as the older spelling of what
+/// is now `chore(release)`, and is excluded for the same reason as `ci` -- so
+/// the eight above plus `ci` and `release` are every type token in history.
 const COMMIT_TYPES: [&str; 8] = [
     "feat", "fix", "chore", "docs", "refactor", "test", "perf", "style",
 ];

--- a/src/cli/commit.rs
+++ b/src/cli/commit.rs
@@ -1,0 +1,934 @@
+//! `legion commit` (#854): the audited commit verb, closing the last
+//! unaudited hop in the mutation path.
+//!
+//! `legion push` (#791/#834) routes pushes and #836 fences `gh`, but the
+//! commit itself -- where authorship, trailers, and signing actually
+//! happen -- was raw `git` with no verb, no audit row, and no preflight.
+//! A perimeter assembled by fencing the hops that caused incidents leaves
+//! the hops that have not yet caused one, and those read as covered
+//! precisely because everything around them is (019fc600).
+//!
+//! Three things this verb does that `git commit` does not:
+//!
+//! 1. **Signer preflight.** A locked signer fails once, by name, before
+//!    anything is written -- not as five cryptic retries. The probe signs a
+//!    throwaway commit object with [`git commit-tree -S`](probe_signer),
+//!    which is git's own `sign_buffer` path; `git commit --dry-run` does
+//!    not exercise the signer at all.
+//! 2. **Message conventions, refused by name.** Subject shape, the
+//!    `Co-Authored-By` trailer, and the no-emoji rule are checked before
+//!    the commit runs, so a violation costs a re-run instead of an amend.
+//! 3. **An audit row on every attempt**, refusals included, carrying the
+//!    resolved checkout, pre/post HEAD, card id, and the quality-gate state
+//!    of the commit being built on.
+//!
+//! The PreToolUse hook that rewrites plain `git commit` into this verb is
+//! deliberately NOT part of this change -- it is the second half of #854.
+//! Note for whoever builds it: this validator requires a scope on every
+//! subject (see [`validate_subject`]), so routing every `git commit` through
+//! here makes that repo-wide policy.
+
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+
+use crate::cli::util::{audit, open_db, relay_and_capture_stderr};
+use crate::verify::GateResult;
+use crate::{db, error};
+
+/// Commit types accepted in a subject line, derived from this repo's own
+/// history rather than from the Conventional Commits spec: these are the
+/// eight that appear across the last 600 subjects (`feat` and `fix` account
+/// for most of them; `perf` and `style` are rare but real). Types the repo
+/// has never used (`ci`, `build`, `revert`) are deliberately absent -- the
+/// rule encodes what the repo does, and widening it is a decision someone
+/// should make on purpose.
+const COMMIT_TYPES: [&str; 8] = [
+    "feat", "fix", "chore", "docs", "refactor", "test", "perf", "style",
+];
+
+/// Quality gates whose verdict is recorded on the audit row, in the order
+/// the pipeline runs them. Same skill keys `pr create` reads (`src/cli/pr.rs`),
+/// which is what makes the two surfaces comparable in the audit log.
+const RECORDED_GATES: [(&str, &str); 2] = [
+    ("simplify", "legion-simplify"),
+    ("pr_write", "legion-pr-write"),
+];
+
+/// Codepoint ranges rejected anywhere in a commit message.
+///
+/// Not a complete Unicode-emoji property table -- deliberately. The blocks
+/// below cover every emoji anyone actually reaches for (check marks,
+/// sparkles, rockets, warning signs, flags, emoticons) while leaving Misc
+/// Technical (U+2300..U+23FF) alone, because that block mixes a handful of
+/// emoji in with the Mac modifier glyphs, and a false refusal on a
+/// legitimate character is worse than missing a stopwatch.
+const EMOJI_RANGES: [(u32, u32); 5] = [
+    (0x2600, 0x27BF),   // Misc Symbols + Dingbats: warning, check mark, sparkles
+    (0x2B00, 0x2BFF),   // Misc Symbols and Arrows: stars
+    (0x20E3, 0x20E3),   // Combining Enclosing Keycap
+    (0xFE0F, 0xFE0F),   // Variation Selector-16 (the emoji-presentation selector)
+    (0x1F000, 0x1FAFF), // Cards through Symbols and Pictographs Extended-A
+];
+
+/// Message given to the throwaway probe commit object so a stray `git fsck`
+/// on a dangling object reads as intentional rather than as corruption.
+const PROBE_MESSAGE: &str = "legion signer preflight (#854)";
+
+/// Commit staged changes in the CWD's checkout, audited.
+///
+/// Order is load-bearing: the signer preflight runs before message
+/// validation even though validation is far cheaper, because a locked
+/// signer needs the operator to go unlock something while a malformed
+/// subject is a five-second fix. Surfacing the slow failure first means one
+/// round trip instead of two.
+pub(crate) fn handle_commit(
+    repo: String,
+    message: Option<String>,
+    message_file: Option<String>,
+    card: Option<String>,
+) -> error::Result<()> {
+    // Argument-shape errors are resolved before anything is audited: no
+    // mutation has been attempted yet, so there is nothing to record.
+    let text: String = resolve_message(message.as_deref(), message_file.as_deref())?;
+
+    let checkout: PathBuf = resolve_checkout()?;
+    let branch: String = current_branch(&checkout)?;
+    let pre_sha: Option<String> = head_sha(&checkout)?;
+
+    // Opened before the commit (not after) so a DB-open failure fails fast
+    // rather than masking the commit result behind a DB error once the
+    // commit has already landed -- same ordering as `legion push`.
+    let database = open_db()?;
+
+    // Gate state describes the commit being built ON, so it is read from
+    // the PRE-commit HEAD and read before the commit runs.
+    let gates: serde_json::Value = gate_state(&database, pre_sha.as_deref());
+
+    let result: error::Result<String> = preflight_validate_and_commit(&checkout, &text);
+
+    // Every attempt leaves a row, refusals included. A refused commit is an
+    // attempted mutation that the perimeter blocked, and that is exactly
+    // the signal the audit trail exists to carry -- especially once the
+    // deferred hook starts routing every plain `git commit` through here.
+    // The error (if any) propagates AFTER the row is written.
+    let details = serde_json::json!({
+        "checkout": checkout.display().to_string(),
+        "pre_sha": pre_sha,
+        "post_sha": result.as_ref().ok(),
+        "card_id": card,
+        "gates": gates,
+    })
+    .to_string();
+    audit(
+        &database,
+        &db::AuditInput {
+            agent: &repo,
+            action: "commit",
+            target_type: "branch",
+            target_ref: &branch,
+            task_id: card.as_deref(),
+            source_type: "git",
+            details: Some(&details),
+            outcome: if result.is_ok() { "success" } else { "failure" },
+        },
+    );
+
+    let post_sha = result?;
+    println!(
+        "committed {} on {branch} ({})",
+        short_sha(&post_sha),
+        checkout.display()
+    );
+    Ok(())
+}
+
+/// Preflight the signer, validate the message, then commit. Split out from
+/// [`handle_commit`] so every failure between "we know which checkout and
+/// branch" and "the commit landed" funnels through one `Result` the audit
+/// row can classify, instead of each refusal needing its own audit call.
+fn preflight_validate_and_commit(checkout: &Path, message: &str) -> error::Result<String> {
+    preflight_signer(checkout)?;
+    validate_message(message)?;
+    run_git_commit(checkout, message)
+}
+
+/// Resolve the commit message from exactly one of `--message` /
+/// `--message-file`. Both or neither is a refusal rather than a silent
+/// precedence rule -- a verb that quietly picks one when given two is how a
+/// stale file ends up as the commit message.
+fn resolve_message(message: Option<&str>, message_file: Option<&str>) -> error::Result<String> {
+    match (message, message_file) {
+        (Some(_), Some(_)) => Err(error::LegionError::CommitRefused {
+            reason: "--message and --message-file are mutually exclusive -- pass exactly one"
+                .to_string(),
+        }),
+        (Some(m), None) => Ok(m.to_string()),
+        (None, Some(p)) => {
+            std::fs::read_to_string(p).map_err(|e| error::LegionError::CommitRefused {
+                reason: format!("failed to read --message-file '{p}': {e}"),
+            })
+        }
+        (None, None) => Err(error::LegionError::CommitRefused {
+            reason: "no commit message -- pass --message or --message-file".to_string(),
+        }),
+    }
+}
+
+/// Resolve the checkout to commit in: the repo root containing the CWD.
+///
+/// v1 deliberately does NOT do `legion push`-style cross-checkout
+/// resolution. Push has to, because it takes a `--branch` that may live in
+/// a different worktree than the caller stands in; commit operates on a
+/// staged index, which is per-checkout state that only the CWD's checkout
+/// has. Resolving to the repo root (rather than using the CWD verbatim)
+/// still matters -- it makes the verb work from a subdirectory, and it is
+/// the path recorded on the audit row.
+fn resolve_checkout() -> error::Result<PathBuf> {
+    let output = Command::new("git")
+        .args(["rev-parse", "--show-toplevel"])
+        .output()
+        .map_err(|e| error::LegionError::WorkSource(format!("failed to run git rev-parse: {e}")))?;
+    if !output.status.success() {
+        return Err(error::LegionError::CommitRefused {
+            reason: "not inside a git repository -- run legion commit from the checkout whose \
+                     staged changes you want committed"
+                .to_string(),
+        });
+    }
+    let path = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if path.is_empty() {
+        return Err(error::LegionError::CommitRefused {
+            reason: "git rev-parse --show-toplevel returned an empty path".to_string(),
+        });
+    }
+    Ok(PathBuf::from(path))
+}
+
+/// Branch name for the audit row's `target_ref`.
+///
+/// `git branch --show-current` rather than `rev-parse --abbrev-ref HEAD`:
+/// it is the only one of the two that answers on an unborn branch (a repo
+/// with zero commits), where `rev-parse` fails outright. Empty output means
+/// a detached HEAD, which is recorded as such rather than being smuggled in
+/// as the literal string "HEAD".
+fn current_branch(checkout: &Path) -> error::Result<String> {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(checkout)
+        .args(["branch", "--show-current"])
+        .output()
+        .map_err(|e| {
+            error::LegionError::WorkSource(format!("failed to run git branch --show-current: {e}"))
+        })?;
+    if !output.status.success() {
+        return Err(error::LegionError::WorkSource(format!(
+            "git branch --show-current failed: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        )));
+    }
+    let branch = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if branch.is_empty() {
+        Ok("detached".to_string())
+    } else {
+        Ok(branch)
+    }
+}
+
+/// Current HEAD commit, or `None` when HEAD is unborn (a repo whose first
+/// commit is the one being made).
+///
+/// Not [`crate::cli::util::git_head_commit_and_branch`]: that helper reports
+/// an unresolvable HEAD as "is this a git repo?", which is the wrong
+/// diagnosis for a repo with zero commits and would send the caller looking
+/// in the wrong place. `-q --verify` distinguishes the two cleanly.
+fn head_sha(checkout: &Path) -> error::Result<Option<String>> {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(checkout)
+        .args(["rev-parse", "-q", "--verify", "HEAD"])
+        .output()
+        .map_err(|e| {
+            error::LegionError::WorkSource(format!("failed to run git rev-parse HEAD: {e}"))
+        })?;
+    if !output.status.success() {
+        return Ok(None);
+    }
+    let sha = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if sha.is_empty() {
+        Ok(None)
+    } else {
+        Ok(Some(sha))
+    }
+}
+
+/// First 8 characters of a commit hash, for the confirmation line.
+fn short_sha(sha: &str) -> &str {
+    &sha[..sha.len().min(8)]
+}
+
+/// Quality-gate verdicts for the pre-commit HEAD, as the `gates` object on
+/// the audit row.
+///
+/// Three states, not the two the issue sketched: a gate that recorded
+/// ISSUES is neither clean nor absent, and collapsing it into either bucket
+/// would put a falsehood in the audit trail. A DB read failure records
+/// "unknown" and warns, matching [`audit`]'s own posture -- a details field
+/// must never be the reason a row goes unwritten.
+fn gate_state(database: &db::Database, pre_sha: Option<&str>) -> serde_json::Value {
+    let mut gates = serde_json::Map::new();
+    for (key, skill) in RECORDED_GATES {
+        let verdict: &str = match pre_sha {
+            None => "absent",
+            Some(sha) => match database.get_quality_gate(sha, skill) {
+                Ok(None) => "absent",
+                Ok(Some(gate)) if gate.result == GateResult::Clean => "clean",
+                Ok(Some(_)) => "issues",
+                Err(e) => {
+                    eprintln!("[legion] warning: could not read {skill} gate: {e}");
+                    "unknown"
+                }
+            },
+        };
+        gates.insert(
+            key.to_string(),
+            serde_json::Value::String(verdict.to_string()),
+        );
+    }
+    serde_json::Value::Object(gates)
+}
+
+/// Fail once, by name, if commit signing is configured but the signer
+/// cannot sign right now.
+///
+/// `commit.gpgsign` alone decides whether this runs; `gpg.format` only
+/// selects which program name appears in the error. The probe is `git
+/// commit-tree -S` against the tree we are about to commit, and the
+/// resulting oid is discarded.
+///
+/// Why `commit-tree` and not invoking the configured signer directly: the
+/// direct route means reimplementing git's key selection -- `user.signingkey`
+/// resolution, ssh literal-key-vs-path handling, and openpgp's fallback of
+/// deriving the key from the committer email -- and a probe that picks a
+/// different key than the real commit will is worse than no probe. Going
+/// through `commit-tree` is git's own `sign_buffer` path by construction.
+/// It writes one unreferenced object into the object store and touches no
+/// ref, index, or working-tree file, which is what "before touching
+/// anything" means in the sense that matters. `git commit --dry-run` is not
+/// an option: it never reaches the signer.
+fn preflight_signer(checkout: &Path) -> error::Result<()> {
+    if !signing_enabled(checkout) {
+        return Ok(());
+    }
+    let program: String = signer_program(checkout);
+    let tree: String = probe_tree(checkout)?;
+    probe_signer(checkout, &tree, &program)
+}
+
+/// Run the probe. Split from [`preflight_signer`] so the config reads and
+/// the sign attempt stay separately readable.
+fn probe_signer(checkout: &Path, tree: &str, program: &str) -> error::Result<()> {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(checkout)
+        .args(["commit-tree", "-S", "-m", PROBE_MESSAGE, tree])
+        .stdin(Stdio::null())
+        .output()
+        .map_err(|e| {
+            error::LegionError::WorkSource(format!("failed to run git commit-tree: {e}"))
+        })?;
+    if output.status.success() {
+        return Ok(());
+    }
+    Err(error::LegionError::CommitSigningUnavailable {
+        program: program.to_string(),
+        detail: signer_failure_detail(&String::from_utf8_lossy(&output.stderr)),
+    })
+}
+
+/// Whether `commit.gpgsign` is on. An absent key exits non-zero, which is
+/// "off" -- there is no signer to preflight, and this verb never turns
+/// signing on or off, it only reports what is configured.
+fn signing_enabled(checkout: &Path) -> bool {
+    git_config(checkout, "commit.gpgsign").as_deref() == Some("true")
+}
+
+/// Name of the program git would invoke to sign, for the error message.
+/// Mirrors git's own format-to-program mapping and its defaults, so an
+/// operator reading the refusal sees the binary they need to unlock.
+fn signer_program(checkout: &Path) -> String {
+    let format: String =
+        git_config(checkout, "gpg.format").unwrap_or_else(|| "openpgp".to_string());
+    let (key, default) = match format.as_str() {
+        "ssh" => ("gpg.ssh.program", "ssh-keygen"),
+        "x509" => ("gpg.x509.program", "gpgsm"),
+        _ => ("gpg.program", "gpg"),
+    };
+    git_config(checkout, key).unwrap_or_else(|| default.to_string())
+}
+
+/// Read one git config value, `None` when unset or unreadable.
+/// `--type=bool` is not used: `signing_enabled` compares against "true" and
+/// the other reads are strings, so one accessor covers both.
+fn git_config(checkout: &Path, key: &str) -> Option<String> {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(checkout)
+        .args(["config", "--get", key])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let value = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if value.is_empty() { None } else { Some(value) }
+}
+
+/// Tree object for the probe to sign: HEAD's tree when there is a HEAD,
+/// otherwise the staged tree (the unborn-branch case, where HEAD^{tree}
+/// does not resolve). `write-tree` reads the index and writes tree objects;
+/// it does not modify the index.
+fn probe_tree(checkout: &Path) -> error::Result<String> {
+    let head_tree = Command::new("git")
+        .arg("-C")
+        .arg(checkout)
+        .args(["rev-parse", "-q", "--verify", "HEAD^{tree}"])
+        .output()
+        .map_err(|e| {
+            error::LegionError::WorkSource(format!(
+                "failed to run git rev-parse HEAD^{{tree}}: {e}"
+            ))
+        })?;
+    if head_tree.status.success() {
+        let tree = String::from_utf8_lossy(&head_tree.stdout)
+            .trim()
+            .to_string();
+        if !tree.is_empty() {
+            return Ok(tree);
+        }
+    }
+
+    let written = Command::new("git")
+        .arg("-C")
+        .arg(checkout)
+        .args(["write-tree"])
+        .output()
+        .map_err(|e| {
+            error::LegionError::WorkSource(format!("failed to run git write-tree: {e}"))
+        })?;
+    if !written.status.success() {
+        return Err(error::LegionError::WorkSource(format!(
+            "git write-tree failed, so the signer could not be preflighted: {}",
+            String::from_utf8_lossy(&written.stderr).trim()
+        )));
+    }
+    Ok(String::from_utf8_lossy(&written.stdout).trim().to_string())
+}
+
+/// Pull the useful line out of a failed signing attempt's stderr.
+///
+/// git relays the signer's own stderr behind a bare `error: ` prefix, so a
+/// signer that fails silently (a stub like `/usr/bin/false`, or an agent
+/// that exits without a message) leaves nothing but the prefix -- measured,
+/// not assumed: `/usr/bin/false` produces exactly `"error: \n"`. Stripping
+/// the prefix and falling back to a literal keeps the refusal from reading
+/// "signing unavailable (...):  -- unlock your signer and re-run" with a
+/// hole where the reason should be.
+fn signer_failure_detail(stderr: &str) -> String {
+    for line in stderr.lines() {
+        let trimmed = line.trim();
+        let stripped = trimmed
+            .strip_prefix("error:")
+            .or_else(|| trimmed.strip_prefix("fatal:"))
+            .unwrap_or(trimmed)
+            .trim();
+        if !stripped.is_empty() {
+            return stripped.to_string();
+        }
+    }
+    "the signer exited non-zero without a message".to_string()
+}
+
+/// Enforce this repo's commit-message conventions, refusing by name.
+///
+/// Four rules, each a distinct refusal so the caller knows what to change:
+/// no emoji anywhere, a conventional subject line, a blank line after the
+/// subject, and a `Co-Authored-By` trailer as the last line. The emoji scan
+/// runs first because it is the only rule that can fire on the subject AND
+/// the body, and reporting "bad subject" for a message whose real problem is
+/// a rocket in paragraph three would send the caller to the wrong line.
+fn validate_message(message: &str) -> error::Result<()> {
+    if let Some(ch) = find_emoji(message) {
+        return Err(error::LegionError::CommitRefused {
+            reason: format!(
+                "commit message contains an emoji ({ch:?}, U+{:04X}) -- legion commit messages \
+                 are plain text",
+                ch as u32
+            ),
+        });
+    }
+
+    let lines: Vec<&str> = message.lines().collect();
+    if lines.iter().all(|l| l.trim().is_empty()) {
+        return Err(error::LegionError::CommitRefused {
+            reason: "commit message is empty".to_string(),
+        });
+    }
+    let Some(subject) = lines.first() else {
+        return Err(error::LegionError::CommitRefused {
+            reason: "commit message is empty".to_string(),
+        });
+    };
+    if subject.trim().is_empty() {
+        return Err(error::LegionError::CommitRefused {
+            reason: "commit message starts with a blank line -- the first line is the subject"
+                .to_string(),
+        });
+    }
+    validate_subject(subject)?;
+
+    match lines.get(1) {
+        None => {
+            return Err(error::LegionError::CommitRefused {
+                reason: "commit message has no body -- it must end with a 'Co-Authored-By: \
+                         <name> <email>' trailer"
+                    .to_string(),
+            });
+        }
+        Some(second) if !second.trim().is_empty() => {
+            return Err(error::LegionError::CommitRefused {
+                reason: format!("the subject must be followed by a blank line, found: {second:?}"),
+            });
+        }
+        Some(_) => {}
+    }
+
+    let last: &str = lines
+        .iter()
+        .rev()
+        .find(|l| !l.trim().is_empty())
+        .copied()
+        .unwrap_or("");
+    if !is_coauthor_trailer(last) {
+        return Err(error::LegionError::CommitRefused {
+            reason: format!(
+                "commit message must end with a 'Co-Authored-By: <name> <email>' trailer, \
+                 last line was: {last:?}"
+            ),
+        });
+    }
+
+    Ok(())
+}
+
+/// Accept `<type>(<scope>): <summary>`.
+///
+/// The pattern encoded here is what this repo's history actually contains,
+/// not the Conventional Commits grammar. Of the last 50 subjects, every
+/// conventional one carries a scope -- 43 of them an issue ref (`#854`), the
+/// rest a bare word (`release`, `worksource`) -- so the scope is REQUIRED,
+/// which is what makes `chore(release): 0.25.0` pass and a bare
+/// `chore: bump` fail. Types come from [`COMMIT_TYPES`].
+///
+/// No length cap: this repo routinely writes subjects well past 72
+/// characters (`feat(#780): provenance + void columns, validator registry,
+/// ...`), and a rule the repo violates on most commits is not a rule.
+fn validate_subject(subject: &str) -> error::Result<()> {
+    let refuse = |detail: &str| error::LegionError::CommitRefused {
+        reason: format!(
+            "bad subject line ({detail}) -- expected '<type>(<scope>): <summary>' where <type> \
+             is one of {} and <scope> is an issue ref like '#854' or a bare word like 'release'",
+            COMMIT_TYPES.join("/")
+        ),
+    };
+
+    let Some((prefix, summary)) = subject.split_once(": ") else {
+        return Err(refuse("no '<type>(<scope>): ' prefix"));
+    };
+    if summary.trim().is_empty() {
+        return Err(refuse("empty summary after the colon"));
+    }
+
+    let Some((commit_type, scope_with_paren)) = prefix.split_once('(') else {
+        return Err(refuse("missing '(<scope>)'"));
+    };
+    if !COMMIT_TYPES.contains(&commit_type) {
+        return Err(refuse(&format!("unknown type '{commit_type}'")));
+    }
+    let Some(scope) = scope_with_paren.strip_suffix(')') else {
+        return Err(refuse("unclosed '(' in the scope"));
+    };
+    if scope.is_empty() {
+        return Err(refuse("empty scope"));
+    }
+    if !scope
+        .chars()
+        .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || "#._/-".contains(c))
+    {
+        return Err(refuse(&format!(
+            "scope '{scope}' has unexpected characters"
+        )));
+    }
+
+    Ok(())
+}
+
+/// The first emoji codepoint in `text`, if any. See [`EMOJI_RANGES`] for
+/// what counts and what deliberately does not.
+fn find_emoji(text: &str) -> Option<char> {
+    text.chars().find(|ch| {
+        let cp = *ch as u32;
+        EMOJI_RANGES
+            .iter()
+            .any(|(start, end)| cp >= *start && cp <= *end)
+    })
+}
+
+/// Whether `line` is a `Co-Authored-By` trailer with a non-empty value.
+/// Case-insensitive on the key: this repo's history carries both
+/// `Co-Authored-By:` and GitHub's canonical `Co-authored-by:`, and refusing
+/// one of the two spellings the repo already uses would be inventing a rule.
+fn is_coauthor_trailer(line: &str) -> bool {
+    let trimmed = line.trim();
+    let Some(rest) = trimmed
+        .get(..COAUTHOR_KEY.len())
+        .filter(|head| head.eq_ignore_ascii_case(COAUTHOR_KEY))
+        .map(|head| &trimmed[head.len()..])
+    else {
+        return false;
+    };
+    !rest.trim().is_empty()
+}
+
+/// Trailer key, including the colon, matched case-insensitively.
+const COAUTHOR_KEY: &str = "co-authored-by:";
+
+/// Run `git commit -F <tempfile>` in `checkout` and return the new HEAD.
+///
+/// `--cleanup=whitespace` is pinned on the command line rather than left to
+/// git's default for `-F`. The default IS `whitespace`, but an ambient
+/// `commit.cleanup` overrides it, and this verb runs in real repos with real
+/// config -- the same argument that pins `-M50%` on every `git diff` in
+/// `cli::util`. It matters here because `strip` would delete any body line
+/// beginning with `#`, and issue refs at the start of a line are ordinary in
+/// this repo's commit bodies.
+///
+/// No `-a`: only the staged index is committed, exactly as `git commit`
+/// would. Nothing here stages anything.
+fn run_git_commit(checkout: &Path, message: &str) -> error::Result<String> {
+    // UUIDv7 name rather than a fixed one so two concurrent agents (the
+    // situation 019fc46c is about) cannot overwrite each other's message
+    // file between write and read.
+    let msg_path: PathBuf =
+        std::env::temp_dir().join(format!("legion-commit-{}.msg", uuid::Uuid::now_v7()));
+    std::fs::write(&msg_path, message)?;
+
+    let outcome = spawn_git_commit(checkout, &msg_path);
+
+    // Best-effort: a leftover message file in the temp dir is noise, not a
+    // failure, and must never mask the commit's own result.
+    let _ = std::fs::remove_file(&msg_path);
+
+    outcome?;
+
+    head_sha(checkout)?.ok_or_else(|| {
+        error::LegionError::WorkSource(
+            "git commit reported success but HEAD does not resolve".to_string(),
+        )
+    })
+}
+
+/// Spawn the commit with stderr relayed live and captured. Live relay is not
+/// cosmetic here: this repo's `pre-commit` hook runs a nested Claude review
+/// with a 120-second budget, and a two-minute silence with no output reads
+/// as a hang.
+fn spawn_git_commit(checkout: &Path, msg_path: &Path) -> error::Result<()> {
+    let mut child = Command::new("git")
+        .arg("-C")
+        .arg(checkout)
+        .args(["commit", "--cleanup=whitespace", "-F"])
+        .arg(msg_path)
+        .stdin(Stdio::null())
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::piped())
+        .spawn()
+        .map_err(|e| error::LegionError::WorkSource(format!("failed to spawn git commit: {e}")))?;
+
+    let stderr_pipe = child
+        .stderr
+        .take()
+        .ok_or_else(|| error::LegionError::WorkSource("git commit stderr missing".to_string()))?;
+    let captured = relay_and_capture_stderr(stderr_pipe);
+
+    let status = child
+        .wait()
+        .map_err(|e| error::LegionError::WorkSource(format!("git commit wait failed: {e}")))?;
+
+    if !status.success() {
+        return Err(error::LegionError::CommitFailed { stderr: captured });
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A message that satisfies every rule, for the tests that mutate one
+    /// thing at a time.
+    fn good_message() -> String {
+        "feat(#854): legion commit\n\
+         \n\
+         Body text.\n\
+         \n\
+         Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>\n"
+            .to_string()
+    }
+
+    fn refusal_reason(err: error::LegionError) -> String {
+        match err {
+            error::LegionError::CommitRefused { reason } => reason,
+            other => panic!("expected CommitRefused, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn validate_message_accepts_the_house_style() {
+        validate_message(&good_message()).expect("the house style must validate");
+    }
+
+    #[test]
+    fn validate_message_accepts_release_scope() {
+        let msg = "chore(release): 0.25.0\n\nCo-Authored-By: Claude <x@y.invalid>\n";
+        validate_message(msg).expect("chore(release) is real history and must validate");
+    }
+
+    #[test]
+    fn validate_message_accepts_bare_word_scope() {
+        let msg = "fix(worksource): name the operation\n\nCo-authored-by: Claude <x@y.invalid>\n";
+        validate_message(msg).expect("a bare-word scope is real history and must validate");
+    }
+
+    #[test]
+    fn validate_message_refuses_empty() {
+        let reason = refusal_reason(validate_message("   \n\n  \n").unwrap_err());
+        assert!(reason.contains("empty"), "got: {reason}");
+    }
+
+    #[test]
+    fn validate_message_refuses_unscoped_subject() {
+        let msg = "feat: no scope here\n\nCo-Authored-By: Claude <x@y.invalid>\n";
+        let reason = refusal_reason(validate_message(msg).unwrap_err());
+        assert!(reason.contains("missing '(<scope>)'"), "got: {reason}");
+    }
+
+    #[test]
+    fn validate_message_refuses_unknown_type() {
+        let msg = "wip(#854): something\n\nCo-Authored-By: Claude <x@y.invalid>\n";
+        let reason = refusal_reason(validate_message(msg).unwrap_err());
+        assert!(reason.contains("unknown type 'wip'"), "got: {reason}");
+    }
+
+    #[test]
+    fn validate_message_refuses_missing_prefix_entirely() {
+        let msg = "just some words\n\nCo-Authored-By: Claude <x@y.invalid>\n";
+        let reason = refusal_reason(validate_message(msg).unwrap_err());
+        assert!(
+            reason.contains("no '<type>(<scope>): ' prefix"),
+            "got: {reason}"
+        );
+    }
+
+    #[test]
+    fn validate_message_refuses_empty_summary() {
+        let msg = "feat(#854): \n\nCo-Authored-By: Claude <x@y.invalid>\n";
+        let reason = refusal_reason(validate_message(msg).unwrap_err());
+        assert!(reason.contains("empty summary"), "got: {reason}");
+    }
+
+    #[test]
+    fn validate_message_refuses_missing_trailer() {
+        let msg = "feat(#854): legion commit\n\nBody without a trailer.\n";
+        let reason = refusal_reason(validate_message(msg).unwrap_err());
+        assert!(reason.contains("Co-Authored-By"), "got: {reason}");
+    }
+
+    #[test]
+    fn validate_message_refuses_subject_only() {
+        let msg = "feat(#854): legion commit\n";
+        let reason = refusal_reason(validate_message(msg).unwrap_err());
+        assert!(reason.contains("no body"), "got: {reason}");
+    }
+
+    #[test]
+    fn validate_message_refuses_missing_blank_line_after_subject() {
+        let msg =
+            "feat(#854): legion commit\nBody on line two.\n\nCo-Authored-By: C <x@y.invalid>\n";
+        let reason = refusal_reason(validate_message(msg).unwrap_err());
+        assert!(reason.contains("blank line"), "got: {reason}");
+    }
+
+    #[test]
+    fn validate_message_refuses_leading_blank_line() {
+        let msg = "\nfeat(#854): legion commit\n\nCo-Authored-By: C <x@y.invalid>\n";
+        let reason = refusal_reason(validate_message(msg).unwrap_err());
+        assert!(reason.contains("starts with a blank line"), "got: {reason}");
+    }
+
+    #[test]
+    fn validate_message_refuses_emoji_in_subject() {
+        let msg = "feat(#854): ship it \u{1F680}\n\nCo-Authored-By: C <x@y.invalid>\n";
+        let reason = refusal_reason(validate_message(msg).unwrap_err());
+        assert!(reason.contains("emoji"), "got: {reason}");
+        assert!(reason.contains("U+1F680"), "got: {reason}");
+    }
+
+    #[test]
+    fn validate_message_refuses_emoji_in_body() {
+        // The emoji scan must beat the subject check to the punch, or the
+        // caller is told the subject is wrong when the subject is fine.
+        let msg =
+            "feat(#854): legion commit\n\nAll done \u{2705}\n\nCo-Authored-By: C <x@y.invalid>\n";
+        let reason = refusal_reason(validate_message(msg).unwrap_err());
+        assert!(reason.contains("emoji"), "got: {reason}");
+    }
+
+    #[test]
+    fn find_emoji_ignores_ordinary_prose_and_punctuation() {
+        // Every one of these appears in this repo's real commit bodies and
+        // must not be mistaken for an emoji: em dash, curly quotes, arrows
+        // written as ASCII, backticks, accented latin.
+        assert_eq!(
+            find_emoji("a -- b \u{2014} \u{201c}quoted\u{201d} -> `code` caf\u{e9}"),
+            None
+        );
+    }
+
+    #[test]
+    fn find_emoji_catches_each_configured_range() {
+        assert_eq!(find_emoji("x \u{2705}"), Some('\u{2705}')); // dingbats
+        assert_eq!(find_emoji("x \u{2B50}"), Some('\u{2B50}')); // misc symbols/arrows
+        assert_eq!(find_emoji("x \u{1F389}"), Some('\u{1F389}')); // pictographs
+        assert_eq!(find_emoji("x \u{FE0F}"), Some('\u{FE0F}')); // variation selector
+        assert_eq!(find_emoji("x \u{20E3}"), Some('\u{20E3}')); // keycap
+    }
+
+    #[test]
+    fn is_coauthor_trailer_matches_both_spellings_in_history() {
+        assert!(is_coauthor_trailer("Co-Authored-By: Claude <x@y.invalid>"));
+        assert!(is_coauthor_trailer("Co-authored-by: Claude <x@y.invalid>"));
+        assert!(is_coauthor_trailer(
+            "  co-authored-by: Claude <x@y.invalid>  "
+        ));
+    }
+
+    #[test]
+    fn is_coauthor_trailer_rejects_empty_value_and_near_misses() {
+        assert!(!is_coauthor_trailer("Co-Authored-By:"));
+        assert!(!is_coauthor_trailer("Co-Authored-By:   "));
+        assert!(!is_coauthor_trailer("Signed-off-by: Claude <x@y.invalid>"));
+        assert!(!is_coauthor_trailer(""));
+        // Multi-byte lead: the key match must not slice mid-codepoint.
+        assert!(!is_coauthor_trailer(
+            "\u{e9}\u{e9}\u{e9}\u{e9}\u{e9}\u{e9}\u{e9}\u{e9}"
+        ));
+    }
+
+    #[test]
+    fn resolve_message_requires_exactly_one_source() {
+        let reason = refusal_reason(resolve_message(None, None).unwrap_err());
+        assert!(
+            reason.contains("--message or --message-file"),
+            "got: {reason}"
+        );
+
+        let reason = refusal_reason(resolve_message(Some("x"), Some("y")).unwrap_err());
+        assert!(reason.contains("mutually exclusive"), "got: {reason}");
+
+        assert_eq!(resolve_message(Some("hello"), None).unwrap(), "hello");
+    }
+
+    #[test]
+    fn resolve_message_names_the_unreadable_file() {
+        let reason =
+            refusal_reason(resolve_message(None, Some("/nonexistent/legion/msg")).unwrap_err());
+        assert!(reason.contains("/nonexistent/legion/msg"), "got: {reason}");
+    }
+
+    #[test]
+    fn signer_failure_detail_falls_back_when_the_signer_says_nothing() {
+        // Measured from `git -c gpg.ssh.program=/usr/bin/false commit-tree -S`:
+        // stderr is exactly "error: \n", which strips to nothing.
+        assert_eq!(
+            signer_failure_detail("error: \n"),
+            "the signer exited non-zero without a message"
+        );
+        assert_eq!(
+            signer_failure_detail(""),
+            "the signer exited non-zero without a message"
+        );
+    }
+
+    #[test]
+    fn signer_failure_detail_uses_the_first_informative_line() {
+        let stderr = "error: \nerror: gpg failed to sign the data\nfatal: failed to write commit\n";
+        assert_eq!(signer_failure_detail(stderr), "gpg failed to sign the data");
+    }
+
+    /// Record a gate row so the three verdicts can be told apart.
+    fn record_gate(database: &db::Database, sha: &str, skill: &str, result: GateResult) {
+        use crate::db::quality_gates::QualityGateInput;
+        use crate::verify::GateProvenance;
+
+        database
+            .record_quality_gate(&QualityGateInput {
+                branch: "feat/854-legion-commit",
+                commit_hash: sha,
+                skill,
+                result,
+                findings_count: if result == GateResult::Clean { 0 } else { 3 },
+                details: None,
+                provenance: GateProvenance::Validated,
+                base: None,
+            })
+            .expect("recording a gate row must succeed");
+    }
+
+    #[test]
+    fn gate_state_distinguishes_clean_issues_and_absent() {
+        let database = db::testutil::test_db();
+        let sha = "0123456789abcdef0123456789abcdef01234567";
+        record_gate(&database, sha, "legion-simplify", GateResult::Clean);
+        record_gate(&database, sha, "legion-pr-write", GateResult::Issues);
+
+        let gates = gate_state(&database, Some(sha));
+        assert_eq!(gates["simplify"], "clean");
+        // A gate that recorded ISSUES is neither clean nor absent -- the
+        // whole reason this is three-valued rather than the two the issue
+        // sketched.
+        assert_eq!(gates["pr_write"], "issues");
+    }
+
+    #[test]
+    fn gate_state_reports_absent_for_an_ungated_commit() {
+        let database = db::testutil::test_db();
+        let gates = gate_state(&database, Some("deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"));
+        assert_eq!(gates["simplify"], "absent");
+        assert_eq!(gates["pr_write"], "absent");
+    }
+
+    #[test]
+    fn gate_state_reports_absent_when_head_is_unborn() {
+        // The first commit in a repo has no pre-HEAD to key gates on, so
+        // there is nothing to look up rather than nothing recorded.
+        let database = db::testutil::test_db();
+        let gates = gate_state(&database, None);
+        assert_eq!(gates["simplify"], "absent");
+        assert_eq!(gates["pr_write"], "absent");
+    }
+
+    #[test]
+    fn short_sha_truncates_and_tolerates_short_input() {
+        assert_eq!(short_sha("0123456789abcdef"), "01234567");
+        assert_eq!(short_sha("abc"), "abc");
+    }
+}

--- a/src/cli/commit.rs
+++ b/src/cli/commit.rs
@@ -326,6 +326,14 @@ fn gate_state(database: &db::Database, pre_sha: Option<&str>) -> serde_json::Val
 /// ref, index, or working-tree file, which is what "before touching
 /// anything" means in the sense that matters. `git commit --dry-run` is not
 /// an option: it never reaches the signer.
+///
+/// Accepted cost, stated here so it is not a mystery: an INTERACTIVE signer
+/// is invoked twice per commit -- once by this probe, once by the real
+/// commit -- so a pinentry prompt, a 1Password confirm dialog, or a
+/// touch-required hardware key asks twice. That is inherent to preflighting
+/// at all; you cannot ask a signer whether it can sign without asking it to
+/// sign. Invisible with a cached agent (the agent-driven case this verb is
+/// built for), a real per-commit tax otherwise.
 fn preflight_signer(checkout: &Path) -> error::Result<()> {
     if !signing_enabled(checkout) {
         return Ok(());
@@ -359,8 +367,17 @@ fn probe_signer(checkout: &Path, tree: &str, program: &str) -> error::Result<()>
 /// Whether `commit.gpgsign` is on. An absent key exits non-zero, which is
 /// "off" -- there is no signer to preflight, and this verb never turns
 /// signing on or off, it only reports what is configured.
+///
+/// Read as a bool through git rather than string-compared against "true":
+/// git's boolean parser also accepts `yes`, `on`, `1`, any case variant, and
+/// the bare-key form (`[commit]` / `gpgsign` with no value). Comparing the
+/// raw string means every one of those spellings reads as "off", skips the
+/// preflight, and then signs for real during the commit -- surfacing exactly
+/// the cryptic signer failure this verb exists to replace, with nothing
+/// erroring to say why. Same reasoning that routes the probe through
+/// `commit-tree`: delegate to git's own parser instead of reimplementing it.
 fn signing_enabled(checkout: &Path) -> bool {
-    git_config(checkout, "commit.gpgsign").as_deref() == Some("true")
+    git_config_bool(checkout, "commit.gpgsign") == Some(true)
 }
 
 /// Name of the program git would invoke to sign, for the error message.
@@ -377,14 +394,30 @@ fn signer_program(checkout: &Path) -> String {
     git_config(checkout, key).unwrap_or_else(|| default.to_string())
 }
 
-/// Read one git config value, `None` when unset or unreadable.
-/// `--type=bool` is not used: `signing_enabled` compares against "true" and
-/// the other reads are strings, so one accessor covers both.
+/// Read one git config value as a string, `None` when unset or unreadable.
+/// Used for the signer-program reads, which are genuinely strings.
 fn git_config(checkout: &Path, key: &str) -> Option<String> {
+    git_config_raw(checkout, key, &[])
+}
+
+/// Read one git config value as a boolean, letting git canonicalize it.
+/// `None` when unset or unreadable, so a caller can tell "off" from
+/// "no such key" if it ever needs to. See [`signing_enabled`] for why this
+/// is not a string comparison.
+fn git_config_bool(checkout: &Path, key: &str) -> Option<bool> {
+    Some(git_config_raw(checkout, key, &["--type", "bool"])? == "true")
+}
+
+/// Shared body of the two accessors above. `extra` carries the `--type`
+/// flag for the bool read and is empty for the string reads, which is the
+/// only way the two differ.
+fn git_config_raw(checkout: &Path, key: &str, extra: &[&str]) -> Option<String> {
     let output = Command::new("git")
         .arg("-C")
         .arg(checkout)
-        .args(["config", "--get", key])
+        .args(["config", "--get"])
+        .args(extra)
+        .arg(key)
         .output()
         .ok()?;
     if !output.status.success() {

--- a/src/cli/commit.rs
+++ b/src/cli/commit.rs
@@ -265,9 +265,16 @@ fn head_sha(checkout: &Path) -> error::Result<Option<String>> {
     }
 }
 
-/// First 8 characters of a commit hash, for the confirmation line.
+/// First 8 characters of a commit hash, for the confirmation line. Shorter
+/// input (should not happen for a real SHA) is returned as-is.
+///
+/// `get` (byte-index-checked) rather than a raw slice, matching the same
+/// choice and the same reasoning as `cli::index_cmd`'s 7-char display form:
+/// a real SHA is all-ASCII hex so byte 8 is always a char boundary, but the
+/// value arrives via `from_utf8_lossy` on git's stdout, and no code path
+/// here may assume it cannot panic.
 fn short_sha(sha: &str) -> &str {
-    &sha[..sha.len().min(8)]
+    sha.get(..8).unwrap_or(sha)
 }
 
 /// Quality-gate verdicts for the pre-commit HEAD, as the `gates` object on

--- a/src/cli/commit.rs
+++ b/src/cli/commit.rs
@@ -51,8 +51,10 @@ use crate::{db, error};
 /// should make deliberately rather than inherit from a single 2026 commit.
 /// One token outside the spec set completes the census: `release` appeared
 /// twice (4c44f5f and c9b357d, both 2026-06-18) as the older spelling of what
-/// is now `chore(release)`, and is excluded for the same reason as `ci` -- so
-/// the eight above plus `ci` and `release` are every type token in history.
+/// is now `chore(release)`, and is excluded for the same reason as `ci`. Those
+/// ten are the whole census: every remaining subject in history parses as no
+/// type at all -- merge subjects, git's generated `Revert "..."`, and
+/// pre-convention prose (`Recovery: ...`, `v0.6.2: ...`, `Initial commit`).
 const COMMIT_TYPES: [&str; 8] = [
     "feat", "fix", "chore", "docs", "refactor", "test", "perf", "style",
 ];

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -2,6 +2,7 @@
 //! Domain handlers live in the sibling modules; `main.rs` owns dispatch.
 
 pub(crate) mod autonomy;
+pub(crate) mod commit;
 pub(crate) mod datadir;
 pub(crate) mod document;
 pub(crate) mod index_cmd;
@@ -871,6 +872,44 @@ pub(crate) enum Commands {
         branch: Option<String>,
     },
 
+    /// Commit the staged index -- the sanctioned in-band commit path (#854).
+    ///
+    /// Closes the last unaudited hop in the mutation path: `legion push`
+    /// (#791/#834) routes pushes and #836 fences `gh`, but the commit --
+    /// where authorship, trailers, and signing happen -- was raw `git`.
+    ///
+    /// Preflights the configured signer before touching anything, by
+    /// signing a throwaway commit object (`git commit --dry-run` never
+    /// reaches the signer). A locked or absent signer fails once, by name,
+    /// naming the program to unlock. Signing is never disabled and never
+    /// retried in a loop.
+    ///
+    /// Validates the message and refuses violations by name: the subject
+    /// must be `<type>(<scope>): <summary>` with a scope, the message must
+    /// end with a `Co-Authored-By:` trailer, and no emoji anywhere.
+    ///
+    /// Commits only the staged index (no `-a`, nothing is staged for you)
+    /// and audit-logs every attempt -- refusals included -- with the
+    /// resolved checkout, pre/post HEAD, card id, and the simplify /
+    /// pr-write gate state of the commit being built on.
+    Commit {
+        /// Repository name (identifies the calling agent for the audit log)
+        #[arg(long)]
+        repo: String,
+
+        /// Commit message. Mutually exclusive with --message-file.
+        #[arg(long)]
+        message: Option<String>,
+
+        /// File holding the commit message. Mutually exclusive with --message.
+        #[arg(long)]
+        message_file: Option<String>,
+
+        /// Kanban card this commit belongs to, recorded on the audit row.
+        #[arg(long)]
+        card: Option<String>,
+    },
+
     /// View the audit log of work source actions
     Audit {
         /// Filter by agent name
@@ -880,7 +919,7 @@ pub(crate) enum Commands {
         /// Filter by action type. Known verbs:
         /// create-issue, close-issue, reopen-issue, edit-issue,
         /// create-pr, close-pr, review, merge, comment,
-        /// delete-card, update-card, push.
+        /// delete-card, update-card, push, commit.
         /// Filter is an exact string match; additional verbs
         /// introduced by future subcommands work automatically.
         /// `push` was written by `legion push` from #791 onward but was

--- a/src/cli/push.rs
+++ b/src/cli/push.rs
@@ -12,7 +12,7 @@
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 
-use crate::cli::util::{audit, git_head_commit_and_branch, open_db};
+use crate::cli::util::{audit, git_head_commit_and_branch, open_db, relay_and_capture_stderr};
 use crate::{db, error};
 
 /// Branches this command refuses to push under any circumstances. Merges to
@@ -249,25 +249,6 @@ fn run_push(checkout: &Path, branch: &str) -> error::Result<()> {
     }
 
     Ok(())
-}
-
-/// Read `pipe` line by line, relaying each line to our own stderr as it
-/// arrives and accumulating it into the returned string.
-fn relay_and_capture_stderr(pipe: impl std::io::Read) -> String {
-    use std::io::BufRead;
-    let reader = std::io::BufReader::new(pipe);
-    let mut captured = String::new();
-    for line in reader.lines() {
-        match line {
-            Ok(l) => {
-                eprintln!("{l}");
-                captured.push_str(&l);
-                captured.push('\n');
-            }
-            Err(_) => break,
-        }
-    }
-    captured
 }
 
 #[cfg(test)]

--- a/src/cli/util.rs
+++ b/src/cli/util.rs
@@ -354,6 +354,32 @@ pub(crate) fn git_changed_files(base: Option<&str>) -> Result<ChangedFiles, erro
     })
 }
 
+/// Read `pipe` line by line, relaying each line to our own stderr as it
+/// arrives and accumulating it into the returned string.
+///
+/// Shared by `legion push` and `legion commit`: both shell out to a git
+/// command that can sit behind a long-running hook (the nested-claude
+/// pre-push review, the pre-commit simplify review), and both need that
+/// output visible AS IT HAPPENS as well as captured for the failure
+/// message. Buffering until exit turns a two-minute hook into what looks
+/// like a hang.
+pub(crate) fn relay_and_capture_stderr(pipe: impl std::io::Read) -> String {
+    use std::io::BufRead;
+    let reader = std::io::BufReader::new(pipe);
+    let mut captured = String::new();
+    for line in reader.lines() {
+        match line {
+            Ok(l) => {
+                eprintln!("{l}");
+                captured.push_str(&l);
+                captured.push('\n');
+            }
+            Err(_) => break,
+        }
+    }
+    captured
+}
+
 pub(crate) fn format_age(d: std::time::Duration) -> String {
     let secs = d.as_secs();
     if secs < 60 {

--- a/src/error.rs
+++ b/src/error.rs
@@ -305,7 +305,7 @@ pub enum LegionError {
     /// to go poke at an agent that was never locked. `detail` carries git's
     /// own output, which is the part that actually discriminates.
     #[error(
-        "signing unavailable ({program}): {detail} -- the configured signer could not sign; \
+        "signing unavailable ({program}): {detail}\nthe configured signer could not sign; \
          unlock your signer or fix the signing configuration (git's output above names the cause)"
     )]
     CommitSigningUnavailable { program: String, detail: String },
@@ -536,6 +536,13 @@ mod tests {
         // sends half the callers to the wrong place.
         assert!(msg.contains("unlock your signer"), "got: {msg}");
         assert!(msg.contains("fix the signing configuration"), "got: {msg}");
+        // The remedy starts its own line: `detail` is relayed git stderr,
+        // often multi-line, and a remedy glued to its last line reads as
+        // part of git's output rather than as ours.
+        assert!(
+            msg.contains("agent refused operation\nthe configured signer"),
+            "got: {msg}"
+        );
     }
 
     #[test]

--- a/src/error.rs
+++ b/src/error.rs
@@ -284,10 +284,13 @@ pub enum LegionError {
     #[error("git push failed: {stderr}")]
     PushFailed { stderr: String },
 
-    /// `legion commit` (#854) declined before running git: bad arguments,
-    /// no git repo, or a message-convention violation. The reason is always
-    /// specific enough to fix without a second look at the docs -- a
-    /// refusal the caller cannot act on is just a failure.
+    /// `legion commit` (#854) declined before the commit ran: bad
+    /// arguments, no git repo, a message-convention violation, or git
+    /// itself refusing the signer probe (an unresolvable committer identity
+    /// is the ordinary way -- git dies there without reaching the signer,
+    /// which makes it a refusal rather than a signing failure). The reason
+    /// is always specific enough to fix without a second look at the docs --
+    /// a refusal the caller cannot act on is just a failure.
     #[error("refusing to commit: {reason}")]
     CommitRefused { reason: String },
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -284,6 +284,22 @@ pub enum LegionError {
     #[error("git push failed: {stderr}")]
     PushFailed { stderr: String },
 
+    /// `legion commit` (#854) declined before running git: bad arguments,
+    /// no git repo, or a message-convention violation. The reason is always
+    /// specific enough to fix without a second look at the docs -- a
+    /// refusal the caller cannot act on is just a failure.
+    #[error("refusing to commit: {reason}")]
+    CommitRefused { reason: String },
+
+    /// The configured commit signer could not sign (#854). Raised by the
+    /// preflight probe BEFORE the commit runs, so a locked signer costs one
+    /// named error instead of a retry loop against a hardware key.
+    #[error("signing unavailable ({program}): {detail} -- unlock your signer and re-run")]
+    CommitSigningUnavailable { program: String, detail: String },
+
+    #[error("git commit failed: {stderr}")]
+    CommitFailed { stderr: String },
+
     /// Signals that the process should exit with a specific non-zero code.
     ///
     /// Used by CLI handlers that have already printed a user-facing message
@@ -480,6 +496,37 @@ mod tests {
             stderr: "! [rejected]".to_string(),
         };
         assert!(err.to_string().contains("! [rejected]"));
+    }
+
+    #[test]
+    fn commit_refused_display() {
+        let err = LegionError::CommitRefused {
+            reason: "commit message is empty".to_string(),
+        };
+        assert_eq!(
+            err.to_string(),
+            "refusing to commit: commit message is empty"
+        );
+    }
+
+    #[test]
+    fn commit_signing_unavailable_display() {
+        let err = LegionError::CommitSigningUnavailable {
+            program: "/usr/bin/op-ssh-sign".to_string(),
+            detail: "agent refused operation".to_string(),
+        };
+        let msg = err.to_string();
+        assert!(msg.starts_with("signing unavailable (/usr/bin/op-ssh-sign):"));
+        assert!(msg.contains("agent refused operation"));
+        assert!(msg.ends_with("unlock your signer and re-run"));
+    }
+
+    #[test]
+    fn commit_failed_display() {
+        let err = LegionError::CommitFailed {
+            stderr: "nothing to commit".to_string(),
+        };
+        assert!(err.to_string().contains("nothing to commit"));
     }
 
     #[test]

--- a/src/error.rs
+++ b/src/error.rs
@@ -294,7 +294,17 @@ pub enum LegionError {
     /// The configured commit signer could not sign (#854). Raised by the
     /// preflight probe BEFORE the commit runs, so a locked signer costs one
     /// named error instead of a retry loop against a hardware key.
-    #[error("signing unavailable ({program}): {detail} -- unlock your signer and re-run")]
+    ///
+    /// The remedy names two possibilities on purpose. A signer that exits
+    /// non-zero has not told us WHY -- a locked agent and a misconfigured
+    /// key look identical from here -- and a message that asserts "unlock
+    /// your signer" sends everyone whose real problem is the configuration
+    /// to go poke at an agent that was never locked. `detail` carries git's
+    /// own output, which is the part that actually discriminates.
+    #[error(
+        "signing unavailable ({program}): {detail} -- the configured signer could not sign; \
+         unlock your signer or fix the signing configuration (git's output above names the cause)"
+    )]
     CommitSigningUnavailable { program: String, detail: String },
 
     #[error("git commit failed: {stderr}")]
@@ -518,7 +528,11 @@ mod tests {
         let msg = err.to_string();
         assert!(msg.starts_with("signing unavailable (/usr/bin/op-ssh-sign):"));
         assert!(msg.contains("agent refused operation"));
-        assert!(msg.ends_with("unlock your signer and re-run"));
+        // Both remedies, not just the lock: the probe cannot tell a locked
+        // agent from a misconfigured signer, so naming only one of them
+        // sends half the callers to the wrong place.
+        assert!(msg.contains("unlock your signer"), "got: {msg}");
+        assert!(msg.contains("fix the signing configuration"), "got: {msg}");
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -299,6 +299,12 @@ fn run() -> error::Result<()> {
         Commands::Issue { action } => cli::issue::handle(action)?,
         Commands::Pr { action } => cli::pr::handle(action)?,
         Commands::Push { repo, branch } => cli::push::handle_push(repo, branch)?,
+        Commands::Commit {
+            repo,
+            message,
+            message_file,
+            card,
+        } => cli::commit::handle_commit(repo, message, message_file, card)?,
         Commands::Comment { repo, number, body } => cli::issue::handle_comment(repo, number, body)?,
         Commands::Audit {
             repo,

--- a/tests/integration/commit.rs
+++ b/tests/integration/commit.rs
@@ -1,0 +1,520 @@
+//! Integration tests for `legion commit` (#854): the audited commit verb.
+//!
+//! Every test drives a real `git` fixture repo, because the command's whole
+//! job is shelling out to git -- resolving the checkout, probing the signer,
+//! and running the commit.
+//!
+//! Two isolation rules these fixtures must follow, and neither is optional:
+//!
+//! 1. **Identity goes in the temp repo's LOCAL config**, not as `-c`
+//!    overrides. `run_git_fixture` passes identity per-invocation and never
+//!    writes it (#723), which is right for fixture setup -- but the binary
+//!    under test spawns its own `git commit` with no `-c` flags, so without
+//!    a local config those subprocesses fail with "Committer identity
+//!    unknown" and every commit test fails for the wrong reason. Writing to
+//!    a tempdir's own config is safe; `RealRepoConfigGuard` protects the
+//!    enclosing real checkout, which is untouched here.
+//! 2. **`GIT_CONFIG_GLOBAL`/`GIT_CONFIG_SYSTEM` go on the binary's env.**
+//!    The operator's real global config carries `commit.gpgsign=true` and a
+//!    `core.hooksPath` pointing at this repo's pre-commit hook, which runs a
+//!    nested Claude review with a two-minute budget. Isolating keeps these
+//!    tests hermetic and fast.
+
+use crate::common::*;
+use std::path::Path;
+
+/// The message every happy-path test commits: house style, so a failure
+/// here means the verb is wrong rather than the fixture.
+const GOOD_MESSAGE: &str = "feat(#854): add a thing\n\
+                            \n\
+                            Body paragraph explaining why.\n\
+                            \n\
+                            Co-Authored-By: Legion Test <fixture@example.invalid>\n";
+
+/// A repo with one commit on `main`, a second change already staged, and
+/// identity plus `commit.gpgsign=false` written into its LOCAL config so
+/// the binary's own `git` subprocesses inherit them. Signing-off by config
+/// is what keeps CI from needing a signer; the preflight path gets its own
+/// test that turns signing back on.
+fn setup_repo_with_staged_change() -> tempfile::TempDir {
+    let repo = tempfile::tempdir().unwrap();
+    let rp = repo.path();
+    run_git_fixture(rp, &["init", "-q", "-b", "main"]);
+    run_git_fixture(rp, &["config", "user.name", "Legion Test Fixture"]);
+    run_git_fixture(rp, &["config", "user.email", "fixture@example.invalid"]);
+    run_git_fixture(rp, &["config", "commit.gpgsign", "false"]);
+
+    std::fs::write(rp.join("README.md"), "seed\n").unwrap();
+    run_git_fixture(rp, &["add", "README.md"]);
+    run_git_fixture(rp, &["commit", "-q", "-m", "seed"]);
+
+    std::fs::write(rp.join("feature.txt"), "change\n").unwrap();
+    run_git_fixture(rp, &["add", "feature.txt"]);
+
+    repo
+}
+
+/// `legion` invoked in `cwd` with the host's global/system git config
+/// swapped out. See the module docs for why this is on the command under
+/// test and not just on fixture setup.
+fn commit_cmd(data_dir: &Path, cwd: &Path) -> std::process::Command {
+    let (global, system) = isolated_git_config_paths();
+    let mut cmd = legion_cmd(data_dir);
+    cmd.current_dir(cwd)
+        .env("GIT_CONFIG_GLOBAL", global)
+        .env("GIT_CONFIG_SYSTEM", system);
+    cmd
+}
+
+fn head_sha(repo: &Path) -> String {
+    run_git_fixture_output(repo, &["rev-parse", "HEAD"])
+}
+
+fn head_message(repo: &Path) -> String {
+    run_git_fixture_output(repo, &["log", "-1", "--format=%B"])
+}
+
+/// Run `legion commit --message <msg>` and expect a refusal, returning
+/// stderr. Every convention test is this shape.
+fn refuse_message(repo: &Path, data_dir: &Path, message: &str) -> String {
+    let (_stdout, stderr) = run_fail(commit_cmd(data_dir, repo).args([
+        "commit",
+        "--repo",
+        "test-agent",
+        "--message",
+        message,
+    ]));
+    stderr
+}
+
+/// Happy path: the staged change lands, the message survives verbatim, and
+/// the confirmation names the branch.
+#[cfg(unix)]
+#[test]
+fn commit_lands_the_staged_change_and_reports_it() {
+    let _guard = RealRepoConfigGuard::new();
+    let repo = setup_repo_with_staged_change();
+    let data_dir = tempfile::tempdir().unwrap();
+    let before = head_sha(repo.path());
+
+    let stdout = run_ok(commit_cmd(data_dir.path(), repo.path()).args([
+        "commit",
+        "--repo",
+        "test-agent",
+        "--message",
+        GOOD_MESSAGE,
+    ]));
+
+    let after = head_sha(repo.path());
+    assert_ne!(before, after, "expected HEAD to advance");
+    assert!(
+        stdout.contains("main"),
+        "expected the confirmation to name the branch, got: {stdout}"
+    );
+    assert!(
+        stdout.contains(&after[..8]),
+        "expected the confirmation to name the new commit, got: {stdout}"
+    );
+
+    let body = head_message(repo.path());
+    assert!(body.contains("feat(#854): add a thing"), "got: {body}");
+    assert!(
+        body.contains("Body paragraph explaining why."),
+        "the body must survive --cleanup=whitespace, got: {body}"
+    );
+    assert!(body.contains("Co-Authored-By:"), "got: {body}");
+}
+
+/// Only the staged index is committed. `legion commit` never stages for
+/// you, so an unstaged file must still be unstaged afterwards.
+#[cfg(unix)]
+#[test]
+fn commit_leaves_unstaged_changes_alone() {
+    let _guard = RealRepoConfigGuard::new();
+    let repo = setup_repo_with_staged_change();
+    std::fs::write(repo.path().join("untracked.txt"), "not staged\n").unwrap();
+    let data_dir = tempfile::tempdir().unwrap();
+
+    run_ok(commit_cmd(data_dir.path(), repo.path()).args([
+        "commit",
+        "--repo",
+        "test-agent",
+        "--message",
+        GOOD_MESSAGE,
+    ]));
+
+    let status = run_git_fixture_output(repo.path(), &["status", "--porcelain"]);
+    assert!(
+        status.contains("untracked.txt"),
+        "the untracked file must be untouched, got: {status:?}"
+    );
+    let committed =
+        run_git_fixture_output(repo.path(), &["show", "--name-only", "--format=", "HEAD"]);
+    assert!(committed.contains("feature.txt"), "got: {committed}");
+    assert!(!committed.contains("untracked.txt"), "got: {committed}");
+}
+
+/// Works from a subdirectory: the checkout is the repo root, not the CWD.
+#[cfg(unix)]
+#[test]
+fn commit_resolves_the_repo_root_from_a_subdirectory() {
+    let _guard = RealRepoConfigGuard::new();
+    let repo = setup_repo_with_staged_change();
+    let sub = repo.path().join("nested/deeper");
+    std::fs::create_dir_all(&sub).unwrap();
+    let data_dir = tempfile::tempdir().unwrap();
+
+    run_ok(commit_cmd(data_dir.path(), &sub).args([
+        "commit",
+        "--repo",
+        "test-agent",
+        "--message",
+        GOOD_MESSAGE,
+    ]));
+
+    assert!(head_message(repo.path()).contains("feat(#854): add a thing"));
+}
+
+/// A subject with no scope is refused by name. Every conventional subject
+/// in this repo's recent history carries one.
+#[cfg(unix)]
+#[test]
+fn commit_refuses_unscoped_subject() {
+    let _guard = RealRepoConfigGuard::new();
+    let repo = setup_repo_with_staged_change();
+    let data_dir = tempfile::tempdir().unwrap();
+    let before = head_sha(repo.path());
+
+    let stderr = refuse_message(
+        repo.path(),
+        data_dir.path(),
+        "feat: no scope\n\nCo-Authored-By: Legion Test <fixture@example.invalid>\n",
+    );
+    assert!(stderr.contains("bad subject line"), "got: {stderr}");
+    assert!(stderr.contains("<scope>"), "got: {stderr}");
+    assert_eq!(before, head_sha(repo.path()), "a refusal must not commit");
+}
+
+/// An unknown commit type is refused, naming the type.
+#[cfg(unix)]
+#[test]
+fn commit_refuses_unknown_type() {
+    let _guard = RealRepoConfigGuard::new();
+    let repo = setup_repo_with_staged_change();
+    let data_dir = tempfile::tempdir().unwrap();
+
+    let stderr = refuse_message(
+        repo.path(),
+        data_dir.path(),
+        "wip(#854): halfway\n\nCo-Authored-By: Legion Test <fixture@example.invalid>\n",
+    );
+    assert!(stderr.contains("unknown type 'wip'"), "got: {stderr}");
+}
+
+/// A message with no `Co-Authored-By` trailer is refused by name.
+#[cfg(unix)]
+#[test]
+fn commit_refuses_missing_coauthor_trailer() {
+    let _guard = RealRepoConfigGuard::new();
+    let repo = setup_repo_with_staged_change();
+    let data_dir = tempfile::tempdir().unwrap();
+    let before = head_sha(repo.path());
+
+    let stderr = refuse_message(
+        repo.path(),
+        data_dir.path(),
+        "feat(#854): add a thing\n\nBody with no trailer.\n",
+    );
+    assert!(stderr.contains("Co-Authored-By"), "got: {stderr}");
+    assert_eq!(before, head_sha(repo.path()), "a refusal must not commit");
+}
+
+/// An emoji anywhere in the message is refused, naming the codepoint.
+#[cfg(unix)]
+#[test]
+fn commit_refuses_emoji() {
+    let _guard = RealRepoConfigGuard::new();
+    let repo = setup_repo_with_staged_change();
+    let data_dir = tempfile::tempdir().unwrap();
+    let before = head_sha(repo.path());
+
+    let stderr = refuse_message(
+        repo.path(),
+        data_dir.path(),
+        "feat(#854): add a thing\n\nShipped \u{1F680}\n\nCo-Authored-By: L <f@example.invalid>\n",
+    );
+    assert!(stderr.contains("emoji"), "got: {stderr}");
+    assert!(stderr.contains("U+1F680"), "got: {stderr}");
+    assert_eq!(before, head_sha(repo.path()), "a refusal must not commit");
+}
+
+/// `--message` and `--message-file` together is a refusal, not a silent
+/// precedence rule.
+#[cfg(unix)]
+#[test]
+fn commit_refuses_both_message_sources() {
+    let _guard = RealRepoConfigGuard::new();
+    let repo = setup_repo_with_staged_change();
+    let data_dir = tempfile::tempdir().unwrap();
+    let msg_file = repo.path().join("msg.txt");
+    std::fs::write(&msg_file, GOOD_MESSAGE).unwrap();
+
+    let (_stdout, stderr) = run_fail(commit_cmd(data_dir.path(), repo.path()).args([
+        "commit",
+        "--repo",
+        "test-agent",
+        "--message",
+        GOOD_MESSAGE,
+        "--message-file",
+        msg_file.to_str().unwrap(),
+    ]));
+    assert!(stderr.contains("mutually exclusive"), "got: {stderr}");
+}
+
+/// `--message-file` is the path the bootstrap commit uses, so it gets its
+/// own happy-path coverage rather than riding on `--message`.
+#[cfg(unix)]
+#[test]
+fn commit_accepts_a_message_file() {
+    let _guard = RealRepoConfigGuard::new();
+    let repo = setup_repo_with_staged_change();
+    let data_dir = tempfile::tempdir().unwrap();
+    // Outside the repo, so the message file is not itself a staged change.
+    let msg_dir = tempfile::tempdir().unwrap();
+    let msg_file = msg_dir.path().join("msg.txt");
+    std::fs::write(&msg_file, GOOD_MESSAGE).unwrap();
+
+    run_ok(commit_cmd(data_dir.path(), repo.path()).args([
+        "commit",
+        "--repo",
+        "test-agent",
+        "--message-file",
+        msg_file.to_str().unwrap(),
+    ]));
+    assert!(head_message(repo.path()).contains("feat(#854): add a thing"));
+}
+
+/// Outside a git repo the verb refuses rather than emitting a raw git
+/// error the caller has to decode.
+#[cfg(unix)]
+#[test]
+fn commit_refuses_outside_a_git_repository() {
+    let not_a_repo = tempfile::tempdir().unwrap();
+    let data_dir = tempfile::tempdir().unwrap();
+
+    let (_stdout, stderr) = run_fail(commit_cmd(data_dir.path(), not_a_repo.path()).args([
+        "commit",
+        "--repo",
+        "test-agent",
+        "--message",
+        GOOD_MESSAGE,
+    ]));
+    assert!(
+        stderr.contains("not inside a git repository"),
+        "got: {stderr}"
+    );
+}
+
+/// The preflight is the point of the verb: with signing enabled and the
+/// signer pointed at a program that always fails, the commit is refused by
+/// name BEFORE anything is written, naming the program to unlock.
+///
+/// `/usr/bin/false` emits nothing at all, so this also exercises the
+/// empty-signer-output fallback -- the assertion is on the refusal's shape
+/// and the program name, never on text `/usr/bin/false` did not produce.
+#[cfg(unix)]
+#[test]
+fn commit_preflight_refuses_when_the_signer_cannot_sign() {
+    let _guard = RealRepoConfigGuard::new();
+    let repo = setup_repo_with_staged_change();
+    let rp = repo.path();
+    run_git_fixture(rp, &["config", "commit.gpgsign", "true"]);
+    run_git_fixture(rp, &["config", "gpg.format", "ssh"]);
+    run_git_fixture(rp, &["config", "gpg.ssh.program", "/usr/bin/false"]);
+    run_git_fixture(
+        rp,
+        &[
+            "config",
+            "user.signingkey",
+            "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIExampleKeyForFixtureUseOnly000000000",
+        ],
+    );
+    let data_dir = tempfile::tempdir().unwrap();
+    let before = head_sha(rp);
+
+    let (_stdout, stderr) = run_fail(commit_cmd(data_dir.path(), rp).args([
+        "commit",
+        "--repo",
+        "test-agent",
+        "--message",
+        GOOD_MESSAGE,
+    ]));
+
+    assert!(stderr.contains("signing unavailable"), "got: {stderr}");
+    assert!(
+        stderr.contains("/usr/bin/false"),
+        "the refusal must name the program to unlock, got: {stderr}"
+    );
+    assert!(stderr.contains("unlock your signer"), "got: {stderr}");
+    assert_eq!(
+        before,
+        head_sha(rp),
+        "the preflight must refuse before anything is committed"
+    );
+}
+
+/// A locked signer is caught by the preflight even when the message is
+/// ALSO invalid: preflight runs first on purpose, because a locked signer
+/// needs the operator to go unlock something while a bad subject is a
+/// five-second fix, and surfacing the slow failure first means one round
+/// trip instead of two.
+#[cfg(unix)]
+#[test]
+fn commit_preflight_runs_before_message_validation() {
+    let _guard = RealRepoConfigGuard::new();
+    let repo = setup_repo_with_staged_change();
+    let rp = repo.path();
+    run_git_fixture(rp, &["config", "commit.gpgsign", "true"]);
+    run_git_fixture(rp, &["config", "gpg.format", "ssh"]);
+    run_git_fixture(rp, &["config", "gpg.ssh.program", "/usr/bin/false"]);
+    run_git_fixture(
+        rp,
+        &[
+            "config",
+            "user.signingkey",
+            "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIExampleKeyForFixtureUseOnly000000000",
+        ],
+    );
+    let data_dir = tempfile::tempdir().unwrap();
+
+    let stderr = refuse_message(rp, data_dir.path(), "garbage subject, no trailer");
+    assert!(stderr.contains("signing unavailable"), "got: {stderr}");
+}
+
+/// The audit row is the reason this verb exists. A successful commit
+/// records the resolved checkout, both SHAs, the card, and the gate state
+/// of the commit it was built on.
+#[cfg(unix)]
+#[test]
+fn commit_writes_audit_row_with_shas_card_and_gates() {
+    let _guard = RealRepoConfigGuard::new();
+    let repo = setup_repo_with_staged_change();
+    let data_dir = tempfile::tempdir().unwrap();
+    let before = head_sha(repo.path());
+
+    run_ok(commit_cmd(data_dir.path(), repo.path()).args([
+        "commit",
+        "--repo",
+        "test-agent",
+        "--message",
+        GOOD_MESSAGE,
+        "--card",
+        "card-854",
+    ]));
+    let after = head_sha(repo.path());
+
+    let audit_out =
+        run_ok(legion_cmd(data_dir.path()).args(["audit", "--action", "commit", "--json"]));
+    assert!(
+        audit_out.contains("\"action\": \"commit\""),
+        "got: {audit_out}"
+    );
+    assert!(
+        audit_out.contains("\"outcome\": \"success\""),
+        "got: {audit_out}"
+    );
+    assert!(
+        audit_out.contains("\"target_ref\": \"main\""),
+        "the audit row keys on the branch, got: {audit_out}"
+    );
+    assert!(
+        audit_out.contains(repo.path().to_str().unwrap()),
+        "expected the resolved checkout in the details, got: {audit_out}"
+    );
+    assert!(
+        audit_out.contains(&before),
+        "expected the pre-commit SHA in the details, got: {audit_out}"
+    );
+    assert!(
+        audit_out.contains(&after),
+        "expected the post-commit SHA in the details, got: {audit_out}"
+    );
+    assert!(audit_out.contains("card-854"), "got: {audit_out}");
+    // No gates were recorded on the pre-commit HEAD, which is a real state
+    // ("absent"), distinct from a gate that ran and found issues.
+    assert!(
+        audit_out.contains("\\\"simplify\\\":\\\"absent\\\""),
+        "expected the simplify gate verdict in the details, got: {audit_out}"
+    );
+    assert!(
+        audit_out.contains("\\\"pr_write\\\":\\\"absent\\\""),
+        "expected the pr-write gate verdict in the details, got: {audit_out}"
+    );
+}
+
+/// A refused commit is still an attempted mutation, and the audit trail
+/// exists to carry exactly that -- especially once the deferred PreToolUse
+/// hook starts routing every plain `git commit` through this verb.
+#[cfg(unix)]
+#[test]
+fn commit_writes_a_failure_audit_row_when_it_refuses() {
+    let _guard = RealRepoConfigGuard::new();
+    let repo = setup_repo_with_staged_change();
+    let data_dir = tempfile::tempdir().unwrap();
+
+    refuse_message(
+        repo.path(),
+        data_dir.path(),
+        "feat(#854): add a thing\n\nBody with no trailer.\n",
+    );
+
+    let audit_out =
+        run_ok(legion_cmd(data_dir.path()).args(["audit", "--action", "commit", "--json"]));
+    assert!(
+        audit_out.contains("\"outcome\": \"failure\""),
+        "expected a failure-outcome row for the refused commit, got: {audit_out}"
+    );
+    assert!(
+        audit_out.contains("\\\"post_sha\\\":null"),
+        "a refused commit has no post SHA, got: {audit_out}"
+    );
+}
+
+/// An underlying `git commit` failure (nothing staged) surfaces git's own
+/// text and is audited as a failure -- the message passed validation, so
+/// this exercises the run-git-commit arm rather than a refusal.
+#[cfg(unix)]
+#[test]
+fn commit_underlying_git_failure_surfaces_and_audits() {
+    let _guard = RealRepoConfigGuard::new();
+    let repo = tempfile::tempdir().unwrap();
+    let rp = repo.path();
+    run_git_fixture(rp, &["init", "-q", "-b", "main"]);
+    run_git_fixture(rp, &["config", "user.name", "Legion Test Fixture"]);
+    run_git_fixture(rp, &["config", "user.email", "fixture@example.invalid"]);
+    run_git_fixture(rp, &["config", "commit.gpgsign", "false"]);
+    std::fs::write(rp.join("README.md"), "seed\n").unwrap();
+    run_git_fixture(rp, &["add", "README.md"]);
+    run_git_fixture(rp, &["commit", "-q", "-m", "seed"]);
+    // Nothing staged beyond the seed commit.
+
+    let data_dir = tempfile::tempdir().unwrap();
+    let (_stdout, stderr) = run_fail(commit_cmd(data_dir.path(), rp).args([
+        "commit",
+        "--repo",
+        "test-agent",
+        "--message",
+        GOOD_MESSAGE,
+    ]));
+    assert!(
+        stderr.contains("git commit failed"),
+        "expected the commit-failed error, got: {stderr}"
+    );
+
+    let audit_out =
+        run_ok(legion_cmd(data_dir.path()).args(["audit", "--action", "commit", "--json"]));
+    assert!(
+        audit_out.contains("\"outcome\": \"failure\""),
+        "got: {audit_out}"
+    );
+}

--- a/tests/integration/commit.rs
+++ b/tests/integration/commit.rs
@@ -363,6 +363,163 @@ fn commit_preflight_refuses_when_the_signer_cannot_sign() {
     );
 }
 
+/// The preflight's SUCCESS direction, which the failure tests cannot prove:
+/// with a real signer configured, the verb signs and the commit lands.
+/// Without this, every signing assertion in the suite is about refusing, and
+/// a preflight that refused unconditionally would pass all of them.
+///
+/// Hermetic: the ed25519 key is generated per-run with no passphrase, so
+/// there is no agent to unlock and nothing on the host is consulted. The key
+/// lives in its OWN tempdir, not the repo -- a key file inside the checkout
+/// would be an untracked file in the tree under test.
+///
+/// This is also the unborn-branch path end to end. The commit is the FIRST
+/// in the repo, so `HEAD^{tree}` does not resolve and the probe falls back
+/// to `git write-tree` -- the one fallback in `probe_tree` that the
+/// repo-with-a-seed-commit fixtures never reach.
+///
+/// The assertion is `gpgsig ` in the raw commit object rather than
+/// `--format=%G?`: %G? reports `N` (no signature) without a configured
+/// `gpg.ssh.allowedSignersFile`, because it answers whether the signature
+/// VERIFIES against known signers, which is a different question and would
+/// fail this test for a reason that has nothing to do with signing.
+#[cfg(unix)]
+#[test]
+fn commit_signs_when_a_real_signer_is_configured() {
+    let _guard = RealRepoConfigGuard::new();
+    let repo = tempfile::tempdir().unwrap();
+    let rp = repo.path();
+    let keydir = tempfile::tempdir().unwrap();
+    let key = keydir.path().join("id_ed25519");
+
+    let keygen = std::process::Command::new("ssh-keygen")
+        .args(["-q", "-t", "ed25519", "-N", "", "-f"])
+        .arg(&key)
+        .status()
+        .expect("ssh-keygen must be available to test ssh signing");
+    assert!(keygen.success(), "ssh-keygen failed to generate a test key");
+
+    run_git_fixture(rp, &["init", "-q", "-b", "main"]);
+    run_git_fixture(rp, &["config", "user.name", "Legion Test Fixture"]);
+    run_git_fixture(rp, &["config", "user.email", "fixture@example.invalid"]);
+    run_git_fixture(rp, &["config", "commit.gpgsign", "true"]);
+    run_git_fixture(rp, &["config", "gpg.format", "ssh"]);
+    run_git_fixture(
+        rp,
+        &[
+            "config",
+            "user.signingkey",
+            keydir.path().join("id_ed25519.pub").to_str().unwrap(),
+        ],
+    );
+
+    // Staged, uncommitted: the repo is on an unborn branch.
+    std::fs::write(rp.join("README.md"), "first\n").unwrap();
+    run_git_fixture(rp, &["add", "README.md"]);
+
+    let data_dir = tempfile::tempdir().unwrap();
+    run_ok(commit_cmd(data_dir.path(), rp).args([
+        "commit",
+        "--repo",
+        "test-agent",
+        "--message",
+        GOOD_MESSAGE,
+    ]));
+
+    let raw = run_git_fixture_output(rp, &["cat-file", "commit", "HEAD"]);
+    assert!(
+        raw.contains("gpgsig "),
+        "the commit object must carry a signature, got: {raw}"
+    );
+
+    let audit_out =
+        run_ok(legion_cmd(data_dir.path()).args(["audit", "--action", "commit", "--json"]));
+    assert!(
+        audit_out.contains("\"outcome\": \"success\""),
+        "got: {audit_out}"
+    );
+    // The direction that matters: `signing` must track the config rather
+    // than being a constant that happens to read right when signing is off.
+    assert!(
+        audit_out.contains("\\\"signing\\\":true"),
+        "the audit row must record that this commit was signed, got: {audit_out}"
+    );
+}
+
+/// git can die BEFORE it ever reaches the signer -- an unresolvable
+/// committer identity is the common way -- and that is not a signing
+/// failure. Reporting it as one tells the operator to go unlock an agent
+/// that was never the problem, while git's own stderr was sitting there
+/// naming the actual fix.
+///
+/// This pins the 1-vs-128 split the probe relies on, which is an
+/// implementation detail of git rather than a documented contract: if a
+/// future git stops dying with 128 here, this test is what notices.
+#[cfg(unix)]
+#[test]
+fn commit_preflight_reports_a_git_refusal_as_a_refusal() {
+    let _guard = RealRepoConfigGuard::new();
+    let repo = tempfile::tempdir().unwrap();
+    let rp = repo.path();
+    run_git_fixture(rp, &["init", "-q", "-b", "main"]);
+    // No identity, and auto-detection disabled so git cannot invent one from
+    // the host's gecos/hostname -- which is exactly what it does otherwise,
+    // making this test pass or fail on whose machine it runs.
+    run_git_fixture(rp, &["config", "user.useConfigOnly", "true"]);
+    run_git_fixture(rp, &["config", "commit.gpgsign", "true"]);
+    run_git_fixture(rp, &["config", "gpg.format", "ssh"]);
+    run_git_fixture(rp, &["config", "gpg.ssh.program", "/usr/bin/false"]);
+    run_git_fixture(
+        rp,
+        &[
+            "config",
+            "user.signingkey",
+            "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIExampleKeyForFixtureUseOnly000000000",
+        ],
+    );
+    std::fs::write(rp.join("README.md"), "first\n").unwrap();
+    run_git_fixture(rp, &["add", "README.md"]);
+
+    let data_dir = tempfile::tempdir().unwrap();
+    let mut cmd = commit_cmd(data_dir.path(), rp);
+    // Identity from the ambient environment would defeat useConfigOnly.
+    for var in [
+        "GIT_AUTHOR_NAME",
+        "GIT_AUTHOR_EMAIL",
+        "GIT_COMMITTER_NAME",
+        "GIT_COMMITTER_EMAIL",
+        "EMAIL",
+    ] {
+        cmd.env_remove(var);
+    }
+    let (_stdout, stderr) =
+        run_fail(cmd.args(["commit", "--repo", "test-agent", "--message", GOOD_MESSAGE]));
+
+    assert!(stderr.contains("refusing to commit"), "got: {stderr}");
+    // git's own remediation must survive into the refusal -- it is the part
+    // that names the fix.
+    assert!(
+        stderr.contains("user.email"),
+        "git's guidance must be relayed, got: {stderr}"
+    );
+    // The discriminators: git's guidance appears on OTHER failure paths too,
+    // so containing it proves nothing on its own. This must be the probe's
+    // refusal, not a signing verdict and not the real commit failing.
+    assert!(
+        !stderr.contains("signing unavailable"),
+        "a git die is not a signer failure, got: {stderr}"
+    );
+    assert!(
+        !stderr.contains("git commit failed"),
+        "the preflight must catch this before the real commit runs, got: {stderr}"
+    );
+    assert_eq!(
+        run_git_fixture_output(rp, &["rev-list", "--all", "--count"]),
+        "0",
+        "nothing may be committed"
+    );
+}
+
 /// A locked signer is caught by the preflight even when the message is
 /// ALSO invalid: preflight runs first on purpose, because a locked signer
 /// needs the operator to go unlock something while a bad subject is a
@@ -449,6 +606,14 @@ fn commit_writes_audit_row_with_shas_card_and_gates() {
     assert!(
         audit_out.contains("\\\"pr_write\\\":\\\"absent\\\""),
         "expected the pr-write gate verdict in the details, got: {audit_out}"
+    );
+    // This fixture commits with `commit.gpgsign=false`, so the row must say
+    // so. The true direction is pinned by
+    // `commit_signs_when_a_real_signer_is_configured`, without which a
+    // hardcoded `false` would satisfy this assertion.
+    assert!(
+        audit_out.contains("\\\"signing\\\":false"),
+        "expected the signing flag in the details, got: {audit_out}"
     );
 }
 

--- a/tests/integration/commit.rs
+++ b/tests/integration/commit.rs
@@ -518,3 +518,49 @@ fn commit_underlying_git_failure_surfaces_and_audits() {
         "got: {audit_out}"
     );
 }
+
+/// The preflight must fire for every spelling git accepts as true, not just
+/// the literal `true`. `commit.gpgsign = yes` is valid git config; reading
+/// it as a raw string makes it read as "off", skips the preflight, and then
+/// signs for real during the commit -- surfacing the exact cryptic failure
+/// the preflight exists to replace, with nothing erroring to say why.
+#[cfg(unix)]
+#[test]
+fn commit_preflight_fires_for_every_truthy_gpgsign_spelling() {
+    let _guard = RealRepoConfigGuard::new();
+    for spelling in ["yes", "on", "1", "True"] {
+        let repo = setup_repo_with_staged_change();
+        let rp = repo.path();
+        run_git_fixture(rp, &["config", "commit.gpgsign", spelling]);
+        run_git_fixture(rp, &["config", "gpg.format", "ssh"]);
+        run_git_fixture(rp, &["config", "gpg.ssh.program", "/usr/bin/false"]);
+        run_git_fixture(
+            rp,
+            &[
+                "config",
+                "user.signingkey",
+                "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIExampleKeyForFixtureUseOnly000000000",
+            ],
+        );
+        let data_dir = tempfile::tempdir().unwrap();
+        let before = head_sha(rp);
+
+        let (_stdout, stderr) = run_fail(commit_cmd(data_dir.path(), rp).args([
+            "commit",
+            "--repo",
+            "test-agent",
+            "--message",
+            GOOD_MESSAGE,
+        ]));
+
+        assert!(
+            stderr.contains("signing unavailable"),
+            "commit.gpgsign={spelling} must preflight, got: {stderr}"
+        );
+        assert_eq!(
+            before,
+            head_sha(rp),
+            "commit.gpgsign={spelling} must refuse before committing"
+        );
+    }
+}

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -8,6 +8,7 @@
 mod common;
 
 mod bullpen;
+mod commit;
 mod css_symbols;
 mod daemon_watch;
 mod documents;


### PR DESCRIPTION
## Summary

`legion commit` closes the last unaudited hop in the mutation path. `legion push` (#791/#834)
routes pushes and #836 fences `gh`, but the commit itself -- where authorship, trailers, and
signing happen -- was still raw `git`, invisible to the audit log and unprotected by any
preflight. A perimeter assembled by fencing the hops that caused incidents leaves the hops that
have not yet caused one, and those read as covered precisely because everything around them is.

The verb does three things `git commit` does not. It preflights the configured signer before
anything is written, so a locked key fails once by name instead of as five cryptic retries. It
validates the message against this repo's actual conventions and refuses violations by name,
so a bad subject costs a re-run rather than an amend. And it writes an audit row on every
attempt -- refusals included -- carrying the resolved checkout, pre/post HEAD, card id, whether
the commit was signed, and the quality-gate state of the commit being built on.

This is the first of the two halves #854 describes. The verb is here; the PreToolUse hook that
routes plain `git commit` into it is deliberately not, and is mapped honestly below.

Dogfooding note: the last three commits on this branch were made with the verb itself, which
exercised preflight, validation, and the audit row end to end against a real signer. That is
also how the `commit.gpgsign` spelling bug described under the preflight criterion was worth
catching before merge rather than after.

## Acceptance criteria mapping

### `legion commit` lands a signed commit in the resolved checkout with an audit row carrying agent, branch, pre/post SHA, and gate state

`handle_commit` resolves the checkout to the repo root containing the CWD via `git rev-parse
--show-toplevel`, so the verb works from a subdirectory and records the resolved root rather
than wherever the caller happened to stand. Signing is never turned on or off by this code --
git's own `commit.gpgsign` config decides, and the verb only preflights it -- so "lands a
signed commit" is a contract inherited from the repo's configuration, not one this verb
asserts. What the verb owes is that it reports that configuration honestly and does not
silently skip the signer, and both halves are now proven rather than assumed: the audit row
records `signing` (read once, before the commit, so it describes the config as it was when the
commit ran rather than as it is when someone reads the row later), and a positive fixture
generates a real ed25519 key, commits through the verb, and asserts the resulting commit object
actually carries a `gpgsig ` header.

The audit row is written through the same `cli::util::audit` helper `legion push` uses, with
`agent` from `--repo`, `target_ref` set to the branch, and a `details` payload carrying
`checkout`, `pre_sha`, `post_sha`, `post_sha_error`, `card_id`, `gates`, and `signing`.

Three details worth calling out because they are decisions rather than mechanics. Gate state is
read from the PRE-commit HEAD and read before the commit runs, because it describes the commit
being built ON, not the one being created. It is three-valued, not the two the issue sketched:
a gate that recorded ISSUES is neither clean nor absent, and collapsing it into either bucket
would put a falsehood in the audit trail -- so `gate_state` reports `clean`/`issues`/`absent`,
plus `unknown` if the DB read itself fails. And the row's `outcome` tracks whether the COMMIT
happened and nothing else: a landed commit whose new HEAD will not read back is still a landed
commit, so that case records the read failure in `post_sha_error` and stays `success`, rather
than flipping the row to `failure` and denying a mutation that is already on disk.

Checkout resolution deliberately does NOT copy `legion push`'s cross-worktree resolution.
Push has to resolve, because it takes a `--branch` that may live in another worktree; commit
operates on the staged index, which is per-checkout state only the CWD's checkout has.

Evidence: `commit_writes_audit_row_with_shas_card_and_gates` (tests/integration/commit.rs:556)
asserts the action, outcome, branch, resolved checkout path, both SHAs, the card id, both gate
verdicts, and `signing:false` on a real audit row. `commit_signs_when_a_real_signer_is_configured`
(:388) is the success direction, and is what keeps the signing assertions honest -- every other
signing test asserts a refusal, so a preflight that refused unconditionally would satisfy all of
them; this one asserts `gpgsig ` in the raw commit object and `signing:true` on the row.
`commit_resolves_the_repo_root_from_a_subdirectory` (:160) covers subdirectory invocation.
`gate_state_distinguishes_clean_issues_and_absent` (src/cli/commit.rs:1143) pins the
three-valued verdict; the `Committed` split that keeps a landed commit out of the failure
bucket is at src/cli/commit.rs:200.

### Locked-signer preflight fails with a named reason before mutating anything

`preflight_signer` runs first in `preflight_validate_and_commit`, before message validation.
That order is load-bearing and deliberate even though validation is far cheaper: a locked
signer needs the operator to go unlock something, while a malformed subject is a five-second
fix, so surfacing the slow failure first costs one round trip instead of two.

The probe signs a throwaway commit object with `git commit-tree -S`, which is git's own
`sign_buffer` path by construction -- it writes one unreferenced object and touches no ref,
index, or working-tree file. `git commit --dry-run` was not an option: it never reaches the
signer at all. Invoking the configured signer directly was rejected for a sharper reason --
it would mean reimplementing git's key selection (`user.signingkey` resolution, ssh
literal-key-vs-path handling, openpgp's fallback of deriving the key from the committer
email), and a probe that picks a different key than the real commit will is worse than no
probe.

The refusal is only useful if it points at the right thing, and review found that it did not.
git can die BEFORE it ever invokes the signer -- an unresolvable committer identity is the
ordinary way -- and every non-zero exit was being reported as "signing unavailable", which
sends the operator to unlock an agent that was never the problem while git's own stderr sat
there naming the actual fix. Exit code discriminates, measured against git 2.54.0: 128 is git
giving up before the signer, 1 is the signer itself failing. A 128 is now a plain refusal
carrying git's stderr verbatim; anything else keeps the signing arm, so an unrecognized code
degrades to the previous behaviour rather than to silence. Because that reading depends on
git's English output, the probe pins `LC_ALL=C` and clears `LANGUAGE` -- under `fr_FR` git says
`erreur:` and every assumption about the text quietly stops holding. Deliberately NOT done:
discriminating on the `error:`/`fatal:` prefixes themselves, which is the same locale bet
wearing a different hat.

The error names the program to unlock, mirroring git's format-to-program mapping so the
operator sees the binary they actually need, and it now names both remedies rather than one:
the probe cannot tell a locked agent from a misconfigured signer, so a message that asserts
"unlock your signer" sends half the callers to the wrong place. `signer_failure_detail` relays
every informative line rather than the first, because the first is routinely the least useful
one and the remedy tends to be the last -- the previous first-line-only extraction discarded
git's `git config user.email` guidance entirely. It still handles the measured case where git
relays a silent signer's failure as nothing but a bare `error: ` prefix, falling back to a
literal rather than printing a refusal with a hole where the reason should be.

Whether the preflight runs at all is decided by reading `commit.gpgsign` through `git config
--type=bool`, not by string-comparing it against `"true"`. This is the one thing that changed
during review on this branch, and it is worth stating plainly because it was a silent
degradation rather than a visible bug: git's boolean parser also accepts `yes`, `on`, `1`, any
case variant, and the bare-key form, and every one of those spellings previously read as "off",
skipped the preflight, and then signed for real during the commit -- producing exactly the
cryptic signer failure this verb exists to replace, with nothing erroring to say why. Delegating
to `--type=bool` is the same argument the module already makes for routing the probe through
`commit-tree`: use git's own parser rather than reimplementing it.

One accepted cost, documented rather than fixed: an INTERACTIVE signer is invoked twice per
commit, once by the probe and once by the real commit, so pinentry, a 1Password confirm dialog,
or a touch-required key asks twice. That is inherent to preflighting -- you cannot ask a signer
whether it can sign without asking it to sign. Invisible with a cached agent, a real per-commit
tax otherwise, so it is stated in the module doc where someone debugging "why am I touching my
key twice" will find it.

Evidence: `commit_preflight_refuses_when_the_signer_cannot_sign`
(tests/integration/commit.rs:327) points `gpg.ssh.program` at `/usr/bin/false` and asserts the
refusal names the program, says "unlock your signer", and that HEAD did not move.
`commit_preflight_reports_a_git_refusal_as_a_refusal` (:460) pins the 1-vs-128 split with an
unresolvable identity, asserting the refusal relays git's `user.email` guidance and is neither
a signing verdict nor the real commit failing; it was verified to fail against the pre-fix
implementation with `signing unavailable (/usr/bin/false): Author identity unknown`, which is
the misattribution and the truncation in one line.
`commit_preflight_runs_before_message_validation` (:530) pins the ordering by passing a message
that is ALSO invalid and asserting the signer error wins.
`commit_preflight_fires_for_every_truthy_gpgsign_spelling` (:694) loops `yes`/`on`/`1`/`True`
and asserts each one preflights; it was verified to fail against the pre-fix implementation
(the commit reached the real signer and died on "failed to write commit object") and pass
after. The probe's exit-code handling and locale pin are at src/cli/commit.rs:438; the
double-prompt cost is documented at src/cli/commit.rs:402-408.

### Message-convention violations are refused by name (bad ref format, missing trailer, emoji)

`validate_message` enforces four rules as four distinct refusals, each naming what to change:
no emoji anywhere, a `<type>(<scope>): <summary>` subject, a blank line after the subject, and
a `Co-Authored-By` trailer as the last non-empty line. The emoji scan runs first because it is
the only rule that can fire on the subject AND the body, and reporting "bad subject" for a
message whose real problem is a rocket in paragraph three sends the caller to the wrong line.

The rules encode what this repo's history actually contains rather than the Conventional
Commits spec. The accepted types are the eight that appear as type tokens across all 494
commits of history -- not a recent window, so there is nothing outside it to have missed. Three
types are absent for two different reasons, and review caught this PR stating it wrongly:
`build` and `revert` have genuinely never appeared as type tokens (git's auto-generated
`Revert "..."` subjects are not the conventional `revert` type and do not parse as one), while
`ci` HAS appeared, exactly once, in bdd7dd8 (2026-04-28). It stays excluded on purpose -- one
subject is an instance, not a convention -- but the exclusion is now justified by that, rather
than by a claim about history that was not true. One token outside the spec set completes the
census: `release` appeared twice (4c44f5f and c9b357d, both 2026-06-18) as the older spelling of
what is now `chore(release)`, and is excluded for the same reason as `ci`. Those ten are the
whole census, established by scanning the complement rather than by asserting it: every
remaining subject parses as no type at all -- merges, git's generated `Revert "..."`, and
pre-convention prose (`Recovery: ...`, `v0.6.2: ...`, `Initial commit`). The scope is REQUIRED,
which is what makes `chore(release): 0.25.0` pass and a bare `chore: bump` fail. There is no
subject length cap, because this repo routinely writes subjects past 72 characters and a rule
the repo violates on most commits is not a rule. The trailer match is case-insensitive because history carries both
`Co-Authored-By:` and GitHub's `Co-authored-by:`, and refusing one of two spellings already in
use would be inventing a rule rather than encoding one.

The emoji table is a codepoint-range const, deliberately not a complete Unicode-emoji property
table: it covers the blocks anyone actually reaches for while leaving Misc Technical alone,
because that block mixes a few emoji in with Mac modifier glyphs and a false refusal on a
legitimate character is worse than missing a stopwatch.

Evidence: `commit_refuses_unscoped_subject` (tests/integration/commit.rs:182),
`commit_refuses_unknown_type` (:201), `commit_refuses_missing_coauthor_trailer` (:217), and
`commit_refuses_emoji` (:235), which asserts the codepoint `U+1F680` appears in the refusal.
Each also asserts HEAD did not move. Unit-level: sixteen `validate_message`/`validate_subject`
cases at src/cli/commit.rs:889-1017, including
`validate_message_reports_the_emoji_when_the_subject_is_also_wrong` (:1004), which pins the
emoji-first ordering with a message that breaks both rules at once, and
`find_emoji_ignores_ordinary_prose_and_punctuation` (:1019), which pins em dashes, curly quotes
and accented latin as NOT emoji. The corrected type-list rationale is at src/cli/commit.rs:52.

### Hook routes `git commit` to the verb; deny shapes (`--amend` on a pushed head, `-n`/`--no-verify`) are refused with the reason named

**Not implemented in this PR.** No `no-git-commit.sh` hook ships here and no `settings.json`
PreToolUse entry is added; plain `git commit` still runs unrouted after this merges. This is
the deliberate second half of #854, split so the verb can be reviewed and used on its own
merits before it becomes mandatory for every commit in the repo.

The split is not just sequencing convenience -- the hook makes this verb's policy repo-wide,
and one of those policies deserves an explicit decision rather than inheritance. The validator
requires a scope on every subject, so routing every `git commit` through here makes
scope-required the law for all commits, including shapes that do not carry one today (`Revert
"..."` subjects that git generates, and merge-commit subjects). That question belongs to the
hook issue, where it is a policy choice, not to this one, where it would be a silent
side effect. The module doc records this for whoever picks it up.

Evidence: src/cli/commit.rs:25-29 states the deferral and the scope-required consequence in the
module doc, so the constraint is carried in the code rather than only in this PR description.
Follow-up issue #856 covers the hook, the deny shapes, and the three policy questions listed
under "Not done".

### Test coverage for preflight failure, convention refusals, audit row content, and hook translation

Three of the four are covered; the fourth follows the criterion above.

Preflight failure, convention refusals, and audit row content each have dedicated integration
tests driving a real git fixture repo, because the command's whole job is shelling out to git
and a mocked git would test the mock. The coverage is deliberately two-sided in two places. The
audit trail: a refused commit is still an attempted mutation, and a verb whose point is the
audit trail must prove it records the refusals too, not just the successes. And the signer: the
suite now proves the preflight lets a WORKING signer through, not only that it catches broken
ones, which is the assertion that would fail first if the probe ever started refusing
unconditionally. There is also coverage for the underlying `git commit` failing after
validation passed (nothing staged), which exercises a different arm than any refusal does.

The positive signing fixture doubles as the unborn-branch path end to end: it commits as the
FIRST commit in a fresh repo, so `HEAD^{tree}` does not resolve and the probe takes
`probe_tree`'s `git write-tree` fallback (src/cli/commit.rs:537) -- the one branch that every
seed-a-commit-first fixture skips. It is hermetic: the ed25519 key is generated per run with no
passphrase, in its own tempdir rather than inside the checkout under test, so nothing on the
host is consulted and no key file shows up as a staged change. It asserts `gpgsig ` in the raw
commit object rather than `git log --format=%G?`, because %G? answers whether the signature
VERIFIES against a configured `allowedSignersFile` and would report `N` here for a reason that
has nothing to do with whether signing happened.

The fixtures carry two isolation rules that are load-bearing rather than incidental: identity
goes in the temp repo's LOCAL config, because the binary under test spawns its own `git commit`
with no `-c` overrides and would otherwise fail with "Committer identity unknown" for the wrong
reason; and `GIT_CONFIG_GLOBAL`/`GIT_CONFIG_SYSTEM` are swapped on the binary's env, because the
operator's real global config carries `commit.gpgsign=true` and a `core.hooksPath` pointing at
a pre-commit hook that runs a nested Claude review with a two-minute budget. The exit-128 test
adds a third: it clears `GIT_AUTHOR_*`/`GIT_COMMITTER_*`/`EMAIL` from the child env and sets
`user.useConfigOnly`, so git cannot invent an identity from the host's gecos and make the test
pass or fail on whose machine it runs.

Hook-translation coverage is absent because the hook is absent; it ships with the hook.

Evidence: `commit_writes_audit_row_with_shas_card_and_gates`
(tests/integration/commit.rs:556), `commit_signs_when_a_real_signer_is_configured` (:388),
`commit_writes_a_failure_audit_row_when_it_refuses` (:625),
`commit_underlying_git_failure_surfaces_and_audits` (:653), plus the preflight and convention
tests cited above -- 18 integration tests and 29 unit tests for this verb. Full suite:
`cargo test` at 1717 unit + 375 integration passed, 0 failed; `cargo clippy --all-targets --
-D warnings` clean; `cargo fmt -- --check` clean.

## Not done

- **The PreToolUse hook (`no-git-commit.sh`) and its deny shapes.** Deferred by scope, as
  mapped above. Plain `git commit` remains unrouted after this merges, so the perimeter is not
  yet complete -- this PR makes the audited path exist and usable, it does not make it
  mandatory. Follow-up issue #856 covers the hook, `--amend`-on-a-pushed-head and
  `-n`/`--no-verify` refusals, and the hook-translation tests.
- **Three policy questions flagged for issue #856, not decided here.** (1) Scope-required
  currently has no exemption for `Revert "..."` or merge-commit subjects, which git generates
  in shapes this validator would refuse; once every `git commit` routes through the verb that
  becomes a real blocker rather than a hypothetical. (2) Whether scope-required is the right
  repo-wide law at all, versus warn-only for non-agent commits. (3) Multi-ref scopes are refused
  by the current scope charset, which allows neither the comma nor the space -- four historical
  uses: `feat(#279, #280, #281)`, `feat(#283, #413)`, `feat(#395, #396)`, and
  `feat(#426, #427, #428, #429, #430)`. Allowing them or ruling them out is a decision, not an
  oversight to patch quietly. All three are cheap to decide with the hook in front of you and
  expensive to guess at now.
- **No staged-changes precheck.** With nothing staged, the verb runs the signer preflight and
  message validation, then lets `git commit` fail with its own "nothing to commit" text. The
  outcome is correct and audited (`commit_underlying_git_failure_surfaces_and_audits`), but the
  ordering is a papercut: the caller pays for a signer probe before being told there was
  nothing to commit. A cheap `git diff --cached --quiet` ahead of the preflight would fix it.
  Left alone here rather than widening the diff.
- **`--card` is recorded but not validated against the kanban.** The value lands on the audit
  row's `task_id` and in `details.card_id` verbatim; a typo'd or nonexistent card id is stored
  as given. Validating would mean a DB lookup and a refusal path with its own semantics
  (does an unknown card block the commit, or warn?), which is a decision worth making
  deliberately rather than inside this change.
- **No cross-worktree resolution.** Unlike `legion push`, the verb only commits in the CWD's
  checkout. This is a design choice, not an omission -- the staged index is per-checkout state
  -- but it is worth stating so nobody reads the asymmetry with `push` as an oversight.
- **The 1-vs-128 exit-code split is an implementation detail of git, not a documented
  contract.** It is measured against git 2.54.0 and pinned by
  `commit_preflight_reports_a_git_refusal_as_a_refusal`, so a future git that stops dying with
  128 here fails a test rather than silently misattributing again. An unrecognized exit code
  falls through to the signing arm, which is the pre-existing behaviour.
- **`git_config_bool` groups a malformed value with an unset one.** `commit.gpgsign = maybe`
  makes `--type=bool` exit non-zero, which reads as `None` and therefore as "no signing
  configured", so the preflight is skipped. The failure mode is benign -- the real `git commit`
  then fails on git's own self-explanatory "bad boolean config value" -- but the accessor's doc
  comment claims a caller can distinguish "off" from "no such key", which is only true for
  well-formed values. Worth tightening if anything ever relies on that distinction.

Refs #854
