### PR TITLE
fix(#861): close the perimeter's edges and commit the assertions that prove them

### DIFF
--- a/plugin/commands/legion-release.md
+++ b/plugin/commands/legion-release.md
@@ -67,15 +67,34 @@ NEW" --head release/NEW --body-file <the body you validated>`, then `legion pr
 merge --repo legion --number <N>`. On a queue-enabled base this enqueues and
 returns immediately; the merge is asynchronous.
 
-**4d. Tag the commit that actually landed.** Run `scripts/release.sh NEW
---finish=<N>` (re-pass `--activate` if the operator asked for it). It polls until
-the merge lands, then re-reads `origin/main`, verifies that tree really carries
-`NEW`, tags **that** sha, and pushes only the tag -- which fires the release CI.
-The verification is load-bearing: the queue may squash or rebase, so the merged
-sha is not the branch tip, and tagging the branch tip would point the release at
-an object that is not on `main`.
+**4d. Tag the release commit.** Run `scripts/release.sh NEW --finish=<N>`
+(re-pass `--activate` if the operator asked for it). It polls until the merge
+lands, then does two separate things that are easy to run together and must not
+be:
 
-Three failures this step reports rather than papers over, all of which leave
+1. **Re-reads `origin/main` as the landed gate.** This proves the release
+   actually reached the branch *and* that no later release superseded it. It is
+   the right question to ask of the tip -- and it is not the sha to tag.
+2. **Resolves the release commit, and tags that.** Between `legion pr merge` and
+   `--finish`, unrelated PRs land on `main`. None of them touch the version file,
+   so the "does this tree carry `NEW`" check still passes several commits past
+   the release, and tagging the tip would ship a tree nobody released. The script
+   therefore walks the commits that *touch the version file*, newest first, and
+   takes the last one still reading `NEW` -- the commit before it reads the
+   previous version, which is what makes it the boundary. The queue may squash or
+   rebase, so this is derived from history, never assumed from the branch tip.
+
+It prints both shas (`release commit for NEW is <sha> (origin/main tip is
+<other>)`); two different shas is the normal case, not a warning. Then it pushes
+**only the tag**, which fires the release CI.
+
+Resolving the boundary from history rather than from the tip is also what makes
+re-running `--finish` idempotent: a second run derives the *same* sha however far
+`main` has moved on, matches the tag that already exists on it, and re-pushes it.
+Tip-resolution derived a different sha every time and died on "tag already exists
+and points at <other>".
+
+Four failures this step reports rather than papers over, all of which leave
 nothing tagged:
 
 - **Ejected from the queue.** It happens (it happened in the 0.25.0 batch).
@@ -83,6 +102,12 @@ nothing tagged:
   path -- re-run the gates, push, re-enqueue, then re-run `--finish`.
 - **Timeout.** A failure to *observe* the merge, not evidence the release commit
   failed. Check the PR, then re-run `--finish` once it has landed.
+- **The version could not be read.** Distinct from "the branch carries the wrong
+  version", and reported as such: the file may be absent on the ref, or `legion
+  sym etc extract` may have failed. Also a failure to observe -- it never counts
+  as evidence that the release did not land, because a poll loop that treats an
+  unreadable version as a definite "no" reports an *ejection* for a release that
+  merged fine.
 - **Tagging failed after a successful merge.** Reported as INCOMPLETE BUT
   RECOVERABLE, naming the merged sha. The version bump is already on `main`;
   re-running `--finish` completes it and is idempotent from that point.

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -309,15 +309,34 @@ tag_target_matches() {
 # stands on <ref>, read WITHOUT checking anything out (git show into a scratch
 # file, then the same `legion sym etc extract` the rest of the script uses).
 # The scratch file keeps the source file's basename so extract can sniff the
-# format from the extension. Prints empty when the ref or the file is absent.
+# format from the extension.
+#
+#   rc 0 + the version on stdout -- the read succeeded.
+#   rc 2 + nothing on stdout     -- THE QUESTION COULD NOT BE ASKED: the scratch
+#                                   dir failed, the ref or the file is absent, or
+#                                   extract failed or came back empty.
+#
+# The distinction is load-bearing and it was the second door into the false
+# ejection. Fix 2 correctly keyed `unknown` on the FETCH's exit status, but a
+# fetch that SUCCEEDS followed by a read that fails used to be indistinguishable
+# from "the remote definitely does not carry this version": every failure path
+# here was swallowed (`|| true`) into an empty string, and `release_landed` then
+# printed a confident 0. Sustained past the point where the queue ref has been
+# seen, a 0 is an EJECTED verdict -- reported for a release that landed, sending
+# the operator to re-run gates on a merged PR. An empty read is not evidence of
+# absence, so it must not be able to produce one.
 ref_version() {
-  local ref="$1" file_rel="$2" field="$3" tmpdir scratch got=""
-  tmpdir="$(mktemp -d)" || { printf '\n'; return 0; }
+  local ref="$1" file_rel="$2" field="$3" tmpdir scratch got rc=0
+  tmpdir="$(mktemp -d)" || return 2
   scratch="${tmpdir}/${file_rel##*/}"
   if git show "${ref}:${file_rel}" >"$scratch" 2>/dev/null; then
-    got="$(legion sym etc extract "$scratch" --field "$field" 2>/dev/null || true)"
+    got="$(legion sym etc extract "$scratch" --field "$field" 2>/dev/null)" || rc=2
+  else
+    rc=2
   fi
   rm -rf "$tmpdir"
+  [ "$rc" -eq 0 ] || return "$rc"
+  [ -n "$got" ] || return 2
   printf '%s\n' "$got"
 }
 
@@ -389,12 +408,20 @@ release_boundary_commit() {
 # then reports an ejection for a release nobody could see. The fetch is the only
 # step that actually touches the remote, so its rc is the only honest signal.
 release_landed() {
-  local branch="$1" file_rel="$2" field="$3" want="$4"
+  local branch="$1" file_rel="$2" field="$3" want="$4" got
   if ! git fetch origin "$branch" --quiet >/dev/null 2>&1; then
     printf 'unknown\n'
     return 0
   fi
-  if [ "$(ref_version "origin/${branch}" "$file_rel" "$field")" = "$want" ]; then
+  # A successful fetch is necessary but NOT sufficient. If the version could not
+  # be read off the ref that was just fetched, the honest answer is still
+  # `unknown` -- printing 0 here is what turns an unreadable file into an
+  # ejection verdict for a release that landed.
+  if ! got="$(ref_version "origin/${branch}" "$file_rel" "$field")"; then
+    printf 'unknown\n'
+    return 0
+  fi
+  if [ "$got" = "$want" ]; then
     printf '1\n'
   else
     printf '0\n'
@@ -848,7 +875,7 @@ finish_release() {
   local SOURCE_FIELD="$5" NEW="$6" TAG="$7" TAG_MESSAGE="$8" PR_NUMBER="$9"
   local MAX_POLLS="${10}" INTERVAL="${11}" ACTIVATE="${12}"
   local OUTCOME RC=0 TIP_SHA TIP_VERSION MERGED_SHA MERGED_VERSION EXISTING_TAG_SHA
-  local BOUNDARY_LIST BOUNDARY_RC=0
+  local BOUNDARY_LIST BOUNDARY_RC=0 TIP_VERSION_RC=0 MERGED_VERSION_RC=0
   # How far back the release-commit walk may go, counted in commits that TOUCH
   # the version file -- so this is "releases", not "commits", and 200 of them is
   # already far past any sane re-run.
@@ -896,7 +923,16 @@ finish_release() {
   # This asks of the branch TIP, and it is the right question to ask of the tip:
   # it proves the release is on the branch AND that no LATER release superseded
   # it. It is not, however, the sha to tag -- see below.
-  TIP_VERSION="$(merged_version_at "origin/${RELEASE_BRANCH}")"
+  # `|| TIP_VERSION=""` is required, not defensive: ref_version now returns rc 2
+  # when the read fails, and a bare assignment carries that rc under `set -e`,
+  # which would kill the run with no message at all. Empty flows into
+  # tag_target_matches, which fails closed -- and the rc is kept so the operator
+  # is told WHICH failure this is, since "the branch carries the wrong version"
+  # and "the version could not be read" need different responses.
+  TIP_VERSION="$(merged_version_at "origin/${RELEASE_BRANCH}")" || TIP_VERSION_RC=$?
+  if [ "$TIP_VERSION_RC" -ne 0 ]; then
+    fail "could not READ ${SOURCE_FILE_REL} at ${SOURCE_FIELD} on origin/${RELEASE_BRANCH} (${TIP_SHA}) -- the file may be absent on that ref, or 'legion sym etc extract' may have failed. This is not evidence the release did not land; it is a failure to observe. Nothing was tagged."
+  fi
   tag_target_matches "$NEW" "$TIP_VERSION" \
     || fail "tag-target mismatch: origin/${RELEASE_BRANCH} is ${TIP_SHA}, whose ${SOURCE_FILE_REL} says '${TIP_VERSION:-<none>}', not ${NEW}. Refusing to tag a commit that is not the release. Nothing was tagged."
 
@@ -930,7 +966,10 @@ finish_release() {
   # is exactly why it is cheap to keep: it makes the tag step self-verifying no
   # matter how the sha was resolved, and the resolution above reaches it through
   # a dynamically-scoped closure that a later refactor could quietly repoint.
-  MERGED_VERSION="$(merged_version_at "$MERGED_SHA")"
+  MERGED_VERSION="$(merged_version_at "$MERGED_SHA")" || MERGED_VERSION_RC=$?
+  if [ "$MERGED_VERSION_RC" -ne 0 ]; then
+    fail "could not READ ${SOURCE_FILE_REL} at ${SOURCE_FIELD} on the resolved release commit ${MERGED_SHA} -- a failure to observe, not a mismatch. Nothing was tagged."
+  fi
   tag_target_matches "$NEW" "$MERGED_VERSION" \
     || fail "tag-target mismatch: resolved the ${NEW} release commit as ${MERGED_SHA}, but its ${SOURCE_FILE_REL} says '${MERGED_VERSION:-<none>}'. Nothing was tagged."
   info "release commit for ${NEW} is ${MERGED_SHA} (origin/${RELEASE_BRANCH} tip is ${TIP_SHA})"

--- a/scripts/test-release.sh
+++ b/scripts/test-release.sh
@@ -90,11 +90,67 @@ repo_key() {
   phys "$g"
 }
 
+# fixture_resolve <path>: the physical form of <path>, WHETHER OR NOT IT EXISTS.
+#
+# THIS IS THE FUNCTION THE GUARD'S CONTAINMENT TESTS ARE BUILT ON, and it exists
+# because `case` is a glob matcher, not a path resolver. `path_under
+# "${SUITE_TMP}/../../../x" "$SUITE_TMP"` is TRUE: the string starts with the
+# root, so the test passes while the path lands wherever it likes. Every site
+# that decides "is this mine?" about a path that may not exist yet -- the
+# `git init` target, the remote-URL arm, the `rm -rf` cleanup vector -- resolves
+# through here first, and a resolution FAILURE is a refusal, never a fallback to
+# the raw string. The raw-string fallback is the same defect wearing a different
+# hat: it is reached precisely when the path is exotic.
+#
+# An existing path resolves directly through `phys`. A path that does not exist
+# yet -- the normal case for `git init` and for a `set-url` naming a bare repo
+# not created yet -- resolves its PARENT and re-appends the leaf. A leaf of `.`
+# or `..` is refused rather than re-appended: `${SUITE_TMP}/gone/..` would
+# otherwise rejoin as a path that string-matches the root while leaving it.
+fixture_resolve() {
+  local d="$1" parent leaf rp
+  [ -n "$d" ] || return 1
+  if rp="$(phys "$d")"; then
+    printf '%s' "$rp"
+    return 0
+  fi
+  leaf="$(basename -- "$d")"
+  case "$leaf" in "" | . | ..) return 1 ;; esac
+  parent="$(phys "$(dirname -- "$d")")" || return 1
+  printf '%s/%s' "$parent" "$leaf"
+}
+
+# The fixtures run against a PINNED git config, not the operator's. Ambient
+# config silently degraded these assertions: a global `merge.ff = only` or
+# `user.useConfigOnly = true` took the suite from 103 passed to 98, and a global
+# `core.hooksPath` pointing at a failing pre-push took it to 87 -- all of it
+# reported as ordinary failures with no hint that the machine, not the code, had
+# changed. Identity is then set PER REPO (linked worktrees read the main
+# checkout's config, so worktree commits inherit it) because /dev/null as a
+# global config leaves git with no committer.
+#
+# The pin is established BEFORE the identity capture below, not after. Those two
+# captures are `git rev-parse` calls, and ambient config that makes rev-parse
+# fail (a broken `include.path`, an unreadable `core.hooksPath`) would leave both
+# keys EMPTY -- and an empty key silently skips the identity comparison in
+# `fixture_git`, turning the check that catches a planted worktree of the
+# runner's repo into a no-op. Defense in depth, but it costs one line of
+# ordering.
+export GIT_CONFIG_GLOBAL=/dev/null
+export GIT_CONFIG_SYSTEM=/dev/null
+
 # The forbidden repository, captured TWICE: the repo containing this script, and
 # the repo at the cwd the suite started in. Under preflight they are the same;
 # run standalone from elsewhere they need not be, and both are equally fatal.
-# These two calls are the only git invocations in this file that are exempt from
-# fixture_git by definition -- they are how it learns what to refuse.
+#
+# The git invocations in this file that do NOT go through `fixture_git` are, in
+# full: the `git rev-parse --git-common-dir` inside `repo_key`, the `git
+# rev-parse --show-toplevel` that fills SUITE_SELF_TOP, and the `git config
+# --get-regexp` inside `fixture_assert_remote`. All three ARE the guard -- they
+# are how it learns what to refuse, so routing them through it would recurse --
+# and all three are reads. (The PERIMETER SELF-TEST block plants hostile fixtures
+# with raw `git` too, but that block only ever runs in a child process whose own
+# "runner" is a sacrificial copy; see its banner.)
 SUITE_SELF_REPO="$(repo_key "$DIR" || printf '')"
 SUITE_CWD_REPO="$(repo_key "." || printf '')"
 SUITE_SELF_TOP="$( (cd "$DIR" 2>/dev/null && git rev-parse --show-toplevel 2>/dev/null) || printf '' )"
@@ -154,7 +210,14 @@ register_temp() {
     # Canonicalise before comparing. `mktemp -d` hands back /var/folders/... for
     # what is physically /private/var/folders/..., so a string test against a
     # physically-resolved root rejects a perfectly legitimate temp parent.
-    rp="$(phys "$p" || printf '%s' "$p")"
+    #
+    # A resolution failure is a REFUSAL. The previous `phys "$p" || printf '%s'
+    # "$p"` fell back to the raw string on exactly the inputs worth worrying
+    # about -- a path containing `..` that does not exist string-matches
+    # "$SUITE_TMP"/* and lands outside it -- and this list is an `rm -rf`
+    # argument vector.
+    rp="$(fixture_resolve "$p")" \
+      || suite_abort "register_temp given [${p}], which cannot be resolved to a real location -- refusing to put an unresolvable path on the EXIT 'rm -rf' list"
     if ! path_under "$rp" "$SUITE_TMP" && ! path_under "$rp" "$SYSTEM_TMP"; then
       suite_abort "register_temp given [${p}] (-> ${rp}), which is under neither ${SUITE_TMP} nor ${SYSTEM_TMP}"
     fi
@@ -178,60 +241,168 @@ fixture_dir_allowed() {
   return 1
 }
 
-# fixture_git_verb <args...>: the git subcommand, skipping global options and
-# their values, so the remote assertion fires on the calls that can reach one.
-fixture_git_verb() {
-  local a skip=0
+# fixture_git_argv <args...>: normalise a fixture git invocation into
+#   line 1  -- the subcommand
+#   line 2+ -- the non-flag OPERANDS that follow it, in order
+# rc 1 when there is no subcommand at all (`git --version`).
+#
+# ONE walker, read by both consumers. The verb selects whether the remote
+# assertion fires; the operands are where the DESTINATION of a network verb
+# actually lives. Walking argv twice, in two functions, is how those two
+# readings drift apart -- and `gitp` prepends `-c core.hooksPath=/dev/null` to
+# every push, so both readings have to skip global options and their values
+# identically or the guard reads a different command than git runs.
+#
+# `-C`, `--git-dir` and `--work-tree` are REFUSED rather than skipped. The
+# target repository is the first argument to `fixture_git`, which is what the
+# whole perimeter was applied to; an option in argv that repoints git at a
+# different repo or work tree makes that check describe a directory git never
+# touches. Nothing in this file has any reason to pass one.
+fixture_git_argv() {
+  local a skip=0 verb=""
   for a in "$@"; do
     if [ "$skip" = 1 ]; then
       skip=0
       continue
     fi
+    if [ -z "$verb" ]; then
+      case "$a" in
+        -C | -C=* | --git-dir | --git-dir=* | --work-tree | --work-tree=*)
+          suite_abort "fixture git argv carries the repository REDIRECT [${a}] -- the target repo is fixture_git's first argument and nothing in argv may repoint it: 'git $*'"
+          ;;
+        -c | --namespace | --exec-path | --super-prefix) skip=1 ;;
+        -*) ;;
+        *)
+          verb="$a"
+          printf '%s\n' "$a"
+          ;;
+      esac
+      continue
+    fi
     case "$a" in
-      -c | -C | --git-dir | --work-tree | --namespace) skip=1 ;;
       -*) ;;
-      *)
-        printf '%s' "$a"
-        return 0
-        ;;
+      *) printf '%s\n' "$a" ;;
     esac
   done
-  return 1
+  [ -n "$verb" ]
 }
 
-# fixture_assert_url <url-or-arg> <what>: a fixture's remote must be a temp bare
-# repo. Anything addressable off this machine is refused outright -- that is the
-# difference between a bad test run and a push to GitHub.
+# fixture_git_verb <args...>: just the subcommand. Kept as its own name because
+# it is THE SELECTOR -- if it ever returns empty, fixture_assert_remote silently
+# never runs, in the one file whose failure mode is "push to production" -- and a
+# selector that decides whether a guard fires deserves assertions of its own.
+fixture_git_verb() {
+  fixture_git_argv "$@" | sed -n '1p'
+}
+
+# fixture_assert_url <url-or-arg> <what>: a fixture's remote must be a bare repo
+# inside this suite's own temp tree, or a plain remote NAME whose url is checked
+# separately. Everything else is refused.
+#
+# THE LOGIC IS INVERTED ON PURPOSE, and the previous enumerate-the-hostile-forms
+# version is why. It refused `*://*` and `*@*:*` and waved everything else
+# through, so `github.com:runlegion/legion.git` -- scp-like ssh, which needs no
+# `@` -- fell into the permissive arm and was a perfectly ordinary off-machine
+# remote. Relative paths (`../../elsewhere.git`, resolved against the runner's
+# cwd) sailed through the same arm. A blocklist of URL syntaxes is a losing
+# game: git accepts more forms than anyone enumerates, so the only safe shape is
+# an allowlist of the two things a fixture legitimately names.
 fixture_assert_url() {
   local url="$1" what="$2" rp
   [ -n "$url" ] || return 0
   case "$url" in
     /*)
-      rp="$(phys "$url" || printf '%s' "$url")"
+      # Resolved, never string-matched, and a resolution failure is a refusal:
+      # `${SUITE_TMP}/../../../evil.git` string-matches the root.
+      rp="$(fixture_resolve "$url")" \
+        || suite_abort "fixture remote [${url}] cannot be resolved to a real location -- ${what}"
       fixture_dir_allowed "$rp" \
-        || suite_abort "fixture remote [${url}] resolves OUTSIDE the suite temp root ${SUITE_TMP} -- ${what}"
+        || suite_abort "fixture remote [${url}] resolves to ${rp}, OUTSIDE the suite temp root ${SUITE_TMP} -- ${what}"
+      return 0
       ;;
-    *://* | *@*:*)
-      suite_abort "fixture remote [${url}] is NON-LOCAL -- ${what}"
+  esac
+  # Not an absolute path, so the ONLY thing left that a fixture may name is a
+  # plain remote name. Git remote names are `[A-Za-z0-9._-]`-ish and never begin
+  # with a dot; anything outside that is addressing something -- a scheme, an
+  # scp-like host:path, a relative path, a `~` expansion, a refspec.
+  case "$url" in
+    *[!A-Za-z0-9._-]* | .* | -*)
+      suite_abort "fixture remote [${url}] is neither an absolute path under ${SUITE_TMP} nor a plain remote name -- anything else is addressable off this machine: ${what}"
       ;;
-    *) : ;; # a remote name, refspec or branch, not a URL
   esac
 }
 
-# fixture_assert_remote <dir> <what>: <dir>'s origin, if it has one. The read is
-# a DIRECT git call -- it is part of the guard, so routing it through
-# fixture_git would recurse.
+# fixture_assert_remote <dir> <what>: EVERY remote configured in <dir>, not just
+# `origin`. A fixture that adds `upstream` and pushes to it was completely
+# unexamined while the guard read `origin` and reported itself satisfied; the
+# name a push addresses is chosen by the caller, so the guard cannot assume it.
+# Push URLs are covered too -- `remote.<name>.pushurl` overrides `.url` for
+# exactly the operation that matters here.
+#
+# The read is a DIRECT git call -- it is part of the guard, so routing it
+# through fixture_git would recurse.
 fixture_assert_remote() {
-  local d="$1" what="$2" url
-  url="$(git -C "$d" remote get-url origin 2>/dev/null)" || url=""
-  fixture_assert_url "$url" "${what} (origin of ${d})"
+  local d="$1" what="$2" line key url
+  while IFS= read -r line; do
+    key="${line%% *}"
+    url="${line#* }"
+    case "$key" in
+      remote.*.url | remote.*.pushurl) ;;
+      *) continue ;;
+    esac
+    fixture_assert_url "$url" "${what} (${key} of ${d})"
+  done <<<"$(git -C "$d" config --get-regexp '^remote\.' 2>/dev/null || true)"
+}
+
+# fixture_assert_destinations <verb> <what> <operands...>: the destination a
+# network verb ACTUALLY addresses, which is not the same question as "what is
+# this repo's configured origin".
+#
+# THE HOLE THIS CLOSES: `git push <url> HEAD:refs/heads/x` ignores the
+# configured origin entirely. The old guard read origin, found a temp bare repo,
+# approved -- and the push landed a release-shaped fixture commit in the
+# runner's refs. Substituting a GitHub URL reaches GitHub.
+#
+# Position, not pattern-matching, is what makes this precise. Git's grammar for
+# all five verbs is `<verb> [<options>] [<repository> [<refspec>...]]`, so the
+# FIRST operand is the repository and the rest are refspecs -- and refspecs are
+# full of `:` and `/`, so asserting them as URLs would refuse `HEAD:refs/heads/x`
+# on correct input. `clone` takes a target directory as its second operand,
+# which must be inside the perimeter for the same reason every other fixture
+# path must.
+#
+# The trailing scan is the belt to that braces: an option this walker does not
+# know consumes a value could displace the repository past operand 1, so any
+# LATER operand that is unambiguously a location -- absolute, or carrying a
+# `://` scheme, neither of which is ever a valid refspec -- is asserted too.
+fixture_assert_destinations() {
+  local verb="$1" what="$2"
+  shift 2
+  local first="${1:-}" a
+  case "$verb" in
+    clone)
+      fixture_assert_url "$first" "${what} (clone source)"
+      [ "$#" -lt 2 ] || fixture_assert_url "$2" "${what} (clone target directory)"
+      ;;
+    *)
+      fixture_assert_url "$first" "${what} (destination operand)"
+      ;;
+  esac
+  [ "$#" -gt 1 ] || return 0
+  shift
+  for a in "$@"; do
+    case "$a" in
+      /* | *://*) fixture_assert_url "$a" "${what} (location-shaped operand)" ;;
+    esac
+  done
 }
 
 # fixture_git <dir> <git-args...>: THE ONLY WAY this file addresses a git repo.
 fixture_git() {
   local d="$1"
   shift
-  local p key last a
+  local p key line verb="" a
+  local -a operands=()
   [ -n "$d" ] || suite_abort "fixture git with an EMPTY target directory: 'git $*' -- 'git -C \"\"' silently runs in the CURRENT repo and exits 0"
   case "$d" in
     /*) ;;
@@ -247,15 +418,30 @@ fixture_git() {
     [ "$key" != "$SUITE_CWD_REPO" ] \
       || suite_abort "fixture git target [${p}] is the repository at the suite's startup cwd (${key}): 'git $*'"
   fi
-  case "$(fixture_git_verb "$@")" in
+  # One walk, two readings: which verb this is, and what it addresses.
+  while IFS= read -r line; do
+    [ -n "$line" ] || continue
+    if [ -z "$verb" ]; then verb="$line"; else operands+=("$line"); fi
+  done <<<"$(fixture_git_argv "$@")"
+  case "$verb" in
     push | fetch | pull | clone | ls-remote)
+      # BOTH questions, because they are different questions: what the repo's
+      # remotes point at, AND what this particular command names.
       fixture_assert_remote "$d" "git $*"
+      fixture_assert_destinations "$verb" "git $*" ${operands[@]+"${operands[@]}"}
       ;;
     remote)
       fixture_assert_remote "$d" "git $*"
-      last=""
-      for a in "$@"; do last="$a"; done
-      fixture_assert_url "$last" "git $*"
+      # EVERY operand, not the last one. `git remote set-url [--push] <name>
+      # <newurl> [<oldurl>]` takes an optional TRAILING oldurl, so checking the
+      # last argument checks the url being replaced and leaves the new one --
+      # the one about to become the fixture's remote -- unexamined. Proven
+      # chained: set-url to an off-machine host passed, and the follow-up push
+      # was handed to a real ssh attempt. Remote NAMES pass the name arm of
+      # fixture_assert_url, so asserting all of them costs nothing.
+      for a in ${operands[@]+"${operands[@]}"}; do
+        fixture_assert_url "$a" "git $*"
+      done
       ;;
   esac
   git -C "$d" "$@"
@@ -264,16 +450,40 @@ fixture_git() {
 # fixture_git_init <dir> <git-args...>: <dir> is APPENDED, because `git init` and
 # friends take the target as an argument rather than via -C, and -C requires the
 # directory to already exist.
+#
+# THIS WAS A SECOND DOOR, and it was open. Its only check used to be
+# `path_under "$d" "$SUITE_TMP"` on the UNRESOLVED string, and `case` resolves
+# neither `..` nor symlinks -- so both walked straight out. Proven: a `..`
+# traversal aimed at the runner's `.git` flipped `core.bare` false -> true
+# through this function, which is incident #3, and a symlink inside $SUITE_TMP
+# pointing at the runner passed the same way. `fixture_git` and `register_temp`
+# both refuse all three shapes, so this was an asymmetry, not a design choice.
+#
+# It now runs the SAME pair `fixture_git` runs -- fixture_dir_allowed on the
+# resolved path, then the repo-identity comparison -- against the resolution
+# `fixture_resolve` gives a target that does not exist yet.
 fixture_git_init() {
   local d="$1"
   shift
+  local p key
   [ -n "$d" ] || suite_abort "fixture git init with an EMPTY target directory: 'git $*'"
   case "$d" in
     /*) ;;
     *) suite_abort "fixture git init with the RELATIVE target directory [${d}]: 'git $*'" ;;
   esac
-  path_under "$d" "$SUITE_TMP" \
-    || suite_abort "fixture git init target [${d}] is outside the suite temp root ${SUITE_TMP}"
+  p="$(fixture_resolve "$d")" \
+    || suite_abort "fixture git init target [${d}] cannot be resolved -- its parent directory does not exist: 'git $*'"
+  fixture_dir_allowed "$p" \
+    || suite_abort "fixture git init target [${d}] resolves to ${p}, OUTSIDE the suite temp root ${SUITE_TMP}: 'git $*'"
+  # An init target that ALREADY belongs to a repo is the core.bare case: `git
+  # init --bare` on an existing `.git` rewrites its config in place.
+  key="$(repo_key "$p" || printf '')"
+  if [ -n "$key" ]; then
+    [ "$key" != "$SUITE_SELF_REPO" ] \
+      || suite_abort "fixture git init target [${d}] resolves into the repository this suite is running from (${key}): 'git $*'"
+    [ "$key" != "$SUITE_CWD_REPO" ] \
+      || suite_abort "fixture git init target [${d}] resolves into the repository at the suite's startup cwd (${key}): 'git $*'"
+  fi
   git "$@" "$d"
 }
 
@@ -283,6 +493,37 @@ gitp() {
   local d="$1"
   shift
   fixture_git "$d" -c core.hooksPath=/dev/null "$@"
+}
+
+# in_dir <dir> <cmd...>: THE SECOND DOOR into the runner's repo, and it has to be
+# barred as hard as the first. It hands the cwd to a release.sh function whose
+# own git calls cannot be routed through fixture_git, so whatever `cd` lands on
+# is what that function operates on. `cd ""` returns 0 in bash, so
+# `cd "$X" || return` is NOT a guard on its own. It therefore applies the same
+# perimeter as fixture_git -- absolute, inside the suite temp root, and not the
+# runner's repository -- before it moves anywhere. Refusing a relative path
+# matters as much as refusing an empty one: "." is the value `require_dir` waves
+# through.
+in_dir() {
+  local d="$1"; shift
+  local p key
+  [ -n "$d" ] || return 90
+  case "$d" in
+    /*) ;;
+    *) suite_abort "in_dir given the RELATIVE directory [${d}] -- it would hand the runner's cwd to '$1'" ;;
+  esac
+  p="$(phys "$d")" || return 91
+  fixture_dir_allowed "$p" \
+    || suite_abort "in_dir target [${p}] is outside the suite temp root ${SUITE_TMP} -- refusing to run '$1' there"
+  key="$(repo_key "$p" || printf '')"
+  if [ -n "$key" ]; then
+    [ "$key" != "$SUITE_SELF_REPO" ] \
+      || suite_abort "in_dir target [${p}] IS the repository this suite is running from -- refusing to run '$1' there"
+    [ "$key" != "$SUITE_CWD_REPO" ] \
+      || suite_abort "in_dir target [${p}] is the repository at the suite's startup cwd -- refusing to run '$1' there"
+  fi
+  cd "$p" || return 91
+  "$@"
 }
 
 # require_dir stays, one layer in from the perimeter: it turns "the helper under
@@ -301,16 +542,394 @@ require_dir() { # require_dir <label> <path>
   return 1
 }
 
-# The fixtures run against a PINNED git config, not the operator's. Ambient
-# config silently degraded these assertions: a global `merge.ff = only` or
-# `user.useConfigOnly = true` took the suite from 103 passed to 98, and a global
-# `core.hooksPath` pointing at a failing pre-push took it to 87 -- all of it
-# reported as ordinary failures with no hint that the machine, not the code, had
-# changed. Identity is then set PER REPO (linked worktrees read the main
-# checkout's config, so worktree commits inherit it) because /dev/null as a
-# global config leaves git with no committer.
-export GIT_CONFIG_GLOBAL=/dev/null
-export GIT_CONFIG_SYSTEM=/dev/null
+# -- THE PERIMETER SELF-TEST, CHILD SIDE (#861) ------------------------------
+# The guard aborts by killing the run (`kill -TERM $$`), which is the only thing
+# that works from inside `$( )` and `( )` -- and it means an abort CANNOT be
+# observed from within the run it terminates. So each attack is executed by a
+# CHILD PROCESS: the parent (further down, under PERIMETER SELF-TEST, PARENT
+# SIDE) copies this script and release.sh into a sacrificial git repo, runs
+# `bash <that copy>` with PERIMETER_ATTACK set, and asserts rc 97 plus the reason
+# text. Because the copy lives in the sacrificial repo, THAT repo is what the
+# child computes as SUITE_SELF_REPO -- so every attack aims at a throwaway, and a
+# deleted guard damages a temp directory instead of the operator's checkout.
+# That is what makes these safe to run as mutation checks.
+#
+# rc 98, never 97. 97 is what a real suite_abort produces and this block must not
+# be able to counterfeit it -- and since the block runs BEFORE the first
+# assertion and exits, an ambient PERIMETER_ATTACK in a preflight environment
+# would otherwise turn a suite that asserted NOTHING into a green one. 98 makes
+# that loud. (The parent always passes the variable as a per-command prefix,
+# never an export, so no other child inherits it.)
+if [ -n "${PERIMETER_ATTACK:-}" ]; then
+  attack_bail() { printf '\n[test-release] SELF-TEST HARNESS ERROR: %s\n' "$1" >&2; exit 98; }
+  VICTIM="${PERIMETER_VICTIM:-}"
+  [ -n "$VICTIM" ] || attack_bail "PERIMETER_VICTIM (the sacrificial runner) is required"
+  [ -d "$VICTIM" ] || attack_bail "PERIMETER_VICTIM [${VICTIM}] is not a directory"
+
+  # A legitimate fixture: inside this child's own temp root, with an origin that
+  # is a temp bare repo. Attacks that need a SOURCE repo use it; attacks that
+  # need a destination outside the perimeter use $VICTIM.
+  ATK="${SUITE_TMP}/atk"
+  ATK_ORIGIN="${SUITE_TMP}/atk-origin.git"
+  mkdir -p "$ATK"
+  fixture_git_init "$ATK_ORIGIN" init --bare --quiet
+  fixture_git_init "$ATK" -c init.defaultBranch=main init --quiet
+  fixture_git "$ATK" config user.email t@t
+  fixture_git "$ATK" config user.name t
+  printf 'atk\n' >"${ATK}/f.txt"
+  fixture_git "$ATK" add f.txt
+  fixture_git "$ATK" commit --quiet --no-verify -m "atk"
+  fixture_git "$ATK" remote add origin "$ATK_ORIGIN"
+  gitp "$ATK" push --quiet -u origin main
+
+  # A path that STRING-MATCHES "$SUITE_TMP"/* and yet resolves to $VICTIM: one
+  # `..` per component of $SUITE_TMP walks back to `/`, and the victim's absolute
+  # path is re-appended. This is the shape `path_under` cannot see and the reason
+  # fixture_resolve exists -- no symlink involved, so `cd` resolves it the same
+  # way lexically or physically.
+  ATK_UP="$(printf '%s\n' "${SUITE_TMP#/}" | tr '/' '\n' | sed 's|.*|..|' | tr '\n' '/')"
+  ATK_TRAVERSAL="${SUITE_TMP}/${ATK_UP}${VICTIM#/}"
+
+  case "$PERIMETER_ATTACK" in
+    control-legit)
+      # THE NEGATIVE CONTROL, and it is not optional: without it a guard that
+      # aborted on absolutely everything would pass every assertion below, and
+      # the whole self-test would be measuring nothing.
+      fixture_git "$ATK" status --porcelain >/dev/null
+      gitp "$ATK" push --quiet origin main
+      fixture_git "$ATK" remote set-url origin "$ATK_ORIGIN"
+      fixture_git_init "${SUITE_TMP}/fresh.git" init --bare --quiet
+      printf '[attack] control completed with no abort, as required\n' >&2
+      exit 0
+      ;;
+
+    # -- fixture_git: the target directory ------------------------------------
+    empty-target)    fixture_git "" status ;;
+    relative-target) fixture_git "." status ;;
+    outside-target)  fixture_git "$VICTIM" status ;;
+    planted-worktree)
+      # $PERIMETER_PLANTED is a linked worktree OF THE VICTIM that the parent
+      # created. Admitting it to the allowed set is the point: containment must
+      # PASS so the repo-IDENTITY comparison is the only thing left standing
+      # between the fixture and the runner's object store. The write is real --
+      # if the guard is gone, a commit lands on the victim's `planted` branch,
+      # and the parent asserts that branch never moved.
+      [ -n "${PERIMETER_PLANTED:-}" ] || attack_bail "PERIMETER_PLANTED is required for this attack"
+      CLEANUP_PATHS+=("$PERIMETER_PLANTED")
+      fixture_git "$PERIMETER_PLANTED" commit --quiet --no-verify --allow-empty -m "escape"
+      ;;
+
+    # -- fixture_git_init: the second door (#861 HIGH 1) ----------------------
+    init-traversal)
+      # Incident #3, exactly: `git init --bare` onto the runner's own .git flips
+      # core.bare false -> true and `git status` starts failing with "must be run
+      # in a work tree".
+      fixture_git_init "${ATK_TRAVERSAL}/.git" init --bare --quiet
+      ;;
+    init-symlink)
+      ln -s "$VICTIM" "${SUITE_TMP}/link"
+      fixture_git_init "${SUITE_TMP}/link/.git" init --bare --quiet
+      ;;
+
+    # -- network verbs: the destination in argv (#861 HIGH 2) -----------------
+    push-argv-destination)
+      # The configured origin is a perfectly good temp bare repo. The push does
+      # not use it.
+      fixture_git "$ATK" push "$VICTIM" HEAD:refs/heads/fixture-escape
+      ;;
+    push-argv-url)
+      fixture_git "$ATK" push "https://github.com/runlegion/legion.git" HEAD:refs/heads/fixture-escape
+      ;;
+    push-non-origin-remote)
+      # The hostile remote is planted with a RAW git call -- fixture_git would
+      # (correctly) refuse to create it, and the question here is what happens on
+      # the PUSH when a remote other than `origin` already exists.
+      git -C "$ATK" remote add upstream "https://github.com/runlegion/legion.git"
+      gitp "$ATK" push --quiet upstream main
+      ;;
+    push-pushurl)
+      git -C "$ATK" config remote.origin.pushurl "git@github.com:runlegion/legion.git"
+      gitp "$ATK" push --quiet origin main
+      ;;
+    git-dir-redirect)
+      fixture_git "$ATK" --git-dir="${VICTIM}/.git" status
+      ;;
+
+    # -- URL forms (#861 HIGH 3) and the set-url operand (#861 HIGH 4) --------
+    remote-scp-like)
+      # No `@`, so the old `*@*:*` arm never saw it, and it is an ordinary
+      # off-machine ssh remote.
+      fixture_git "$ATK" remote add ghost "github.com:runlegion/legion.git"
+      ;;
+    remote-relative)
+      fixture_git "$ATK" remote add ghost "../../elsewhere.git"
+      ;;
+    remote-set-url-newurl)
+      # The NEW url is not the last argument -- `set-url` takes an optional
+      # trailing oldurl.
+      fixture_git "$ATK" remote set-url origin "git@github.com:runlegion/legion.git" "$ATK_ORIGIN"
+      ;;
+    assert-url-traversal)
+      fixture_assert_url "${ATK_TRAVERSAL}/evil.git" "self-test"
+      ;;
+
+    # -- the other two doors --------------------------------------------------
+    in-dir-relative)    in_dir "." pwd ;;
+    in-dir-outside)     in_dir "$VICTIM" pwd ;;
+    register-relative)  register_temp "." ;;
+    register-traversal) register_temp "$ATK_TRAVERSAL" ;;
+    register-root)      register_temp "/" ;;
+    register-traversal-unresolved)
+      # The leaf does NOT exist, so `phys` fails on the whole path. That is the
+      # input the old `phys ... || printf '%s' "$p"` fallback was reached by, and
+      # under it the RAW string -- which still begins with $SUITE_TMP -- was what
+      # got compared, so a path physically inside the runner passed every arm and
+      # went onto the `rm -rf` list. A traversal whose components all exist does
+      # NOT exercise this; it resolves and is caught elsewhere.
+      register_temp "${ATK_TRAVERSAL}/not-created-yet"
+      ;;
+
+    *) attack_bail "unknown attack name [${PERIMETER_ATTACK}]" ;;
+  esac
+
+  printf '\n[test-release] SELF-TEST: THE PERIMETER LET [%s] THROUGH\n' "$PERIMETER_ATTACK" >&2
+  exit 98
+fi
+
+# -- THE PERIMETER SELF-TEST, PARENT SIDE (#861) -----------------------------
+# Before this section the perimeter had ZERO committed assertions. Six mutations
+# were run by hand while it was being written, which is development activity, not
+# coverage: nothing in the repository could tell whether the guard still worked.
+# That is an unusually bad thing to leave untested, because the failure mode is
+# not "a test goes red" -- it is a fixture pushing to production, silently, in a
+# file that runs inside the live checkout during every release (preflight.sh cd's
+# to the real toplevel and runs this suite).
+#
+# Two layers. First, unit assertions on the decidable core -- the pure functions
+# whose answers the guard is built out of. Second, the attacks, each run in a
+# child process against a sacrificial runner.
+
+# path_under: a string test, and its LIMIT is the point of the last assertion.
+ok "path_under: identity"            path_under /a/b /a/b
+ok "path_under: child"               path_under /a/b/c /a/b
+no "path_under: sibling with a shared prefix" path_under /a/bc /a/b
+no "path_under: the parent is not under the child" path_under /a /a/b
+no "path_under: empty path"          path_under "" /a
+no "path_under: empty root"          path_under /a ""
+# THE HOLE path_under CANNOT SEE. `case` is a glob matcher: this leaves the root
+# and matches anyway. Every caller therefore resolves BEFORE it tests, and this
+# assertion is what stops someone "simplifying" fixture_resolve back out again.
+ok "path_under: a traversal out of the root still matches the string" path_under /a/b/../../x /a/b
+
+# phys: resolution of an EXISTING directory only.
+eq "phys: normalises an existing path" "$SUITE_TMP" "$(phys "${SUITE_TMP}/.")"
+no "phys: empty"        phys ""
+no "phys: nonexistent"  phys "${SUITE_TMP}/no-such-dir"
+
+# fixture_resolve: resolution of a path that need not exist yet.
+eq "resolve: an existing path" "$SUITE_TMP" "$(fixture_resolve "$SUITE_TMP")"
+eq "resolve: a leaf that does not exist yet, under an existing parent" \
+  "${SUITE_TMP}/not-yet.git" "$(fixture_resolve "${SUITE_TMP}/not-yet.git")"
+eq "resolve: a traversal is RESOLVED, not string-matched" \
+  "$(phys "${SUITE_TMP}/..")/x" "$(fixture_resolve "${SUITE_TMP}/../x")"
+eq "resolve: '..' resolves out of the root rather than staying in it" \
+  "$(phys "${SUITE_TMP}/..")" "$(fixture_resolve "${SUITE_TMP}/..")"
+no "resolve: a missing parent is refused, never guessed" \
+  fixture_resolve "${SUITE_TMP}/no/such/parent/x"
+no "resolve: a '..' leaf under a missing parent is refused, not rejoined" \
+  fixture_resolve "${SUITE_TMP}/gone/.."
+no "resolve: empty" fixture_resolve ""
+
+# fixture_dir_allowed
+ok "allowed: the suite temp root itself"  fixture_dir_allowed "$SUITE_TMP"
+ok "allowed: a child of the temp root"    fixture_dir_allowed "${SUITE_TMP}/x"
+no "allowed: the system temp root itself" fixture_dir_allowed "$SYSTEM_TMP"
+no "allowed: the runner's own checkout"   fixture_dir_allowed "$SUITE_SELF_TOP"
+
+# repo_key: the identity a linked worktree resolves to is the repo it is linked
+# INTO -- which is the whole reason the guard keys on --git-common-dir rather
+# than on the path.
+KEY_TMP="${SUITE_TMP}/key"
+mkdir -p "$KEY_TMP"
+fixture_git_init "${KEY_TMP}/repo" -c init.defaultBranch=main init --quiet
+fixture_git "${KEY_TMP}/repo" config user.email t@t
+fixture_git "${KEY_TMP}/repo" config user.name t
+fixture_git "${KEY_TMP}/repo" commit --quiet --no-verify --allow-empty -m init
+fixture_git "${KEY_TMP}/repo" worktree add --quiet -b linked "${KEY_TMP}/linked" >/dev/null 2>&1
+eq "repo_key: a linked worktree keys to the repo it is linked into" \
+  "$(repo_key "${KEY_TMP}/repo")" "$(repo_key "${KEY_TMP}/linked")"
+no "repo_key: empty"       repo_key ""
+no "repo_key: nonexistent" repo_key "${SUITE_TMP}/no-such-dir"
+
+# fixture_git_verb / fixture_git_argv: THE SELECTOR. If the verb ever comes back
+# empty, fixture_assert_remote never fires and the remote guard is gone without a
+# symptom -- so `gitp`'s exact argv, which is the shape every fixture push takes,
+# is asserted literally.
+eq "verb: plain"                       "push"   "$(fixture_git_verb push origin main)"
+eq "verb: gitp's exact argv"           "push"   "$(fixture_git_verb -c core.hooksPath=/dev/null push --quiet -u origin main)"
+eq "verb: -c consumes its value"       "push"   "$(fixture_git_verb -c core.hooksPath=/dev/null push)"
+eq "verb: after a valueless flag"      "status" "$(fixture_git_verb --no-pager status)"
+eq "verb: a valueless flag after -c"   "remote" "$(fixture_git_verb -c a=b --no-pager remote set-url origin x)"
+no "verb: no subcommand at all"        fixture_git_verb --version
+eq "argv: the destination is the first operand after the verb" "origin" \
+  "$(fixture_git_argv -c core.hooksPath=/dev/null push --quiet -u origin main | sed -n '2p')"
+eq "argv: refspecs follow it in order" "HEAD:refs/heads/x" \
+  "$(fixture_git_argv push --quiet origin HEAD:refs/heads/x | sed -n '3p')"
+
+# fixture_assert_url: the ALLOWED forms, asserted here because every refused form
+# aborts the run and can only be observed from a child process (below).
+ok "assert_url: an absolute path inside the temp root"        fixture_assert_url "$SUITE_TMP" "unit"
+ok "assert_url: a bare repo not created yet, inside the root" fixture_assert_url "${SUITE_TMP}/later.git" "unit"
+ok "assert_url: a plain remote name"                          fixture_assert_url "origin" "unit"
+ok "assert_url: no remote configured at all"                  fixture_assert_url "" "unit"
+
+# SELF-LINT (#861 criterion 1): no unguarded `cd` in this file. The incident's
+# shape was `(cd "$WT" && git ...)` with $WT empty -- `cd ""` is a silent no-op,
+# so the fixture's git commands ran in the real checkout -- which makes an
+# unguarded `cd` a defect class, not a style preference. Asserting the exact SET
+# of targets means a new one fails here and has to be justified, and keeping that
+# set to four is why the attacks copy this script into the sacrificial repo
+# instead of `(cd "$victim" && ...)`.
+#
+# Comment lines are stripped first (several of them quote `cd ""` while
+# explaining why it is fatal), and the pattern requires real whitespace after
+# `cd`, so the regex literals in these two lines do not match themselves.
+SUITE_CD_TARGETS="$(
+  grep -vE '^[[:space:]]*#' "$0" \
+    | grep -E '(^|[^[:alnum:]_])cd[[:space:]]' \
+    | sed -E 's/.*[^[:alnum:]_]cd[[:space:]]+//; s/[[:space:]].*//' \
+    | LC_ALL=C sort -u
+)"
+# The expected value is the literal TEXT of the four targets as they appear in
+# the source, so the single quotes are the point -- expanding them would compare
+# this file against its own runtime values instead of against what it says.
+# shellcheck disable=SC2016
+eq "self-lint: every 'cd' in this file is a perimeter-resolved target" \
+  '"$(dirname
+"$DIR"
+"$d"
+"$p"' "$SUITE_CD_TARGETS"
+
+# THE ATTACKS. The sacrificial runner: a real git repo carrying a COPY of this
+# script and of release.sh, so a child launched from it computes that repo as its
+# own SUITE_SELF_REPO/SUITE_SELF_TOP. Every attack below therefore aims at this
+# throwaway; if a guard is deleted, a temp directory takes the damage and the
+# assertions go red, which is what makes this safe as a mutation check.
+ATTACK_TMP="${SUITE_TMP}/perimeter"
+ATTACK_VICTIM="${ATTACK_TMP}/runner"
+mkdir -p "${ATTACK_VICTIM}/scripts"
+cp "${DIR}/${0##*/}" "${ATTACK_VICTIM}/scripts/${0##*/}"
+cp "${DIR}/release.sh" "${ATTACK_VICTIM}/scripts/release.sh"
+ATTACK_SCRIPT="${ATTACK_VICTIM}/scripts/${0##*/}"
+fixture_git_init "$ATTACK_VICTIM" -c init.defaultBranch=main init --quiet
+fixture_git "$ATTACK_VICTIM" config user.email t@t
+fixture_git "$ATTACK_VICTIM" config user.name t
+fixture_git "$ATTACK_VICTIM" add scripts
+fixture_git "$ATTACK_VICTIM" commit --quiet --no-verify -m "sacrificial runner"
+
+# The fingerprint the four proven attacks were measured against by hand: refs,
+# HEAD, reflog, working-tree status, core.bare (incident #3 flipped exactly
+# this), the worktree registry (a planted worktree is invisible to all of the
+# above) and the local config.
+attack_fingerprint() {
+  local r="$1"
+  fixture_git "$r" for-each-ref --format='%(refname) %(objectname)' 2>/dev/null
+  fixture_git "$r" rev-parse HEAD 2>/dev/null
+  fixture_git "$r" reflog --format='%H %gs' 2>/dev/null
+  fixture_git "$r" status --porcelain 2>/dev/null
+  fixture_git "$r" config --get core.bare 2>/dev/null || true
+  fixture_git "$r" worktree list --porcelain 2>/dev/null
+  fixture_git "$r" config --list --local 2>/dev/null
+}
+ATTACK_FP="$(attack_fingerprint "$ATTACK_VICTIM")"
+
+# attack <label> <name> <reason-substring>: run one attack in a child and assert
+# both that it was refused (rc 97, which only suite_abort produces -- the
+# self-test block's own bail is 98) and WHY. Asserting the reason is what stops a
+# guard from passing these by aborting indiscriminately.
+attack() {
+  local label="$1" name="$2" want="$3" out rc=0
+  out="$(PERIMETER_ATTACK="$name" PERIMETER_VICTIM="$ATTACK_VICTIM" \
+         PERIMETER_PLANTED="${ATTACK_PLANTED:-}" bash "$ATTACK_SCRIPT" 2>&1)" || rc=$?
+  eq "perimeter: ${label} is refused (rc 97)" "97" "$rc"
+  if [ -z "${out##*"$want"*}" ]; then
+    PASS=$((PASS + 1))
+  else
+    FAIL=$((FAIL + 1))
+    printf 'FAIL: perimeter: %s -- the abort did not name [%s]. Output:\n%s\n' "$label" "$want" "$out" >&2
+  fi
+}
+
+# The negative control runs FIRST. If it does not pass, every refusal below is
+# uninterpretable -- a guard that aborts on everything would satisfy them all.
+CONTROL_RC=0
+CONTROL_OUT="$(PERIMETER_ATTACK=control-legit PERIMETER_VICTIM="$ATTACK_VICTIM" \
+               bash "$ATTACK_SCRIPT" 2>&1)" || CONTROL_RC=$?
+eq "perimeter: the negative control is NOT refused" "0" "$CONTROL_RC"
+ok "perimeter: the negative control really ran" \
+  test -z "${CONTROL_OUT##*control completed*}"
+
+# The identity check, which is the only thing standing between a fixture and the
+# runner's object store once containment has been satisfied. The worktree is
+# planted by the PARENT so the fingerprint above is not disturbed by the setup,
+# and the attack's write is real: a working guard leaves `planted` where it was.
+ATTACK_PLANTED="${ATTACK_TMP}/planted"
+fixture_git "$ATTACK_VICTIM" worktree add --quiet -b planted "$ATTACK_PLANTED" >/dev/null 2>&1
+PLANTED_SHA="$(fixture_git "$ATTACK_VICTIM" rev-parse planted)"
+attack "a planted worktree of the runner, inside the temp root" planted-worktree \
+  "IS the repository this suite is running from"
+eq "perimeter: the planted branch was never moved" "$PLANTED_SHA" \
+  "$(fixture_git "$ATTACK_VICTIM" rev-parse planted)"
+ATTACK_PLANTED=""
+fixture_git "$ATTACK_VICTIM" worktree remove --force "${ATTACK_TMP}/planted" >/dev/null 2>&1
+fixture_git "$ATTACK_VICTIM" worktree prune >/dev/null 2>&1
+fixture_git "$ATTACK_VICTIM" branch -D planted >/dev/null 2>&1
+
+# fixture_git's target directory.
+attack "an empty target directory"    empty-target    "EMPTY target directory"
+attack "a relative target directory"  relative-target "RELATIVE target directory"
+attack "a target outside the temp root" outside-target "outside the suite temp root"
+
+# fixture_git_init, the second door (HIGH 1). Both shapes `case` cannot see.
+attack "a '..' traversal through git init" init-traversal "OUTSIDE the suite temp root"
+attack "a symlink out of the temp root through git init" init-symlink "OUTSIDE the suite temp root"
+
+# Network verbs: what the command ADDRESSES, not what origin happens to be
+# (HIGH 2). The fixture in every one of these has a perfectly legitimate origin.
+attack "a push whose destination operand is outside the perimeter" \
+  push-argv-destination "OUTSIDE the suite temp root"
+attack "a push to a forge URL in argv" push-argv-url "plain remote name"
+attack "a push to a remote that is not origin" push-non-origin-remote "plain remote name"
+attack "a push through a hostile pushurl" push-pushurl "plain remote name"
+attack "a --git-dir redirect in argv" git-dir-redirect "repository REDIRECT"
+
+# URL forms (HIGH 3) and the set-url operand (HIGH 4).
+attack "an scp-like ssh remote with no '@'" remote-scp-like "plain remote name"
+attack "a relative-path remote"             remote-relative "plain remote name"
+attack "set-url's NEW url, which is not the last argument" \
+  remote-set-url-newurl "plain remote name"
+attack "a traversal in a remote URL" assert-url-traversal "OUTSIDE the suite temp root"
+
+# The other two doors.
+attack "in_dir given a relative directory" in-dir-relative "RELATIVE directory"
+attack "in_dir given the runner"           in-dir-outside  "outside the suite temp root"
+attack "register_temp given a relative path" register-relative "RELATIVE path"
+# Both arms of the `rm -rf` vector's guard. A traversal that lands ON the runner
+# is caught by the checkout arm; `/` reaches neither temp root and is caught by
+# the containment arm. `dirname ""` is "." and this list is an `rm -rf` argument
+# vector, so neither arm is theoretical.
+attack "register_temp given a traversal onto the runner" register-traversal \
+  "contains or lives inside the runner's checkout"
+attack "register_temp given a path under no temp root at all" register-root "under neither"
+attack "register_temp given a traversal that does not resolve to an existing path" \
+  register-traversal-unresolved "contains or lives inside the runner's checkout"
+
+# THE PROOF, committed: every attack above ran, and the sacrificial runner is
+# byte-identical afterwards. Refusal and inertness are different claims, and this
+# is the one that would have caught incident #1 (a fixture commit in the runner's
+# refs) and incident #3 (core.bare flipped to true).
+eq "perimeter: the sacrificial runner is byte-identical after every attack" \
+  "$ATTACK_FP" "$(attack_fingerprint "$ATTACK_VICTIM")"
 
 # compute_new_version
 eq "patch"         0.18.3 "$(compute_new_version 0.18.2 patch)"
@@ -537,45 +1156,24 @@ eq "wait: injected observer resolves a sourced function" "merged" \
 # no network, no gh -- because the whole finding is about what happens when the
 # remote cannot be reached, which a stubbed observer cannot show.
 #
-# release_landed operates on the CURRENT directory (finish_release cd's to the
-# repo root first), so these run through `in_dir`. `cd ""` returns 0 in bash, so
-# `cd "$X" || return` is NOT a guard on its own.
+# release_landed and release_queue_ref_present operate on the CURRENT directory
+# (finish_release cd's to the repo root first), so the assertions below run them
+# through `in_dir` -- defined up in THE FIXTURE PERIMETER, because it is part of
+# the perimeter rather than a convenience for this section.
 #
-# in_dir is THE SECOND DOOR into the runner's repo, and it has to be barred as
-# hard as the first: it hands the cwd to a release.sh function whose own git
-# calls cannot be routed through fixture_git, so whatever `cd` lands on is what
-# that function operates on. It therefore applies the same perimeter as
-# fixture_git -- absolute, inside the suite temp root, and not the runner's
-# repository -- before it moves anywhere. Refusing a relative path matters as
-# much as refusing an empty one: "." is the value `require_dir` waves through.
-in_dir() { # in_dir <dir> <cmd...>
-  local d="$1"; shift
-  local p key
-  [ -n "$d" ] || return 90
-  case "$d" in
-    /*) ;;
-    *) suite_abort "in_dir given the RELATIVE directory [${d}] -- it would hand the runner's cwd to '$1'" ;;
-  esac
-  p="$(phys "$d")" || return 91
-  fixture_dir_allowed "$p" \
-    || suite_abort "in_dir target [${p}] is outside the suite temp root ${SUITE_TMP} -- refusing to run '$1' there"
-  key="$(repo_key "$p" || printf '')"
-  if [ -n "$key" ]; then
-    [ "$key" != "$SUITE_SELF_REPO" ] \
-      || suite_abort "in_dir target [${p}] IS the repository this suite is running from -- refusing to run '$1' there"
-    [ "$key" != "$SUITE_CWD_REPO" ] \
-      || suite_abort "in_dir target [${p}] is the repository at the suite's startup cwd -- refusing to run '$1' there"
-  fi
-  cd "$p" || return 91
-  "$@"
-}
-
-# THE FIXTURE WHOSE SHAPE IS THE INCIDENT. A one-line Cargo.toml carrying
-# `version = "0.25.0"`, a commit subject of `chore(release): 0.25.0`, and a
-# `push -u origin main` -- which is, byte for byte, what was force-fed onto the
-# real origin/main. Nothing here is exotic; the escape is entirely in WHERE the
-# three lines land, which is why every one of them now goes through the
-# perimeter rather than through a bare `git -C`.
+# THE FIXTURE WHOSE SHAPE IS THE INCIDENT: a `chore(release): 0.25.0` commit
+# bumping the version-of-record, and a `push -u origin main`. Nothing here is
+# exotic; the escape was entirely in WHERE those lines land, which is why every
+# one of them now goes through the perimeter rather than a bare `git -C`.
+#
+# The Cargo.toml carries a REAL [package] table. It used to be the incident's
+# literal one-liner (`version = "0.25.0"`, no table), and that made this whole
+# block self-deceiving: every `--field package.version` read failed, so
+# `ref_version` returned "" on every call here and the assertions -- which all
+# expect 0 or `unknown` -- passed for the wrong reason. Mutating `release_landed`
+# to print 0 unconditionally left the suite green at 159/159. Reproducing the
+# incident's bytes is the perimeter's job, above; this block's job is to exercise
+# the observers, and it cannot do that against a file the reader cannot parse.
 OBS_TMP="${SUITE_TMP}/obs"
 mkdir -p "$OBS_TMP"
 OBS_CO="${OBS_TMP}/repo"
@@ -584,16 +1182,67 @@ fixture_git_init "$OBS_CO" -c init.defaultBranch=main init --quiet
 fixture_git "$OBS_CO" config user.email t@t
 fixture_git "$OBS_CO" config user.name t
 fixture_git "$OBS_CO" checkout --quiet -B main
-printf 'version = "0.25.0"\n' >"${OBS_CO}/Cargo.toml"
+cat >"${OBS_CO}/Cargo.toml" <<'EOF'
+[package]
+name = "observer-fixture"
+version = "0.25.0"
+edition = "2024"
+EOF
 fixture_git "$OBS_CO" add Cargo.toml
 fixture_git "$OBS_CO" commit --quiet --no-verify -m "chore(release): 0.25.0"
 fixture_git "$OBS_CO" remote add origin "${OBS_TMP}/origin.git"
 gitp "$OBS_CO" push --quiet -u origin main
 
 if require_dir "observers: fixture repo" "$OBS_CO"; then
+  # THE PRECONDITION FOR EVERYTHING BELOW, and the assertion that would have
+  # caught the broken fixture: if the version-of-record cannot be READ, every
+  # observer answers "" and the negative assertions all pass vacuously.
+  eq "landed: the fixture's version-of-record is actually readable" "0.25.0" \
+    "$( (in_dir "$OBS_CO" ref_version HEAD Cargo.toml package.version) 2>/dev/null )"
+
+  # THE POSITIVE ARM. Nothing anywhere in this suite covered release_landed = 1,
+  # which is why mutating it to print 0 unconditionally changed no result.
+  eq "landed: a reachable remote that carries the version is 1" "1" \
+    "$( (in_dir "$OBS_CO" release_landed main Cargo.toml package.version 0.25.0) 2>/dev/null )"
+
   # A reachable remote that does not carry the version is a definite NO.
   eq "landed: reachable remote without the version is 0" "0" \
     "$( (in_dir "$OBS_CO" release_landed main Cargo.toml package.version 9.9.9) 2>/dev/null )"
+
+  # THE SECOND DOOR INTO THE FALSE EJECTION. Fix 2 keyed `unknown` on the FETCH's
+  # exit status, which is right as far as it goes -- but a fetch that SUCCEEDS
+  # followed by a READ that fails was indistinguishable from "the remote
+  # definitely does not carry this version". Every failure inside ref_version was
+  # swallowed into an empty string, and release_landed printed a confident 0;
+  # sustained past a queued observation, a 0 is an EJECTED verdict for a release
+  # that landed. This fixture is reachable and fetchable and simply has no
+  # version file on the ref.
+  NOFILE_CO="${OBS_TMP}/nofile"
+  fixture_git_init "${OBS_TMP}/nofile-origin.git" init --bare --quiet
+  fixture_git_init "$NOFILE_CO" -c init.defaultBranch=main init --quiet
+  fixture_git "$NOFILE_CO" config user.email t@t
+  fixture_git "$NOFILE_CO" config user.name t
+  fixture_git "$NOFILE_CO" checkout --quiet -B main
+  printf 'no version file here\n' >"${NOFILE_CO}/README.md"
+  fixture_git "$NOFILE_CO" add README.md
+  fixture_git "$NOFILE_CO" commit --quiet --no-verify -m "no version file"
+  fixture_git "$NOFILE_CO" remote add origin "${OBS_TMP}/nofile-origin.git"
+  gitp "$NOFILE_CO" push --quiet -u origin main
+
+  eq "ref_version: a file absent on the ref is rc 2, not an empty success" "2" \
+    "$( (in_dir "$NOFILE_CO" ref_version HEAD Cargo.toml package.version) >/dev/null 2>&1; printf '%s' $? )"
+  eq "ref_version: and it prints nothing at all" "" \
+    "$( (in_dir "$NOFILE_CO" ref_version HEAD Cargo.toml package.version) 2>/dev/null )"
+  eq "ref_version: a nonexistent ref is rc 2" "2" \
+    "$( (in_dir "$NOFILE_CO" ref_version no-such-ref Cargo.toml package.version) >/dev/null 2>&1; printf '%s' $? )"
+  # A field the file genuinely does not carry is a FAILED read, not an empty one:
+  # `extract` returning nothing is exactly the state that used to read as 0.
+  eq "ref_version: a field the file does not carry is rc 2" "2" \
+    "$( (in_dir "$OBS_CO" ref_version HEAD Cargo.toml package.nosuchfield) >/dev/null 2>&1; printf '%s' $? )"
+  eq "ref_version: a successful read is rc 0" "0" \
+    "$( (in_dir "$OBS_CO" ref_version HEAD Cargo.toml package.version) >/dev/null 2>&1; printf '%s' $? )"
+  eq "landed: a successful fetch with an unreadable version is unknown, not 0" "unknown" \
+    "$( (in_dir "$NOFILE_CO" release_landed main Cargo.toml package.version 0.25.0) 2>/dev/null )"
 
   # THE REGRESSION. Break the remote AFTER a successful fetch, so the
   # remote-tracking ref is still perfectly readable locally -- which is exactly
@@ -951,6 +1600,79 @@ MISMARK_RC=0
 eq "docs teardown: marker naming another worktree refuses" "1" "$MISMARK_RC"
 ok "docs teardown: mismarked worktree retained" test -d "${MISMARK}/wt"
 
+# -- conflict vs. config: two operator-facing messages, one rc (#845) --------
+#
+# `git merge` exits 1 both when CONTENT conflicts and when a hook or a config
+# setting refuses the merge, and the two need opposite responses -- reconcile the
+# branches, versus fix your git config. The discrimination is therefore a
+# behaviour (are there unmerged paths in the index?), and it was chosen by logic
+# nothing exercised. Both arms must also leave the same wreckage behind: no
+# worktree, no branch, and above all no edit to the shared checkout, which is the
+# fallback #845 exists to close.
+
+# ARM 1: REFUSED WITHOUT A CONFLICT. A failing `pre-merge-commit` hook is the
+# honest reproduction -- the content merges cleanly, so the index has no unmerged
+# paths, and it is the COMMIT git declines. The hook lives outside $DOCS_CO so
+# the shared checkout stays clean, which is one of the things asserted below.
+DOCS_HOOKS="${DOCS_TMP}/hooks"
+mkdir -p "$DOCS_HOOKS"
+printf '#!/bin/sh\nexit 1\n' >"${DOCS_HOOKS}/pre-merge-commit"
+chmod +x "${DOCS_HOOKS}/pre-merge-commit"
+DOCS_CO_HEAD="$(fixture_git "$DOCS_CO" rev-parse HEAD)"
+fixture_git "$DOCS_CO" config core.hooksPath "$DOCS_HOOKS"
+NOCONF_RC=0
+NOCONF_ERR="$( (docs_worktree_setup "$DOCS_CO" "$DOCS_BRANCH" main fixture-docs) 2>&1 >/dev/null )" || NOCONF_RC=$?
+fixture_git "$DOCS_CO" config --unset core.hooksPath
+eq "docs config-refusal: setup fails" "1" "$NOCONF_RC"
+ok "docs config-refusal: reports FAILED WITHOUT CONFLICT" \
+  test -z "${NOCONF_ERR##*FAILED WITHOUT CONFLICT (no unmerged paths)*}"
+ok "docs config-refusal: does NOT report a content conflict" \
+  test "${NOCONF_ERR##*CONFLICTED*}" = "$NOCONF_ERR"
+ok "docs config-refusal: names config and hooks as the thing to fix" \
+  test -z "${NOCONF_ERR##*refused by git config or a hook*}"
+ok "docs config-refusal: the worktree was removed" \
+  test -z "$(fixture_git "$DOCS_CO" worktree list --porcelain | worktree_holding_branch "$DOCS_BRANCH" || true)"
+no "docs config-refusal: the branch was removed with it" \
+  fixture_git "$DOCS_CO" show-ref --verify --quiet "refs/heads/${DOCS_BRANCH}"
+eq "docs config-refusal: the shared checkout is clean" "" \
+  "$(fixture_git "$DOCS_CO" status --porcelain)"
+eq "docs config-refusal: the shared checkout did not move" "$DOCS_CO_HEAD" \
+  "$(fixture_git "$DOCS_CO" rev-parse HEAD)"
+
+# ARM 2: A REAL CONTENT CONFLICT. Both sides rewrite the same line of the same
+# file, which is the only way to make the merge fail on content rather than on
+# policy.
+fixture_git "$DOCS_CO" fetch --quiet origin
+fixture_git "$DOCS_CO" checkout --quiet -B conflict-stage "origin/${DOCS_BRANCH}"
+printf 'the docs branch rewrote this line\n' >"${DOCS_CO}/index.md"
+fixture_git "$DOCS_CO" commit --quiet --no-verify -am "docs side"
+gitp "$DOCS_CO" push --quiet origin "conflict-stage:${DOCS_BRANCH}"
+fixture_git "$DOCS_CO" checkout --quiet main
+printf 'main rewrote the same line\n' >"${DOCS_CO}/index.md"
+fixture_git "$DOCS_CO" commit --quiet --no-verify -am "main side"
+gitp "$DOCS_CO" push --quiet origin main
+DOCS_CO_HEAD="$(fixture_git "$DOCS_CO" rev-parse HEAD)"
+CONFLICT_RC=0
+CONFLICT_ERR="$( (docs_worktree_setup "$DOCS_CO" "$DOCS_BRANCH" main fixture-docs) 2>&1 >/dev/null )" || CONFLICT_RC=$?
+eq "docs conflict: setup fails" "1" "$CONFLICT_RC"
+ok "docs conflict: reports CONFLICTED with unmerged paths" \
+  test -z "${CONFLICT_ERR##*CONFLICTED (unmerged paths)*}"
+ok "docs conflict: does NOT blame git config" \
+  test "${CONFLICT_ERR##*FAILED WITHOUT CONFLICT*}" = "$CONFLICT_ERR"
+ok "docs conflict: sends the operator to a worktree of their OWN" \
+  test -z "${CONFLICT_ERR##*worktree of your OWN*}"
+ok "docs conflict: the worktree was removed" \
+  test -z "$(fixture_git "$DOCS_CO" worktree list --porcelain | worktree_holding_branch "$DOCS_BRANCH" || true)"
+no "docs conflict: the branch was removed with it" \
+  fixture_git "$DOCS_CO" show-ref --verify --quiet "refs/heads/${DOCS_BRANCH}"
+eq "docs conflict: the shared checkout is clean" "" \
+  "$(fixture_git "$DOCS_CO" status --porcelain)"
+eq "docs conflict: the shared checkout did not move" "$DOCS_CO_HEAD" \
+  "$(fixture_git "$DOCS_CO" rev-parse HEAD)"
+# Neither arm may leave a half-merged state behind in the shared checkout.
+no "docs conflict: no merge is in progress in the shared checkout" \
+  test -f "${DOCS_CO}/.git/MERGE_HEAD"
+
 # -- the release commit, against a REAL history (#844) -----------------------
 #
 # release_boundary_commit's table tests fix its logic; this fixes its INPUT. The
@@ -1003,8 +1725,11 @@ eq "release commit: walks only commits that touch the version file" "2" \
 eq "release commit: while the branch itself is longer" "5" \
   "$(fixture_git "$BND" rev-list HEAD | wc -l | tr -d ' ')"
 
-# IDEMPOTENCE, which is what release.sh:767 and legion-release.md:88 promise when
-# they say re-running --finish is safe. Re-resolving must return the SAME sha
+# IDEMPOTENCE, which is what finish_release's release-commit comment and step 4d
+# of legion-release.md both promise when they say re-running --finish is safe.
+# (Named, not cited by line number: the previous version of this comment pointed
+# at release.sh:767, which by then was the middle of the ADD_FILES array.)
+# Re-resolving must return the SAME sha
 # however far the branch has moved on: that is what makes the second run match
 # the existing tag and re-push it, instead of deriving a new sha and dying on
 # "tag already exists and points at <other>".

--- a/scripts/test-release.sh
+++ b/scripts/test-release.sh
@@ -793,13 +793,20 @@ ok "assert_url: no remote configured at all"                  fixture_assert_url
 #
 # Comment lines are stripped first (several of them quote `cd ""` while
 # explaining why it is fatal), and the pattern requires real whitespace after
-# `cd`, so the regex literals in these two lines do not match themselves.
+# `cd`, so the regex literals below do not match themselves.
+# ONE filtered stream, two readings -- the same discipline fixture_git_argv
+# applies to argv. Two separately-written filters are two definitions of "what
+# counts as a cd", and they drift.
+SUITE_CD_LINES="$(grep -vE '^[[:space:]]*#' "$0" | grep -E '(^|[^[:alnum:]_])cd[[:space:]]')"
 SUITE_CD_TARGETS="$(
-  grep -vE '^[[:space:]]*#' "$0" \
-    | grep -E '(^|[^[:alnum:]_])cd[[:space:]]' \
+  printf '%s\n' "$SUITE_CD_LINES" \
     | sed -E 's/.*[^[:alnum:]_]cd[[:space:]]+//; s/[[:space:]].*//' \
     | LC_ALL=C sort -u
 )"
+# `grep -c` over that same stream rather than `wc -l`: printf of an EMPTY
+# variable still emits one newline, so `wc -l` would report 1 where the truth
+# is 0 -- and a lint that reads 1 on "nothing matched" fails open.
+SUITE_CD_COUNT="$(printf '%s\n' "$SUITE_CD_LINES" | grep -cE '(^|[^[:alnum:]_])cd[[:space:]]')"
 # The expected value is the literal TEXT of the four targets as they appear in
 # the source, so the single quotes are the point -- expanding them would compare
 # this file against its own runtime values instead of against what it says.
@@ -809,6 +816,11 @@ eq "self-lint: every 'cd' in this file is a perimeter-resolved target" \
 "$DIR"
 "$d"
 "$p"' "$SUITE_CD_TARGETS"
+# The SET alone is not enough, because `sort -u` dedupes: a new `cd "$p"` in an
+# unguarded context adds no new member and would pass the assertion above --
+# and `$p` is exactly the name a future author reuses. The count closes it, so
+# the two together are total.
+eq "self-lint: and there are exactly five of them" "5" "$SUITE_CD_COUNT"
 
 # THE ATTACKS. The sacrificial runner: a real git repo carrying a COPY of this
 # script and of release.sh, so a child launched from it computes that repo as its


### PR DESCRIPTION
## Summary

PR #870 shipped the fixture perimeter with four holes in its edges, and a dedicated review proved two of them by reproducing incidents this guard exists to prevent: a `..` traversal through `fixture_git_init` set `core.bare` on a live checkout (incident 3, through the guard), and a push whose destination lived in argv landed a release-shaped fixture commit in a repo outside the temp root (incident 1's payload). #870 merged before these fixes were pushed, so `main` currently carries the holed version. This closes them, adds the committed assertions #861 asked for and #870 did not deliver, and corrects two places where a control reported confidence it did not have.

## Acceptance criteria mapping

### 1. fixture_git aborts when the resolved repo is the runner's own -- with a test proving the abort

#870 built the mechanism and shipped zero assertions for it; the six mutations its body cited were manual development activity, never in the diff, which review correctly called a claims-vs-diff violation. That is now committed coverage: 19 child-process attacks run `bash "$0"` with an injected attack and assert both exit 97 and the reason text, covering empty target, relative target, outside-temp target, planted-worktree identity, refused remote URLs, and the two newly-closed holes. A negative control proves the guard is not simply aborting on everything, and harness bail uses a distinct exit code so an ambient variable cannot fake a pass.
Evidence: the child-process attack block in `scripts/test-release.sh`; assertion count 159 -> 268.

### 2. An empty path from any fixture helper aborts by name

Unit assertions now pin the decidable core -- `path_under`, `phys`, `fixture_resolve`, `repo_key`, `fixture_dir_allowed`, `fixture_assert_url`, and `fixture_git_verb`. The selector matters most and had no coverage: `fixture_git_verb -c X push` must return `push`, because that return value is what decides whether the remote assertion fires at all. If it ever returned empty, a fixture with a real origin would push to it silently.
Evidence: the unit-assertion block in `scripts/test-release.sh`.

### 3. Mutation check: break a path helper, suite fails loudly, runner byte-identical

15 mutations, all killed. Two initially survived and the tests were fixed rather than the claim: `register_temp`'s raw-string fallback (the original traversal resolved cleanly and never reached it, so an unresolvable-leaf attack was added) and `release_landed`-always-zero, which survived because no positive-arm coverage existed anywhere in the suite. The four proven attacks from review were re-run against old and new: all four refused under the new guard, with the runner byte-identical across refs, HEAD, reflog, `status --porcelain`, `core.bare`, `worktree list` and `config --list --local`.
Evidence: the four attack re-runs; the added positive assertion for `release_landed`.

### 4. The suite passes with no ambient git config and no reachable non-temp remote

268 assertions green in a clone with its remote removed and `GIT_CONFIG_GLOBAL`/`GIT_CONFIG_SYSTEM` pinned to `/dev/null`, with the real checkout verified unchanged afterward. The `GIT_CONFIG` pin also moved ahead of the identity capture, so ambient config that breaks `rev-parse` can no longer leave the identity check a silent no-op.
Evidence: suite run in the no-remote clone; the reordered pin.

### 5. The four edge holes, closed as one shape rather than four patches

Every hole was an asymmetry between adjacent functions sharing a stated contract, so each fix makes the sibling use the same lock: `fixture_git_init` resolves before testing and then runs the same `fixture_dir_allowed` + `repo_key` pair as `fixture_git`; the network-verb arm asserts destinations found in argv by git's grammar and refuses `-C`/`--git-dir`/`--work-tree` there, reading every remote rather than `origin` alone; `fixture_assert_url` is inverted from a hostile-form blacklist to an allowlist, which is what closes the scp-like `host:path` form that had no `@` to match; the `remote` arm checks every operand after the verb rather than the last.
Evidence: `fixture_resolve`, `fixture_git_init`, `fixture_assert_url`, the argv walker, and the `remote` operand loop.

### 6. Two controls that reported confidence they did not have

`ref_version` returned an empty string for three distinct situations -- mktemp failure, file absent on the ref, and an extract failure swallowed by `|| true` -- and `release_landed` turned all of them into a confident `0`. A successful fetch with a failed read therefore reported "did not land", and sustained after the queue ref had been seen that is a false ejection for a release that shipped: the exact failure the earlier `unknown` work was chartered to prevent, reached through the extractor instead of the network. `ref_version` now carries a distinct rc and `release_landed` propagates `unknown`. Both `finish_release` call sites keep the rc, since a bare assignment there would have died silently under `set -euo pipefail`. The extend arm's conflict-versus-config messages gained the assertions that select between them.
Evidence: `ref_version` rc contract, `release_landed` unknown propagation, the two rc-preserving call sites, and the two extend-arm assertions.

### 7. legion-release.md step 4d described the behaviour this work replaced

It said `--finish` re-reads `origin/main` and tags that sha. The script re-reads origin/main only as the landed gate, then tags the boundary commit found by walking the version-file history -- and prints both shas, so an operator following the old prose saw two where the text promised one. Rewritten to state why the tip is not the target and that stable resolution is what makes re-running `--finish` idempotent.
Evidence: `plugin/commands/legion-release.md` step 4d against `release_boundary_commit`.

## Not done

Part of #861; **does not close it.** Criterion 1 covers `test-release.sh` **and sibling suites**, and `scripts/test-sync-version.sh` still carries the bare `cd` + `git add -A` shape in its fixture builders -- tracked at #868, and #861 should close when that lands. #861 was auto-closed by #870's merge on a `Closes` line that review had already flagged as overreaching; it has been reopened.

Two residuals are named rather than hidden. In the argv walker, an unrecognised value-taking option could displace the repository past operand 1; later operands are scanned only for `/...` and `://` forms, which can never be a valid refspec. And `release_boundary_commit` still reads an unanswerable version as a mismatch and ends the walk, so a transient extract failure mid-walk yields a too-new candidate -- it surfaces loudly rather than silently, because a later `--finish` with a working reader resolves a different sha and dies on "tag already exists and points at &lt;other&gt;".

The structural fix for this whole class remains #867, now known to be broader than filed: a linked worktree's `--git-common-dir` resolves to the parent repo's `.git`, so config writes from a worktree land in the shared config and git ignores `core.bare` for linked worktrees -- breaking the main checkout while the worktree keeps answering normally. A path-based perimeter cannot close that class; only a throwaway clone or an environment-scoped sandbox can.