### PR TITLE
fix(#844/#845/#861): tag only the release commit, isolate cross-repo docs work, and fence the fixture harness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,12 @@ plugin/.legion-binary-path
 # transient artifact, not source.
 /index.scip
 
+# The embedding model's download cache, written at the repo root the first time
+# a model is fetched. Reproducible from the network on demand, several hundred
+# megabytes, and not source. (Re-added: this line was lost in the 2026-08-03
+# incident that rewrote main.)
+.fastembed_cache/
+
 # Agent worktrees created by the Task tool's worktree isolation mode.
 # These contain .git references back to the parent and must never be
 # committed -- a stray gitlink mode 160000 entry will break checkout@v5

--- a/plugin/commands/legion-release.md
+++ b/plugin/commands/legion-release.md
@@ -35,43 +35,110 @@ version, real prose, every bullet cited, correct release-type rationale. If it i
 thin or wrong, send the agent back with specifics. Do NOT hand-write the entry
 yourself -- that is the agent's job; you are the editor.
 
-## 4. Ship it
+## 4. Ship it -- through the queue, like every other change
 
-Run `scripts/release.sh NEW` (pass the explicit version, plus `--activate` and/or
-`--dry-run` if the operator gave them). The script reads `release.toml` for the
-version source, changelog path, propagation targets, and tag format (`Cargo.toml`
-/ `plugin/CHANGELOG.md` / `v{version}` for legion itself), runs preflight (fmt,
-clippy, test, SCIP regen), bumps the version file, refreshes `Cargo.lock`, syncs
-the manifests, commits `chore(release): NEW`, tags, and pushes -- which fires the
-release CI that builds and publishes the platform binaries. The script validates
+The release commit is not special and no longer behaves as if it were. Until
+#844 this step was one `scripts/release.sh NEW` invocation that committed,
+tagged and pushed straight to `main`, bypassing the pull-request rule, the merge
+queue and seven required status checks on the one commit that reaches every
+agent in the cluster (the marketplace sets `autoUpdate: true`). It now runs as a
+chain, and **only the tag is ever pushed to `main`**.
+
+**4a. Stage.** Run `scripts/release.sh NEW` (explicit version, plus `--activate`
+and/or `--dry-run` if the operator gave them). It reads `release.toml` for the
+version source, changelog path, propagation targets, work-source repo name and
+tag format, runs preflight (fmt, clippy, test, SCIP regen), bumps the version
+file, refreshes `Cargo.lock`, syncs the manifests, commits `chore(release): NEW`
+**onto `release/NEW`**, and pushes that branch with `legion push`. It validates
 that the CHANGELOG header the agent wrote matches the bumped version; a mismatch
-aborts the release, which is the safety net.
+aborts before anything is committed. Nothing is tagged yet, and the script says
+so.
 
 If `--dry-run` was passed, stop here and report what would have happened.
 
-## 5. Docs review on shingle
+**4b. Earn the gates.** On `release/NEW`, run `/legion:legion-simplify` and then
+`/legion:legion-pr-write`. This is not ceremony to work around a tool -- it is
+the point of the change. Both gates are keyed to the release commit's hash and
+`legion pr create` refuses without a clean row for each, which is exactly what
+every feature branch faces. Do not reach for `--skip-gates`.
 
-Resolve the shingle repo path from watch.toml -- `legion watch list` maps `shingle`
-to its working directory; the runlegion.dev docs live under
-`<shingle>/sites/runlegion.dev/src/pages/docs/` (do not hardcode an absolute path,
-it differs per machine). Spawn `writer-legion` (Task, subagent_type `writer-legion`)
-with the new changelog entry. Brief it: review the release against the docs pages
-under that dir (concepts, architecture, cli-reference, getting-started, plugin-guide
-at time of writing -- read the directory rather than trusting this list to stay
-complete). If the
-release changes user-facing behavior -- a new/changed command, verb, flag, config
-knob, or concept -- update the affected pages on a `docs/legion-NEW` branch in the
-shingle repo, in the writer-legion voice. If nothing user-facing changed (internal
-refactor, test-only, CI), it should say so and write nothing -- not every release
-needs docs.
+**4c. Open and enqueue.** `legion pr create --repo legion --title "chore(release):
+NEW" --head release/NEW --body-file <the body you validated>`, then `legion pr
+merge --repo legion --number <N>`. On a queue-enabled base this enqueues and
+returns immediately; the merge is asynchronous.
 
-If writer-legion produced doc changes, open the shingle PR for them through the
-normal gate flow (issue -> branch -> simplify gate -> pr-write -> `legion pr create
---repo shingle`), exactly as a runlegion.dev docs PR is opened. Report the PR URL.
+**4d. Tag the commit that actually landed.** Run `scripts/release.sh NEW
+--finish=<N>` (re-pass `--activate` if the operator asked for it). It polls until
+the merge lands, then re-reads `origin/main`, verifies that tree really carries
+`NEW`, tags **that** sha, and pushes only the tag -- which fires the release CI.
+The verification is load-bearing: the queue may squash or rebase, so the merged
+sha is not the branch tip, and tagging the branch tip would point the release at
+an object that is not on `main`.
+
+Three failures this step reports rather than papers over, all of which leave
+nothing tagged:
+
+- **Ejected from the queue.** It happens (it happened in the 0.25.0 batch).
+  Merge `origin/main` into the branch -- never rebase, `legion push` has no force
+  path -- re-run the gates, push, re-enqueue, then re-run `--finish`.
+- **Timeout.** A failure to *observe* the merge, not evidence the release commit
+  failed. Check the PR, then re-run `--finish` once it has landed.
+- **Tagging failed after a successful merge.** Reported as INCOMPLETE BUT
+  RECOVERABLE, naming the merged sha. The version bump is already on `main`;
+  re-running `--finish` completes it and is idempotent from that point.
+
+## 5. Docs review on shingle -- in a worktree the script gives you
+
+**Do not resolve shingle's checkout path and do not send an agent into it.** That
+repo has its own agent who may be working in that tree right now, and you cannot
+see them. Cutting v0.25.0 swept another agent's uncommitted `cli-reference.mdx`
+edits into the docs commit through the shared working tree -- and note that a
+`git add <file>` *by name*, not `-A`, still took their whole file.
+
+Run `scripts/release.sh --docs-worktree`. It resolves shingle from `watch.toml`
+itself, creates an isolated worktree off a **remote** ref on the stable docs
+branch (`docs/legion-current`), and prints that worktree's path -- the only thing
+on stdout. Hand `writer-legion` **that path and only that path**. If it fails, it
+fails named (a stale worktree or branch from an earlier release is reported, not
+clobbered) and the docs step stops; there is no fallback to the shared checkout,
+because that fallback is the defect.
+
+The branch is stable on purpose (#820). Docs describe the CURRENT state, not
+per-version history, so each release EXTENDS the one open runlegion.dev docs PR
+rather than stacking a `docs/legion-<ver>` branch per release -- five of those
+stacked and conflict-cascaded across 0.20 through 0.24. When the branch already
+exists on the remote, the script starts from it and merges `origin/main` in.
+
+Spawn `writer-legion` (Task, subagent_type `writer-legion`) with the new
+changelog entry and the worktree path. Brief it: the runlegion.dev docs live
+under `<worktree>/sites/runlegion.dev/src/pages/docs/` -- read that directory
+rather than trusting any list of pages to stay complete. If the release changes
+user-facing behavior -- a new/changed command, verb, flag, config knob, or
+concept -- update the affected pages there, in the writer-legion voice, describing
+the current state rather than framing it as "new in X.Y". If nothing user-facing
+changed (internal refactor, test-only, CI), it should say so and write nothing --
+not every release needs docs.
+
+If writer-legion produced doc changes, take them through shingle's normal gate
+flow from inside the worktree (issue -> simplify gate -> pr-write -> `legion pr
+create --repo shingle`), or extend the open docs PR if one is already on that
+branch. `legion push` resolves the checkout holding the branch itself, so it
+works from the worktree unchanged. Report the PR URL.
+
+When the docs step is done, run `scripts/release.sh --docs-worktree-done=<path>`.
+It removes the worktree when nothing would be lost -- unchanged, or already
+pushed -- and RETAINS it, naming the path, when it carries work that is not on
+the remote, so a failed or partial docs run is recoverable rather than discarded.
+
+A docs step that fails does not fail the release: the tag is pushed and the
+binaries are building by then. Report it as an incomplete follow-up naming the
+worktree path so it can be resumed.
 
 ## 6. Report
 
-Summarize: the version shipped, the tag, the release CI status, whether docs were
-updated (and the PR if so), and -- if `--activate` was used -- the local daemon's
-new version from `/health`. Note any follow-up (e.g. "verify the GitHub Release
-published" if the CI build had not finished).
+Summarize: the version shipped, the release PR number and the sha the queue
+actually produced, the tag and what it points at, the release CI status, whether
+docs were updated (and the PR if so), and -- if `--activate` was used -- the local
+daemon's new version from `/health`. Note any follow-up (e.g. "verify the GitHub
+Release published" if the CI build had not finished, or a retained docs worktree
+path if the docs step did not finish).

--- a/release.toml
+++ b/release.toml
@@ -43,6 +43,40 @@ tag_message = "legion {version}"
 # Optional co-authorship trailer appended to the release commit message.
 # Defaults to legion's own release agent when omitted.
 co_authored_by = "Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+# The name this repo answers to in watch.toml -- what `legion push` and
+# `legion pr *` resolve their work source from. Defaults to the checkout's
+# directory name when omitted, which is the convention every registered repo
+# already follows. Since #844 the release commit goes through a PR and the
+# merge queue like any other change, so the release needs this name.
+repo = "legion"
+# Bounded wait for the merge queue (#844): `legion pr merge` enqueues and
+# returns, so `release.sh --finish` polls until the merge lands. Budget is
+# expressed in polls x seconds -- 90 x 20s = 30 minutes -- and expiry is a
+# named "failed to observe the merge" error, not a failed release. Defaults
+# to these values when omitted.
+merge_wait_polls = 90
+merge_wait_interval = 20
+
+# Cross-repo docs target (#845). The release's docs step commits to a repo that
+# is not this one, and the operator rule is that commits to a repo you do not
+# own go in a WORKTREE -- that repo's agent may be in-process in its checkout
+# and you cannot see them. `scripts/release.sh --docs-worktree` reads this
+# section, creates the worktree off a remote ref, and prints only the worktree
+# path; the shared checkout is never handed to an agent. Omit the section
+# entirely in a repo whose release has no cross-repo docs step.
+[docs]
+# watch.toml name of the repo holding the docs. Its checkout is resolved via
+# `legion watch list`, never hardcoded -- the path differs per machine.
+repo = "shingle"
+# The docs branch. This MUST be a STABLE name, not a version-pinned one (#820):
+# a per-release docs/legion-<ver> branch stacks a new PR every release and the
+# stack conflict-cascades (five deep on 0.20->0.24). Docs describe the CURRENT
+# state, so each release extends the same branch. Defaults to
+# "docs/<git.repo>-current" when omitted.
+branch = "docs/legion-current"
+# Branch in the docs repo the worktree starts from (and merges in when the
+# stable branch already exists remotely). Defaults to "main".
+base = "main"
 
 [preflight]
 # Commands run, in order, repo-root relative, before a release is cut. Each

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -52,9 +52,11 @@
 #   8. Polls, bounded, until the merge lands -- `legion pr merge` enqueues and
 #      returns, so the merge is asynchronous. An ejection or a timeout stops the
 #      release with the reason named and tags nothing.
-#   9. Re-reads origin/<branch>, verifies the merged tree really carries <new>,
-#      tags THAT sha per the configured tag format, and pushes ONLY the tag --
-#      which fires release.yml.
+#   9. Re-reads origin/<branch>, verifies its tip really carries <new> (proving
+#      the release landed and that no later release superseded it), resolves the
+#      RELEASE COMMIT within that branch -- not the tip, which by then may be
+#      several unrelated merges ahead -- tags THAT sha per the configured tag
+#      format, and pushes ONLY the tag, which fires release.yml.
 #  10. With --activate: builds the release binary, installs it to the plugin data
 #      dir atomically, and restarts the local daemon (verifying it comes back up).
 #
@@ -68,11 +70,12 @@
 # The pure helpers below (compute_new_version, is_semver, is_strictly_greater,
 # non_changelog_dirty, field_leaf, render_tag, bump_source_file,
 # classify_release_merge, wait_for_release_merge, tag_target_matches,
-# watch_repo_root, docs_start_point, worktree_holding_branch,
-# worktree_is_disposable) are unit-tested by scripts/test-release.sh, which
-# sources this file. main() runs only when the script is executed, not when it is
-# sourced. Implementation is kept POSIX-portable (no GNU-only sed/sort) because
-# the release is cut on darwin, where BSD sed/sort lack the GNU extensions.
+# release_boundary_commit, watch_repo_root, docs_start_point,
+# worktree_holding_branch, worktree_is_disposable) are unit-tested by
+# scripts/test-release.sh, which sources this file. main() runs only when the
+# script is executed, not when it is sourced. Implementation is kept
+# POSIX-portable (no GNU-only sed/sort) because the release is cut on darwin,
+# where BSD sed/sort lack the GNU extensions.
 set -euo pipefail
 
 info() { printf '[release] %s\n' "$1" >&2; }
@@ -206,6 +209,15 @@ bump_source_file() {
 # evidence of ejection on its own (the queue admits a bounded group size, so a
 # PR can sit un-enqueued for a while), which is why that case stays `pending`
 # and expires into a timeout instead of a false ejection report.
+#
+# `landed` and `queue_present` may also be the literal string `unknown`, which
+# means the OBSERVATION FAILED -- the fetch or the ls-remote did not complete,
+# so nothing at all was learned this poll. That is not "no" and it must have its
+# own arm: every comparison below is `= "1"`, so without this a third value
+# falls straight through to the `ejected` branch and a network outage gets
+# reported as an ejection from the merge queue. An unreadable observer is
+# `pending`, which spends the budget and expires into a timeout -- a timeout
+# says "I could not observe the merge", which is exactly what happened.
 classify_release_merge() {
   local landed="$1" state="$2" queue_present="$3" seen_queued="$4"
   if [ "$landed" = "1" ]; then printf 'merged\n'; return 0; fi
@@ -213,6 +225,11 @@ classify_release_merge() {
     MERGED|merged) printf 'merged\n'; return 0 ;;
     CLOSED|closed) printf 'closed\n'; return 0 ;;
   esac
+  # Placed AFTER the state arms deliberately: a PR state read from a different
+  # source is still a positive signal when the git observers are blind.
+  if [ "$landed" = "unknown" ] || [ "$queue_present" = "unknown" ]; then
+    printf 'pending\n'; return 0
+  fi
   if [ "$queue_present" = "1" ]; then
     printf 'queued\n'
   elif [ "$seen_queued" = "1" ]; then
@@ -222,19 +239,28 @@ classify_release_merge() {
   fi
 }
 
-# wait_for_release_merge <max_polls> <interval> <landed_cmd> <state_cmd> <queue_cmd>
+# wait_for_release_merge <max_polls> <interval> <landed_fn> <state_fn> <queue_fn>
 #   -> prints merged|closed|ejected|timeout; rc 0|3|4|5
 #
 # The bounded poll `legion pr merge` makes necessary: enqueuing returns
 # immediately and the merge happens later, so the release has to wait for it.
-# The three observers are injected as command STRINGS rather than called
-# directly, which is what makes the loop testable -- the tests pass `printf`
-# one-liners and a counter file, and never need gh, git or a network. In
-# production they are the release_landed / release_pr_state /
-# release_queue_ref_present calls below. They are `eval`d in THIS shell rather
-# than run under `bash -c`, so a sourced helper resolves without exporting it:
-# a subshell that could not see release_landed would report landed=0 forever
-# and time out a release that had actually merged.
+# The three observers are injected as FUNCTION NAMES and called directly --
+# never `eval`d, and never assembled from interpolated values. That is a
+# security property, not a style choice: the old form built command strings out
+# of the PR number and four release.toml fields, so a hostile (or merely
+# malformed) `git.branch` or `--finish=` argument became shell. Taking a name
+# and calling it removes the sink entirely while keeping the loop just as
+# testable -- the tests pass their OWN function names, and never need gh, git or
+# a network. In production the names are closures defined in finish_release,
+# which bind the release_landed / release_pr_state / release_queue_ref_present
+# arguments as ARGV. Being plain function calls, they resolve in this shell, so
+# a sourced helper is visible without exporting it: a subshell that could not
+# see release_landed would report landed=0 forever and time out a release that
+# had actually merged.
+#
+# An observer that exits non-zero is `unknown` for the two git-backed signals
+# (NOT `0`, which would assert "definitely not merged / definitely not in the
+# queue" on the strength of a failure) and `UNKNOWN` for the advisory PR state.
 #
 # An `ejected` verdict must be seen TWICE in a row before it is reported: the
 # queue ref also disappears at the moment of a successful merge, so a single
@@ -245,13 +271,13 @@ classify_release_merge() {
 # The budget is expressed in polls, not wall-clock, so a timeout is exactly
 # reproducible in a test and the failure message can state the budget it spent.
 wait_for_release_merge() {
-  local max_polls="$1" interval="$2" landed_cmd="$3" state_cmd="$4" queue_cmd="$5"
+  local max_polls="$1" interval="$2" landed_fn="$3" state_fn="$4" queue_fn="$5"
   local poll=0 landed state queue_present obs seen_queued=0 ejected_streak=0
   while [ "$poll" -lt "$max_polls" ]; do
     poll=$((poll + 1))
-    landed="$(eval "$landed_cmd" 2>/dev/null || printf '0')"
-    state="$(eval "$state_cmd" 2>/dev/null || printf 'UNKNOWN')"
-    queue_present="$(eval "$queue_cmd" 2>/dev/null || printf '0')"
+    landed="$("$landed_fn" 2>/dev/null </dev/null || printf 'unknown')"
+    state="$("$state_fn" 2>/dev/null </dev/null || printf 'UNKNOWN')"
+    queue_present="$("$queue_fn" 2>/dev/null </dev/null || printf 'unknown')"
     obs="$(classify_release_merge "$landed" "$state" "$queue_present" "$seen_queued")"
     case "$obs" in
       merged) printf 'merged\n'; return 0 ;;
@@ -295,13 +321,79 @@ ref_version() {
   printf '%s\n' "$got"
 }
 
+# release_boundary_commit <version_reader> <want> <max_walk>
+#   stdin: candidate shas, NEWEST FIRST
+#   -> prints the OLDEST consecutive sha whose version is <want>; rc 0
+#      rc 1: the newest candidate does not carry <want> at all
+#      rc 2: the walk hit <max_walk> without finding the boundary
+#      rc 3: the list ran out while every entry still carried <want>
+#
+# THE RELEASE COMMIT, not the branch tip. Tagging `origin/<branch>` tags whatever
+# has landed since -- and later commits do not touch the version file, so the
+# "does this tree carry <new>" check passes on a tip N commits past the release
+# and the tag ships a tree nobody released. This repo's own history proves it:
+# v0.16.2's tag object was created after 51b3304 had already landed on main.
+#
+# The boundary is found by walking commits that TOUCH THE VERSION FILE, newest
+# first, and taking the last one that still reads <want>: the commit before it
+# reads the previous version, which is what makes it the boundary. That list is
+# `git rev-list <ref> -- <file>`, and the release commit is in it by definition
+# (it is the commit that wrote the version). Two properties matter:
+#
+#   Cost. It is ONE subprocess for the list plus one version read per commit
+#   that touched the file -- 1 read across v0.24.0..v0.25.0, where 8 commits
+#   landed and exactly one touched Cargo.toml. Walking `<ref>^` parents instead
+#   would be a subprocess per commit since the release, and `git rev-parse
+#   <root>^` on a root commit fails FATALLY under `set -euo pipefail`.
+#
+#   Precision. Not `git log --grep "(#<pr>)"`: merge-commit subjects exist in
+#   this repo, so that is merge-method dependent, and --grep is a basic regex
+#   over the WHOLE message -- a body that merely mentions (#844) matches.
+#
+# The walk is capped and every exhausted path returns non-zero. Running off the
+# end must never fall through to tagging something: an unresolved boundary is a
+# reason to stop, and the caller names which of the three it hit.
+release_boundary_commit() {
+  local reader="$1" want="$2" max="$3"
+  local sha candidate="" walked=0
+  while IFS= read -r sha; do
+    [ -n "$sha" ] || continue
+    walked=$((walked + 1))
+    if [ "$walked" -gt "$max" ]; then return 2; fi
+    # </dev/null so a reader that reads stdin cannot eat the candidate list.
+    if [ "$("$reader" "$sha" </dev/null)" = "$want" ]; then
+      candidate="$sha"
+    else
+      [ -n "$candidate" ] || return 1
+      printf '%s\n' "$candidate"
+      return 0
+    fi
+  done
+  # Unreachable in production (the caller gates on the tip carrying <want>
+  # first), but the contract holds standalone: nothing matched at all is rc 1.
+  [ -n "$candidate" ] || return 1
+  return 3
+}
+
 # release_landed <branch> <source_file_rel> <field> <version>: print 1 when
-# origin/<branch> already carries <version>. This is the AUTHORITATIVE merge
-# signal -- the merge queue rewrites the sha, so "did my branch tip appear on
-# main" is unanswerable, while "does main carry the release version" is exact.
+# origin/<branch> already carries <version>, 0 when it demonstrably does not,
+# and `unknown` when the question could not be asked. This is the AUTHORITATIVE
+# merge signal -- the merge queue rewrites the sha, so "did my branch tip appear
+# on main" is unanswerable, while "does main carry the release version" is exact.
+#
+# The unknown arm keys on the FETCH EXIT STATUS, and it has to. `ref_version`
+# reads the LOCAL remote-tracking ref, which stays perfectly readable through a
+# total network outage -- it just answers with whatever was true at the last
+# successful fetch. So a gate phrased as "did the ref read cleanly" returns a
+# confident 0 in precisely the scenario this exists to catch, and the caller
+# then reports an ejection for a release nobody could see. The fetch is the only
+# step that actually touches the remote, so its rc is the only honest signal.
 release_landed() {
   local branch="$1" file_rel="$2" field="$3" want="$4"
-  git fetch origin "$branch" --quiet >/dev/null 2>&1 || true
+  if ! git fetch origin "$branch" --quiet >/dev/null 2>&1; then
+    printf 'unknown\n'
+    return 0
+  fi
   if [ "$(ref_version "origin/${branch}" "$file_rel" "$field")" = "$want" ]; then
     printf '1\n'
   else
@@ -324,17 +416,26 @@ except Exception:
 }
 
 # release_queue_ref_present <number>: print 1 while the PR has a merge-queue ref
-# on the remote. GitHub exposes queue membership as
-# refs/heads/gh-readonly-queue/<base>/pr-<N>-<base-sha>, which `git ls-remote`
-# can read without gh and without auth beyond the push remote.
+# on the remote, 0 when the remote answered and the ref is not there, and
+# `unknown` when the remote could not be reached. GitHub exposes queue
+# membership as refs/heads/gh-readonly-queue/<base>/pr-<N>-<base-sha>, which
+# `git ls-remote` can read without gh and without auth beyond the push remote.
+#
+# The output is CAPTURED BEFORE it is matched, so the rc under test belongs to
+# ls-remote. Piping straight into grep gives the pipeline grep's status, under
+# which "the remote is unreachable" and "the PR is not in the queue" are the
+# same observation -- and the second one, repeated, is what the caller calls an
+# ejection.
 release_queue_ref_present() {
-  local number="$1"
-  if git ls-remote origin "refs/heads/gh-readonly-queue/*" 2>/dev/null \
-    | grep -q -- "/pr-${number}-"; then
-    printf '1\n'
-  else
-    printf '0\n'
-  fi
+  local number="$1" out
+  out="$(git ls-remote origin "refs/heads/gh-readonly-queue/*" 2>/dev/null)" || {
+    printf 'unknown\n'
+    return 0
+  }
+  case "$out" in
+    *"/pr-${number}-"*) printf '1\n' ;;
+    *)                  printf '0\n' ;;
+  esac
 }
 
 # -- cross-repo docs worktree helpers (#845) --------------------------------
@@ -417,9 +518,15 @@ worktree_holding_branch() {
 # is what keeps a SUCCESSFUL docs run from poisoning the next release -- a run
 # that committed and pushed carries commits, and "carries commits" alone would
 # pin the worktree forever and collide on the stable branch next time.
+#
+# Both shas must be READABLE. An empty base -- the marker missing or unreadable
+# -- makes the first arm unfireable, which quietly reduces the whole decision to
+# `pushed`, and "clean and fully pushed" describes almost every worktree in a
+# healthy repo. Fail closed on it, the same way an empty head fails closed.
 worktree_is_disposable() {
   local head="$1" base="$2" status="$3" pushed="$4"
   [ -n "$head" ] || return 1
+  [ -n "$base" ] || return 1
   [ -z "$status" ] || return 1
   [ "$head" = "$base" ] || [ "$pushed" = "1" ]
 }
@@ -483,6 +590,18 @@ main() {
     esac
   done
 
+  # --dry-run is honoured by the STAGE mode only, and the other three modes must
+  # say so rather than accept it and mutate anyway. `run()` -- the thing that
+  # actually implements dry-run -- is defined further down and is not in scope
+  # for the docs modes, which dispatch above it; and finish_release takes no
+  # DRY_RUN argument at all. So `--finish=N --dry-run` really polled, tagged and
+  # pushed, and `--docs-worktree-done=<path> --dry-run` really removed the
+  # worktree. Refusing the combination is both cheaper and less ambiguous than
+  # implementing a no-op for steps whose entire content is the mutation.
+  if [ "$DRY_RUN" = "1" ] && [ "$MODE" != "stage" ]; then
+    fail "--dry-run is not supported in ${MODE} mode -- it polls, tags, pushes or removes worktrees, and there is no meaningful no-op for those. Re-run without --dry-run."
+  fi
+
   # -- cross-repo docs worktree modes (#845) ---------------------------------
   # Dispatched before the release guards on purpose: these run AFTER a release,
   # from a repo that is no longer in the pre-release state those guards assert.
@@ -531,6 +650,13 @@ main() {
   if [ "$MODE" = "finish" ]; then
     local F_TAG F_TAG_MESSAGE
     [ -n "$PR_NUMBER" ] || fail "--finish requires the PR number (--finish=<pr-number>)"
+    # Validated for the same reason $BUMP is: it is a bare operator-supplied
+    # string that flows into a `git ls-remote` match and a `legion pr view`
+    # argument. The realistic failure is not adversarial -- `--finish=#12` or a
+    # pasted PR URL simply never matches the queue ref, so the release burns the
+    # entire 30-minute budget and reports a timeout instead of a typo.
+    [[ "$PR_NUMBER" =~ ^[0-9]+$ ]] \
+      || fail "--finish takes a bare PR NUMBER, got '${PR_NUMBER}' (no '#', no URL): release.sh ${BUMP} --finish=123"
     is_semver "$BUMP" || fail "--finish requires the explicit release version (release.sh X.Y.Z --finish=N), got '${BUMP}'"
     F_TAG="$(render_tag "$TAG_FORMAT" "$BUMP")"
     F_TAG_MESSAGE="$(render_tag "$TAG_MESSAGE_FORMAT" "$BUMP")"
@@ -701,28 +827,41 @@ Co-Authored-By: ${CO_AUTHORED_BY}"
 # The ordering is the whole point of #844 and is not rearrangeable:
 #   1. wait  -- `legion pr merge` enqueues and returns; the merge is
 #               asynchronous, so a bounded poll stands between enqueue and tag.
-#   2. read  -- re-fetch origin/<branch> and take ITS sha. The queue may squash
-#               or rebase, so the local branch tip is not the merged commit;
-#               tagging it would point the release at an object that is not on
-#               the branch and make release.yml build a tree nobody reviewed in
-#               that form.
-#   3. verify -- confirm the merged tree really carries <new> before tagging.
+#   2. read  -- re-fetch origin/<branch>, confirm the release actually landed on
+#               it, then resolve the RELEASE COMMIT within it. The queue may
+#               squash or rebase, so the local branch tip is not the merged
+#               commit; and by the time --finish runs, other PRs may have landed
+#               on top, so the branch TIP is not the release commit either.
+#   3. verify -- confirm the commit about to be tagged really carries <new>.
 #   4. tag + push the TAG ONLY.
 finish_release() {
   local REPO_ROOT="$1" WORK_REPO="$2" RELEASE_BRANCH="$3" SOURCE_FILE_REL="$4"
   local SOURCE_FIELD="$5" NEW="$6" TAG="$7" TAG_MESSAGE="$8" PR_NUMBER="$9"
   local MAX_POLLS="${10}" INTERVAL="${11}" ACTIVATE="${12}"
-  local OUTCOME RC=0 MERGED_SHA MERGED_VERSION EXISTING_TAG_SHA
-  local LANDED_CMD STATE_CMD QUEUE_CMD
+  local OUTCOME RC=0 TIP_SHA TIP_VERSION MERGED_SHA MERGED_VERSION EXISTING_TAG_SHA
+  local BOUNDARY_LIST BOUNDARY_RC=0
+  # How far back the release-commit walk may go, counted in commits that TOUCH
+  # the version file -- so this is "releases", not "commits", and 200 of them is
+  # already far past any sane re-run.
+  local MAX_BOUNDARY_WALK=200
 
   cd "$REPO_ROOT"
 
-  LANDED_CMD="release_landed '${RELEASE_BRANCH}' '${SOURCE_FILE_REL}' '${SOURCE_FIELD}' '${NEW}'"
-  STATE_CMD="release_pr_state '${WORK_REPO}' '${PR_NUMBER}'"
-  QUEUE_CMD="release_queue_ref_present '${PR_NUMBER}'"
+  # The three merge observers, as closures. Their arguments are bound as ARGV
+  # here rather than interpolated into a command string for wait_for_release_merge
+  # to eval: that is what keeps a PR number or a release.toml field from ever
+  # being parsed as shell. They read the enclosing locals dynamically, so they
+  # must stay defined here, inside the function whose scope they capture.
+  release_landed_obs() { release_landed "$RELEASE_BRANCH" "$SOURCE_FILE_REL" "$SOURCE_FIELD" "$NEW"; }
+  release_state_obs()  { release_pr_state "$WORK_REPO" "$PR_NUMBER"; }
+  release_queue_obs()  { release_queue_ref_present "$PR_NUMBER"; }
+  # The version-of-record at <sha>, for the release-commit walk below. Same
+  # reader the landed-gate uses, so the walk cannot disagree with the gate.
+  merged_version_at() { ref_version "$1" "$SOURCE_FILE_REL" "$SOURCE_FIELD"; }
 
   info "waiting for PR #${PR_NUMBER} to merge (up to ${MAX_POLLS} polls, ${INTERVAL}s apart)"
-  OUTCOME="$(wait_for_release_merge "$MAX_POLLS" "$INTERVAL" "$LANDED_CMD" "$STATE_CMD" "$QUEUE_CMD")" || RC=$?
+  OUTCOME="$(wait_for_release_merge "$MAX_POLLS" "$INTERVAL" \
+    release_landed_obs release_state_obs release_queue_obs)" || RC=$?
 
   case "$OUTCOME" in
     merged) info "PR #${PR_NUMBER} merged" ;;
@@ -741,13 +880,51 @@ finish_release() {
   esac
 
   git fetch origin "$RELEASE_BRANCH" --quiet || fail "git fetch failed after the merge -- cannot resolve the sha to tag. Nothing was tagged."
-  MERGED_SHA="$(git rev-parse "origin/${RELEASE_BRANCH}")" \
+  TIP_SHA="$(git rev-parse "origin/${RELEASE_BRANCH}")" \
     || fail "could not resolve origin/${RELEASE_BRANCH}. Nothing was tagged."
 
-  # Fails CLOSED: an unreadable version is a mismatch, not a pass.
-  MERGED_VERSION="$(ref_version "origin/${RELEASE_BRANCH}" "$SOURCE_FILE_REL" "$SOURCE_FIELD")"
+  # LANDED GATE. Fails CLOSED: an unreadable version is a mismatch, not a pass.
+  # This asks of the branch TIP, and it is the right question to ask of the tip:
+  # it proves the release is on the branch AND that no LATER release superseded
+  # it. It is not, however, the sha to tag -- see below.
+  TIP_VERSION="$(merged_version_at "origin/${RELEASE_BRANCH}")"
+  tag_target_matches "$NEW" "$TIP_VERSION" \
+    || fail "tag-target mismatch: origin/${RELEASE_BRANCH} is ${TIP_SHA}, whose ${SOURCE_FILE_REL} says '${TIP_VERSION:-<none>}', not ${NEW}. Refusing to tag a commit that is not the release. Nothing was tagged."
+
+  # THE SHA TO TAG is the release commit, not the tip. Between `legion pr merge`
+  # and this --finish, other PRs land; none of them touch the version file, so
+  # the gate above still passes on a tip several commits past the release, and
+  # tagging it would ship a tree that was never released. Stored ruling
+  # 019e8440: tags sit on the chore(release) commit, not on later HEAD.
+  #
+  # This is also what makes the idempotency promised below (and in
+  # plugin/commands/legion-release.md) TRUE rather than aspirational: the
+  # boundary is a property of the history, so a second --finish run resolves the
+  # same sha, matches the existing tag and re-pushes it, however far the branch
+  # has moved on in between. Tip-resolution re-derived a DIFFERENT sha on every
+  # re-run and hit the "tag already exists and points elsewhere" refusal.
+  BOUNDARY_LIST="$(git rev-list "origin/${RELEASE_BRANCH}" -- "$SOURCE_FILE_REL")" \
+    || fail "could not list the commits touching ${SOURCE_FILE_REL} on origin/${RELEASE_BRANCH} -- cannot resolve the release commit. Nothing was tagged."
+  MERGED_SHA="$(printf '%s\n' "$BOUNDARY_LIST" \
+    | release_boundary_commit merged_version_at "$NEW" "$MAX_BOUNDARY_WALK")" || BOUNDARY_RC=$?
+  case "$BOUNDARY_RC" in
+    0) ;;
+    1) fail "could not find the ${NEW} release commit: no commit touching ${SOURCE_FILE_REL} on origin/${RELEASE_BRANCH} carries ${NEW}, even though its tip does. Nothing was tagged." ;;
+    2) fail "could not find the ${NEW} release commit: walked ${MAX_BOUNDARY_WALK} commits touching ${SOURCE_FILE_REL} on origin/${RELEASE_BRANCH} and every one still read ${NEW}. Refusing to guess which commit is the release. Nothing was tagged." ;;
+    3) fail "could not find the ${NEW} release commit: every commit that ever touched ${SOURCE_FILE_REL} on origin/${RELEASE_BRANCH} reads ${NEW}, so there is no boundary to tag. Nothing was tagged." ;;
+    *) fail "release-commit resolution failed with rc ${BOUNDARY_RC}. Nothing was tagged." ;;
+  esac
+  [ -n "$MERGED_SHA" ] || fail "release-commit resolution returned an empty sha. Nothing was tagged."
+
+  # Re-assert on the sha actually about to be tagged. The walk only ever keeps a
+  # commit whose version matched, so this is redundant BY CONSTRUCTION -- which
+  # is exactly why it is cheap to keep: it makes the tag step self-verifying no
+  # matter how the sha was resolved, and the resolution above reaches it through
+  # a dynamically-scoped closure that a later refactor could quietly repoint.
+  MERGED_VERSION="$(merged_version_at "$MERGED_SHA")"
   tag_target_matches "$NEW" "$MERGED_VERSION" \
-    || fail "tag-target mismatch: origin/${RELEASE_BRANCH} is ${MERGED_SHA}, whose ${SOURCE_FILE_REL} says '${MERGED_VERSION:-<none>}', not ${NEW}. Refusing to tag a commit that is not the release. Nothing was tagged."
+    || fail "tag-target mismatch: resolved the ${NEW} release commit as ${MERGED_SHA}, but its ${SOURCE_FILE_REL} says '${MERGED_VERSION:-<none>}'. Nothing was tagged."
+  info "release commit for ${NEW} is ${MERGED_SHA} (origin/${RELEASE_BRANCH} tip is ${TIP_SHA})"
 
   # A tag left over from a failed push is the documented recovery path, so it is
   # reused when it already points at the verified sha and fatal otherwise.
@@ -803,12 +980,25 @@ docs_worktree_setup() {
   git -C "$root" fetch origin --quiet \
     || fail "docs step: 'git fetch origin' failed in ${root} -- the worktree must start from a remote ref, so this is fatal"
 
+  # Deregister worktrees whose directory no longer exists BEFORE asking who
+  # holds the branch. A retained docs worktree that the operator simply deleted
+  # stays registered as "prunable", and that registration is invisible to
+  # `worktree_holding_branch` (the porcelain still lists it) -- so every later
+  # --docs-worktree failed naming a path that no longer existed, with no hint
+  # that `git worktree prune` was the way out. Pruning is safe precisely here:
+  # it drops bookkeeping for directories that are already gone, and touches no
+  # branch and no commit.
+  git -C "$root" worktree prune >/dev/null 2>&1 || true
+
   # A stale worktree or branch from an earlier release is reported, never
   # reused and never clobbered: it may hold unpushed work.
   holder="$(git -C "$root" worktree list --porcelain | worktree_holding_branch "$branch")" || holder=""
   [ -z "$holder" ] || fail "docs step: ${branch} is already checked out at ${holder} -- it may hold unpushed work from an earlier release. Finish or remove it there; this run will not clobber it and will not fall back to ${root}."
   ! git -C "$root" show-ref --verify --quiet "refs/heads/${branch}" \
-    || fail "docs step: local branch ${branch} exists in ${root} but no worktree holds it -- it may hold unpushed work from an earlier release. Inspect and remove it there; this run will not reuse or clobber it."
+    || fail "docs step: local branch ${branch} exists but no worktree holds it -- it may hold unpushed work from an earlier release. Inspect it, and delete it only once you have confirmed it is on the remote:
+       git -C ${root} log origin/${branch}..${branch}    # what is on it that origin does not have
+       git -C ${root} branch -D ${branch}                # only if that is empty
+       This run will not reuse or clobber it. (Deleting a branch does not touch the shared checkout's working tree.)"
 
   start_point="$(git -C "$root" ls-remote --heads origin | docs_start_point "$branch" "origin/${base_branch}")"
 
@@ -836,28 +1026,63 @@ docs_worktree_setup() {
   # bring it up to the base rather than opening a second stacked docs PR. MERGE,
   # never rebase -- `legion push` has no force path, so rewritten history would
   # strand the branch.
+  #
+  # `-c merge.ff=false --no-ff` pins the merge against the OPERATOR's git config
+  # rather than inheriting it. A global `[merge] ff = only` is an ordinary
+  # setting, and under it this merge dies with "fatal: Not possible to
+  # fast-forward" on entirely correct input -- a diverged docs branch is the
+  # whole reason the merge exists, so it fires in the NORMAL case, not an exotic
+  # one. Forcing a merge commit also keeps the shape stable, which is what
+  # teardown's base-sha comparison assumes.
   if [ "$start_point" != "origin/${base_branch}" ]; then
-    git -C "$wt" merge --quiet "origin/${base_branch}" -m "Merge origin/${base_branch} into ${branch}" \
-      || abandon_setup "docs step: merging origin/${base_branch} into the existing ${branch} conflicted -- resolve it in ${root} first. Not falling back to the shared checkout."
+    if ! git -C "$wt" -c merge.ff=false merge --no-ff --quiet "origin/${base_branch}" \
+      -m "Merge origin/${base_branch} into ${branch}"; then
+      # A real content conflict leaves unmerged paths in the index; a merge
+      # refused by config or a hook leaves none. Same rc, different fix, so the
+      # message must not guess -- and neither answer is "go and do it in the
+      # shared checkout", which is the fallback #845 exists to close.
+      if [ -n "$(git -C "$wt" ls-files -u 2>/dev/null)" ]; then
+        abandon_setup "docs step: merging origin/${base_branch} into the existing ${branch} CONFLICTED (unmerged paths). This worktree has been removed and the shared checkout was not touched. Reconcile ${branch} with origin/${base_branch} in a worktree of your OWN ('git worktree add'), push it, then re-run --docs-worktree."
+      fi
+      abandon_setup "docs step: merging origin/${base_branch} into ${branch} FAILED WITHOUT CONFLICT (no unmerged paths) -- that is a merge refused by git config or a hook, not by content: typically 'merge.ff = only', 'user.useConfigOnly = true' with no identity, or a failing commit hook. Fix the config, then re-run --docs-worktree. Not falling back to the shared checkout."
+    fi
   fi
 
   # The base sha is recorded AFTER any merge-in, so teardown measures what the
   # docs agent added rather than counting setup's own merge as agent work. It
   # lives in the temp parent, NOT inside the worktree, which would dirty the
-  # very tree teardown inspects for cleanliness -- and its presence is later
-  # what proves to teardown that this script created that parent directory.
+  # very tree teardown inspects for cleanliness.
   head="$(git -C "$wt" rev-parse HEAD)" || abandon_setup "docs step: could not read HEAD of the new worktree at ${wt}"
   printf '%s\n' "$head" >"${parent}/base-sha" \
     || abandon_setup "docs step: could not record the base sha for ${wt}"
+  # The OWNERSHIP marker, and it records the worktree PATH, not just the fact
+  # that some marker exists. Teardown destroys three things -- the worktree, its
+  # branch, and this directory -- and "the parent happens to contain a base-sha
+  # file" is a claim about the directory, not about the worktree inside it. This
+  # is what lets teardown answer "did I create THIS worktree", which is the
+  # question a destructive verb actually has to answer.
+  printf '%s\n' "$wt" >"${parent}/worktree-path" \
+    || abandon_setup "docs step: could not record the ownership marker for ${wt}"
 
   info "docs worktree ready: ${wt} (branch ${branch}, from ${start_point})"
   printf '%s\n' "$wt"
 }
 
-# docs_worktree_teardown <worktree_path>: remove the docs worktree when it
-# carries nothing, retain it (naming the path) when it does. A failed or partial
-# docs run is recoverable rather than discarded; a clean or fully-pushed one
-# leaves no residue to collide with the next release's stable branch.
+# docs_worktree_teardown <worktree_path>: remove the docs worktree when this
+# script created it AND it carries nothing; retain it (naming the path) in every
+# other case. A failed or partial docs run is recoverable rather than discarded;
+# a clean or fully-pushed one leaves no residue to collide with the next
+# release's stable branch.
+#
+# OWNERSHIP IS CHECKED BEFORE ANYTHING IS DESTROYED, and it gates all three
+# destructive acts -- `worktree remove --force`, `branch -D`, and `rm -rf` --
+# not just the last one. `--docs-worktree-done=` takes an operator-supplied
+# path, and force-removing a worktree and deleting its branch are exactly as
+# destructive as deleting a directory. Nor is "does the tree look disposable"
+# an ownership claim: without the marker the base sha is empty, so the
+# `head = base` arm can never fire and disposability collapses onto `pushed`
+# alone -- under which every clean, fully-pushed worktree in the docs repo,
+# including one an agent is working in right now, reads as disposable.
 docs_worktree_teardown() {
   local wt="$1" parent base head status branch root pushed=0
 
@@ -868,13 +1093,16 @@ docs_worktree_teardown() {
 
   parent="$(dirname "$wt")"
   base="$(cat "${parent}/base-sha" 2>/dev/null || true)"
-  # `--docs-worktree-done=` takes an operator-supplied path, so the parent
-  # directory is only ever removed when this script demonstrably created it --
-  # the base-sha marker is that proof. A hand-made worktree in a shared
-  # directory would otherwise take its siblings with it, which is precisely the
-  # collateral damage this feature exists to prevent.
-  local parent_is_ours=0
-  if [ -f "${parent}/base-sha" ]; then parent_is_ours=1; fi
+  # The marker must exist AND name THIS worktree. String equality, deliberately:
+  # an ownership check is not the place for tolerance, and a path that does not
+  # match the one setup printed is a case for retain-and-report, which loses
+  # nothing. (Comparing inodes instead would silently re-approve a directory
+  # that was removed and recreated by something else in the meantime.)
+  local wt_is_ours=0 marked
+  marked="$(cat "${parent}/worktree-path" 2>/dev/null || true)"
+  if [ -f "${parent}/base-sha" ] && [ -n "$marked" ] && [ "$marked" = "$wt" ]; then
+    wt_is_ours=1
+  fi
   head="$(git -C "$wt" rev-parse HEAD 2>/dev/null || true)"
   status="$(git -C "$wt" status --porcelain 2>/dev/null || printf 'unknown')"
   branch="$(git -C "$wt" rev-parse --abbrev-ref HEAD 2>/dev/null || true)"
@@ -889,14 +1117,25 @@ docs_worktree_teardown() {
     pushed=1
   fi
 
+  if [ "$wt_is_ours" != "1" ]; then
+    fail "docs step: refusing to tear down ${wt} -- this script cannot prove it created it. ${parent} has no 'worktree-path' marker naming that worktree, so it was made by hand or by another tool, and removing a worktree and deleting its branch are not acts to perform on someone else's checkout. Nothing was removed. If it really is disposable, remove it yourself:
+       git -C <its main checkout> worktree remove ${wt}"
+  fi
+
   if worktree_is_disposable "$head" "$base" "$status" "$pushed"; then
     git -C "$root" worktree remove --force "$wt" \
       || fail "docs step: could not remove the unchanged worktree at ${wt}"
     # Safe by construction: the branch is either untouched since setup or fully
-    # present on origin, so the only thing dropped is setup's own local
-    # merge commit, which the next release re-derives.
-    git -C "$root" branch -D "$branch" >/dev/null 2>&1 || true
-    if [ "$parent_is_ours" = "1" ]; then rm -rf "$parent"; fi
+    # present on origin, so the only thing dropped is setup's own local merge
+    # commit, which the next release re-derives. Reported either way -- a
+    # destructive act that silences its own outcome cannot be audited, and
+    # `|| true` on a `branch -D` hides both the deletion and its failure.
+    if git -C "$root" branch -D "$branch" >/dev/null 2>&1; then
+      info "docs branch ${branch} deleted (it was fully on origin, or untouched since setup)"
+    else
+      info "docs branch ${branch} was NOT deleted -- it is checked out elsewhere or already gone. Harmless, but the next release will report it as a collision if it is still there."
+    fi
+    rm -rf "$parent"
     info "docs worktree removed -- ${branch} carried nothing that is not already on origin"
   else
     info "docs worktree RETAINED at ${wt} (branch ${branch}) -- it carries work that is not on origin. Finish or push it from there, then re-run: scripts/release.sh --docs-worktree-done=${wt}"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -15,35 +15,64 @@
 #                                        # restart the local daemon (legion-
 #                                        # specific; a no-op knob elsewhere)
 #   scripts/release.sh patch --no-preflight  # skip the preflight gate (CI re-runs it)
+#   scripts/release.sh --docs-worktree       # print an isolated worktree for the
+#                                            # cross-repo docs step (#845)
+#   scripts/release.sh --docs-worktree-done=<path>  # tear that worktree down
 #
 # Entry contract: the CHANGELOG entry for the new version must already be written
 # (by the `changelog` agent, or by hand) and left UNCOMMITTED in the working tree.
 # release.sh validates it, bumps the version, syncs the manifests, and commits the
-# whole release in one shot. The only file allowed to be dirty at entry is the
-# configured changelog path; everything else must be committed. (Note: even
+# whole release ONTO A RELEASE BRANCH. The only file allowed to be dirty at entry
+# is the configured changelog path; everything else must be committed. (Note: even
 # --dry-run requires the "## <new>" CHANGELOG header to exist -- the header
 # check is part of what a dry-run verifies.)
 #
-# What it does, in order (unchanged by #741 -- only WHERE paths come from
-# changed, not the sequence):
+# What it does, in order (#844 split the old one-shot "commit + tag + atomic
+# push to main" step into phases 6-8: only the TAG is pushed to the release
+# branch now, and the commit earns its way there through the merge queue):
 #   1. Guards: on the configured branch, tree clean except the changelog,
 #      in sync with origin.
 #   2. Computes the new version from the bump level (or takes it explicitly).
 #   3. Requires the changelog's "## <new>" top header to exist.
 #   4. Runs the configured preflight commands (default: scripts/preflight.sh).
 #   5. Bumps the version-of-record file, refreshes Cargo.lock (Rust sources only).
-#   6. Syncs every configured target (scripts/sync-version.sh) and commits.
-#   7. Tags per the configured tag format and atomically pushes the commit +
-#      tag, firing release.yml.
-#   8. With --activate: builds the release binary, installs it to the plugin data
+#   6. Syncs every configured target (scripts/sync-version.sh), switches to
+#      `release/<new>` and commits there -- never onto the release branch.
+#   7. Pushes that branch via `legion push`, then STOPS. Nothing is tagged.
+#
+# The release is deliberately TWO invocations, with an agent's work between
+# them. Earning the legion-simplify and legion-pr-write gates on the release
+# commit and opening the PR cannot be done by a script: both gates are keyed to
+# the commit's hash and a clean verdict only exists once their CHECK validators
+# have run. So the orchestrator runs the gates, `legion pr create` and `legion
+# pr merge` (see plugin/commands/legion-release.md step 4), and then calls:
+#
+#   scripts/release.sh <X.Y.Z> --finish=<pr-number>
+#
+#   8. Polls, bounded, until the merge lands -- `legion pr merge` enqueues and
+#      returns, so the merge is asynchronous. An ejection or a timeout stops the
+#      release with the reason named and tags nothing.
+#   9. Re-reads origin/<branch>, verifies the merged tree really carries <new>,
+#      tags THAT sha per the configured tag format, and pushes ONLY the tag --
+#      which fires release.yml.
+#  10. With --activate: builds the release binary, installs it to the plugin data
 #      dir atomically, and restarts the local daemon (verifying it comes back up).
 #
+# Atomicity note (#844): the old `git push --atomic origin main <tag>` guaranteed
+# the commit and tag landed together. Separating them in time gives that up by
+# construction, so the recovery is stated rather than assumed -- a tagging failure
+# after a successful merge reports INCOMPLETE BUT RECOVERABLE and names the sha to
+# tag, because the version bump is already on the release branch and only the tag
+# step remains.
+#
 # The pure helpers below (compute_new_version, is_semver, is_strictly_greater,
-# non_changelog_dirty, field_leaf, render_tag, bump_source_file) are unit-tested
-# by scripts/test-release.sh, which sources this file. main() runs only when the
-# script is executed, not when it is sourced. Implementation is kept
-# POSIX-portable (no GNU-only sed/sort) because the release is cut on darwin,
-# where BSD sed/sort lack the GNU extensions.
+# non_changelog_dirty, field_leaf, render_tag, bump_source_file,
+# classify_release_merge, wait_for_release_merge, tag_target_matches,
+# watch_repo_root, docs_start_point, worktree_holding_branch,
+# worktree_is_disposable) are unit-tested by scripts/test-release.sh, which
+# sources this file. main() runs only when the script is executed, not when it is
+# sourced. Implementation is kept POSIX-portable (no GNU-only sed/sort) because
+# the release is cut on darwin, where BSD sed/sort lack the GNU extensions.
 set -euo pipefail
 
 info() { printf '[release] %s\n' "$1" >&2; }
@@ -159,6 +188,242 @@ bump_source_file() {
   esac
 }
 
+# -- merge-queue phase helpers (#844) ---------------------------------------
+
+# classify_release_merge <landed> <pr_state> <queue_ref_present> <seen_queued>
+#   -> merged | closed | queued | ejected | pending
+#
+# One observation of the merge, reduced to a verdict. Pure: every input is
+# already-collected text, so the whole state machine is unit-testable without
+# gh, git or a network.
+#
+# The ORDER of the arms is the correctness point. `landed` -- "origin/<branch>
+# already carries the new version" -- wins over everything, because the queue
+# rewrites the sha and the PR's own `state` is the laggy signal, not the
+# authoritative one. Only after landed and state are both ruled out does queue
+# membership decide, and only a PR that was OBSERVED in the queue and is no
+# longer there can be called ejected: absence from the queue refs is not
+# evidence of ejection on its own (the queue admits a bounded group size, so a
+# PR can sit un-enqueued for a while), which is why that case stays `pending`
+# and expires into a timeout instead of a false ejection report.
+classify_release_merge() {
+  local landed="$1" state="$2" queue_present="$3" seen_queued="$4"
+  if [ "$landed" = "1" ]; then printf 'merged\n'; return 0; fi
+  case "$state" in
+    MERGED|merged) printf 'merged\n'; return 0 ;;
+    CLOSED|closed) printf 'closed\n'; return 0 ;;
+  esac
+  if [ "$queue_present" = "1" ]; then
+    printf 'queued\n'
+  elif [ "$seen_queued" = "1" ]; then
+    printf 'ejected\n'
+  else
+    printf 'pending\n'
+  fi
+}
+
+# wait_for_release_merge <max_polls> <interval> <landed_cmd> <state_cmd> <queue_cmd>
+#   -> prints merged|closed|ejected|timeout; rc 0|3|4|5
+#
+# The bounded poll `legion pr merge` makes necessary: enqueuing returns
+# immediately and the merge happens later, so the release has to wait for it.
+# The three observers are injected as command STRINGS rather than called
+# directly, which is what makes the loop testable -- the tests pass `printf`
+# one-liners and a counter file, and never need gh, git or a network. In
+# production they are the release_landed / release_pr_state /
+# release_queue_ref_present calls below. They are `eval`d in THIS shell rather
+# than run under `bash -c`, so a sourced helper resolves without exporting it:
+# a subshell that could not see release_landed would report landed=0 forever
+# and time out a release that had actually merged.
+#
+# An `ejected` verdict must be seen TWICE in a row before it is reported: the
+# queue ref also disappears at the moment of a successful merge, so a single
+# observation taken in that window would report an ejection for a release that
+# actually landed. The confirming poll re-reads `landed` first, which is what
+# breaks the tie.
+#
+# The budget is expressed in polls, not wall-clock, so a timeout is exactly
+# reproducible in a test and the failure message can state the budget it spent.
+wait_for_release_merge() {
+  local max_polls="$1" interval="$2" landed_cmd="$3" state_cmd="$4" queue_cmd="$5"
+  local poll=0 landed state queue_present obs seen_queued=0 ejected_streak=0
+  while [ "$poll" -lt "$max_polls" ]; do
+    poll=$((poll + 1))
+    landed="$(eval "$landed_cmd" 2>/dev/null || printf '0')"
+    state="$(eval "$state_cmd" 2>/dev/null || printf 'UNKNOWN')"
+    queue_present="$(eval "$queue_cmd" 2>/dev/null || printf '0')"
+    obs="$(classify_release_merge "$landed" "$state" "$queue_present" "$seen_queued")"
+    case "$obs" in
+      merged) printf 'merged\n'; return 0 ;;
+      closed) printf 'closed\n'; return 3 ;;
+      queued) seen_queued=1; ejected_streak=0 ;;
+      ejected)
+        ejected_streak=$((ejected_streak + 1))
+        if [ "$ejected_streak" -ge 2 ]; then printf 'ejected\n'; return 4; fi
+        ;;
+      *) ejected_streak=0 ;;
+    esac
+    if [ "$poll" -lt "$max_polls" ]; then sleep "$interval"; fi
+  done
+  printf 'timeout\n'
+  return 5
+}
+
+# tag_target_matches <expected_version> <observed_version> -> 0 iff the commit
+# about to be tagged really is the release. The merge queue may squash or
+# rebase, so the sha the tag lands on is never assumed to be the branch tip --
+# it is re-read from origin and its version-of-record checked. An empty
+# observed version (file missing on the ref, extract failed) is a mismatch, not
+# a pass: this guard fails closed.
+tag_target_matches() {
+  [ -n "$2" ] && [ "$1" = "$2" ]
+}
+
+# ref_version <ref> <source_file_rel> <field>: the version-of-record as it
+# stands on <ref>, read WITHOUT checking anything out (git show into a scratch
+# file, then the same `legion sym etc extract` the rest of the script uses).
+# The scratch file keeps the source file's basename so extract can sniff the
+# format from the extension. Prints empty when the ref or the file is absent.
+ref_version() {
+  local ref="$1" file_rel="$2" field="$3" tmpdir scratch got=""
+  tmpdir="$(mktemp -d)" || { printf '\n'; return 0; }
+  scratch="${tmpdir}/${file_rel##*/}"
+  if git show "${ref}:${file_rel}" >"$scratch" 2>/dev/null; then
+    got="$(legion sym etc extract "$scratch" --field "$field" 2>/dev/null || true)"
+  fi
+  rm -rf "$tmpdir"
+  printf '%s\n' "$got"
+}
+
+# release_landed <branch> <source_file_rel> <field> <version>: print 1 when
+# origin/<branch> already carries <version>. This is the AUTHORITATIVE merge
+# signal -- the merge queue rewrites the sha, so "did my branch tip appear on
+# main" is unanswerable, while "does main carry the release version" is exact.
+release_landed() {
+  local branch="$1" file_rel="$2" field="$3" want="$4"
+  git fetch origin "$branch" --quiet >/dev/null 2>&1 || true
+  if [ "$(ref_version "origin/${branch}" "$file_rel" "$field")" = "$want" ]; then
+    printf '1\n'
+  else
+    printf '0\n'
+  fi
+}
+
+# release_pr_state <repo> <number>: the PR's state (OPEN/MERGED/CLOSED), or
+# UNKNOWN when it cannot be read. Advisory only -- an unreadable state must not
+# stall or fail the wait, it just leaves the decision to the other two signals.
+release_pr_state() {
+  local repo="$1" number="$2"
+  legion pr view --repo "$repo" --number "$number" --json 2>/dev/null | python3 -c '
+import json, sys
+try:
+    print(json.load(sys.stdin).get("state") or "UNKNOWN")
+except Exception:
+    print("UNKNOWN")
+' 2>/dev/null || printf 'UNKNOWN\n'
+}
+
+# release_queue_ref_present <number>: print 1 while the PR has a merge-queue ref
+# on the remote. GitHub exposes queue membership as
+# refs/heads/gh-readonly-queue/<base>/pr-<N>-<base-sha>, which `git ls-remote`
+# can read without gh and without auth beyond the push remote.
+release_queue_ref_present() {
+  local number="$1"
+  if git ls-remote origin "refs/heads/gh-readonly-queue/*" 2>/dev/null \
+    | grep -q -- "/pr-${number}-"; then
+    printf '1\n'
+  else
+    printf '0\n'
+  fi
+}
+
+# -- cross-repo docs worktree helpers (#845) --------------------------------
+# Operator rule: commits to a repo that is NOT yours go in a worktree. Your own
+# repo you may work in directly; anyone else's you isolate, because that repo's
+# agent may be in-process in its checkout and you cannot see them. Cutting
+# v0.25.0 proved the cost -- another agent's uncommitted edits were swept into
+# the docs commit through the shared working tree. An instruction an agent must
+# remember is not a mechanism, so the script creates the worktree and hands over
+# a path the agent cannot get wrong.
+
+# watch_repo_root <name>: read `legion watch list` on stdin, print the working
+# directory registered for <name>. The listing is "<name>\t<path>" with an
+# optional " (agent: X)" suffix on the path, which is stripped. Returns 1 when
+# the repo is not registered, so the caller can name that rather than handing
+# out an empty path.
+watch_repo_root() {
+  local want="$1" line name path
+  while IFS= read -r line; do
+    name="${line%%$'\t'*}"
+    [ "$name" = "$want" ] || continue
+    path="${line#*$'\t'}"
+    path="${path%% (agent: *}"
+    [ -n "$path" ] || return 1
+    printf '%s\n' "$path"
+    return 0
+  done
+  return 1
+}
+
+# docs_start_point <branch> <base_ref>: read `git ls-remote --heads origin` on
+# stdin and print the ref the docs worktree should start from.
+#
+# This is where #845 and #820 meet. #845 requires the worktree to branch from
+# origin/<base>, NOT from whatever the shared checkout happens to have checked
+# out -- inheriting another agent's in-flight branch is the same defect one step
+# removed. #820 requires the docs branch to be a STABLE name that the next
+# release EXTENDS rather than a version-pinned branch that stacks a new PR per
+# release (five deep on 0.20->0.24 before it was collapsed). So: when the stable
+# docs branch already exists on the remote, start from it and merge the base in
+# (the caller does the merge -- never a rebase, since `legion push` has no force
+# path); when it does not, start from origin/<base>. Either way the start point
+# is a REMOTE ref, which is the guarantee #845 is actually asking for.
+docs_start_point() {
+  local branch="$1" base_ref="$2" line
+  while IFS= read -r line; do
+    case "$line" in
+      *$'\t'"refs/heads/${branch}") printf 'origin/%s\n' "$branch"; return 0 ;;
+    esac
+  done
+  printf '%s\n' "$base_ref"
+}
+
+# worktree_holding_branch <branch>: read `git worktree list --porcelain` on
+# stdin, print the worktree path that currently has <branch> checked out.
+# A stale worktree from a previous failed release is REPORTED, not clobbered --
+# it may contain unpushed work -- and with a stable docs branch this is the
+# ordinary collision, not an exotic one.
+worktree_holding_branch() {
+  local branch="$1" line current=""
+  while IFS= read -r line; do
+    case "$line" in
+      "worktree "*) current="${line#worktree }" ;;
+      "branch refs/heads/${branch}")
+        [ -n "$current" ] || return 1
+        printf '%s\n' "$current"
+        return 0
+        ;;
+    esac
+  done
+  return 1
+}
+
+# worktree_is_disposable <head_sha> <base_sha> <porcelain_status> <pushed>
+#   -> 0 iff removing the worktree throws nothing away.
+#
+# Disposable means the docs agent left nothing behind that only exists here: the
+# tree is clean AND either the branch never moved past the sha the setup step
+# recorded, or everything on it is already on the remote branch. That second arm
+# is what keeps a SUCCESSFUL docs run from poisoning the next release -- a run
+# that committed and pushed carries commits, and "carries commits" alone would
+# pin the worktree forever and collide on the stable branch next time.
+worktree_is_disposable() {
+  local head="$1" base="$2" status="$3" pushed="$4"
+  [ -n "$head" ] || return 1
+  [ -z "$status" ] || return 1
+  [ "$head" = "$base" ] || [ "$pushed" = "1" ]
+}
+
 main() {
   local REPO_ROOT CONFIG SOURCE_FILE CHANGELOG
   REPO_ROOT="$(git rev-parse --show-toplevel)"
@@ -184,6 +449,7 @@ main() {
   }
 
   local SOURCE_FILE_REL SOURCE_FIELD CHANGELOG_REL RELEASE_BRANCH TAG_FORMAT TAG_MESSAGE_FORMAT CO_AUTHORED_BY
+  local WORK_REPO MERGE_WAIT_POLLS MERGE_WAIT_INTERVAL
   SOURCE_FILE_REL="$(extract_cfg version.file)"
   SOURCE_FIELD="$(extract_cfg version.field)"
   CHANGELOG_REL="$(extract_cfg changelog.path)"
@@ -191,12 +457,18 @@ main() {
   TAG_FORMAT="$(extract_cfg_default git.tag_format 'v{version}')"
   TAG_MESSAGE_FORMAT="$(extract_cfg_default git.tag_message '{version}')"
   CO_AUTHORED_BY="$(extract_cfg_default git.co_authored_by 'Claude Opus 4.8 (1M context) <noreply@anthropic.com>')"
+  # The name this repo answers to in watch.toml -- what `legion push` / `legion
+  # pr *` resolve their work source from. Defaults to the checkout's directory
+  # name, which is the convention every registered repo already follows.
+  WORK_REPO="$(extract_cfg_default git.repo "${REPO_ROOT##*/}")"
+  MERGE_WAIT_POLLS="$(extract_cfg_default git.merge_wait_polls 90)"
+  MERGE_WAIT_INTERVAL="$(extract_cfg_default git.merge_wait_interval 20)"
 
   SOURCE_FILE="${REPO_ROOT}/${SOURCE_FILE_REL}"
   CHANGELOG="${REPO_ROOT}/${CHANGELOG_REL}"
 
   # -- arg parsing -----------------------------------------------------------
-  local BUMP="" DRY_RUN=0 ACTIVATE=0 RUN_PREFLIGHT=1 arg
+  local BUMP="" DRY_RUN=0 ACTIVATE=0 RUN_PREFLIGHT=1 MODE=stage PR_NUMBER="" DOCS_WT_DONE="" arg
   for arg in "$@"; do
     case "$arg" in
       patch|minor|major) BUMP="$arg" ;;
@@ -204,11 +476,39 @@ main() {
       --dry-run) DRY_RUN=1 ;;
       --activate) ACTIVATE=1 ;;
       --no-preflight) RUN_PREFLIGHT=0 ;;
+      --finish=*) MODE=finish; PR_NUMBER="${arg#*=}" ;;
+      --docs-worktree) MODE=docs-setup ;;
+      --docs-worktree-done=*) MODE=docs-teardown; DOCS_WT_DONE="${arg#*=}" ;;
       *) echo "[release] unknown argument: $arg" >&2; exit 2 ;;
     esac
   done
+
+  # -- cross-repo docs worktree modes (#845) ---------------------------------
+  # Dispatched before the release guards on purpose: these run AFTER a release,
+  # from a repo that is no longer in the pre-release state those guards assert.
+  if [ "$MODE" = "docs-teardown" ]; then
+    docs_worktree_teardown "$DOCS_WT_DONE"
+    return 0
+  fi
+  if [ "$MODE" = "docs-setup" ]; then
+    local DOCS_REPO DOCS_BRANCH DOCS_BASE DOCS_ROOT DOCS_VERSION
+    DOCS_REPO="$(extract_cfg_default docs.repo '')"
+    [ -n "$DOCS_REPO" ] || fail "docs step: release.toml has no [docs] repo -- this repo declares no cross-repo docs target"
+    # STABLE branch name (#820): the next release extends the open docs PR
+    # instead of stacking a version-pinned branch on top of the previous one.
+    DOCS_BRANCH="$(extract_cfg_default docs.branch "docs/${WORK_REPO}-current")"
+    DOCS_BASE="$(extract_cfg_default docs.base main)"
+    DOCS_ROOT="$(legion watch list | watch_repo_root "$DOCS_REPO")" \
+      || fail "docs step: '${DOCS_REPO}' is not registered in watch.toml -- cannot resolve its checkout"
+    DOCS_VERSION="$(legion sym etc extract "$SOURCE_FILE" --field "$SOURCE_FIELD" 2>/dev/null || printf 'current')"
+    docs_worktree_setup "$DOCS_ROOT" "$DOCS_BRANCH" "$DOCS_BASE" "${DOCS_REPO}-docs-${DOCS_VERSION}"
+    return 0
+  fi
+
   [ -n "$BUMP" ] || {
     echo "[release] usage: release.sh <patch|minor|major|X.Y.Z> [--dry-run] [--activate] [--no-preflight]" >&2
+    echo "                 release.sh <X.Y.Z> --finish=<pr-number> [--activate]" >&2
+    echo "                 release.sh --docs-worktree | --docs-worktree-done=<path>" >&2
     exit 2
   }
 
@@ -220,6 +520,25 @@ main() {
       "$@"
     fi
   }
+
+  # -- finish mode: phases 7b-9 of an already-staged release -----------------
+  # Split from the staging run because the step between them -- earning the
+  # legion-simplify and legion-pr-write gates on the release commit and opening
+  # the PR -- is an AGENT's job, not a script's: both gates are keyed to the
+  # commit hash, and a clean verdict can only be recorded through their CHECK
+  # validators. That is the point of #844, not a workaround for it: the release
+  # commit passes the same gates every other change passes.
+  if [ "$MODE" = "finish" ]; then
+    local F_TAG F_TAG_MESSAGE
+    [ -n "$PR_NUMBER" ] || fail "--finish requires the PR number (--finish=<pr-number>)"
+    is_semver "$BUMP" || fail "--finish requires the explicit release version (release.sh X.Y.Z --finish=N), got '${BUMP}'"
+    F_TAG="$(render_tag "$TAG_FORMAT" "$BUMP")"
+    F_TAG_MESSAGE="$(render_tag "$TAG_MESSAGE_FORMAT" "$BUMP")"
+    finish_release "$REPO_ROOT" "$WORK_REPO" "$RELEASE_BRANCH" "$SOURCE_FILE_REL" \
+      "$SOURCE_FIELD" "$BUMP" "$F_TAG" "$F_TAG_MESSAGE" "$PR_NUMBER" \
+      "$MERGE_WAIT_POLLS" "$MERGE_WAIT_INTERVAL" "$ACTIVATE"
+    return 0
+  fi
 
   # -- 1. guards -------------------------------------------------------------
   local BRANCH LOCAL REMOTE DIRTY_OTHER
@@ -252,8 +571,18 @@ $DIRTY_OTHER"
   TAG_MESSAGE="$(render_tag "$TAG_MESSAGE_FORMAT" "$NEW")"
 
   # Refuse a tag that already exists (a re-run after a partial failure, or a typo
-  # colliding with history) before we mutate anything.
+  # colliding with history) before we mutate anything. Note this guard is
+  # STAGING-only: `--finish` deliberately tolerates a pre-existing tag that
+  # already points at the verified merged sha, because re-running just the tag
+  # step is the documented recovery from a failed tag push.
   ! git rev-parse "$TAG" >/dev/null 2>&1 || fail "tag ${TAG} already exists"
+
+  # The release commit is made on its own branch (#844), so a leftover one from
+  # an abandoned attempt is a collision worth naming before anything mutates.
+  local RELEASE_PR_BRANCH
+  RELEASE_PR_BRANCH="release/${NEW}"
+  ! git rev-parse --verify --quiet "refs/heads/${RELEASE_PR_BRANCH}" >/dev/null 2>&1 \
+    || fail "branch ${RELEASE_PR_BRANCH} already exists -- an earlier attempt at this release did not finish. Inspect it, then delete it or run 'release.sh ${NEW} --finish=<pr-number>' if its PR is already open."
 
   info "releasing ${CURRENT} -> ${NEW}"
 
@@ -317,24 +646,261 @@ for t in json.load(sys.stdin):
       ADD_FILES+=("${REPO_ROOT}/${t}")
     done <<<"$TARGET_FILES_REL"
   fi
+  # The release commit is made on `release/<new>`, never on ${RELEASE_BRANCH}.
+  # `git switch -c` carries the staged and unstaged changes across, so the
+  # CHANGELOG entry written under the entry contract lands in this commit.
+  run git switch -c "$RELEASE_PR_BRANCH"
   run git add "${ADD_FILES[@]}"
   run git commit -m "chore(release): ${NEW}
 
 Co-Authored-By: ${CO_AUTHORED_BY}"
 
-  # -- 7. tag + atomic push --------------------------------------------------
-  # --atomic so the branch and the tag land together: a half-push that left
-  # the commit without its tag would leave release.yml unfired.
-  run git tag -a "$TAG" -m "$TAG_MESSAGE"
-  run git push --atomic origin "$RELEASE_BRANCH" "$TAG"
-  info "pushed ${TAG} -- release.yml will build + publish the platform binaries"
+  # -- 7a. push the release branch through the audited path ------------------
+  # `legion push` only -- there is no `git push` of a commit anywhere in this
+  # script any more. The old `git push --atomic origin main <tag>` is what
+  # #844 removed: it bypassed the pull-request, merge-queue and status-check
+  # rules on the one commit that reaches every agent in the cluster.
+  local FINISH_CMD
+  FINISH_CMD="scripts/release.sh ${NEW} --finish=<pr-number>"
+  if [ "$ACTIVATE" = "1" ]; then FINISH_CMD="${FINISH_CMD} --activate"; fi
 
-  # -- 8. optional local activation ------------------------------------------
+  if [ "$DRY_RUN" = "1" ]; then
+    printf '[dry-run] legion push --repo %s --branch %s\n' "$WORK_REPO" "$RELEASE_PR_BRANCH" >&2
+    printf '[dry-run] then: simplify + pr-write gates, legion pr create, legion pr merge\n' >&2
+    printf '[dry-run] then: %s\n' "$FINISH_CMD" >&2
+    printf '[dry-run] which waits for the queue, verifies origin/%s carries %s, tags that sha as %s and pushes ONLY the tag\n' \
+      "$RELEASE_BRANCH" "$NEW" "$TAG" >&2
+    if [ "$ACTIVATE" = "1" ]; then
+      activate_local "$REPO_ROOT" "$NEW" 1
+    fi
+    info "dry-run complete: ${CURRENT} -> ${NEW} (nothing was mutated, pushed or tagged)"
+    return 0
+  fi
+
+  legion push --repo "$WORK_REPO" --branch "$RELEASE_PR_BRANCH" \
+    || fail "'legion push' failed for ${RELEASE_PR_BRANCH} -- the release commit exists locally but is not on the remote. Fix the push, then re-run it; nothing has been tagged."
+
+  # -- 7b. hand off to the gates, then come back via --finish ----------------
+  # Deliberately NOT done here: the legion-simplify and legion-pr-write gates
+  # are keyed to the release commit's hash and can only be earned through their
+  # CHECK validators, which is an agent's job. That is exactly the point -- the
+  # release commit passes the same gates every other change passes.
+  info "release ${NEW} is STAGED, not shipped: ${RELEASE_PR_BRANCH} is pushed and nothing is tagged."
+  info "next: run the legion-simplify and legion-pr-write gates on this branch, then"
+  info "      legion pr create --repo ${WORK_REPO} --title 'chore(release): ${NEW}' --head ${RELEASE_PR_BRANCH}"
+  info "      legion pr merge --repo ${WORK_REPO} --number <pr-number>"
+  info "      ${FINISH_CMD}"
+}
+
+# finish_release <repo_root> <work_repo> <release_branch> <source_file_rel>
+#   <field> <new> <tag> <tag_message> <pr_number> <max_polls> <interval> <activate>
+#
+# Phases 7b-9: wait for the merge queue, verify what actually landed, tag THAT
+# commit, and push only the tag.
+#
+# The ordering is the whole point of #844 and is not rearrangeable:
+#   1. wait  -- `legion pr merge` enqueues and returns; the merge is
+#               asynchronous, so a bounded poll stands between enqueue and tag.
+#   2. read  -- re-fetch origin/<branch> and take ITS sha. The queue may squash
+#               or rebase, so the local branch tip is not the merged commit;
+#               tagging it would point the release at an object that is not on
+#               the branch and make release.yml build a tree nobody reviewed in
+#               that form.
+#   3. verify -- confirm the merged tree really carries <new> before tagging.
+#   4. tag + push the TAG ONLY.
+finish_release() {
+  local REPO_ROOT="$1" WORK_REPO="$2" RELEASE_BRANCH="$3" SOURCE_FILE_REL="$4"
+  local SOURCE_FIELD="$5" NEW="$6" TAG="$7" TAG_MESSAGE="$8" PR_NUMBER="$9"
+  local MAX_POLLS="${10}" INTERVAL="${11}" ACTIVATE="${12}"
+  local OUTCOME RC=0 MERGED_SHA MERGED_VERSION EXISTING_TAG_SHA
+  local LANDED_CMD STATE_CMD QUEUE_CMD
+
+  cd "$REPO_ROOT"
+
+  LANDED_CMD="release_landed '${RELEASE_BRANCH}' '${SOURCE_FILE_REL}' '${SOURCE_FIELD}' '${NEW}'"
+  STATE_CMD="release_pr_state '${WORK_REPO}' '${PR_NUMBER}'"
+  QUEUE_CMD="release_queue_ref_present '${PR_NUMBER}'"
+
+  info "waiting for PR #${PR_NUMBER} to merge (up to ${MAX_POLLS} polls, ${INTERVAL}s apart)"
+  OUTCOME="$(wait_for_release_merge "$MAX_POLLS" "$INTERVAL" "$LANDED_CMD" "$STATE_CMD" "$QUEUE_CMD")" || RC=$?
+
+  case "$OUTCOME" in
+    merged) info "PR #${PR_NUMBER} merged" ;;
+    ejected)
+      fail "PR #${PR_NUMBER} was EJECTED from the merge queue -- it was in the queue, it is no longer, and origin/${RELEASE_BRANCH} does not carry ${NEW}. Nothing was tagged. Merge origin/${RELEASE_BRANCH} into the branch (never rebase -- 'legion push' has no force path), re-run the gates, push, re-enqueue, then re-run this --finish."
+      ;;
+    closed)
+      fail "PR #${PR_NUMBER} is closed without ${NEW} reaching origin/${RELEASE_BRANCH}. Nothing was tagged."
+      ;;
+    timeout)
+      fail "timed out after ${MAX_POLLS} polls (${INTERVAL}s apart) waiting for PR #${PR_NUMBER}. This is a failure to OBSERVE the merge, not evidence the release commit failed -- check PR #${PR_NUMBER} yourself, and re-run 'scripts/release.sh ${NEW} --finish=${PR_NUMBER}' once it has landed. Nothing was tagged."
+      ;;
+    *)
+      fail "merge wait returned an unrecognized outcome '${OUTCOME}' (rc ${RC}). Nothing was tagged."
+      ;;
+  esac
+
+  git fetch origin "$RELEASE_BRANCH" --quiet || fail "git fetch failed after the merge -- cannot resolve the sha to tag. Nothing was tagged."
+  MERGED_SHA="$(git rev-parse "origin/${RELEASE_BRANCH}")" \
+    || fail "could not resolve origin/${RELEASE_BRANCH}. Nothing was tagged."
+
+  # Fails CLOSED: an unreadable version is a mismatch, not a pass.
+  MERGED_VERSION="$(ref_version "origin/${RELEASE_BRANCH}" "$SOURCE_FILE_REL" "$SOURCE_FIELD")"
+  tag_target_matches "$NEW" "$MERGED_VERSION" \
+    || fail "tag-target mismatch: origin/${RELEASE_BRANCH} is ${MERGED_SHA}, whose ${SOURCE_FILE_REL} says '${MERGED_VERSION:-<none>}', not ${NEW}. Refusing to tag a commit that is not the release. Nothing was tagged."
+
+  # A tag left over from a failed push is the documented recovery path, so it is
+  # reused when it already points at the verified sha and fatal otherwise.
+  if EXISTING_TAG_SHA="$(git rev-parse --verify --quiet "refs/tags/${TAG}^{commit}" 2>/dev/null)" && [ -n "$EXISTING_TAG_SHA" ]; then
+    [ "$EXISTING_TAG_SHA" = "$MERGED_SHA" ] \
+      || fail "tag ${TAG} already exists and points at ${EXISTING_TAG_SHA}, not the merged commit ${MERGED_SHA}. Refusing to move it. Nothing was pushed."
+    info "tag ${TAG} already exists on the merged commit -- pushing it"
+  else
+    git tag -a "$TAG" -m "$TAG_MESSAGE" "$MERGED_SHA" \
+      || fail "release INCOMPLETE BUT RECOVERABLE: ${NEW} IS merged on origin/${RELEASE_BRANCH} as ${MERGED_SHA}, but creating ${TAG} failed, so release.yml has NOT fired and no binaries are building. Finish it with:
+       git tag -a ${TAG} -m '${TAG_MESSAGE}' ${MERGED_SHA} && git push origin refs/tags/${TAG}"
+  fi
+
+  git push origin "refs/tags/${TAG}" \
+    || fail "release INCOMPLETE BUT RECOVERABLE: ${NEW} IS merged on origin/${RELEASE_BRANCH} as ${MERGED_SHA} and ${TAG} exists locally on it, but pushing the tag failed, so release.yml has NOT fired and no binaries are building. Re-run only the tag step:
+       git push origin refs/tags/${TAG}
+       (or re-run 'scripts/release.sh ${NEW} --finish=${PR_NUMBER}', which is idempotent from here)"
+
+  info "pushed ${TAG} -> ${MERGED_SHA} -- release.yml will build + publish the platform binaries"
+
+  # Bring the local release branch up to what was just tagged, so an --activate
+  # build (and the next release's in-sync guard) sees the merged tree.
+  if git switch "$RELEASE_BRANCH" --quiet; then
+    git merge --ff-only "origin/${RELEASE_BRANCH}" --quiet \
+      || info "WARNING: local ${RELEASE_BRANCH} could not fast-forward to origin/${RELEASE_BRANCH} -- reconcile it before the next release"
+  else
+    info "WARNING: could not switch back to ${RELEASE_BRANCH} -- the tag is pushed and the release is complete, but reconcile the local checkout before the next one"
+  fi
+
   if [ "$ACTIVATE" = "1" ]; then
-    activate_local "$REPO_ROOT" "$NEW" "$DRY_RUN"
+    activate_local "$REPO_ROOT" "$NEW" 0
   fi
 
   info "done: ${NEW}"
+}
+
+# docs_worktree_setup <docs_root> <branch> <base_branch> <label>: create the
+# isolated worktree the cross-repo docs step runs in and print ITS PATH on
+# stdout -- the only thing on stdout, so the caller can capture it directly.
+# The shared checkout path is never printed and never handed onward.
+#
+# Every failure arm below ends in `fail`. There is deliberately no fallback to
+# the shared checkout: that fallback IS the defect this exists to close, and a
+# docs step that silently degrades to the shared tree is worse than one that
+# stops with a reason.
+docs_worktree_setup() {
+  local root="$1" branch="$2" base_branch="$3" label="$4"
+  local holder start_point parent wt head
+
+  [ -n "$root" ] || fail "docs step: no checkout path resolved for the docs repo"
+  git -C "$root" rev-parse --git-dir >/dev/null 2>&1 \
+    || fail "docs step: '${root}' is not a git checkout -- cannot create the docs worktree"
+  git -C "$root" fetch origin --quiet \
+    || fail "docs step: 'git fetch origin' failed in ${root} -- the worktree must start from a remote ref, so this is fatal"
+
+  # A stale worktree or branch from an earlier release is reported, never
+  # reused and never clobbered: it may hold unpushed work.
+  holder="$(git -C "$root" worktree list --porcelain | worktree_holding_branch "$branch")" || holder=""
+  [ -z "$holder" ] || fail "docs step: ${branch} is already checked out at ${holder} -- it may hold unpushed work from an earlier release. Finish or remove it there; this run will not clobber it and will not fall back to ${root}."
+  ! git -C "$root" show-ref --verify --quiet "refs/heads/${branch}" \
+    || fail "docs step: local branch ${branch} exists in ${root} but no worktree holds it -- it may hold unpushed work from an earlier release. Inspect and remove it there; this run will not reuse or clobber it."
+
+  start_point="$(git -C "$root" ls-remote --heads origin | docs_start_point "$branch" "origin/${base_branch}")"
+
+  parent="$(mktemp -d)" || fail "docs step: could not create a temp dir for the docs worktree"
+  wt="${parent}/${label}"
+
+  git -C "$root" worktree add --quiet -b "$branch" "$wt" "$start_point" \
+    || fail "docs step: 'git worktree add -b ${branch} ${wt} ${start_point}' failed in ${root} -- not falling back to the shared checkout"
+
+  # abandon_setup <message>: every failure AFTER the worktree exists unwinds the
+  # whole of setup's own work -- worktree, branch and temp parent -- before it
+  # reports. A half-built worktree left behind would hold the stable branch and
+  # collide with the next release, which is the state this function refuses to
+  # create in the first place. Nothing here can lose agent work: the docs agent
+  # has not been handed the path yet.
+  abandon_setup() {
+    git -C "$wt" merge --abort >/dev/null 2>&1 || true
+    git -C "$root" worktree remove --force "$wt" >/dev/null 2>&1 || true
+    git -C "$root" branch -D "$branch" >/dev/null 2>&1 || true
+    rm -rf "$parent"
+    fail "$1"
+  }
+
+  # Extend arm (#820): the stable docs branch already exists on the remote, so
+  # bring it up to the base rather than opening a second stacked docs PR. MERGE,
+  # never rebase -- `legion push` has no force path, so rewritten history would
+  # strand the branch.
+  if [ "$start_point" != "origin/${base_branch}" ]; then
+    git -C "$wt" merge --quiet "origin/${base_branch}" -m "Merge origin/${base_branch} into ${branch}" \
+      || abandon_setup "docs step: merging origin/${base_branch} into the existing ${branch} conflicted -- resolve it in ${root} first. Not falling back to the shared checkout."
+  fi
+
+  # The base sha is recorded AFTER any merge-in, so teardown measures what the
+  # docs agent added rather than counting setup's own merge as agent work. It
+  # lives in the temp parent, NOT inside the worktree, which would dirty the
+  # very tree teardown inspects for cleanliness -- and its presence is later
+  # what proves to teardown that this script created that parent directory.
+  head="$(git -C "$wt" rev-parse HEAD)" || abandon_setup "docs step: could not read HEAD of the new worktree at ${wt}"
+  printf '%s\n' "$head" >"${parent}/base-sha" \
+    || abandon_setup "docs step: could not record the base sha for ${wt}"
+
+  info "docs worktree ready: ${wt} (branch ${branch}, from ${start_point})"
+  printf '%s\n' "$wt"
+}
+
+# docs_worktree_teardown <worktree_path>: remove the docs worktree when it
+# carries nothing, retain it (naming the path) when it does. A failed or partial
+# docs run is recoverable rather than discarded; a clean or fully-pushed one
+# leaves no residue to collide with the next release's stable branch.
+docs_worktree_teardown() {
+  local wt="$1" parent base head status branch root pushed=0
+
+  [ -n "$wt" ] || fail "--docs-worktree-done requires the worktree path (--docs-worktree-done=<path>)"
+  [ -d "$wt" ] || fail "docs step: no worktree at ${wt} -- nothing to tear down"
+  git -C "$wt" rev-parse --git-dir >/dev/null 2>&1 \
+    || fail "docs step: ${wt} is not a git worktree"
+
+  parent="$(dirname "$wt")"
+  base="$(cat "${parent}/base-sha" 2>/dev/null || true)"
+  # `--docs-worktree-done=` takes an operator-supplied path, so the parent
+  # directory is only ever removed when this script demonstrably created it --
+  # the base-sha marker is that proof. A hand-made worktree in a shared
+  # directory would otherwise take its siblings with it, which is precisely the
+  # collateral damage this feature exists to prevent.
+  local parent_is_ours=0
+  if [ -f "${parent}/base-sha" ]; then parent_is_ours=1; fi
+  head="$(git -C "$wt" rev-parse HEAD 2>/dev/null || true)"
+  status="$(git -C "$wt" status --porcelain 2>/dev/null || printf 'unknown')"
+  branch="$(git -C "$wt" rev-parse --abbrev-ref HEAD 2>/dev/null || true)"
+  root="$(git -C "$wt" worktree list --porcelain 2>/dev/null | head -1)"
+  root="${root#worktree }"
+  [ -n "$root" ] || fail "docs step: could not resolve the main checkout backing ${wt}"
+
+  # "Already on the remote" is the second disposal arm: a docs run that
+  # committed AND pushed carries commits but loses nothing when removed.
+  git -C "$wt" fetch origin "$branch" --quiet >/dev/null 2>&1 || true
+  if [ -n "$branch" ] && git -C "$wt" merge-base --is-ancestor HEAD "origin/${branch}" >/dev/null 2>&1; then
+    pushed=1
+  fi
+
+  if worktree_is_disposable "$head" "$base" "$status" "$pushed"; then
+    git -C "$root" worktree remove --force "$wt" \
+      || fail "docs step: could not remove the unchanged worktree at ${wt}"
+    # Safe by construction: the branch is either untouched since setup or fully
+    # present on origin, so the only thing dropped is setup's own local
+    # merge commit, which the next release re-derives.
+    git -C "$root" branch -D "$branch" >/dev/null 2>&1 || true
+    if [ "$parent_is_ours" = "1" ]; then rm -rf "$parent"; fi
+    info "docs worktree removed -- ${branch} carried nothing that is not already on origin"
+  else
+    info "docs worktree RETAINED at ${wt} (branch ${branch}) -- it carries work that is not on origin. Finish or push it from there, then re-run: scripts/release.sh --docs-worktree-done=${wt}"
+  fi
 }
 
 # activate_local <repo_root> <new> <dry_run>: build the release binary, install it

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -598,8 +598,17 @@ main() {
   # pushed, and `--docs-worktree-done=<path> --dry-run` really removed the
   # worktree. Refusing the combination is both cheaper and less ambiguous than
   # implementing a no-op for steps whose entire content is the mutation.
+  # The message names the FLAG the operator typed, not the internal mode name:
+  # "docs-setup mode" appears in neither the usage text nor legion-release.md.
   if [ "$DRY_RUN" = "1" ] && [ "$MODE" != "stage" ]; then
-    fail "--dry-run is not supported in ${MODE} mode -- it polls, tags, pushes or removes worktrees, and there is no meaningful no-op for those. Re-run without --dry-run."
+    local DRY_RUN_CONFLICT
+    case "$MODE" in
+      finish)        DRY_RUN_CONFLICT="--finish= (it polls the merge queue, tags the release commit and pushes the tag)" ;;
+      docs-setup)    DRY_RUN_CONFLICT="--docs-worktree (it creates a branch and a worktree, and its whole output is that worktree's path)" ;;
+      docs-teardown) DRY_RUN_CONFLICT="--docs-worktree-done= (it removes a worktree and deletes a branch)" ;;
+      *)             DRY_RUN_CONFLICT="${MODE}" ;;
+    esac
+    fail "--dry-run cannot be combined with ${DRY_RUN_CONFLICT}. There is no meaningful no-op for a step whose entire content is the mutation, and this combination used to be accepted and then ignored. Re-run without --dry-run. (--dry-run applies to the staging run: 'release.sh <X.Y.Z> --dry-run'.)"
   fi
 
   # -- cross-repo docs worktree modes (#845) ---------------------------------

--- a/scripts/test-release.sh
+++ b/scripts/test-release.sh
@@ -111,5 +111,273 @@ echo "unsupported" >"${BUMP_DIR}/version.yaml"
 no "bump: unsupported format refused" bump_source_file "${BUMP_DIR}/version.yaml" version 0.1.0 0.2.0
 eq "bump: unsupported format untouched" "unsupported" "$(cat "${BUMP_DIR}/version.yaml")"
 
+# -- merge-queue phase helpers (#844) ---------------------------------------
+
+# Stdin-reading helpers are wrapped so `ok`/`no` can exercise their exit status
+# in THIS shell -- a `bash -c` subshell would not see the sourced functions at
+# all, and would "fail" for the wrong reason.
+feed_watch_root() { printf '%s' "$1" | watch_repo_root "$2"; }
+feed_wt_holder()  { printf '%s' "$1" | worktree_holding_branch "$2"; }
+
+# classify_release_merge <landed> <state> <queue_present> <seen_queued>.
+# The ORDER of the arms is the correctness property: "origin/main carries the
+# new version" beats the PR's own state, which lags and which the queue's
+# squash/rebase makes unreliable as a sha-level signal.
+eq "merge: landed wins over open pr"    "merged"  "$(classify_release_merge 1 OPEN 1 1)"
+eq "merge: landed wins over closed pr"  "merged"  "$(classify_release_merge 1 CLOSED 0 1)"
+eq "merge: state merged"                "merged"  "$(classify_release_merge 0 MERGED 0 1)"
+eq "merge: state closed"                "closed"  "$(classify_release_merge 0 CLOSED 0 1)"
+eq "merge: in the queue"                "queued"  "$(classify_release_merge 0 OPEN 1 0)"
+# Was in the queue, is no longer, and main does not carry the release: ejection.
+eq "merge: ejected"                     "ejected" "$(classify_release_merge 0 OPEN 0 1)"
+# Never seen in the queue is NOT evidence of ejection -- the queue admits a
+# bounded group size, so a PR can sit un-enqueued for a while. Stays pending and
+# expires into a timeout rather than reporting a false ejection.
+eq "merge: never queued stays pending"  "pending" "$(classify_release_merge 0 OPEN 0 0)"
+eq "merge: unknown state stays pending" "pending" "$(classify_release_merge 0 UNKNOWN 0 0)"
+
+# wait_for_release_merge: the bounded poll, driven entirely by injected command
+# STRINGS -- no gh, no git, no network. Each observer is a shell one-liner; a
+# counter file makes a sequence of observations across polls.
+WAIT_DIR=$(mktemp -d)
+# step <file>: print the call count so far, then increment it.
+step() { local f="$1" n; n="$(cat "$f")"; printf '%s\n' "$((n + 1))" >"$f"; printf '%s\n' "$n"; }
+
+eq "wait: merged on the first poll" "merged" \
+  "$(wait_for_release_merge 5 0 'printf 1' 'printf OPEN' 'printf 0')"
+eq "wait: merged rc" "0" \
+  "$(wait_for_release_merge 5 0 'printf 1' 'printf OPEN' 'printf 0' >/dev/null; printf '%s' $?)"
+
+eq "wait: closed pr stops the release" "closed" \
+  "$(wait_for_release_merge 5 0 'printf 0' 'printf CLOSED' 'printf 0')"
+eq "wait: closed rc" "3" \
+  "$(wait_for_release_merge 5 0 'printf 0' 'printf CLOSED' 'printf 0' >/dev/null || printf '%s' $?)"
+
+# Queued for two polls, then lands: the authoritative `landed` signal flips
+# while the queue ref disappears in the same window. Must read as merged, not
+# as an ejection.
+printf '0\n' >"${WAIT_DIR}/land"
+LANDED_SEQ="n=\$(step ${WAIT_DIR}/land); if [ \"\$n\" -ge 2 ]; then printf 1; else printf 0; fi"
+QUEUE_SEQ="if [ \"\$(cat ${WAIT_DIR}/land)\" -lt 2 ]; then printf 1; else printf 0; fi"
+eq "wait: queued then merged" "merged" \
+  "$(wait_for_release_merge 6 0 "$LANDED_SEQ" 'printf OPEN' "$QUEUE_SEQ")"
+
+# Seen in the queue, then gone, and main never carries the release: ejection --
+# but only after the CONFIRMING second observation, since the queue ref also
+# disappears at the moment of a successful merge.
+printf '0\n' >"${WAIT_DIR}/ej"
+QUEUE_ONCE="n=\$(step ${WAIT_DIR}/ej); if [ \"\$n\" = 0 ]; then printf 1; else printf 0; fi"
+eq "wait: ejection reported" "ejected" \
+  "$(wait_for_release_merge 6 0 'printf 0' 'printf OPEN' "$QUEUE_ONCE")"
+printf '0\n' >"${WAIT_DIR}/ej2"
+QUEUE_ONCE2="n=\$(step ${WAIT_DIR}/ej2); if [ \"\$n\" = 0 ]; then printf 1; else printf 0; fi"
+eq "wait: ejection rc" "4" \
+  "$(wait_for_release_merge 6 0 'printf 0' 'printf OPEN' "$QUEUE_ONCE2" >/dev/null || printf '%s' $?)"
+# A single missing-ref observation immediately after a queued one is NOT an
+# ejection: with a budget of exactly 2 polls the confirming observation is the
+# last one, so a merge that lands on it still reads as merged.
+printf '0\n' >"${WAIT_DIR}/race"
+RACE_LANDED="n=\$(step ${WAIT_DIR}/race); if [ \"\$n\" -ge 1 ]; then printf 1; else printf 0; fi"
+RACE_QUEUE="if [ \"\$(cat ${WAIT_DIR}/race)\" -lt 1 ]; then printf 1; else printf 0; fi"
+eq "wait: merge-window ref drop is not an ejection" "merged" \
+  "$(wait_for_release_merge 2 0 "$RACE_LANDED" 'printf OPEN' "$RACE_QUEUE")"
+
+eq "wait: budget expiry is a timeout" "timeout" \
+  "$(wait_for_release_merge 3 0 'printf 0' 'printf OPEN' 'printf 0')"
+eq "wait: timeout rc" "5" \
+  "$(wait_for_release_merge 3 0 'printf 0' 'printf OPEN' 'printf 0' >/dev/null || printf '%s' $?)"
+# An observer that cannot be read must not stall or crash the wait -- it falls
+# back to "no signal" and the budget still expires cleanly.
+eq "wait: unreadable observers expire" "timeout" \
+  "$(wait_for_release_merge 2 0 'exit 7' 'exit 7' 'exit 7')"
+# The observers are eval'd in THIS shell, so a SOURCED helper resolves. If they
+# were run in a subshell that could not see release.sh's own functions, every
+# poll would read landed=0 and a merged release would time out.
+sourced_probe() { printf '1\n'; }
+eq "wait: injected command resolves a sourced helper" "merged" \
+  "$(wait_for_release_merge 2 0 'sourced_probe' 'printf OPEN' 'printf 0')"
+
+# tag_target_matches: the guard between "the queue merged something" and "the
+# tag points at the release". Fails CLOSED on an unreadable version.
+ok "tag target: match"          tag_target_matches 0.26.0 0.26.0
+no "tag target: mismatch"       tag_target_matches 0.26.0 0.25.0
+no "tag target: empty observed" tag_target_matches 0.26.0 ""
+
+# -- cross-repo docs worktree helpers (#845) --------------------------------
+
+# watch_repo_root: the docs repo's checkout is resolved, never hardcoded (the
+# path differs per machine). Tab-separated "<name>\t<path>", with an optional
+# " (agent: X)" suffix on the path.
+WATCH_FIXTURE="$(printf 'legion\t/p/legion\nshingle\t/p/shingle\nastro-consent\t/p/astro-consent (agent: shingle)\n')"
+eq "watch: resolves a repo"        "/p/shingle"      "$(printf '%s\n' "$WATCH_FIXTURE" | watch_repo_root shingle)"
+eq "watch: strips agent suffix"    "/p/astro-consent" "$(printf '%s\n' "$WATCH_FIXTURE" | watch_repo_root astro-consent)"
+eq "watch: exact name match only"  ""                "$(printf '%s\n' "$WATCH_FIXTURE" | watch_repo_root shing || true)"
+no "watch: unregistered repo refused" feed_watch_root "$WATCH_FIXTURE" nope
+
+# docs_start_point: where #845 (start from a REMOTE ref, never the shared
+# checkout's current branch) meets #820 (a STABLE branch the next release
+# extends, not a version-pinned one that stacks a PR per release).
+LSREMOTE="$(printf 'aaa\trefs/heads/main\nbbb\trefs/heads/docs/legion-current\nccc\trefs/heads/docs/legion-0.24.0\n')"
+eq "docs start: extends the existing stable branch" "origin/docs/legion-current" \
+  "$(printf '%s\n' "$LSREMOTE" | docs_start_point 'docs/legion-current' 'origin/main')"
+eq "docs start: falls back to the base when absent" "origin/main" \
+  "$(printf 'aaa\trefs/heads/main\n' | docs_start_point 'docs/legion-current' 'origin/main')"
+eq "docs start: no remote heads at all" "origin/main" \
+  "$(printf '' | docs_start_point 'docs/legion-current' 'origin/main')"
+# A prefix lookalike must not be mistaken for the branch -- starting from the
+# wrong remote branch is the same class of defect as starting from the shared
+# checkout's branch.
+eq "docs start: prefix lookalike ignored" "origin/main" \
+  "$(printf 'ccc\trefs/heads/docs/legion-current-old\n' | docs_start_point 'docs/legion-current' 'origin/main')"
+
+# worktree_holding_branch: a stale worktree on the stable docs branch is
+# REPORTED, not clobbered -- it may hold unpushed work.
+WTLIST="$(printf 'worktree /p/shingle\nHEAD aaa\nbranch refs/heads/main\n\nworktree /tmp/x/shingle-docs\nHEAD bbb\nbranch refs/heads/docs/legion-current\n')"
+eq "worktree: finds the holder" "/tmp/x/shingle-docs" \
+  "$(printf '%s\n' "$WTLIST" | worktree_holding_branch 'docs/legion-current')"
+eq "worktree: finds the main checkout" "/p/shingle" \
+  "$(printf '%s\n' "$WTLIST" | worktree_holding_branch 'main')"
+no "worktree: nobody holds it" \
+  feed_wt_holder "$(printf 'worktree /p/shingle\nHEAD aaa\nbranch refs/heads/main\n')" 'docs/legion-current'
+# A detached worktree has no `branch` line at all and must not match.
+no "worktree: detached entry does not match" \
+  feed_wt_holder "$(printf 'worktree /p/shingle\nHEAD aaa\ndetached\n')" 'docs/legion-current'
+
+# worktree_is_disposable <head> <base> <status> <pushed>: removing it must
+# throw nothing away.
+ok "disposable: untouched since setup"      worktree_is_disposable aaa aaa "" 0
+no "disposable: uncommitted changes kept"   worktree_is_disposable aaa aaa " M docs/x.mdx" 0
+no "disposable: unpushed commits kept"      worktree_is_disposable bbb aaa "" 0
+# The second arm: a docs run that committed AND pushed carries commits but
+# loses nothing when removed. Without it a SUCCESSFUL run would pin the
+# worktree forever and collide on the stable branch at the next release.
+ok "disposable: committed but pushed"       worktree_is_disposable bbb aaa "" 1
+no "disposable: pushed but tree dirty"      worktree_is_disposable bbb aaa " M docs/x.mdx" 1
+no "disposable: unreadable head fails closed" worktree_is_disposable "" aaa "" 1
+
+# docs_worktree_setup / docs_worktree_teardown against REAL git repos. These two
+# are the mechanism #845 is actually buying -- the pure helpers above only decide
+# what they should do -- so they are exercised end to end against a local bare
+# remote. No network, no gh, no shingle. Both call `fail` (which exits), so every
+# arm runs in a subshell.
+#
+# EVERY fixture command below addresses its repo with `git -C <dir>` and writes
+# through absolute paths. Nothing here uses `cd`, and that is a hard rule, not a
+# style preference: `cd ""` is a SILENT NO-OP in bash, so a `(cd "$WT" && git
+# commit ...)` where the helper under test returned nothing runs the fixture's
+# git commands in whatever repo is running the tests. That is not hypothetical --
+# it happened while building this file, during a mutation run that deliberately
+# broke docs_worktree_setup, and it committed the test runner's own staged work
+# onto a fixture branch. `require_dir` below turns that class into a loud test
+# failure instead of collateral damage.
+require_dir() { # require_dir <label> <path>
+  local label="$1" d="$2"
+  if [ -n "$d" ] && [ -d "$d" ]; then PASS=$((PASS + 1)); return 0; fi
+  FAIL=$((FAIL + 1))
+  printf 'FAIL: %s -- no usable directory [%s]; dependent assertions skipped\n' "$label" "$d" >&2
+  return 1
+}
+gitc() { git -c user.email=t@t -c user.name=t "$@"; }
+
+DOCS_TMP=$(mktemp -d)
+DOCS_CO="${DOCS_TMP}/checkout"
+DOCS_BRANCH="docs/fixture-current"
+git init --bare --quiet "${DOCS_TMP}/origin.git"
+git -c init.defaultBranch=main init --quiet "$DOCS_CO"
+git -C "$DOCS_CO" checkout --quiet -B main
+printf 'docs\n' >"${DOCS_CO}/index.md"
+git -C "$DOCS_CO" add index.md
+gitc -C "$DOCS_CO" commit --quiet --no-verify -m "init"
+git -C "$DOCS_CO" remote add origin "${DOCS_TMP}/origin.git"
+git -C "$DOCS_CO" push --quiet -u origin main
+
+# Fresh arm: no such branch on the remote, so the worktree starts from
+# origin/main -- NOT from whatever the shared checkout has checked out. Prove
+# that by parking the shared checkout on an unrelated branch first.
+git -C "$DOCS_CO" checkout --quiet -b someone-elses-work
+printf 'wip\n' >"${DOCS_CO}/wip.md"
+git -C "$DOCS_CO" add wip.md
+gitc -C "$DOCS_CO" commit --quiet --no-verify -m "wip"
+WT1="$( (docs_worktree_setup "$DOCS_CO" "$DOCS_BRANCH" main fixture-docs) 2>/dev/null )"
+if require_dir "docs wt: created" "$WT1"; then
+  eq "docs wt: on the stable branch" "$DOCS_BRANCH" "$(git -C "$WT1" rev-parse --abbrev-ref HEAD 2>/dev/null)"
+  # The load-bearing one: it must NOT have inherited the other agent's branch.
+  eq "docs wt: starts from origin/main, not the shared checkout's branch" \
+    "$(git -C "$DOCS_CO" rev-parse origin/main)" "$(git -C "$WT1" rev-parse HEAD 2>/dev/null)"
+  ok "docs wt: the other agent's file is absent" test ! -f "${WT1}/wip.md"
+  ok "docs wt: base sha recorded outside the worktree" test -f "$(dirname "$WT1")/base-sha"
+  eq "docs wt: worktree left clean" "" "$(git -C "$WT1" status --porcelain 2>/dev/null)"
+fi
+
+# Collision: the stable branch is already checked out. Report it, never clobber
+# it, and above all never emit the shared checkout path as the answer.
+COLLIDE_RC=0
+COLLIDE_OUT="$( (docs_worktree_setup "$DOCS_CO" "$DOCS_BRANCH" main fixture-docs) 2>/dev/null )" || COLLIDE_RC=$?
+eq "docs wt: collision fails" "1" "$COLLIDE_RC"
+eq "docs wt: collision emits no path at all" "" "$COLLIDE_OUT"
+ok "docs wt: collision never yields the shared checkout" test "$COLLIDE_OUT" != "$DOCS_CO"
+
+# Teardown, unchanged: removed, and the local branch with it, so the next
+# release does not collide on the stable name.
+(docs_worktree_teardown "$WT1") >/dev/null 2>&1
+ok "docs teardown: unchanged worktree removed" test ! -d "$WT1"
+no "docs teardown: unchanged branch removed too" \
+  git -C "$DOCS_CO" show-ref --verify --quiet "refs/heads/${DOCS_BRANCH}"
+
+# Teardown, carrying unpushed commits: RETAINED, so a failed docs run is
+# recoverable rather than discarded.
+WT2="$( (docs_worktree_setup "$DOCS_CO" "$DOCS_BRANCH" main fixture-docs) 2>/dev/null )"
+if require_dir "docs teardown: second worktree created" "$WT2"; then
+  printf 'draft\n' >"${WT2}/draft.md"
+  git -C "$WT2" add draft.md
+  gitc -C "$WT2" commit --quiet --no-verify -m "docs: draft"
+  (docs_worktree_teardown "$WT2") >/dev/null 2>&1
+  ok "docs teardown: unpushed work retained" test -d "$WT2"
+  ok "docs teardown: retained worktree keeps its commit" test -f "${WT2}/draft.md"
+
+  # Same worktree once the work is PUSHED: now disposable. Without this arm a
+  # successful docs run would pin the worktree forever and collide next release.
+  git -C "$WT2" push --quiet -u origin "$DOCS_BRANCH"
+  (docs_worktree_teardown "$WT2") >/dev/null 2>&1
+  ok "docs teardown: pushed work is disposable" test ! -d "$WT2"
+fi
+
+# Extend arm (#820): the stable branch now exists on the remote, so the next
+# release starts from IT and merges origin/main in -- one docs PR that each
+# release extends, not a new version-pinned branch stacked on the last.
+git -C "$DOCS_CO" checkout --quiet main
+printf 'more\n' >>"${DOCS_CO}/index.md"
+gitc -C "$DOCS_CO" commit --quiet --no-verify -am "main moves on"
+git -C "$DOCS_CO" push --quiet origin main
+WT3="$( (docs_worktree_setup "$DOCS_CO" "$DOCS_BRANCH" main fixture-docs) 2>/dev/null )"
+if require_dir "docs extend: worktree created on the existing stable branch" "$WT3"; then
+  ok "docs extend: the earlier release's docs commit is still there" test -f "${WT3}/draft.md"
+  ok "docs extend: origin/main was merged in" \
+    git -C "$WT3" merge-base --is-ancestor origin/main HEAD
+  # The merge is setup's own work, so it must not count as agent work at teardown.
+  eq "docs extend: base sha recorded after the merge-in" \
+    "$(git -C "$WT3" rev-parse HEAD 2>/dev/null)" "$(cat "$(dirname "$WT3")/base-sha" 2>/dev/null)"
+  (docs_worktree_teardown "$WT3") >/dev/null 2>&1
+  ok "docs extend: unchanged extend-arm worktree removed" test ! -d "$WT3"
+fi
+
+# --docs-worktree-done= takes an OPERATOR-supplied path. A worktree this script
+# did not create lives in a directory it does not own, so teardown must remove
+# the worktree and nothing else -- deleting the parent would take the siblings
+# with it, which is the collateral damage this whole feature exists to prevent.
+SHARED="${DOCS_TMP}/shared"
+mkdir -p "$SHARED"
+printf 'do not delete me\n' >"${SHARED}/sibling.txt"
+git -C "$DOCS_CO" worktree add --quiet -b hand-made "${SHARED}/hand-made" main >/dev/null 2>&1
+# Push it so it reaches the DISPOSABLE arm -- the guard only matters there, and
+# a retained worktree would never have reached the `rm -rf` in the first place.
+git -C "${SHARED}/hand-made" push --quiet -u origin hand-made
+(docs_worktree_teardown "${SHARED}/hand-made") >/dev/null 2>&1
+ok "docs teardown: foreign worktree still removed" test ! -d "${SHARED}/hand-made"
+ok "docs teardown: an unowned parent directory survives" test -d "$SHARED"
+ok "docs teardown: its siblings survive" test -f "${SHARED}/sibling.txt"
+
+rm -rf "$WAIT_DIR" "$DOCS_TMP"
+
 printf '\n[test-release] %d passed, %d failed\n' "$PASS" "$FAIL" >&2
 [ "$FAIL" -eq 0 ]

--- a/scripts/test-release.sh
+++ b/scripts/test-release.sh
@@ -29,6 +29,45 @@ no() { # no <label> <cmd...>   (expect non-zero)
   if "$@"; then FAIL=$((FAIL + 1)); printf 'FAIL: %s -- expected failure\n' "$label" >&2; else PASS=$((PASS + 1)); fi
 }
 
+# -- git fixture preamble ----------------------------------------------------
+# Shared by every block below that builds a real repo. Defined up here because
+# the first of those blocks is the merge-observer section, well before the docs
+# worktree fixtures.
+#
+# `require_dir` IS THE GUARD on fixture commands, and it is worth being exact
+# about that, because the natural reading is that addressing repos with `git -C
+# <dir>` instead of `cd` closed the incident class by itself. It did not:
+# `git -C ""` does NOT fail -- inside a repo it runs in the CURRENT repo and
+# exits 0, exactly the silent cwd fallback `cd ""` gives you. So a fixture
+# command built on a helper that returned nothing is just as capable of
+# operating on the test runner's own checkout either way. That is not
+# hypothetical: during a mutation run that deliberately broke
+# docs_worktree_setup, the fixture committed the test runner's own staged work
+# onto a fixture branch. What prevents it is refusing to run the dependent
+# assertions at all when the path is empty or missing -- so do not add an
+# unguarded `git -C "$SOMETHING"` believing the primitive protects you.
+require_dir() { # require_dir <label> <path>
+  local label="$1" d="$2"
+  if [ -n "$d" ] && [ -d "$d" ]; then PASS=$((PASS + 1)); return 0; fi
+  FAIL=$((FAIL + 1))
+  printf 'FAIL: %s -- no usable directory [%s]; dependent assertions skipped\n' "$label" "$d" >&2
+  return 1
+}
+
+# The fixtures run against a PINNED git config, not the operator's. Ambient
+# config silently degraded these assertions: a global `merge.ff = only` or
+# `user.useConfigOnly = true` took the suite from 103 passed to 98, and a global
+# `core.hooksPath` pointing at a failing pre-push took it to 87 -- all of it
+# reported as ordinary failures with no hint that the machine, not the code, had
+# changed. Identity is then set PER REPO (linked worktrees read the main
+# checkout's config, so worktree commits inherit it) because /dev/null as a
+# global config leaves git with no committer.
+export GIT_CONFIG_GLOBAL=/dev/null
+export GIT_CONFIG_SYSTEM=/dev/null
+# gitp: a push with hooks pinned off, so a stray repo-level hook cannot turn a
+# fixture push into a mystery failure.
+gitp() { git -c core.hooksPath=/dev/null "$@"; }
+
 # compute_new_version
 eq "patch"         0.18.3 "$(compute_new_version 0.18.2 patch)"
 eq "minor"         0.19.0 "$(compute_new_version 0.18.2 minor)"
@@ -85,8 +124,28 @@ eq "tag: custom format"   "ledger@0.2.0"   "$(render_tag '{version}' ledger@0.2.
 # #741's proof that the bump step generalizes beyond Cargo.toml (a package.json
 # source, e.g. a JS repo's `[version] file = "package.json"`, bumps the same way
 # a flat json target does in scripts/sync-version.sh).
+# Every temp directory this file creates goes on one list with one EXIT trap, so
+# a RED run cleans up as thoroughly as a green one. docs_worktree_setup makes its
+# OWN `mktemp -d` parent, outside $DOCS_TMP, and only a successful teardown ever
+# removed it -- so each failing run leaked a worktree parent into the system temp
+# dir, which is where the release is cut. Registering the parent as soon as the
+# path is known covers the failure paths too.
+CLEANUP_PATHS=()
+cleanup_temps() {
+  [ "${#CLEANUP_PATHS[@]}" -eq 0 ] || rm -rf "${CLEANUP_PATHS[@]}"
+}
+trap cleanup_temps EXIT
+# register_temp <path...>: add a directory to the EXIT cleanup list.
+register_temp() {
+  local p
+  for p in "$@"; do
+    [ -n "$p" ] || continue
+    CLEANUP_PATHS+=("$p")
+  done
+}
+
 BUMP_DIR=$(mktemp -d)
-trap 'rm -rf "$BUMP_DIR"' EXIT
+register_temp "$BUMP_DIR"
 
 cat >"${BUMP_DIR}/Cargo.toml" <<'EOF'
 [package]
@@ -118,6 +177,7 @@ eq "bump: unsupported format untouched" "unsupported" "$(cat "${BUMP_DIR}/versio
 # all, and would "fail" for the wrong reason.
 feed_watch_root() { printf '%s' "$1" | watch_repo_root "$2"; }
 feed_wt_holder()  { printf '%s' "$1" | worktree_holding_branch "$2"; }
+feed_boundary()   { local input="$1"; shift; release_boundary_commit "$@" <<<"$input"; }
 
 # classify_release_merge <landed> <state> <queue_present> <seen_queued>.
 # The ORDER of the arms is the correctness property: "origin/main carries the
@@ -136,72 +196,236 @@ eq "merge: ejected"                     "ejected" "$(classify_release_merge 0 OP
 eq "merge: never queued stays pending"  "pending" "$(classify_release_merge 0 OPEN 0 0)"
 eq "merge: unknown state stays pending" "pending" "$(classify_release_merge 0 UNKNOWN 0 0)"
 
-# wait_for_release_merge: the bounded poll, driven entirely by injected command
-# STRINGS -- no gh, no git, no network. Each observer is a shell one-liner; a
-# counter file makes a sequence of observations across polls.
+# `unknown` = the observation FAILED. Every comparison in the classifier is
+# `= "1"`, so without an explicit arm a third value falls through to `ejected` --
+# and these two are the exact shape of a sustained network outage: seen in the
+# queue once, then nothing readable. Reporting that as "EJECTED from the merge
+# queue" sends the operator to re-run gates on a PR that may have merged fine.
+eq "merge: unknown landed is not an ejection" "pending" "$(classify_release_merge unknown OPEN 0 1)"
+eq "merge: unknown queue is not an ejection"  "pending" "$(classify_release_merge 0 OPEN unknown 1)"
+eq "merge: both observers unknown stays pending" "pending" "$(classify_release_merge unknown OPEN unknown 1)"
+# ...but an unknown git observer must not veto a POSITIVE read from the other
+# source: the PR state comes from the work-source API, not from the git remote.
+eq "merge: pr state still decides under unknown landed" "merged" \
+  "$(classify_release_merge unknown MERGED unknown 1)"
+eq "merge: closed still decides under unknown landed"   "closed" \
+  "$(classify_release_merge unknown CLOSED unknown 1)"
+# A definite landed=1 outranks everything, unknowns included.
+eq "merge: landed wins over unknown queue" "merged" "$(classify_release_merge 1 OPEN unknown 1)"
+
+# wait_for_release_merge: the bounded poll, driven entirely by injected observer
+# FUNCTIONS -- no gh, no git, no network, and no eval. The observers are passed
+# by NAME and called directly, so nothing the tests (or a release.toml, or a
+# --finish= argument) supply is ever parsed as shell. Sequenced observers keep
+# their state in a counter FILE because each observer runs in a command
+# substitution, i.e. a subshell: a shell variable would not survive the poll.
 WAIT_DIR=$(mktemp -d)
+register_temp "$WAIT_DIR"
 # step <file>: print the call count so far, then increment it.
 step() { local f="$1" n; n="$(cat "$f")"; printf '%s\n' "$((n + 1))" >"$f"; printf '%s\n' "$n"; }
 
+obs_landed_yes()  { printf '1\n'; }
+obs_landed_no()   { printf '0\n'; }
+obs_state_open()  { printf 'OPEN\n'; }
+obs_state_closed(){ printf 'CLOSED\n'; }
+obs_queue_yes()   { printf '1\n'; }
+obs_queue_no()    { printf '0\n'; }
+obs_unreadable()  { return 7; }
+
 eq "wait: merged on the first poll" "merged" \
-  "$(wait_for_release_merge 5 0 'printf 1' 'printf OPEN' 'printf 0')"
+  "$(wait_for_release_merge 5 0 obs_landed_yes obs_state_open obs_queue_no)"
 eq "wait: merged rc" "0" \
-  "$(wait_for_release_merge 5 0 'printf 1' 'printf OPEN' 'printf 0' >/dev/null; printf '%s' $?)"
+  "$(wait_for_release_merge 5 0 obs_landed_yes obs_state_open obs_queue_no >/dev/null; printf '%s' $?)"
 
 eq "wait: closed pr stops the release" "closed" \
-  "$(wait_for_release_merge 5 0 'printf 0' 'printf CLOSED' 'printf 0')"
+  "$(wait_for_release_merge 5 0 obs_landed_no obs_state_closed obs_queue_no)"
 eq "wait: closed rc" "3" \
-  "$(wait_for_release_merge 5 0 'printf 0' 'printf CLOSED' 'printf 0' >/dev/null || printf '%s' $?)"
+  "$(wait_for_release_merge 5 0 obs_landed_no obs_state_closed obs_queue_no >/dev/null || printf '%s' $?)"
 
 # Queued for two polls, then lands: the authoritative `landed` signal flips
 # while the queue ref disappears in the same window. Must read as merged, not
 # as an ejection.
 printf '0\n' >"${WAIT_DIR}/land"
-LANDED_SEQ="n=\$(step ${WAIT_DIR}/land); if [ \"\$n\" -ge 2 ]; then printf 1; else printf 0; fi"
-QUEUE_SEQ="if [ \"\$(cat ${WAIT_DIR}/land)\" -lt 2 ]; then printf 1; else printf 0; fi"
+seq_landed_on_3() { local n; n="$(step "${WAIT_DIR}/land")"; if [ "$n" -ge 2 ]; then printf '1\n'; else printf '0\n'; fi; }
+seq_queue_till_3() { if [ "$(cat "${WAIT_DIR}/land")" -lt 2 ]; then printf '1\n'; else printf '0\n'; fi; }
 eq "wait: queued then merged" "merged" \
-  "$(wait_for_release_merge 6 0 "$LANDED_SEQ" 'printf OPEN' "$QUEUE_SEQ")"
+  "$(wait_for_release_merge 6 0 seq_landed_on_3 obs_state_open seq_queue_till_3)"
 
 # Seen in the queue, then gone, and main never carries the release: ejection --
 # but only after the CONFIRMING second observation, since the queue ref also
 # disappears at the moment of a successful merge.
 printf '0\n' >"${WAIT_DIR}/ej"
-QUEUE_ONCE="n=\$(step ${WAIT_DIR}/ej); if [ \"\$n\" = 0 ]; then printf 1; else printf 0; fi"
+seq_queue_once() { local n; n="$(step "${WAIT_DIR}/ej")"; if [ "$n" = 0 ]; then printf '1\n'; else printf '0\n'; fi; }
 eq "wait: ejection reported" "ejected" \
-  "$(wait_for_release_merge 6 0 'printf 0' 'printf OPEN' "$QUEUE_ONCE")"
+  "$(wait_for_release_merge 6 0 obs_landed_no obs_state_open seq_queue_once)"
 printf '0\n' >"${WAIT_DIR}/ej2"
-QUEUE_ONCE2="n=\$(step ${WAIT_DIR}/ej2); if [ \"\$n\" = 0 ]; then printf 1; else printf 0; fi"
+seq_queue_once2() { local n; n="$(step "${WAIT_DIR}/ej2")"; if [ "$n" = 0 ]; then printf '1\n'; else printf '0\n'; fi; }
 eq "wait: ejection rc" "4" \
-  "$(wait_for_release_merge 6 0 'printf 0' 'printf OPEN' "$QUEUE_ONCE2" >/dev/null || printf '%s' $?)"
-# A single missing-ref observation immediately after a queued one is NOT an
-# ejection: with a budget of exactly 2 polls the confirming observation is the
-# last one, so a merge that lands on it still reads as merged.
+  "$(wait_for_release_merge 6 0 obs_landed_no obs_state_open seq_queue_once2 >/dev/null || printf '%s' $?)"
+
+# THE MERGE WINDOW, and the reason the ejection verdict needs a streak of two.
+# The sequence is a real one: poll 1 the PR is in the queue; poll 2 the queue ref
+# is GONE but origin/main is not yet observed to carry the version -- which is
+# indistinguishable from an ejection in a single observation; poll 3 it lands.
+# Correct code holds its verdict at poll 2 and reports merged. The counters are
+# INDEPENDENT on purpose: driving the queue observer off the landed counter made
+# poll 1 read "not queued", so seen_queued never became 1, the ejected arm was
+# never reached, and the test passed just as happily with the streak guard
+# mutated to -ge 1.
 printf '0\n' >"${WAIT_DIR}/race"
-RACE_LANDED="n=\$(step ${WAIT_DIR}/race); if [ \"\$n\" -ge 1 ]; then printf 1; else printf 0; fi"
-RACE_QUEUE="if [ \"\$(cat ${WAIT_DIR}/race)\" -lt 1 ]; then printf 1; else printf 0; fi"
+printf '0\n' >"${WAIT_DIR}/raceq"
+race_landed() { local n; n="$(step "${WAIT_DIR}/race")"; if [ "$n" -ge 2 ]; then printf '1\n'; else printf '0\n'; fi; }
+race_queue()  { local n; n="$(step "${WAIT_DIR}/raceq")"; if [ "$n" = 0 ]; then printf '1\n'; else printf '0\n'; fi; }
 eq "wait: merge-window ref drop is not an ejection" "merged" \
-  "$(wait_for_release_merge 2 0 "$RACE_LANDED" 'printf OPEN' "$RACE_QUEUE")"
+  "$(wait_for_release_merge 4 0 race_landed obs_state_open race_queue)"
 
 eq "wait: budget expiry is a timeout" "timeout" \
-  "$(wait_for_release_merge 3 0 'printf 0' 'printf OPEN' 'printf 0')"
+  "$(wait_for_release_merge 3 0 obs_landed_no obs_state_open obs_queue_no)"
 eq "wait: timeout rc" "5" \
-  "$(wait_for_release_merge 3 0 'printf 0' 'printf OPEN' 'printf 0' >/dev/null || printf '%s' $?)"
-# An observer that cannot be read must not stall or crash the wait -- it falls
-# back to "no signal" and the budget still expires cleanly.
+  "$(wait_for_release_merge 3 0 obs_landed_no obs_state_open obs_queue_no >/dev/null || printf '%s' $?)"
+# An observer that cannot be read must not stall or crash the wait -- and must
+# not be counted as a NEGATIVE either. It becomes `unknown`, the budget expires,
+# and the release reports a timeout ("I could not observe the merge"), which is
+# the truth. Under the old `|| printf 0` fallback the same outage read as
+# "definitely not in the queue" and was reported as an ejection.
 eq "wait: unreadable observers expire" "timeout" \
-  "$(wait_for_release_merge 2 0 'exit 7' 'exit 7' 'exit 7')"
-# The observers are eval'd in THIS shell, so a SOURCED helper resolves. If they
-# were run in a subshell that could not see release.sh's own functions, every
-# poll would read landed=0 and a merged release would time out.
+  "$(wait_for_release_merge 2 0 obs_unreadable obs_unreadable obs_unreadable)"
+# The sustained-outage shape end to end: queued once, then every observer blind.
+printf '0\n' >"${WAIT_DIR}/out"
+outage_queue() { local n; n="$(step "${WAIT_DIR}/out")"; if [ "$n" = 0 ]; then printf '1\n'; else return 7; fi; }
+eq "wait: outage after a queued poll is a timeout, not an ejection" "timeout" \
+  "$(wait_for_release_merge 4 0 obs_unreadable obs_state_open outage_queue)"
+eq "wait: outage rc is timeout not ejection" "5" \
+  "$(printf '0\n' >"${WAIT_DIR}/out"; wait_for_release_merge 4 0 obs_unreadable obs_state_open outage_queue >/dev/null || printf '%s' $?)"
+# The observers are called in THIS shell, so a SOURCED helper resolves. Run in a
+# subshell that could not see release.sh's own functions, every poll would read
+# landed=unknown and a merged release would time out.
 sourced_probe() { printf '1\n'; }
-eq "wait: injected command resolves a sourced helper" "merged" \
-  "$(wait_for_release_merge 2 0 'sourced_probe' 'printf OPEN' 'printf 0')"
+eq "wait: injected observer resolves a sourced function" "merged" \
+  "$(wait_for_release_merge 2 0 sourced_probe obs_state_open obs_queue_no)"
+
+# release_landed / release_queue_ref_present: the two GIT-BACKED observers, and
+# the only place `unknown` is actually produced. Against a real local remote --
+# no network, no gh -- because the whole finding is about what happens when the
+# remote cannot be reached, which a stubbed observer cannot show.
+#
+# release_landed operates on the CURRENT directory (finish_release cd's to the
+# repo root first), so these run through `in_dir`, which refuses an empty path.
+# `cd ""` returns 0 in bash, so `cd "$X" || return` is NOT a guard on its own.
+in_dir() { # in_dir <dir> <cmd...>
+  local d="$1"; shift
+  [ -n "$d" ] || return 90
+  cd "$d" || return 91
+  "$@"
+}
+
+OBS_TMP=$(mktemp -d)
+register_temp "$OBS_TMP"
+OBS_CO="${OBS_TMP}/repo"
+git init --bare --quiet "${OBS_TMP}/origin.git"
+git -c init.defaultBranch=main init --quiet "$OBS_CO"
+git -C "$OBS_CO" config user.email t@t
+git -C "$OBS_CO" config user.name t
+git -C "$OBS_CO" checkout --quiet -B main
+printf 'version = "0.25.0"\n' >"${OBS_CO}/Cargo.toml"
+git -C "$OBS_CO" add Cargo.toml
+git -C "$OBS_CO" commit --quiet --no-verify -m "chore(release): 0.25.0"
+git -C "$OBS_CO" remote add origin "${OBS_TMP}/origin.git"
+gitp -C "$OBS_CO" push --quiet -u origin main
+
+if require_dir "observers: fixture repo" "$OBS_CO"; then
+  # A reachable remote that does not carry the version is a definite NO.
+  eq "landed: reachable remote without the version is 0" "0" \
+    "$( (in_dir "$OBS_CO" release_landed main Cargo.toml package.version 9.9.9) 2>/dev/null )"
+
+  # THE REGRESSION. Break the remote AFTER a successful fetch, so the
+  # remote-tracking ref is still perfectly readable locally -- which is exactly
+  # what a network outage looks like: origin/main does not vanish, it just stops
+  # being updated. A gate phrased as "did the ref read cleanly" answers a
+  # confident 0 here, and the poll loop turns a sustained 0 into an EJECTED
+  # verdict. Only the fetch's exit status can tell the difference.
+  git -C "$OBS_CO" remote set-url origin "${OBS_TMP}/does-not-exist.git"
+  ok "landed: the remote-tracking ref is still readable during the outage" \
+    test -n "$(git -C "$OBS_CO" rev-parse --verify --quiet origin/main 2>/dev/null)"
+  eq "landed: unreachable remote is unknown, not 0" "unknown" \
+    "$( (in_dir "$OBS_CO" release_landed main Cargo.toml package.version 0.25.0) 2>/dev/null )"
+  # Same failure, same requirement, for the queue observer: the rc must belong to
+  # ls-remote, not to the grep that used to consume it.
+  eq "queue: unreachable remote is unknown, not 0" "unknown" \
+    "$( (in_dir "$OBS_CO" release_queue_ref_present 42) 2>/dev/null )"
+
+  git -C "$OBS_CO" remote set-url origin "${OBS_TMP}/origin.git"
+  eq "queue: reachable remote without the ref is 0" "0" \
+    "$( (in_dir "$OBS_CO" release_queue_ref_present 42) 2>/dev/null )"
+  # A real merge-queue ref: refs/heads/gh-readonly-queue/<base>/pr-<N>-<sha>.
+  OBS_SHA="$(git -C "$OBS_CO" rev-parse HEAD)"
+  git -C "${OBS_TMP}/origin.git" update-ref \
+    "refs/heads/gh-readonly-queue/main/pr-42-${OBS_SHA}" "$OBS_SHA"
+  eq "queue: the PR's queue ref is present" "1" \
+    "$( (in_dir "$OBS_CO" release_queue_ref_present 42) 2>/dev/null )"
+  # Another PR's queue ref is not this PR's.
+  eq "queue: another PR's ref does not count" "0" \
+    "$( (in_dir "$OBS_CO" release_queue_ref_present 7) 2>/dev/null )"
+  # And a number that is a PREFIX of the queued one must not match either.
+  eq "queue: a prefix of the queued PR number does not match" "0" \
+    "$( (in_dir "$OBS_CO" release_queue_ref_present 4) 2>/dev/null )"
+fi
 
 # tag_target_matches: the guard between "the queue merged something" and "the
 # tag points at the release". Fails CLOSED on an unreadable version.
 ok "tag target: match"          tag_target_matches 0.26.0 0.26.0
 no "tag target: mismatch"       tag_target_matches 0.26.0 0.25.0
 no "tag target: empty observed" tag_target_matches 0.26.0 ""
+# The fail-closed conjunct specifically. Without it the function is plain string
+# equality, under which two empty strings MATCH -- "we could not read the
+# expected version" and "we could not read what is on the branch" would agree
+# with each other and authorise the tag. The mismatch case above still returns 1
+# under that mutation, so this is the only assertion that pins the conjunct.
+no "tag target: both empty fails closed" tag_target_matches "" ""
+
+# release_boundary_commit: which commit the tag actually lands on. The tip of
+# the release branch is the WRONG answer -- later commits do not touch the
+# version file, so "this tree carries <new>" still passes N merges past the
+# release and the tag would ship a tree nobody released.
+#
+# The reader is injected by NAME, so these cases are a pure table: a fake
+# history where sha -> version is a lookup.
+fake_version() {
+  case "$1" in
+    f1|f2|f3) printf '0.26.0\n' ;;   # f1 = tip-most, f3 = the release commit
+    f4|f5)    printf '0.25.0\n' ;;
+    *)        printf '\n' ;;
+  esac
+}
+eq "boundary: oldest consecutive match wins" "f3" \
+  "$(printf 'f1\nf2\nf3\nf4\nf5\n' | release_boundary_commit fake_version 0.26.0 50)"
+eq "boundary: a single-commit release resolves to itself" "f3" \
+  "$(printf 'f3\nf4\nf5\n' | release_boundary_commit fake_version 0.26.0 50)"
+# The tip-most entry not carrying the version at all: rc 1. The caller gates on
+# the branch tip before it ever walks, so production cannot reach this -- it is
+# the standalone contract, and a rc that is never asserted is a rc that drifts.
+no "boundary: newest does not carry the version" \
+  feed_boundary "$(printf 'f4\nf5\n')" fake_version 0.26.0 50
+eq "boundary: rc when nothing matches" "1" \
+  "$(printf 'f4\nf5\n' | release_boundary_commit fake_version 0.26.0 50 >/dev/null; printf '%s' $?)"
+# Running off the end of the list is NOT "tag the oldest thing you saw". Every
+# exhausted path returns non-zero and the caller stops: an unresolved boundary
+# must never fall through to tagging.
+eq "boundary: list exhausted is rc 3" "3" \
+  "$(printf 'f1\nf2\nf3\n' | release_boundary_commit fake_version 0.26.0 50 >/dev/null; printf '%s' $?)"
+eq "boundary: exhausted prints nothing" "" \
+  "$(printf 'f1\nf2\nf3\n' | release_boundary_commit fake_version 0.26.0 50 2>/dev/null)"
+eq "boundary: cap exceeded is rc 2" "2" \
+  "$(printf 'f1\nf2\nf3\nf4\n' | release_boundary_commit fake_version 0.26.0 2 >/dev/null; printf '%s' $?)"
+eq "boundary: cap exceeded prints nothing" "" \
+  "$(printf 'f1\nf2\nf3\nf4\n' | release_boundary_commit fake_version 0.26.0 2 2>/dev/null)"
+# A cap that exactly covers the boundary still resolves it.
+eq "boundary: cap exactly at the boundary" "f3" \
+  "$(printf 'f1\nf2\nf3\nf4\n' | release_boundary_commit fake_version 0.26.0 4)"
+# An unreadable version reads as a mismatch, which ends the walk -- it never
+# widens it.
+eq "boundary: unreadable version ends the walk" "f1" \
+  "$(printf 'f1\nunknown-sha\nf3\n' | release_boundary_commit fake_version 0.26.0 50)"
 
 # -- cross-repo docs worktree helpers (#845) --------------------------------
 
@@ -254,6 +478,12 @@ no "disposable: unpushed commits kept"      worktree_is_disposable bbb aaa "" 0
 ok "disposable: committed but pushed"       worktree_is_disposable bbb aaa "" 1
 no "disposable: pushed but tree dirty"      worktree_is_disposable bbb aaa " M docs/x.mdx" 1
 no "disposable: unreadable head fails closed" worktree_is_disposable "" aaa "" 1
+# A missing base sha fails closed too. With base empty the `head = base` arm can
+# never fire, so the whole decision silently collapses onto `pushed` -- and
+# "clean and fully pushed" describes nearly every worktree in a healthy repo,
+# including one another agent is working in.
+no "disposable: missing base sha fails closed" worktree_is_disposable bbb "" "" 1
+no "disposable: missing base sha even when untouched" worktree_is_disposable bbb "" "" 0
 
 # docs_worktree_setup / docs_worktree_teardown against REAL git repos. These two
 # are the mechanism #845 is actually buying -- the pure helpers above only decide
@@ -261,35 +491,30 @@ no "disposable: unreadable head fails closed" worktree_is_disposable "" aaa "" 1
 # remote. No network, no gh, no shingle. Both call `fail` (which exits), so every
 # arm runs in a subshell.
 #
-# EVERY fixture command below addresses its repo with `git -C <dir>` and writes
-# through absolute paths. Nothing here uses `cd`, and that is a hard rule, not a
-# style preference: `cd ""` is a SILENT NO-OP in bash, so a `(cd "$WT" && git
-# commit ...)` where the helper under test returned nothing runs the fixture's
-# git commands in whatever repo is running the tests. That is not hypothetical --
-# it happened while building this file, during a mutation run that deliberately
-# broke docs_worktree_setup, and it committed the test runner's own staged work
-# onto a fixture branch. `require_dir` below turns that class into a loud test
-# failure instead of collateral damage.
-require_dir() { # require_dir <label> <path>
-  local label="$1" d="$2"
-  if [ -n "$d" ] && [ -d "$d" ]; then PASS=$((PASS + 1)); return 0; fi
-  FAIL=$((FAIL + 1))
-  printf 'FAIL: %s -- no usable directory [%s]; dependent assertions skipped\n' "$label" "$d" >&2
-  return 1
-}
-gitc() { git -c user.email=t@t -c user.name=t "$@"; }
-
+# Every fixture command below addresses its repo with `git -C <dir>` and writes
+# through absolute paths, and `require_dir` (see the fixture preamble at the top
+# of this file -- it, not `git -C`, is what makes that safe) gates every block on
+# the helper under test having returned a real directory.
 DOCS_TMP=$(mktemp -d)
+register_temp "$DOCS_TMP"
 DOCS_CO="${DOCS_TMP}/checkout"
 DOCS_BRANCH="docs/fixture-current"
 git init --bare --quiet "${DOCS_TMP}/origin.git"
 git -c init.defaultBranch=main init --quiet "$DOCS_CO"
+git -C "$DOCS_CO" config user.email t@t
+git -C "$DOCS_CO" config user.name t
 git -C "$DOCS_CO" checkout --quiet -B main
 printf 'docs\n' >"${DOCS_CO}/index.md"
 git -C "$DOCS_CO" add index.md
-gitc -C "$DOCS_CO" commit --quiet --no-verify -m "init"
+git -C "$DOCS_CO" commit --quiet --no-verify -m "init"
 git -C "$DOCS_CO" remote add origin "${DOCS_TMP}/origin.git"
-git -C "$DOCS_CO" push --quiet -u origin main
+gitp -C "$DOCS_CO" push --quiet -u origin main
+# Prove the pin took, rather than assuming it: every assertion below about
+# config-independence rests on this.
+eq "fixture: ambient global config is neutralised" "" \
+  "$(git -C "$DOCS_CO" config --global --get merge.ff 2>/dev/null || true)"
+eq "fixture: repo identity is set for worktree commits" "t@t" \
+  "$(git -C "$DOCS_CO" config user.email 2>/dev/null)"
 
 # Fresh arm: no such branch on the remote, so the worktree starts from
 # origin/main -- NOT from whatever the shared checkout has checked out. Prove
@@ -297,8 +522,11 @@ git -C "$DOCS_CO" push --quiet -u origin main
 git -C "$DOCS_CO" checkout --quiet -b someone-elses-work
 printf 'wip\n' >"${DOCS_CO}/wip.md"
 git -C "$DOCS_CO" add wip.md
-gitc -C "$DOCS_CO" commit --quiet --no-verify -m "wip"
+git -C "$DOCS_CO" commit --quiet --no-verify -m "wip"
 WT1="$( (docs_worktree_setup "$DOCS_CO" "$DOCS_BRANCH" main fixture-docs) 2>/dev/null )"
+# Registered for cleanup the moment the path is known: docs_worktree_setup makes
+# its own mktemp parent OUTSIDE $DOCS_TMP, and a red run never reaches teardown.
+[ -z "$WT1" ] || register_temp "$(dirname "$WT1")"
 if require_dir "docs wt: created" "$WT1"; then
   eq "docs wt: on the stable branch" "$DOCS_BRANCH" "$(git -C "$WT1" rev-parse --abbrev-ref HEAD 2>/dev/null)"
   # The load-bearing one: it must NOT have inherited the other agent's branch.
@@ -307,6 +535,11 @@ if require_dir "docs wt: created" "$WT1"; then
   ok "docs wt: the other agent's file is absent" test ! -f "${WT1}/wip.md"
   ok "docs wt: base sha recorded outside the worktree" test -f "$(dirname "$WT1")/base-sha"
   eq "docs wt: worktree left clean" "" "$(git -C "$WT1" status --porcelain 2>/dev/null)"
+  # The OWNERSHIP marker, and it must name this worktree by path -- teardown
+  # refuses to destroy anything it cannot match against this file.
+  ok "docs wt: ownership marker written" test -f "$(dirname "$WT1")/worktree-path"
+  eq "docs wt: ownership marker names this worktree" "$WT1" \
+    "$(cat "$(dirname "$WT1")/worktree-path" 2>/dev/null)"
 fi
 
 # Collision: the stable branch is already checked out. Report it, never clobber
@@ -327,17 +560,18 @@ no "docs teardown: unchanged branch removed too" \
 # Teardown, carrying unpushed commits: RETAINED, so a failed docs run is
 # recoverable rather than discarded.
 WT2="$( (docs_worktree_setup "$DOCS_CO" "$DOCS_BRANCH" main fixture-docs) 2>/dev/null )"
+[ -z "$WT2" ] || register_temp "$(dirname "$WT2")"
 if require_dir "docs teardown: second worktree created" "$WT2"; then
   printf 'draft\n' >"${WT2}/draft.md"
   git -C "$WT2" add draft.md
-  gitc -C "$WT2" commit --quiet --no-verify -m "docs: draft"
+  git -C "$WT2" commit --quiet --no-verify -m "docs: draft"
   (docs_worktree_teardown "$WT2") >/dev/null 2>&1
   ok "docs teardown: unpushed work retained" test -d "$WT2"
   ok "docs teardown: retained worktree keeps its commit" test -f "${WT2}/draft.md"
 
   # Same worktree once the work is PUSHED: now disposable. Without this arm a
   # successful docs run would pin the worktree forever and collide next release.
-  git -C "$WT2" push --quiet -u origin "$DOCS_BRANCH"
+  gitp -C "$WT2" push --quiet -u origin "$DOCS_BRANCH"
   (docs_worktree_teardown "$WT2") >/dev/null 2>&1
   ok "docs teardown: pushed work is disposable" test ! -d "$WT2"
 fi
@@ -347,37 +581,187 @@ fi
 # release extends, not a new version-pinned branch stacked on the last.
 git -C "$DOCS_CO" checkout --quiet main
 printf 'more\n' >>"${DOCS_CO}/index.md"
-gitc -C "$DOCS_CO" commit --quiet --no-verify -am "main moves on"
-git -C "$DOCS_CO" push --quiet origin main
+git -C "$DOCS_CO" commit --quiet --no-verify -am "main moves on"
+gitp -C "$DOCS_CO" push --quiet origin main
+
+# The extend arm runs under a HOSTILE-BUT-ORDINARY config, pinned on the repo so
+# the assertion does not depend on the operator's machine. `merge.ff = only` is a
+# common global setting, and under it the plain `git merge` this used to run dies
+# with "fatal: Not possible to fast-forward" -- on entirely CORRECT input, since a
+# diverged docs branch is the whole reason the merge exists. It then told the
+# operator to go and resolve it in the shared checkout, which is the fallback
+# #845 exists to close. `user.useConfigOnly` is pinned alongside it because it
+# breaks the same step a different way.
+git -C "$DOCS_CO" config merge.ff only
+git -C "$DOCS_CO" config user.useConfigOnly true
 WT3="$( (docs_worktree_setup "$DOCS_CO" "$DOCS_BRANCH" main fixture-docs) 2>/dev/null )"
-if require_dir "docs extend: worktree created on the existing stable branch" "$WT3"; then
+[ -z "$WT3" ] || register_temp "$(dirname "$WT3")"
+if require_dir "docs extend: worktree created under merge.ff=only" "$WT3"; then
   ok "docs extend: the earlier release's docs commit is still there" test -f "${WT3}/draft.md"
   ok "docs extend: origin/main was merged in" \
     git -C "$WT3" merge-base --is-ancestor origin/main HEAD
+  # --no-ff, so the merge-in is a real merge commit (two parents) regardless of
+  # whether it could have fast-forwarded.
+  eq "docs extend: merge-in is a merge commit" "2" \
+    "$(git -C "$WT3" rev-list --parents -n 1 HEAD 2>/dev/null | awk '{print NF-1}')"
   # The merge is setup's own work, so it must not count as agent work at teardown.
   eq "docs extend: base sha recorded after the merge-in" \
     "$(git -C "$WT3" rev-parse HEAD 2>/dev/null)" "$(cat "$(dirname "$WT3")/base-sha" 2>/dev/null)"
   (docs_worktree_teardown "$WT3") >/dev/null 2>&1
   ok "docs extend: unchanged extend-arm worktree removed" test ! -d "$WT3"
 fi
+git -C "$DOCS_CO" config --unset merge.ff
+git -C "$DOCS_CO" config --unset user.useConfigOnly
 
-# --docs-worktree-done= takes an OPERATOR-supplied path. A worktree this script
-# did not create lives in a directory it does not own, so teardown must remove
-# the worktree and nothing else -- deleting the parent would take the siblings
-# with it, which is the collateral damage this whole feature exists to prevent.
+# A retained worktree whose DIRECTORY was deleted by hand stays registered as
+# "prunable". That registration is invisible to worktree_holding_branch, so every
+# later --docs-worktree failed naming a path that no longer existed, with no hint
+# that `git worktree prune` was the way out. Setup prunes first now, so the
+# stale registration resolves itself and what remains is the local BRANCH -- a
+# real, inspectable object the message can name a recovery for.
+WT4="$( (docs_worktree_setup "$DOCS_CO" "$DOCS_BRANCH" main fixture-docs) 2>/dev/null )"
+[ -z "$WT4" ] || register_temp "$(dirname "$WT4")"
+if require_dir "docs prune: worktree created" "$WT4"; then
+  rm -rf "$WT4"
+  PRUNE_ERR="$( (docs_worktree_setup "$DOCS_CO" "$DOCS_BRANCH" main fixture-docs) 2>&1 >/dev/null )"
+  ok "docs prune: vanished worktree no longer reported as the holder" \
+    test -z "${PRUNE_ERR##*local branch*}"
+  ok "docs prune: message does not name the vanished path" \
+    test "${PRUNE_ERR##*"$WT4"*}" = "$PRUNE_ERR"
+  ok "docs prune: registration was actually pruned" \
+    test -z "$(git -C "$DOCS_CO" worktree list --porcelain | worktree_holding_branch "$DOCS_BRANCH" || true)"
+  # And the named recovery genuinely unblocks it: delete the branch, run again.
+  git -C "$DOCS_CO" branch -D "$DOCS_BRANCH" >/dev/null 2>&1
+  WT5="$( (docs_worktree_setup "$DOCS_CO" "$DOCS_BRANCH" main fixture-docs) 2>/dev/null )"
+  [ -z "$WT5" ] || register_temp "$(dirname "$WT5")"
+  ok "docs prune: docs step is unblocked after the named recovery" test -n "$WT5"
+  [ -z "$WT5" ] || (docs_worktree_teardown "$WT5") >/dev/null 2>&1
+fi
+
+# --docs-worktree-done= takes an OPERATOR-supplied path, and a worktree this
+# script did not create is one it has NO CLAIM TO DESTROY. All three destructive
+# acts are gated on the ownership marker, not just the `rm -rf`: force-removing
+# someone's worktree and deleting their branch are exactly as destructive as
+# deleting a directory, and `branch -D ... >/dev/null 2>&1 || true` did not even
+# report that it had happened.
+#
+# This assertion was previously INVERTED -- it asserted the foreign worktree was
+# "still removed" and only checked that the parent survived. It encoded the
+# defect as a requirement, which is why no mutation ever surfaced it: the guard
+# it was protecting was the `rm -rf`, and the two genuinely destructive calls
+# above it were never covered at all.
 SHARED="${DOCS_TMP}/shared"
 mkdir -p "$SHARED"
 printf 'do not delete me\n' >"${SHARED}/sibling.txt"
 git -C "$DOCS_CO" worktree add --quiet -b hand-made "${SHARED}/hand-made" main >/dev/null 2>&1
-# Push it so it reaches the DISPOSABLE arm -- the guard only matters there, and
-# a retained worktree would never have reached the `rm -rf` in the first place.
-git -C "${SHARED}/hand-made" push --quiet -u origin hand-made
-(docs_worktree_teardown "${SHARED}/hand-made") >/dev/null 2>&1
-ok "docs teardown: foreign worktree still removed" test ! -d "${SHARED}/hand-made"
+# Pushed, so it satisfies the DISPOSABLE arm on content. It must survive anyway:
+# "looks disposable" is not an ownership claim, and every clean fully-pushed
+# worktree in the docs repo looks exactly like this one.
+gitp -C "${SHARED}/hand-made" push --quiet -u origin hand-made
+FOREIGN_RC=0
+(docs_worktree_teardown "${SHARED}/hand-made") >/dev/null 2>&1 || FOREIGN_RC=$?
+eq "docs teardown: foreign worktree teardown refuses" "1" "$FOREIGN_RC"
+ok "docs teardown: foreign worktree RETAINED" test -d "${SHARED}/hand-made"
+ok "docs teardown: foreign worktree's branch survives" \
+  git -C "$DOCS_CO" show-ref --verify --quiet "refs/heads/hand-made"
+ok "docs teardown: foreign worktree keeps its registration" \
+  test -n "$(git -C "$DOCS_CO" worktree list --porcelain | worktree_holding_branch hand-made || true)"
 ok "docs teardown: an unowned parent directory survives" test -d "$SHARED"
 ok "docs teardown: its siblings survive" test -f "${SHARED}/sibling.txt"
 
-rm -rf "$WAIT_DIR" "$DOCS_TMP"
+# A marker naming a DIFFERENT worktree is not a claim to this one either -- the
+# marker has to match, or "some sibling directory has a base-sha in it" would be
+# enough to authorise the removal.
+MISMARK="${DOCS_TMP}/mismarked"
+mkdir -p "$MISMARK"
+git -C "$DOCS_CO" worktree add --quiet -b mis-marked "${MISMARK}/wt" main >/dev/null 2>&1
+gitp -C "${MISMARK}/wt" push --quiet -u origin mis-marked
+printf '%s\n' "$(git -C "${MISMARK}/wt" rev-parse HEAD)" >"${MISMARK}/base-sha"
+printf '%s\n' "${MISMARK}/some-other-worktree" >"${MISMARK}/worktree-path"
+MISMARK_RC=0
+(docs_worktree_teardown "${MISMARK}/wt") >/dev/null 2>&1 || MISMARK_RC=$?
+eq "docs teardown: marker naming another worktree refuses" "1" "$MISMARK_RC"
+ok "docs teardown: mismarked worktree retained" test -d "${MISMARK}/wt"
+
+# -- the release commit, against a REAL history (#844) -----------------------
+#
+# release_boundary_commit's table tests fix its logic; this fixes its INPUT. The
+# whole finding is that `git rev-parse origin/main` answers a different question
+# than "which commit is the release", and that the difference is invisible to
+# every check the script made -- later commits do not touch the version file, so
+# the version-carries-<new> gate passes on all of them.
+#
+# Deliberately no `legion`: the reader is injected by name, so the fixture reads
+# the version with git+sed. CI never runs this file (only scripts/preflight.sh
+# does), and a standalone preflight run is not guaranteed a legion binary.
+BND_TMP=$(mktemp -d)
+register_temp "$BND_TMP"
+BND="${BND_TMP}/repo"
+git -c init.defaultBranch=main init --quiet "$BND"
+git -C "$BND" config user.email t@t
+git -C "$BND" config user.name t
+bnd_commit() { # bnd_commit <file> <content> <subject>
+  printf '%s\n' "$2" >"${BND}/$1"
+  git -C "$BND" add "$1"
+  git -C "$BND" commit --quiet --no-verify -m "$3"
+}
+# The reader under test's production twin is ref_version; here it is git show
+# plus a sed, so the fixture stays hermetic.
+bnd_version() { git -C "$BND" show "${1}:Cargo.toml" 2>/dev/null | sed -n 's/^version = "\(.*\)"$/\1/p'; }
+
+bnd_commit Cargo.toml 'version = "0.24.0"' "chore(release): 0.24.0"
+bnd_commit src.txt 'work' "feat: something"
+bnd_commit Cargo.toml 'version = "0.25.0"' "chore(release): 0.25.0"
+BND_RELEASE="$(git -C "$BND" rev-parse HEAD)"
+# What lands between `legion pr merge` and `--finish`: ordinary merges that do
+# not touch the version file at all.
+bnd_commit a.txt 'a' "feat(#1): a"
+bnd_commit b.txt 'b' "fix(#2): b"
+BND_TIP="$(git -C "$BND" rev-parse HEAD)"
+
+BND_LIST="$(git -C "$BND" rev-list HEAD -- Cargo.toml)"
+eq "release commit: resolved from a real history" "$BND_RELEASE" \
+  "$(printf '%s\n' "$BND_LIST" | release_boundary_commit bnd_version 0.25.0 200)"
+# The point of the finding, stated as an assertion: the tip is NOT the answer,
+# and yet it passes the tag-target check that used to be the only guard.
+ok "release commit: the branch tip is a different commit" test "$BND_RELEASE" != "$BND_TIP"
+ok "release commit: the tip still passes the version gate (why tip-resolution looked correct)" \
+  tag_target_matches 0.25.0 "$(bnd_version "$BND_TIP")"
+# One version read per commit that TOUCHED the file -- 2 here, across a history
+# of 5 commits. The `<ref>^` parent walk this replaced would have been a
+# subprocess per commit since the release, and fatal on a root commit.
+eq "release commit: walks only commits that touch the version file" "2" \
+  "$(printf '%s\n' "$BND_LIST" | wc -l | tr -d ' ')"
+eq "release commit: while the branch itself is longer" "5" \
+  "$(git -C "$BND" rev-list HEAD | wc -l | tr -d ' ')"
+
+# IDEMPOTENCE, which is what release.sh:767 and legion-release.md:88 promise when
+# they say re-running --finish is safe. Re-resolving must return the SAME sha
+# however far the branch has moved on: that is what makes the second run match
+# the existing tag and re-push it, instead of deriving a new sha and dying on
+# "tag already exists and points at <other>".
+bnd_commit c.txt 'c' "fix(#3): c"
+BND_AGAIN="$(git -C "$BND" rev-list HEAD -- Cargo.toml | release_boundary_commit bnd_version 0.25.0 200)"
+eq "release commit: stable across re-runs as the branch moves" "$BND_RELEASE" "$BND_AGAIN"
+# And the next release's boundary is its own commit, not the previous one.
+bnd_commit Cargo.toml 'version = "0.26.0"' "chore(release): 0.26.0"
+BND_NEXT="$(git -C "$BND" rev-parse HEAD)"
+eq "release commit: the next release resolves to its own commit" "$BND_NEXT" \
+  "$(git -C "$BND" rev-list HEAD -- Cargo.toml | release_boundary_commit bnd_version 0.26.0 200)"
+# Once a NEWER release has landed, the older one no longer resolves at all
+# (rc 1) rather than resolving to something plausible-looking. In production the
+# branch-tip landed gate refuses first, for the same reason: --finish on a
+# superseded release must stop, not tag.
+eq "release commit: a superseded release refuses to resolve" "1" \
+  "$(git -C "$BND" rev-list HEAD -- Cargo.toml | release_boundary_commit bnd_version 0.25.0 200 >/dev/null; printf '%s' $?)"
+# A commit that touches the version file WITHOUT changing the version (a
+# dependency edit) must not be mistaken for the release commit.
+bnd_commit Cargo.toml 'version = "0.26.0"
+serde = "1.0.1"' "chore: dep bump"
+ok "release commit: the dep-bump commit really landed" \
+  test "$(git -C "$BND" rev-parse HEAD)" != "$BND_NEXT"
+eq "release commit: a non-version edit to the file is not the release" "$BND_NEXT" \
+  "$(git -C "$BND" rev-list HEAD -- Cargo.toml | release_boundary_commit bnd_version 0.26.0 200)"
 
 printf '\n[test-release] %d passed, %d failed\n' "$PASS" "$FAIL" >&2
 [ "$FAIL" -eq 0 ]

--- a/scripts/test-release.sh
+++ b/scripts/test-release.sh
@@ -29,26 +29,273 @@ no() { # no <label> <cmd...>   (expect non-zero)
   if "$@"; then FAIL=$((FAIL + 1)); printf 'FAIL: %s -- expected failure\n' "$label" >&2; else PASS=$((PASS + 1)); fi
 }
 
-# -- git fixture preamble ----------------------------------------------------
-# Shared by every block below that builds a real repo. Defined up here because
-# the first of those blocks is the merge-observer section, well before the docs
-# worktree fixtures.
+# -- THE FIXTURE PERIMETER (#861) --------------------------------------------
+# Everything below this banner exists because this suite has twice driven git
+# against the REAL repository it was running from, and the second time force-fed
+# a one-line Cargo.toml and a `chore(release): 0.25.0` commit onto origin/main.
 #
-# `require_dir` IS THE GUARD on fixture commands, and it is worth being exact
-# about that, because the natural reading is that addressing repos with `git -C
-# <dir>` instead of `cd` closed the incident class by itself. It did not:
-# `git -C ""` does NOT fail -- inside a repo it runs in the CURRENT repo and
-# exits 0, exactly the silent cwd fallback `cd ""` gives you. So a fixture
-# command built on a helper that returned nothing is just as capable of
-# operating on the test runner's own checkout either way. That is not
-# hypothetical: during a mutation run that deliberately broke
-# docs_worktree_setup, the fixture committed the test runner's own staged work
-# onto a fixture branch. What prevents it is refusing to run the dependent
-# assertions at all when the path is empty or missing -- so do not add an
-# unguarded `git -C "$SOMETHING"` believing the primitive protects you.
+# THE DELIVERY CHANNEL, stated plainly, because it is not obvious from this
+# file: scripts/release.sh runs scripts/preflight.sh, and preflight.sh does
+# `cd "$(git rev-parse --show-toplevel)"` and then `bash scripts/test-release.sh`.
+# So during a real release this suite executes with its CWD SET TO THE REAL
+# CHECKOUT, inside a repo whose `origin` is the real GitHub remote. Every
+# fallback-to-cwd in here is therefore a fallback to production.
+#
+# `require_dir` was the previous guard and it is DEMONSTRABLY NOT ENOUGH:
+#   * `git -C ""` does not fail. Verified: inside a repo it runs in the CURRENT
+#     repo and exits 0, exactly the silent no-op `cd ""` gives you. The
+#     primitive protects nothing.
+#   * `require_dir` accepts "." -- `[ -n "." ] && [ -d "." ]` is true. A path
+#     helper that degrades to a RELATIVE path sails straight through it, and
+#     then `git -C .` and `rm -rf "$(dirname .)"` both address the runner.
+#   * `dirname ""` is ".", so a single empty variable turns the EXIT cleanup
+#     into `rm -rf .` at the root of the real checkout.
+#
+# So the guard cannot be a check on the value. It is a check on the RESOLVED
+# TARGET: every fixture git call goes through `fixture_git`, which refuses any
+# directory that is not absolute, not under this suite's own temp root, or that
+# resolves to the same git repository the suite is running from -- and refuses
+# it by killing the suite, not by returning non-zero (most calls here sit inside
+# `$( )` or `( )`, where a `return`/`exit` is swallowed by the subshell and the
+# run marches on into the next block).
+SUITE_PID=$$
+
+# phys <path>: the physical, symlink-free form of an EXISTING directory. Path
+# STRINGS are not comparable identities here: /Users/seansilvius/projects/... and
+# /Volumes/store/projects/... are the same checkout through a symlink, and
+# mktemp hands out /var/folders/... for /private/var/folders/....
+phys() {
+  local p="$1"
+  [ -n "$p" ] || return 1
+  (cd "$p" 2>/dev/null && pwd -P) || return 1
+}
+
+# path_under <path> <root>: <path> is <root> or lives beneath it.
+path_under() {
+  local p="$1" root="$2"
+  [ -n "$p" ] && [ -n "$root" ] || return 1
+  case "$p" in "$root" | "$root"/*) return 0 ;; esac
+  return 1
+}
+
+# repo_key <dir>: a canonical identity for the git REPOSITORY <dir> belongs to.
+# The common git dir, so a linked worktree keys to the repo it is linked into --
+# a fixture pointed at a worktree of the runner's checkout must be caught too.
+repo_key() {
+  local d="$1" g
+  [ -n "$d" ] || return 1
+  g="$(cd "$d" 2>/dev/null && git rev-parse --git-common-dir 2>/dev/null)" || return 1
+  [ -n "$g" ] || return 1
+  case "$g" in /*) ;; *) g="${d}/${g}" ;; esac
+  phys "$g"
+}
+
+# The forbidden repository, captured TWICE: the repo containing this script, and
+# the repo at the cwd the suite started in. Under preflight they are the same;
+# run standalone from elsewhere they need not be, and both are equally fatal.
+# These two calls are the only git invocations in this file that are exempt from
+# fixture_git by definition -- they are how it learns what to refuse.
+SUITE_SELF_REPO="$(repo_key "$DIR" || printf '')"
+SUITE_CWD_REPO="$(repo_key "." || printf '')"
+SUITE_SELF_TOP="$( (cd "$DIR" 2>/dev/null && git rev-parse --show-toplevel 2>/dev/null) || printf '' )"
+[ -z "$SUITE_SELF_TOP" ] || SUITE_SELF_TOP="$(phys "$SUITE_SELF_TOP" || printf '%s' "$SUITE_SELF_TOP")"
+
+# ONE temp root for the whole suite, so "is this path mine?" is a containment
+# test rather than a list of four unrelated mktemp results.
+SUITE_TMP="$(phys "$(mktemp -d)")" || {
+  printf '[test-release] could not create the suite temp root\n' >&2
+  exit 90
+}
+SYSTEM_TMP="$(phys "${TMPDIR:-/tmp}" || printf '/tmp')"
+SUITE_ABORT_NOTE="${SUITE_TMP}/ABORT"
+
+# suite_abort <reason>: kill the RUN, from wherever it is called. `exit` alone
+# is not enough (subshells), and `return 1` is not enough (`set +e` on line 13),
+# so the signal goes to the top-level shell by pid and the local shell dies too.
+suite_abort() {
+  printf '\n[test-release] PERIMETER ABORT -- %s\n' "$1" >&2
+  printf '[test-release] the fixture harness refuses to run git outside its own temp root.\n' >&2
+  printf '%s\n' "$1" >"$SUITE_ABORT_NOTE" 2>/dev/null || true
+  kill -TERM "$SUITE_PID" 2>/dev/null || true
+  exit 97
+}
+suite_terminated() {
+  printf '\n[test-release] SUITE ABORTED BY THE PERIMETER GUARD: %s\n' \
+    "$(cat "$SUITE_ABORT_NOTE" 2>/dev/null || printf 'reason unavailable')" >&2
+  exit 97
+}
+trap suite_terminated TERM
+
+# Every temp directory this file creates goes on one list with one EXIT trap, so
+# a RED run cleans up as thoroughly as a green one -- and an ABORTED run cleans
+# up too. docs_worktree_setup makes its OWN `mktemp -d` parent, outside
+# $SUITE_TMP, and only a successful teardown ever removed it, so each failing run
+# leaked a worktree parent into the system temp dir, which is where the release
+# is cut. Registering the parent as soon as the path is known covers the failure
+# paths too.
+CLEANUP_PATHS=("$SUITE_TMP")
+cleanup_temps() {
+  [ "${#CLEANUP_PATHS[@]}" -eq 0 ] || rm -rf "${CLEANUP_PATHS[@]}"
+}
+trap cleanup_temps EXIT
+
+# register_temp <path...>: add a directory to the EXIT cleanup list. This list
+# is an `rm -rf` argument vector, so it is guarded at least as hard as the git
+# targets: `dirname ""` is ".", and a "." on this list is `rm -rf` at the root of
+# the runner's checkout when the suite exits.
+register_temp() {
+  local p rp
+  for p in "$@"; do
+    [ -n "$p" ] || continue
+    case "$p" in
+      /*) ;;
+      *) suite_abort "register_temp given the RELATIVE path [${p}] -- the EXIT 'rm -rf' would resolve it against the runner's checkout" ;;
+    esac
+    # Canonicalise before comparing. `mktemp -d` hands back /var/folders/... for
+    # what is physically /private/var/folders/..., so a string test against a
+    # physically-resolved root rejects a perfectly legitimate temp parent.
+    rp="$(phys "$p" || printf '%s' "$p")"
+    if ! path_under "$rp" "$SUITE_TMP" && ! path_under "$rp" "$SYSTEM_TMP"; then
+      suite_abort "register_temp given [${p}] (-> ${rp}), which is under neither ${SUITE_TMP} nor ${SYSTEM_TMP}"
+    fi
+    if [ -n "$SUITE_SELF_TOP" ] && { path_under "$rp" "$SUITE_SELF_TOP" || path_under "$SUITE_SELF_TOP" "$rp"; }; then
+      suite_abort "register_temp given [${p}] (-> ${rp}), which contains or lives inside the runner's checkout ${SUITE_SELF_TOP}"
+    fi
+    CLEANUP_PATHS+=("$rp")
+  done
+}
+
+# fixture_dir_allowed <physical-path>: under the suite temp root, or under a
+# directory already registered for cleanup. The second arm is what admits the
+# worktree parents docs_worktree_setup mints with its own `mktemp -d` -- those
+# are outside $SUITE_TMP by construction, and release.sh is not in scope here.
+fixture_dir_allowed() {
+  local p="$1" reg
+  path_under "$p" "$SUITE_TMP" && return 0
+  for reg in "${CLEANUP_PATHS[@]}"; do
+    path_under "$p" "$reg" && return 0
+  done
+  return 1
+}
+
+# fixture_git_verb <args...>: the git subcommand, skipping global options and
+# their values, so the remote assertion fires on the calls that can reach one.
+fixture_git_verb() {
+  local a skip=0
+  for a in "$@"; do
+    if [ "$skip" = 1 ]; then
+      skip=0
+      continue
+    fi
+    case "$a" in
+      -c | -C | --git-dir | --work-tree | --namespace) skip=1 ;;
+      -*) ;;
+      *)
+        printf '%s' "$a"
+        return 0
+        ;;
+    esac
+  done
+  return 1
+}
+
+# fixture_assert_url <url-or-arg> <what>: a fixture's remote must be a temp bare
+# repo. Anything addressable off this machine is refused outright -- that is the
+# difference between a bad test run and a push to GitHub.
+fixture_assert_url() {
+  local url="$1" what="$2" rp
+  [ -n "$url" ] || return 0
+  case "$url" in
+    /*)
+      rp="$(phys "$url" || printf '%s' "$url")"
+      fixture_dir_allowed "$rp" \
+        || suite_abort "fixture remote [${url}] resolves OUTSIDE the suite temp root ${SUITE_TMP} -- ${what}"
+      ;;
+    *://* | *@*:*)
+      suite_abort "fixture remote [${url}] is NON-LOCAL -- ${what}"
+      ;;
+    *) : ;; # a remote name, refspec or branch, not a URL
+  esac
+}
+
+# fixture_assert_remote <dir> <what>: <dir>'s origin, if it has one. The read is
+# a DIRECT git call -- it is part of the guard, so routing it through
+# fixture_git would recurse.
+fixture_assert_remote() {
+  local d="$1" what="$2" url
+  url="$(git -C "$d" remote get-url origin 2>/dev/null)" || url=""
+  fixture_assert_url "$url" "${what} (origin of ${d})"
+}
+
+# fixture_git <dir> <git-args...>: THE ONLY WAY this file addresses a git repo.
+fixture_git() {
+  local d="$1"
+  shift
+  local p key last a
+  [ -n "$d" ] || suite_abort "fixture git with an EMPTY target directory: 'git $*' -- 'git -C \"\"' silently runs in the CURRENT repo and exits 0"
+  case "$d" in
+    /*) ;;
+    *) suite_abort "fixture git with the RELATIVE target directory [${d}]: 'git $*' -- it would resolve against the runner's cwd" ;;
+  esac
+  p="$(phys "$d")" || suite_abort "fixture git target does not exist [${d}]: 'git $*'"
+  fixture_dir_allowed "$p" \
+    || suite_abort "fixture git target [${p}] is outside the suite temp root ${SUITE_TMP}: 'git $*'"
+  key="$(repo_key "$p" || printf '')"
+  if [ -n "$key" ]; then
+    [ "$key" != "$SUITE_SELF_REPO" ] \
+      || suite_abort "fixture git target [${p}] IS the repository this suite is running from (${key}): 'git $*'"
+    [ "$key" != "$SUITE_CWD_REPO" ] \
+      || suite_abort "fixture git target [${p}] is the repository at the suite's startup cwd (${key}): 'git $*'"
+  fi
+  case "$(fixture_git_verb "$@")" in
+    push | fetch | pull | clone | ls-remote)
+      fixture_assert_remote "$d" "git $*"
+      ;;
+    remote)
+      fixture_assert_remote "$d" "git $*"
+      last=""
+      for a in "$@"; do last="$a"; done
+      fixture_assert_url "$last" "git $*"
+      ;;
+  esac
+  git -C "$d" "$@"
+}
+
+# fixture_git_init <dir> <git-args...>: <dir> is APPENDED, because `git init` and
+# friends take the target as an argument rather than via -C, and -C requires the
+# directory to already exist.
+fixture_git_init() {
+  local d="$1"
+  shift
+  [ -n "$d" ] || suite_abort "fixture git init with an EMPTY target directory: 'git $*'"
+  case "$d" in
+    /*) ;;
+    *) suite_abort "fixture git init with the RELATIVE target directory [${d}]: 'git $*'" ;;
+  esac
+  path_under "$d" "$SUITE_TMP" \
+    || suite_abort "fixture git init target [${d}] is outside the suite temp root ${SUITE_TMP}"
+  git "$@" "$d"
+}
+
+# gitp <dir> <git-args...>: a fixture git call with hooks pinned off, so a stray
+# repo-level or inherited hook cannot turn a fixture push into a mystery failure.
+gitp() {
+  local d="$1"
+  shift
+  fixture_git "$d" -c core.hooksPath=/dev/null "$@"
+}
+
+# require_dir stays, one layer in from the perimeter: it turns "the helper under
+# test returned nothing usable" into a NAMED test failure with its dependent
+# assertions skipped, rather than a pile of confusing downstream failures. It is
+# not a safety boundary -- it passes on "." -- and nothing below may rely on it
+# as one.
 require_dir() { # require_dir <label> <path>
   local label="$1" d="$2"
-  if [ -n "$d" ] && [ -d "$d" ]; then PASS=$((PASS + 1)); return 0; fi
+  if [ -n "$d" ] && [ -d "$d" ]; then
+    PASS=$((PASS + 1))
+    return 0
+  fi
   FAIL=$((FAIL + 1))
   printf 'FAIL: %s -- no usable directory [%s]; dependent assertions skipped\n' "$label" "$d" >&2
   return 1
@@ -64,9 +311,6 @@ require_dir() { # require_dir <label> <path>
 # global config leaves git with no committer.
 export GIT_CONFIG_GLOBAL=/dev/null
 export GIT_CONFIG_SYSTEM=/dev/null
-# gitp: a push with hooks pinned off, so a stray repo-level hook cannot turn a
-# fixture push into a mystery failure.
-gitp() { git -c core.hooksPath=/dev/null "$@"; }
 
 # compute_new_version
 eq "patch"         0.18.3 "$(compute_new_version 0.18.2 patch)"
@@ -124,28 +368,12 @@ eq "tag: custom format"   "ledger@0.2.0"   "$(render_tag '{version}' ledger@0.2.
 # #741's proof that the bump step generalizes beyond Cargo.toml (a package.json
 # source, e.g. a JS repo's `[version] file = "package.json"`, bumps the same way
 # a flat json target does in scripts/sync-version.sh).
-# Every temp directory this file creates goes on one list with one EXIT trap, so
-# a RED run cleans up as thoroughly as a green one. docs_worktree_setup makes its
-# OWN `mktemp -d` parent, outside $DOCS_TMP, and only a successful teardown ever
-# removed it -- so each failing run leaked a worktree parent into the system temp
-# dir, which is where the release is cut. Registering the parent as soon as the
-# path is known covers the failure paths too.
-CLEANUP_PATHS=()
-cleanup_temps() {
-  [ "${#CLEANUP_PATHS[@]}" -eq 0 ] || rm -rf "${CLEANUP_PATHS[@]}"
-}
-trap cleanup_temps EXIT
-# register_temp <path...>: add a directory to the EXIT cleanup list.
-register_temp() {
-  local p
-  for p in "$@"; do
-    [ -n "$p" ] || continue
-    CLEANUP_PATHS+=("$p")
-  done
-}
-
-BUMP_DIR=$(mktemp -d)
-register_temp "$BUMP_DIR"
+#
+# Every fixture directory below is a CHILD of $SUITE_TMP rather than its own
+# `mktemp -d`, so "is this path the suite's own?" -- which is what the perimeter
+# guard asks on every git call -- is a single containment test.
+BUMP_DIR="${SUITE_TMP}/bump"
+mkdir -p "$BUMP_DIR"
 
 cat >"${BUMP_DIR}/Cargo.toml" <<'EOF'
 [package]
@@ -219,8 +447,8 @@ eq "merge: landed wins over unknown queue" "merged" "$(classify_release_merge 1 
 # --finish= argument) supply is ever parsed as shell. Sequenced observers keep
 # their state in a counter FILE because each observer runs in a command
 # substitution, i.e. a subshell: a shell variable would not survive the poll.
-WAIT_DIR=$(mktemp -d)
-register_temp "$WAIT_DIR"
+WAIT_DIR="${SUITE_TMP}/wait"
+mkdir -p "$WAIT_DIR"
 # step <file>: print the call count so far, then increment it.
 step() { local f="$1" n; n="$(cat "$f")"; printf '%s\n' "$((n + 1))" >"$f"; printf '%s\n' "$n"; }
 
@@ -310,28 +538,57 @@ eq "wait: injected observer resolves a sourced function" "merged" \
 # remote cannot be reached, which a stubbed observer cannot show.
 #
 # release_landed operates on the CURRENT directory (finish_release cd's to the
-# repo root first), so these run through `in_dir`, which refuses an empty path.
-# `cd ""` returns 0 in bash, so `cd "$X" || return` is NOT a guard on its own.
+# repo root first), so these run through `in_dir`. `cd ""` returns 0 in bash, so
+# `cd "$X" || return` is NOT a guard on its own.
+#
+# in_dir is THE SECOND DOOR into the runner's repo, and it has to be barred as
+# hard as the first: it hands the cwd to a release.sh function whose own git
+# calls cannot be routed through fixture_git, so whatever `cd` lands on is what
+# that function operates on. It therefore applies the same perimeter as
+# fixture_git -- absolute, inside the suite temp root, and not the runner's
+# repository -- before it moves anywhere. Refusing a relative path matters as
+# much as refusing an empty one: "." is the value `require_dir` waves through.
 in_dir() { # in_dir <dir> <cmd...>
   local d="$1"; shift
+  local p key
   [ -n "$d" ] || return 90
-  cd "$d" || return 91
+  case "$d" in
+    /*) ;;
+    *) suite_abort "in_dir given the RELATIVE directory [${d}] -- it would hand the runner's cwd to '$1'" ;;
+  esac
+  p="$(phys "$d")" || return 91
+  fixture_dir_allowed "$p" \
+    || suite_abort "in_dir target [${p}] is outside the suite temp root ${SUITE_TMP} -- refusing to run '$1' there"
+  key="$(repo_key "$p" || printf '')"
+  if [ -n "$key" ]; then
+    [ "$key" != "$SUITE_SELF_REPO" ] \
+      || suite_abort "in_dir target [${p}] IS the repository this suite is running from -- refusing to run '$1' there"
+    [ "$key" != "$SUITE_CWD_REPO" ] \
+      || suite_abort "in_dir target [${p}] is the repository at the suite's startup cwd -- refusing to run '$1' there"
+  fi
+  cd "$p" || return 91
   "$@"
 }
 
-OBS_TMP=$(mktemp -d)
-register_temp "$OBS_TMP"
+# THE FIXTURE WHOSE SHAPE IS THE INCIDENT. A one-line Cargo.toml carrying
+# `version = "0.25.0"`, a commit subject of `chore(release): 0.25.0`, and a
+# `push -u origin main` -- which is, byte for byte, what was force-fed onto the
+# real origin/main. Nothing here is exotic; the escape is entirely in WHERE the
+# three lines land, which is why every one of them now goes through the
+# perimeter rather than through a bare `git -C`.
+OBS_TMP="${SUITE_TMP}/obs"
+mkdir -p "$OBS_TMP"
 OBS_CO="${OBS_TMP}/repo"
-git init --bare --quiet "${OBS_TMP}/origin.git"
-git -c init.defaultBranch=main init --quiet "$OBS_CO"
-git -C "$OBS_CO" config user.email t@t
-git -C "$OBS_CO" config user.name t
-git -C "$OBS_CO" checkout --quiet -B main
+fixture_git_init "${OBS_TMP}/origin.git" init --bare --quiet
+fixture_git_init "$OBS_CO" -c init.defaultBranch=main init --quiet
+fixture_git "$OBS_CO" config user.email t@t
+fixture_git "$OBS_CO" config user.name t
+fixture_git "$OBS_CO" checkout --quiet -B main
 printf 'version = "0.25.0"\n' >"${OBS_CO}/Cargo.toml"
-git -C "$OBS_CO" add Cargo.toml
-git -C "$OBS_CO" commit --quiet --no-verify -m "chore(release): 0.25.0"
-git -C "$OBS_CO" remote add origin "${OBS_TMP}/origin.git"
-gitp -C "$OBS_CO" push --quiet -u origin main
+fixture_git "$OBS_CO" add Cargo.toml
+fixture_git "$OBS_CO" commit --quiet --no-verify -m "chore(release): 0.25.0"
+fixture_git "$OBS_CO" remote add origin "${OBS_TMP}/origin.git"
+gitp "$OBS_CO" push --quiet -u origin main
 
 if require_dir "observers: fixture repo" "$OBS_CO"; then
   # A reachable remote that does not carry the version is a definite NO.
@@ -344,9 +601,9 @@ if require_dir "observers: fixture repo" "$OBS_CO"; then
   # being updated. A gate phrased as "did the ref read cleanly" answers a
   # confident 0 here, and the poll loop turns a sustained 0 into an EJECTED
   # verdict. Only the fetch's exit status can tell the difference.
-  git -C "$OBS_CO" remote set-url origin "${OBS_TMP}/does-not-exist.git"
+  fixture_git "$OBS_CO" remote set-url origin "${OBS_TMP}/does-not-exist.git"
   ok "landed: the remote-tracking ref is still readable during the outage" \
-    test -n "$(git -C "$OBS_CO" rev-parse --verify --quiet origin/main 2>/dev/null)"
+    test -n "$(fixture_git "$OBS_CO" rev-parse --verify --quiet origin/main 2>/dev/null)"
   eq "landed: unreachable remote is unknown, not 0" "unknown" \
     "$( (in_dir "$OBS_CO" release_landed main Cargo.toml package.version 0.25.0) 2>/dev/null )"
   # Same failure, same requirement, for the queue observer: the rc must belong to
@@ -354,12 +611,14 @@ if require_dir "observers: fixture repo" "$OBS_CO"; then
   eq "queue: unreachable remote is unknown, not 0" "unknown" \
     "$( (in_dir "$OBS_CO" release_queue_ref_present 42) 2>/dev/null )"
 
-  git -C "$OBS_CO" remote set-url origin "${OBS_TMP}/origin.git"
+  fixture_git "$OBS_CO" remote set-url origin "${OBS_TMP}/origin.git"
   eq "queue: reachable remote without the ref is 0" "0" \
     "$( (in_dir "$OBS_CO" release_queue_ref_present 42) 2>/dev/null )"
   # A real merge-queue ref: refs/heads/gh-readonly-queue/<base>/pr-<N>-<sha>.
-  OBS_SHA="$(git -C "$OBS_CO" rev-parse HEAD)"
-  git -C "${OBS_TMP}/origin.git" update-ref \
+  OBS_SHA="$(fixture_git "$OBS_CO" rev-parse HEAD)"
+  # A BARE repo: fixture_git keys on the common git dir, which a bare repo has,
+  # so this is guarded exactly like the checkouts are.
+  fixture_git "${OBS_TMP}/origin.git" update-ref \
     "refs/heads/gh-readonly-queue/main/pr-42-${OBS_SHA}" "$OBS_SHA"
   eq "queue: the PR's queue ref is present" "1" \
     "$( (in_dir "$OBS_CO" release_queue_ref_present 42) 2>/dev/null )"
@@ -491,50 +750,59 @@ no "disposable: missing base sha even when untouched" worktree_is_disposable bbb
 # remote. No network, no gh, no shingle. Both call `fail` (which exits), so every
 # arm runs in a subshell.
 #
-# Every fixture command below addresses its repo with `git -C <dir>` and writes
-# through absolute paths, and `require_dir` (see the fixture preamble at the top
-# of this file -- it, not `git -C`, is what makes that safe) gates every block on
-# the helper under test having returned a real directory.
-DOCS_TMP=$(mktemp -d)
-register_temp "$DOCS_TMP"
+# Every fixture command below goes through `fixture_git`, which resolves the
+# target repo and refuses anything that is not this suite's own temp tree (see
+# THE FIXTURE PERIMETER at the top of this file). `docs_worktree_setup` and
+# `docs_worktree_teardown` are the functions UNDER TEST, so their internal git
+# calls cannot be routed -- what bounds them is `in_dir`/`require_dir` on the
+# way in, the fact that the only checkout they are ever handed is $DOCS_CO, and
+# the perimeter on every assertion made about their output afterwards.
+DOCS_TMP="${SUITE_TMP}/docs"
+mkdir -p "$DOCS_TMP"
 DOCS_CO="${DOCS_TMP}/checkout"
 DOCS_BRANCH="docs/fixture-current"
-git init --bare --quiet "${DOCS_TMP}/origin.git"
-git -c init.defaultBranch=main init --quiet "$DOCS_CO"
-git -C "$DOCS_CO" config user.email t@t
-git -C "$DOCS_CO" config user.name t
-git -C "$DOCS_CO" checkout --quiet -B main
+fixture_git_init "${DOCS_TMP}/origin.git" init --bare --quiet
+fixture_git_init "$DOCS_CO" -c init.defaultBranch=main init --quiet
+fixture_git "$DOCS_CO" config user.email t@t
+fixture_git "$DOCS_CO" config user.name t
+fixture_git "$DOCS_CO" checkout --quiet -B main
 printf 'docs\n' >"${DOCS_CO}/index.md"
-git -C "$DOCS_CO" add index.md
-git -C "$DOCS_CO" commit --quiet --no-verify -m "init"
-git -C "$DOCS_CO" remote add origin "${DOCS_TMP}/origin.git"
-gitp -C "$DOCS_CO" push --quiet -u origin main
+fixture_git "$DOCS_CO" add index.md
+fixture_git "$DOCS_CO" commit --quiet --no-verify -m "init"
+fixture_git "$DOCS_CO" remote add origin "${DOCS_TMP}/origin.git"
+gitp "$DOCS_CO" push --quiet -u origin main
 # Prove the pin took, rather than assuming it: every assertion below about
 # config-independence rests on this.
 eq "fixture: ambient global config is neutralised" "" \
-  "$(git -C "$DOCS_CO" config --global --get merge.ff 2>/dev/null || true)"
+  "$(fixture_git "$DOCS_CO" config --global --get merge.ff 2>/dev/null || true)"
 eq "fixture: repo identity is set for worktree commits" "t@t" \
-  "$(git -C "$DOCS_CO" config user.email 2>/dev/null)"
+  "$(fixture_git "$DOCS_CO" config user.email 2>/dev/null)"
+# The remote guard, asserted rather than assumed: the fixture's origin resolves
+# inside the suite temp root. A fixture whose origin is a real forge is the
+# entire incident, so this must be a checked property of the fixture, not a
+# property of the line that happened to create it.
+ok "fixture: origin is a temp bare repo inside the suite root" \
+  path_under "$(phys "$(fixture_git "$DOCS_CO" remote get-url origin)")" "$SUITE_TMP"
 
 # Fresh arm: no such branch on the remote, so the worktree starts from
 # origin/main -- NOT from whatever the shared checkout has checked out. Prove
 # that by parking the shared checkout on an unrelated branch first.
-git -C "$DOCS_CO" checkout --quiet -b someone-elses-work
+fixture_git "$DOCS_CO" checkout --quiet -b someone-elses-work
 printf 'wip\n' >"${DOCS_CO}/wip.md"
-git -C "$DOCS_CO" add wip.md
-git -C "$DOCS_CO" commit --quiet --no-verify -m "wip"
+fixture_git "$DOCS_CO" add wip.md
+fixture_git "$DOCS_CO" commit --quiet --no-verify -m "wip"
 WT1="$( (docs_worktree_setup "$DOCS_CO" "$DOCS_BRANCH" main fixture-docs) 2>/dev/null )"
 # Registered for cleanup the moment the path is known: docs_worktree_setup makes
 # its own mktemp parent OUTSIDE $DOCS_TMP, and a red run never reaches teardown.
 [ -z "$WT1" ] || register_temp "$(dirname "$WT1")"
 if require_dir "docs wt: created" "$WT1"; then
-  eq "docs wt: on the stable branch" "$DOCS_BRANCH" "$(git -C "$WT1" rev-parse --abbrev-ref HEAD 2>/dev/null)"
+  eq "docs wt: on the stable branch" "$DOCS_BRANCH" "$(fixture_git "$WT1" rev-parse --abbrev-ref HEAD 2>/dev/null)"
   # The load-bearing one: it must NOT have inherited the other agent's branch.
   eq "docs wt: starts from origin/main, not the shared checkout's branch" \
-    "$(git -C "$DOCS_CO" rev-parse origin/main)" "$(git -C "$WT1" rev-parse HEAD 2>/dev/null)"
+    "$(fixture_git "$DOCS_CO" rev-parse origin/main)" "$(fixture_git "$WT1" rev-parse HEAD 2>/dev/null)"
   ok "docs wt: the other agent's file is absent" test ! -f "${WT1}/wip.md"
   ok "docs wt: base sha recorded outside the worktree" test -f "$(dirname "$WT1")/base-sha"
-  eq "docs wt: worktree left clean" "" "$(git -C "$WT1" status --porcelain 2>/dev/null)"
+  eq "docs wt: worktree left clean" "" "$(fixture_git "$WT1" status --porcelain 2>/dev/null)"
   # The OWNERSHIP marker, and it must name this worktree by path -- teardown
   # refuses to destroy anything it cannot match against this file.
   ok "docs wt: ownership marker written" test -f "$(dirname "$WT1")/worktree-path"
@@ -555,7 +823,7 @@ ok "docs wt: collision never yields the shared checkout" test "$COLLIDE_OUT" != 
 (docs_worktree_teardown "$WT1") >/dev/null 2>&1
 ok "docs teardown: unchanged worktree removed" test ! -d "$WT1"
 no "docs teardown: unchanged branch removed too" \
-  git -C "$DOCS_CO" show-ref --verify --quiet "refs/heads/${DOCS_BRANCH}"
+  fixture_git "$DOCS_CO" show-ref --verify --quiet "refs/heads/${DOCS_BRANCH}"
 
 # Teardown, carrying unpushed commits: RETAINED, so a failed docs run is
 # recoverable rather than discarded.
@@ -563,15 +831,15 @@ WT2="$( (docs_worktree_setup "$DOCS_CO" "$DOCS_BRANCH" main fixture-docs) 2>/dev
 [ -z "$WT2" ] || register_temp "$(dirname "$WT2")"
 if require_dir "docs teardown: second worktree created" "$WT2"; then
   printf 'draft\n' >"${WT2}/draft.md"
-  git -C "$WT2" add draft.md
-  git -C "$WT2" commit --quiet --no-verify -m "docs: draft"
+  fixture_git "$WT2" add draft.md
+  fixture_git "$WT2" commit --quiet --no-verify -m "docs: draft"
   (docs_worktree_teardown "$WT2") >/dev/null 2>&1
   ok "docs teardown: unpushed work retained" test -d "$WT2"
   ok "docs teardown: retained worktree keeps its commit" test -f "${WT2}/draft.md"
 
   # Same worktree once the work is PUSHED: now disposable. Without this arm a
   # successful docs run would pin the worktree forever and collide next release.
-  gitp -C "$WT2" push --quiet -u origin "$DOCS_BRANCH"
+  gitp "$WT2" push --quiet -u origin "$DOCS_BRANCH"
   (docs_worktree_teardown "$WT2") >/dev/null 2>&1
   ok "docs teardown: pushed work is disposable" test ! -d "$WT2"
 fi
@@ -579,10 +847,10 @@ fi
 # Extend arm (#820): the stable branch now exists on the remote, so the next
 # release starts from IT and merges origin/main in -- one docs PR that each
 # release extends, not a new version-pinned branch stacked on the last.
-git -C "$DOCS_CO" checkout --quiet main
+fixture_git "$DOCS_CO" checkout --quiet main
 printf 'more\n' >>"${DOCS_CO}/index.md"
-git -C "$DOCS_CO" commit --quiet --no-verify -am "main moves on"
-gitp -C "$DOCS_CO" push --quiet origin main
+fixture_git "$DOCS_CO" commit --quiet --no-verify -am "main moves on"
+gitp "$DOCS_CO" push --quiet origin main
 
 # The extend arm runs under a HOSTILE-BUT-ORDINARY config, pinned on the repo so
 # the assertion does not depend on the operator's machine. `merge.ff = only` is a
@@ -592,26 +860,26 @@ gitp -C "$DOCS_CO" push --quiet origin main
 # operator to go and resolve it in the shared checkout, which is the fallback
 # #845 exists to close. `user.useConfigOnly` is pinned alongside it because it
 # breaks the same step a different way.
-git -C "$DOCS_CO" config merge.ff only
-git -C "$DOCS_CO" config user.useConfigOnly true
+fixture_git "$DOCS_CO" config merge.ff only
+fixture_git "$DOCS_CO" config user.useConfigOnly true
 WT3="$( (docs_worktree_setup "$DOCS_CO" "$DOCS_BRANCH" main fixture-docs) 2>/dev/null )"
 [ -z "$WT3" ] || register_temp "$(dirname "$WT3")"
 if require_dir "docs extend: worktree created under merge.ff=only" "$WT3"; then
   ok "docs extend: the earlier release's docs commit is still there" test -f "${WT3}/draft.md"
   ok "docs extend: origin/main was merged in" \
-    git -C "$WT3" merge-base --is-ancestor origin/main HEAD
+    fixture_git "$WT3" merge-base --is-ancestor origin/main HEAD
   # --no-ff, so the merge-in is a real merge commit (two parents) regardless of
   # whether it could have fast-forwarded.
   eq "docs extend: merge-in is a merge commit" "2" \
-    "$(git -C "$WT3" rev-list --parents -n 1 HEAD 2>/dev/null | awk '{print NF-1}')"
+    "$(fixture_git "$WT3" rev-list --parents -n 1 HEAD 2>/dev/null | awk '{print NF-1}')"
   # The merge is setup's own work, so it must not count as agent work at teardown.
   eq "docs extend: base sha recorded after the merge-in" \
-    "$(git -C "$WT3" rev-parse HEAD 2>/dev/null)" "$(cat "$(dirname "$WT3")/base-sha" 2>/dev/null)"
+    "$(fixture_git "$WT3" rev-parse HEAD 2>/dev/null)" "$(cat "$(dirname "$WT3")/base-sha" 2>/dev/null)"
   (docs_worktree_teardown "$WT3") >/dev/null 2>&1
   ok "docs extend: unchanged extend-arm worktree removed" test ! -d "$WT3"
 fi
-git -C "$DOCS_CO" config --unset merge.ff
-git -C "$DOCS_CO" config --unset user.useConfigOnly
+fixture_git "$DOCS_CO" config --unset merge.ff
+fixture_git "$DOCS_CO" config --unset user.useConfigOnly
 
 # A retained worktree whose DIRECTORY was deleted by hand stays registered as
 # "prunable". That registration is invisible to worktree_holding_branch, so every
@@ -629,9 +897,9 @@ if require_dir "docs prune: worktree created" "$WT4"; then
   ok "docs prune: message does not name the vanished path" \
     test "${PRUNE_ERR##*"$WT4"*}" = "$PRUNE_ERR"
   ok "docs prune: registration was actually pruned" \
-    test -z "$(git -C "$DOCS_CO" worktree list --porcelain | worktree_holding_branch "$DOCS_BRANCH" || true)"
+    test -z "$(fixture_git "$DOCS_CO" worktree list --porcelain | worktree_holding_branch "$DOCS_BRANCH" || true)"
   # And the named recovery genuinely unblocks it: delete the branch, run again.
-  git -C "$DOCS_CO" branch -D "$DOCS_BRANCH" >/dev/null 2>&1
+  fixture_git "$DOCS_CO" branch -D "$DOCS_BRANCH" >/dev/null 2>&1
   WT5="$( (docs_worktree_setup "$DOCS_CO" "$DOCS_BRANCH" main fixture-docs) 2>/dev/null )"
   [ -z "$WT5" ] || register_temp "$(dirname "$WT5")"
   ok "docs prune: docs step is unblocked after the named recovery" test -n "$WT5"
@@ -653,19 +921,19 @@ fi
 SHARED="${DOCS_TMP}/shared"
 mkdir -p "$SHARED"
 printf 'do not delete me\n' >"${SHARED}/sibling.txt"
-git -C "$DOCS_CO" worktree add --quiet -b hand-made "${SHARED}/hand-made" main >/dev/null 2>&1
+fixture_git "$DOCS_CO" worktree add --quiet -b hand-made "${SHARED}/hand-made" main >/dev/null 2>&1
 # Pushed, so it satisfies the DISPOSABLE arm on content. It must survive anyway:
 # "looks disposable" is not an ownership claim, and every clean fully-pushed
 # worktree in the docs repo looks exactly like this one.
-gitp -C "${SHARED}/hand-made" push --quiet -u origin hand-made
+gitp "${SHARED}/hand-made" push --quiet -u origin hand-made
 FOREIGN_RC=0
 (docs_worktree_teardown "${SHARED}/hand-made") >/dev/null 2>&1 || FOREIGN_RC=$?
 eq "docs teardown: foreign worktree teardown refuses" "1" "$FOREIGN_RC"
 ok "docs teardown: foreign worktree RETAINED" test -d "${SHARED}/hand-made"
 ok "docs teardown: foreign worktree's branch survives" \
-  git -C "$DOCS_CO" show-ref --verify --quiet "refs/heads/hand-made"
+  fixture_git "$DOCS_CO" show-ref --verify --quiet "refs/heads/hand-made"
 ok "docs teardown: foreign worktree keeps its registration" \
-  test -n "$(git -C "$DOCS_CO" worktree list --porcelain | worktree_holding_branch hand-made || true)"
+  test -n "$(fixture_git "$DOCS_CO" worktree list --porcelain | worktree_holding_branch hand-made || true)"
 ok "docs teardown: an unowned parent directory survives" test -d "$SHARED"
 ok "docs teardown: its siblings survive" test -f "${SHARED}/sibling.txt"
 
@@ -674,9 +942,9 @@ ok "docs teardown: its siblings survive" test -f "${SHARED}/sibling.txt"
 # enough to authorise the removal.
 MISMARK="${DOCS_TMP}/mismarked"
 mkdir -p "$MISMARK"
-git -C "$DOCS_CO" worktree add --quiet -b mis-marked "${MISMARK}/wt" main >/dev/null 2>&1
-gitp -C "${MISMARK}/wt" push --quiet -u origin mis-marked
-printf '%s\n' "$(git -C "${MISMARK}/wt" rev-parse HEAD)" >"${MISMARK}/base-sha"
+fixture_git "$DOCS_CO" worktree add --quiet -b mis-marked "${MISMARK}/wt" main >/dev/null 2>&1
+gitp "${MISMARK}/wt" push --quiet -u origin mis-marked
+printf '%s\n' "$(fixture_git "${MISMARK}/wt" rev-parse HEAD)" >"${MISMARK}/base-sha"
 printf '%s\n' "${MISMARK}/some-other-worktree" >"${MISMARK}/worktree-path"
 MISMARK_RC=0
 (docs_worktree_teardown "${MISMARK}/wt") >/dev/null 2>&1 || MISMARK_RC=$?
@@ -694,32 +962,32 @@ ok "docs teardown: mismarked worktree retained" test -d "${MISMARK}/wt"
 # Deliberately no `legion`: the reader is injected by name, so the fixture reads
 # the version with git+sed. CI never runs this file (only scripts/preflight.sh
 # does), and a standalone preflight run is not guaranteed a legion binary.
-BND_TMP=$(mktemp -d)
-register_temp "$BND_TMP"
+BND_TMP="${SUITE_TMP}/bnd"
+mkdir -p "$BND_TMP"
 BND="${BND_TMP}/repo"
-git -c init.defaultBranch=main init --quiet "$BND"
-git -C "$BND" config user.email t@t
-git -C "$BND" config user.name t
+fixture_git_init "$BND" -c init.defaultBranch=main init --quiet
+fixture_git "$BND" config user.email t@t
+fixture_git "$BND" config user.name t
 bnd_commit() { # bnd_commit <file> <content> <subject>
   printf '%s\n' "$2" >"${BND}/$1"
-  git -C "$BND" add "$1"
-  git -C "$BND" commit --quiet --no-verify -m "$3"
+  fixture_git "$BND" add "$1"
+  fixture_git "$BND" commit --quiet --no-verify -m "$3"
 }
 # The reader under test's production twin is ref_version; here it is git show
 # plus a sed, so the fixture stays hermetic.
-bnd_version() { git -C "$BND" show "${1}:Cargo.toml" 2>/dev/null | sed -n 's/^version = "\(.*\)"$/\1/p'; }
+bnd_version() { fixture_git "$BND" show "${1}:Cargo.toml" 2>/dev/null | sed -n 's/^version = "\(.*\)"$/\1/p'; }
 
 bnd_commit Cargo.toml 'version = "0.24.0"' "chore(release): 0.24.0"
 bnd_commit src.txt 'work' "feat: something"
 bnd_commit Cargo.toml 'version = "0.25.0"' "chore(release): 0.25.0"
-BND_RELEASE="$(git -C "$BND" rev-parse HEAD)"
+BND_RELEASE="$(fixture_git "$BND" rev-parse HEAD)"
 # What lands between `legion pr merge` and `--finish`: ordinary merges that do
 # not touch the version file at all.
 bnd_commit a.txt 'a' "feat(#1): a"
 bnd_commit b.txt 'b' "fix(#2): b"
-BND_TIP="$(git -C "$BND" rev-parse HEAD)"
+BND_TIP="$(fixture_git "$BND" rev-parse HEAD)"
 
-BND_LIST="$(git -C "$BND" rev-list HEAD -- Cargo.toml)"
+BND_LIST="$(fixture_git "$BND" rev-list HEAD -- Cargo.toml)"
 eq "release commit: resolved from a real history" "$BND_RELEASE" \
   "$(printf '%s\n' "$BND_LIST" | release_boundary_commit bnd_version 0.25.0 200)"
 # The point of the finding, stated as an assertion: the tip is NOT the answer,
@@ -733,7 +1001,7 @@ ok "release commit: the tip still passes the version gate (why tip-resolution lo
 eq "release commit: walks only commits that touch the version file" "2" \
   "$(printf '%s\n' "$BND_LIST" | wc -l | tr -d ' ')"
 eq "release commit: while the branch itself is longer" "5" \
-  "$(git -C "$BND" rev-list HEAD | wc -l | tr -d ' ')"
+  "$(fixture_git "$BND" rev-list HEAD | wc -l | tr -d ' ')"
 
 # IDEMPOTENCE, which is what release.sh:767 and legion-release.md:88 promise when
 # they say re-running --finish is safe. Re-resolving must return the SAME sha
@@ -741,27 +1009,27 @@ eq "release commit: while the branch itself is longer" "5" \
 # the existing tag and re-push it, instead of deriving a new sha and dying on
 # "tag already exists and points at <other>".
 bnd_commit c.txt 'c' "fix(#3): c"
-BND_AGAIN="$(git -C "$BND" rev-list HEAD -- Cargo.toml | release_boundary_commit bnd_version 0.25.0 200)"
+BND_AGAIN="$(fixture_git "$BND" rev-list HEAD -- Cargo.toml | release_boundary_commit bnd_version 0.25.0 200)"
 eq "release commit: stable across re-runs as the branch moves" "$BND_RELEASE" "$BND_AGAIN"
 # And the next release's boundary is its own commit, not the previous one.
 bnd_commit Cargo.toml 'version = "0.26.0"' "chore(release): 0.26.0"
-BND_NEXT="$(git -C "$BND" rev-parse HEAD)"
+BND_NEXT="$(fixture_git "$BND" rev-parse HEAD)"
 eq "release commit: the next release resolves to its own commit" "$BND_NEXT" \
-  "$(git -C "$BND" rev-list HEAD -- Cargo.toml | release_boundary_commit bnd_version 0.26.0 200)"
+  "$(fixture_git "$BND" rev-list HEAD -- Cargo.toml | release_boundary_commit bnd_version 0.26.0 200)"
 # Once a NEWER release has landed, the older one no longer resolves at all
 # (rc 1) rather than resolving to something plausible-looking. In production the
 # branch-tip landed gate refuses first, for the same reason: --finish on a
 # superseded release must stop, not tag.
 eq "release commit: a superseded release refuses to resolve" "1" \
-  "$(git -C "$BND" rev-list HEAD -- Cargo.toml | release_boundary_commit bnd_version 0.25.0 200 >/dev/null; printf '%s' $?)"
+  "$(fixture_git "$BND" rev-list HEAD -- Cargo.toml | release_boundary_commit bnd_version 0.25.0 200 >/dev/null; printf '%s' $?)"
 # A commit that touches the version file WITHOUT changing the version (a
 # dependency edit) must not be mistaken for the release commit.
 bnd_commit Cargo.toml 'version = "0.26.0"
 serde = "1.0.1"' "chore: dep bump"
 ok "release commit: the dep-bump commit really landed" \
-  test "$(git -C "$BND" rev-parse HEAD)" != "$BND_NEXT"
+  test "$(fixture_git "$BND" rev-parse HEAD)" != "$BND_NEXT"
 eq "release commit: a non-version edit to the file is not the release" "$BND_NEXT" \
-  "$(git -C "$BND" rev-list HEAD -- Cargo.toml | release_boundary_commit bnd_version 0.26.0 200)"
+  "$(fixture_git "$BND" rev-list HEAD -- Cargo.toml | release_boundary_commit bnd_version 0.26.0 200)"
 
 printf '\n[test-release] %d passed, %d failed\n' "$PASS" "$FAIL" >&2
 [ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## Summary

The release pipeline stopped pushing commits to main. Cutting v0.25.0 exposed two defects at once: the script pushed the release commit directly to main (GitHub reported "Bypassed rule violations" out loud, and it was easy to scroll past), and the docs step sent an agent into shingle's shared checkout, where another agent's uncommitted edits were swept into the docs commit. This splits the release into two invocations with the normal gates between them -- the release commit earns its way onto main through a PR and the merge queue like any other change, and only the tag is pushed afterward -- and gives the cross-repo docs step its own worktree created by the script rather than a path an agent has to remember not to misuse.

## Acceptance criteria mapping

### 1. A release pushes only the tag to main; no commit push to main appears in the script

The version bump now commits onto `release/<new>` and leaves via `legion push`, which refuses main by construction. The only executable `git push` remaining in the script targets a tag ref: `git push origin refs/tags/<TAG>`.
Evidence: `scripts/release.sh` phase 6-7 (commit on `release/<new>`, `legion push`) and the single tag push in the `--finish` path; the header's phase list documents the split.

### 2. The release commit lands through a PR and the merge queue, with the same gates any other change passes

Phase 7 stops the script deliberately. The gates it would need to fake -- `legion-simplify` and `legion-pr-write` -- are keyed to the release commit's hash and only exist once their CHECK validators have run, which is agent work, not script work. So the orchestrator runs the gates, `legion pr create` and `legion pr merge`, then re-enters with `--finish=<pr>`. That is the criterion satisfied rather than worked around: the release commit passes the identical gate chain as any other PR.
Evidence: `scripts/release.sh` header phases 6-10 and the `--finish` argument path; `plugin/commands/legion-release.md` step 4.

### 3. The tag points at the post-merge origin/main SHA, verified when the queue produced a different commit than the branch tip

`--finish` never assumes the branch tip is the merged commit, because the queue squashes. It re-fetches `origin/<branch>`, reads the version-of-record off that ref without checking anything out (`ref_version` via `git show` into a scratch file), and refuses to tag unless it matches the release version. `tag_target_matches` fails closed: an empty observed version is a mismatch, not a pass.
Evidence: `ref_version`, `release_landed`, and `tag_target_matches` in `scripts/release.sh`; verified end to end against a simulated squashing queue where the tag followed squash commit `039c614` rather than the branch tip `7f7ba74` it was cut from.

### 4. A tagging failure after a successful merge reports incomplete-but-recoverable and names the SHA

Separating the commit and the tag in time gives up the old `--atomic` guarantee by construction, so the recovery is stated rather than assumed. A tag creation or push failure after a successful merge reports INCOMPLETE BUT RECOVERABLE, names the merged sha and the literal commands, and `--finish` is idempotent from that point: an existing tag already on the verified sha is pushed; one pointing elsewhere is fatal and is never moved.
Evidence: the atomicity note in `scripts/release.sh`'s header and the `--finish` tagging arm; idempotent re-run verified in the suite.

### 5. A merge-queue ejection stops the release with the ejection named, and tags nothing

`classify_release_merge` reduces one observation to a verdict, and its arm order is the correctness point: "origin/main already carries the new version" outranks the PR's own state, because the queue rewrites the sha and the state field lags. Ejection additionally requires two consecutive observations, because the queue ref also disappears at the moment of a successful merge -- a single reading in that window would report an ejection for a release that landed. Absence from the queue with no prior sighting stays `pending` and expires into a timeout rather than a false ejection, since the queue admits a bounded group size.
Evidence: `classify_release_merge` and `wait_for_release_merge` in `scripts/release.sh`; 8 + 11 assertions in `scripts/test-release.sh` covering arm ordering, landed-beats-state, pending-vs-ejected, and the merge-window ref drop.

### 6. legion-release.md step 4 describes the new flow rather than the one-shot push

Steps 4 and 5 are rewritten to the two-invocation shape and step 6's report is expanded. The doc's sequence matches the phase numbering in the script header so the two cannot drift silently.
Evidence: `plugin/commands/legion-release.md` steps 4-6.

### 7. (#845) The docs step runs in a script-created worktree; the shared checkout path is never handed to the agent

`--docs-worktree` resolves the docs repo from `watch.toml`, creates a worktree, and prints only that path. Creation failure fails the step with a named reason and never falls back to the shared checkout. `--docs-worktree-done=<path>` tears it down.
Evidence: `watch_repo_root` and the `--docs-worktree` path in `scripts/release.sh`; `plugin/commands/legion-release.md` step 5.

### 8. (#845) The worktree branches from origin/main, not the shared checkout's current branch -- reconciled with #820

`docs_start_point` always yields a REMOTE ref, which is the guarantee #845 is asking for. Where #820 requires a stable docs branch that each release extends rather than a version-pinned branch that stacks PRs (five deep on 0.20-0.24 before it was collapsed), the existing stable branch is the start point and the base is merged in -- never rebased, since `legion push` has no force path. Where it does not exist yet, the start point is `origin/<base>`.
Evidence: `docs_start_point` in `scripts/release.sh` with its #845/#820 reconciliation comment; 4 assertions including a prefix-lookalike branch name.

### 9. (#845) A worktree carrying commits survives a failed run; an unchanged one is removed

`worktree_is_disposable` requires a clean tree AND either an unmoved head or everything already pushed. The already-pushed arm is what keeps a SUCCESSFUL docs run from poisoning the next release: a run that committed and pushed carries commits, and "carries commits" alone would pin the worktree forever and collide on the stable branch next time. Stale worktrees are reported, never clobbered.
Evidence: `worktree_is_disposable` and `worktree_holding_branch` in `scripts/release.sh`; 6 + 4 assertions plus an end-to-end block against real local repos with a bare remote.

### 10. (#861) The fixture harness can no longer touch the runner's repository

Folded in deliberately rather than deferred: this branch's own suite corrupted the real repository three times during development (fixture commits pushed to main, a release-shaped commit that reduced Cargo.toml to one line, and core.bare set on the live checkout), so shipping the release rework without the containment would have been shipping the loaded gun with the safety filed off. `fixture_git` is now the only way the suite addresses a repo, refusing empty targets (`git -C ""` runs in the current repo and exits 0 -- verified, it is not a loud failure), relative targets, targets outside the suite temp root, and any target whose resolved repo identity matches the runner's. Identity resolves through `--git-common-dir` and a physical path, which is what catches a linked worktree of the runner's repo planted inside the temp root. The abort is `kill -TERM $$` because the suite runs under `set +e` and most call sites are subshells, where a returning guard is inert.
Evidence: `scripts/test-release.sh` `fixture_git`, `repo_key`, `suite_abort`; six mutations (empty path, `.` path, empty observer, foreign remote, planted linked worktree, `in_dir` given `.`) each abort by name with the runner's repository byte-identical afterward across refs, HEAD, reflog, status, worktree registrations and Cargo.toml.

## Not done

This branch also closes #861, which was filed separately from the first fixture escape; it is folded in because the offending file lives here and building it on main would have collided. The structural fix for that whole class is #867 -- `preflight.sh` runs fixture suites with cwd inside the live checkout, which is what made every cwd fallback a write to production -- and it stays open: this branch contains the suite, not the caller. The docs-branch stacking fix (#820) is satisfied here only as a constraint on this branch's naming -- the issue stays open for its own verification that a second release extends rather than stacks. Nothing in this branch changes the Rust side (test count unchanged at 1724), and `--activate` is untouched. The release has not been exercised end to end against a real merge queue; the queue behaviour is covered by a simulated squashing fixture and the first real cut is the live test, which is why the incomplete-but-recoverable path names its recovery commands explicitly.

Closes #844
Closes #845
Closes #861