### PR TITLE
fix(#867): run fixture suites in a disposable sandbox, never the release checkout

### DIFF
--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -6,7 +6,8 @@
 #   2. cargo clippy --all-targets -D warnings  (CI parity -- bare clippy misses
 #                                               test/example/bench code)
 #   3. cargo test                    (the suite is green)
-#   4. legion index <repo>           (SCIP index regenerated so sym queries
+#   4. scripts/test-*.sh             (the shell suites, IN A DISPOSABLE SANDBOX)
+#   5. legion index <repo>           (SCIP index regenerated so sym queries
 #                                     answer against current code)
 #
 # Exits non-zero on the FIRST failing gate, naming it. Safe to run standalone:
@@ -17,10 +18,56 @@
 # The SCIP step is best-effort by default: a missing `legion` binary or indexer
 # is a warning, not a hard failure, so the script still gates code quality on a
 # machine without the plugin installed. Set REQUIRE_SCIP=1 to make it mandatory.
+#
+# -- WHY THE SHELL SUITES RUN SOMEWHERE ELSE (#867) ---------------------------
+# This file used to do `cd "$(git rev-parse --show-toplevel)"` and then
+# `bash "${REPO_ROOT}/scripts/test-release.sh"`. release.sh runs preflight as its
+# step 4, so during a REAL RELEASE the fixture suites executed with their cwd
+# inside the live checkout, in a repo whose `origin` is the real remote. Every
+# cwd fallback in a fixture was therefore a write to production, and that is the
+# delivery channel behind three main-branch corruptions: fixture commits pushed
+# to origin/main, a release-shaped commit that reduced Cargo.toml to one line,
+# and `core.bare=true` set on the live checkout twice.
+#
+# A LINKED WORKTREE IS NOT A SANDBOX and must never be used as the fix. From a
+# linked worktree `git rev-parse --git-common-dir` resolves to the PARENT repo's
+# .git, so non-worktree-scoped config writes land in the shared config and refs
+# are visible repo-wide -- and git IGNORES core.bare for linked worktrees, so a
+# fixture that sets it breaks the MAIN checkout while the worktree it was run
+# from keeps answering normally. Invisible from the worktree, from the suite, and
+# from every gate.
+#
+# So the suites run in a THROWAWAY REPOSITORY: scripts/ is copied into a temp
+# directory which is `git init`ed as a repo of its own, with no remote, no
+# ambient git config, and no relationship to the checkout being released. A copy
+# rather than a clone because the suites need no parent history -- verified: both
+# build their own fixtures from scratch and pass identically from a bare copy --
+# and because a clone carries the origin URL that has to be removed again anyway.
+# The copy is also what makes #861's in-suite perimeter resolve SUITE_SELF_REPO
+# to the throwaway instead of production; running the suites from a worktree
+# would have keyed that guard on the real repo.
+#
+# Three gates surround the run, and each fails closed:
+#   * before each suite -- the sandbox must resolve to a DIFFERENT repository
+#     than the one being released, must contain no remote, and must not overlap
+#     the release checkout. An unresolvable check is a failure, not a pass.
+#   * after each suite  -- the sandbox must be byte-identical. The suites build
+#     their fixtures in their own temp roots and never touch the repo they run
+#     in, so any change means a suite reached for its host repository -- which
+#     under the old arrangement WAS the live checkout. Named and fatal.
+#   * around the phase   -- the release checkout must be byte-identical: refs,
+#     HEAD, reflog, status, core.bare, the worktree registry and the local
+#     config. This is the one that catches an escape by absolute path, which no
+#     amount of cwd discipline can prevent.
 set -euo pipefail
 
-REPO_ROOT="$(git rev-parse --show-toplevel)"
-cd "$REPO_ROOT"
+# The suites that MUST exist. Previously the runner was `if [ -f ... ]`, so
+# renaming or deleting a suite silently stopped gating on it; a missing required
+# suite is now a failure.
+PREFLIGHT_REQUIRED_SUITES=(test-release.sh test-sync-version.sh)
+
+# Sandbox roots created by this process, for the EXIT cleanup.
+PREFLIGHT_SANDBOX_ROOTS=()
 
 # Repo name as known to watch.toml (for the SCIP index step). Override with
 # LEGION_REPO=<name> if this clone is registered under a different name.
@@ -29,38 +76,347 @@ LEGION_REPO="${LEGION_REPO:-legion}"
 step() { printf '\n[preflight] === %s ===\n' "$1" >&2; }
 fail() { printf '\n[preflight] FAILED at: %s\n' "$1" >&2; exit 1; }
 
-step "cargo fmt -- --check"
-cargo fmt -- --check || fail "formatting (run: cargo fmt)"
+# pf_env_run <cmd...>: run <cmd> with the ambient git environment SCRUBBED.
+#
+# ONE definition, used by both the guard's own reads and the suite runs, because
+# two separately-written scrubs are two definitions of "isolated" and they drift.
+#
+# The unsets matter as much as the config pins: an inherited GIT_DIR or
+# GIT_WORK_TREE repoints EVERY git call at the release repo while every path this
+# script compares stays innocent -- the leak is through the environment, not
+# through the argument. And the pins apply to the guard's reads too, because
+# ambient config that makes `rev-parse` fail leaves the repository key EMPTY, and
+# an empty key compares equal to nothing, which silently turns the identity gate
+# into a no-op. Pin first, then capture.
+#
+# The subshell scoping is the point, not an accident, hence the disable.
+# shellcheck disable=SC2030,SC2031
+pf_env_run() {
+  (
+    unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_COMMON_DIR GIT_NAMESPACE \
+      GIT_OBJECT_DIRECTORY GIT_ALTERNATE_OBJECT_DIRECTORIES
+    export GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null \
+      GIT_CONFIG_NOSYSTEM=1 GIT_TERMINAL_PROMPT=0
+    "$@"
+  )
+}
 
-step "cargo clippy --all-targets -- -D warnings"
-cargo clippy --all-targets -- -D warnings || fail "clippy"
+# pf_git <args...>: git, scrubbed.
+pf_git() { pf_env_run git "$@"; }
 
-step "cargo test"
-cargo test || fail "tests"
+# pf_phys <dir>: the physical, symlink-free form of an EXISTING directory. Path
+# strings are not comparable identities here -- /Users/... and /Volumes/... are
+# the same checkout through a symlink on this machine, and mktemp hands back
+# /var/... for what is physically /private/var/....
+pf_phys() {
+  local p="${1:-}"
+  [ -n "$p" ] || return 1
+  (cd "$p" 2>/dev/null && pwd -P) || return 1
+}
 
-step "shell-script tests"
-for t in test-release.sh test-sync-version.sh; do
-  if [ -f "${REPO_ROOT}/scripts/${t}" ]; then
-    bash "${REPO_ROOT}/scripts/${t}" || fail "scripts/${t}"
+# pf_path_under <path> <root>: <path> is <root> or lives beneath it. Both
+# arguments must already be physically resolved -- `case` is a glob matcher, not
+# a path resolver, and a `..` traversal string-matches a root it has left.
+pf_path_under() {
+  local p="${1:-}" root="${2:-}"
+  [ -n "$p" ] && [ -n "$root" ] || return 1
+  case "$p" in "$root" | "$root"/*) return 0 ;; esac
+  return 1
+}
+
+# pf_repo_key <dir>: a canonical identity for the git REPOSITORY <dir> belongs
+# to. The COMMON git dir, so a linked worktree keys to the repo it is linked
+# into -- which is the entire point here, since a worktree of the release
+# checkout shares its config and refs and would otherwise look like a sandbox.
+pf_repo_key() {
+  local d="${1:-}" g
+  [ -n "$d" ] || return 1
+  g="$(cd "$d" 2>/dev/null && pf_git rev-parse --git-common-dir 2>/dev/null)" || return 1
+  [ -n "$g" ] || return 1
+  case "$g" in /*) ;; *) g="${d}/${g}" ;; esac
+  pf_phys "$g"
+}
+
+# pf_fingerprint <repo-dir>: the byte-identity of a checkout, and the exact set
+# of things the three incidents landed in -- refs (a fixture commit), HEAD, the
+# reflog, the working tree, core.bare (flipped twice), the worktree registry (a
+# planted worktree is invisible to all of the above) and the local config
+# (config OUTLIVES refs, so a stale branch stanza is the longest-lived
+# fingerprint of an escape).
+#
+# Every command must SUCCEED. A fingerprint that silently degrades to empty
+# compares equal to another empty one and the whole check passes on nothing, so
+# an unreadable repository is a failure rather than a clean bill of health.
+# `--abbrev-ref` rather than `symbolic-ref` because a detached HEAD prints
+# "HEAD" and exits 0 instead of being an error; `--default` on core.bare because
+# an unset key is rc 1.
+pf_fingerprint() {
+  local d="${1:-}"
+  [ -n "$d" ] || return 1
+  pf_git -C "$d" for-each-ref --format='%(refname) %(objectname)' || return 1
+  pf_git -C "$d" rev-parse HEAD || return 1
+  pf_git -C "$d" rev-parse --abbrev-ref HEAD || return 1
+  pf_git -C "$d" reflog --format='%H %gs' || return 1
+  pf_git -C "$d" status --porcelain || return 1
+  pf_git -C "$d" config --default '<unset>' --get core.bare || return 1
+  pf_git -C "$d" worktree list --porcelain || return 1
+  pf_git -C "$d" config --list --local || return 1
+}
+
+# pf_sandbox_rm <path>: ONE guarded removal. This is an `rm -rf` argument vector,
+# so it is guarded at least as hard as the git targets are: a relative path is
+# refused outright (`dirname ""` is ".", which would be `rm -rf` at the root of
+# whatever the cwd happens to be), an unresolvable path is refused rather than
+# guessed at, and so is anything that does not land strictly beneath the system
+# temp root. Refusal is reported and never fatal -- this runs on the failure path
+# too, and a cleanup that exits non-zero would mask the failure being reported.
+pf_sandbox_rm() {
+  local p="${1:-}" rp tmp
+  [ -n "$p" ] || return 0
+  case "$p" in
+    /*) ;;
+    *)
+      printf '[preflight] refusing to clean up the RELATIVE path [%s]\n' "$p" >&2
+      return 1
+      ;;
+  esac
+  rp="$(pf_phys "$p")" || return 0
+  tmp="$(pf_phys "${TMPDIR:-/tmp}" || printf '/tmp')"
+  if ! pf_path_under "$rp" "$tmp" || [ "$rp" = "$tmp" ] || [ "$rp" = "/" ]; then
+    printf '[preflight] refusing to clean up [%s] -- not strictly under %s\n' "$rp" "$tmp" >&2
+    return 1
   fi
-done
+  rm -rf "$rp"
+}
 
-if [ "${SKIP_SCIP:-0}" = "1" ]; then
-  printf '\n[preflight] SCIP regen skipped (SKIP_SCIP=1)\n' >&2
-else
-  step "legion index ${LEGION_REPO} (SCIP regen)"
-  if command -v legion >/dev/null 2>&1; then
-    if ! legion index "$LEGION_REPO"; then
-      if [ "${REQUIRE_SCIP:-0}" = "1" ]; then
-        fail "SCIP index regen"
-      fi
-      printf '[preflight] WARNING: SCIP regen failed (non-fatal; set REQUIRE_SCIP=1 to enforce)\n' >&2
+# pf_sandbox_cleanup: the EXIT handler -- every sandbox root THIS shell created.
+# The list is deliberately not consulted by pf_make_sandbox's caller: a subshell
+# inherits a copy, so a cleanup that ran there would otherwise delete roots the
+# parent still owns.
+pf_sandbox_cleanup() {
+  local p
+  for p in ${PREFLIGHT_SANDBOX_ROOTS[@]+"${PREFLIGHT_SANDBOX_ROOTS[@]}"}; do
+    pf_sandbox_rm "$p" || true
+  done
+  PREFLIGHT_SANDBOX_ROOTS=()
+}
+
+# pf_make_sandbox <repo-root>: build the throwaway repository the shell suites
+# run in. Only scripts/ is copied -- the suites are unit tests OF those scripts
+# and build every other fixture themselves -- so the sandbox carries none of the
+# release checkout's history, remotes, hooks or config.
+#
+# It gets one commit at creation because a repo with no HEAD makes half the
+# fingerprint commands error, and a fingerprint that errors is a fingerprint
+# that cannot prove anything.
+#
+# THE RESULT IS A GLOBAL, NOT STDOUT, and that is load-bearing: read through
+# `$(pf_make_sandbox ...)` the whole body runs in a command-substitution
+# SUBSHELL, so the cleanup registration below is discarded the moment it returns
+# and every run leaks its sandbox into the system temp dir -- silently, since
+# nothing else changes. Callers read $PREFLIGHT_SANDBOX.
+PREFLIGHT_SANDBOX=""
+pf_make_sandbox() {
+  local repo_root="$1" root sandbox
+  PREFLIGHT_SANDBOX=""
+  root="$(mktemp -d)" || return 1
+  root="$(pf_phys "$root")" || return 1
+  # Registered, not trapped: installing the EXIT trap here would clobber a trap
+  # the caller set (scripts/test-preflight-isolation.sh owns one), and traps are
+  # global. The caller arranges for pf_sandbox_cleanup to run.
+  PREFLIGHT_SANDBOX_ROOTS+=("$root")
+
+  sandbox="${root}/sandbox"
+  mkdir -p "$sandbox" || return 1
+  cp -R "${repo_root}/scripts" "${sandbox}/scripts" || return 1
+
+  pf_git -c init.defaultBranch=main init --quiet "$sandbox" >/dev/null || return 1
+  pf_git -C "$sandbox" config user.email preflight@localhost || return 1
+  pf_git -C "$sandbox" config user.name preflight || return 1
+  # A repo-level hooks pin, so nothing a suite does can pick up a hook: the
+  # global config is already /dev/null, and a fresh init has no hooks of its own.
+  pf_git -C "$sandbox" config core.hooksPath /dev/null || return 1
+  pf_git -C "$sandbox" add -A || return 1
+  pf_git -C "$sandbox" -c commit.gpgsign=false commit --quiet --no-verify \
+    -m "preflight sandbox" >/dev/null || return 1
+
+  PREFLIGHT_SANDBOX="$sandbox"
+}
+
+# pf_assert_sandbox_isolated <sandbox> <repo-root> <what>: the pre-run gate.
+# Every arm fails CLOSED -- a check that cannot be resolved is a refusal.
+pf_assert_sandbox_isolated() {
+  local sandbox="$1" repo_root="$2" what="$3"
+  local sandbox_phys release_phys sandbox_key release_key remotes
+
+  sandbox_phys="$(pf_phys "$sandbox")" \
+    || fail "${what}: the sandbox [${sandbox}] does not resolve to a real directory"
+  release_phys="$(pf_phys "$repo_root")" \
+    || fail "${what}: the release checkout [${repo_root}] does not resolve to a real directory"
+
+  # Containment, both ways. A sandbox inside the checkout would be committable
+  # from it; a checkout inside the sandbox would be inside the cleanup vector.
+  if pf_path_under "$sandbox_phys" "$release_phys" || pf_path_under "$release_phys" "$sandbox_phys"; then
+    fail "${what}: the sandbox [${sandbox_phys}] overlaps the release checkout [${release_phys}]"
+  fi
+
+  # Repository IDENTITY, keyed on the common git dir so a linked worktree of the
+  # release repo cannot pose as a sandbox. THIS is the check the issue asks for:
+  # a suite whose resolved repo would be the repository being released is named
+  # and refused, never run.
+  sandbox_key="$(pf_repo_key "$sandbox_phys")" \
+    || fail "${what}: cannot resolve the sandbox's git repository -- refusing to run it"
+  release_key="$(pf_repo_key "$release_phys")" \
+    || fail "${what}: cannot resolve the release checkout's git repository -- refusing to run anything against it"
+  if [ "$sandbox_key" = "$release_key" ]; then
+    fail "${what}: WOULD RUN AGAINST THE REPOSITORY BEING RELEASED (${release_key}) -- refusing"
+  fi
+
+  # No remote, asserted immediately before the run rather than assumed from the
+  # way the sandbox was built. A fixture that reaches a real remote is the whole
+  # incident, so this is a checked property, and a read that FAILS is a refusal.
+  remotes="$(pf_git -C "$sandbox_phys" remote)" \
+    || fail "${what}: cannot read the sandbox's remotes -- refusing to run it"
+  if [ -n "$remotes" ]; then
+    fail "${what}: the sandbox has remotes configured [$(printf '%s' "$remotes" | tr '\n' ' ')] -- refusing to run it"
+  fi
+}
+
+# pf_run_shell_suites <repo-root>: every scripts/test-*.sh, each executed in the
+# sandbox with the cwd, the git config and the git environment all pointed away
+# from the release checkout.
+pf_run_shell_suites() {
+  local repo_root="$1"
+  local sandbox t before after release_before release_after rc
+  local -a suites=()
+
+  # The sandbox must be removed on the failure path too, and `fail` exits.
+  trap pf_sandbox_cleanup EXIT
+
+  local f
+  for f in "${repo_root}"/scripts/test-*.sh; do
+    [ -f "$f" ] || continue
+    suites+=("${f##*/}")
+  done
+  # Fail closed: "the glob matched nothing" is indistinguishable from "the
+  # suites were renamed", and both must stop a release rather than pass it.
+  [ "${#suites[@]}" -gt 0 ] \
+    || fail "shell-script tests -- no scripts/test-*.sh found under ${repo_root}"
+
+  release_before="$(pf_fingerprint "$repo_root")" \
+    || fail "shell-script tests -- cannot fingerprint the release checkout ${repo_root}"
+
+  pf_make_sandbox "$repo_root" \
+    || fail "shell-script tests -- could not build the disposable sandbox"
+  sandbox="$PREFLIGHT_SANDBOX"
+  [ -n "$sandbox" ] \
+    || fail "shell-script tests -- the disposable sandbox has no path"
+
+  for t in "${suites[@]}"; do
+    pf_assert_sandbox_isolated "$sandbox" "$repo_root" "scripts/${t}"
+
+    before="$(pf_fingerprint "$sandbox")" \
+      || fail "scripts/${t} -- cannot fingerprint the sandbox before the run"
+
+    # This exact format is PARSED by test-preflight-isolation.sh's
+    # iso_sandbox_path, which asserts the sandbox is removed afterwards on both
+    # the success and the failure path. Reformat both ends together.
+    printf '\n[preflight] --- scripts/%s (sandbox: %s) ---\n' "$t" "$sandbox" >&2
+    # The cwd the suite inherits is the sandbox, never the release checkout --
+    # which is the whole of #867. $sandbox has just been resolved and gated, so
+    # the `cd` is a perimeter-checked target rather than a bare one.
+    rc=0
+    (cd "$sandbox" && pf_env_run bash "${sandbox}/scripts/${t}") || rc=$?
+    [ "$rc" -eq 0 ] || fail "scripts/${t} (exit ${rc})"
+
+    # An unreadable sandbox AFTER the run is not an inconvenience, it is the
+    # finding: `core.bare=true` is exactly what makes `git status` answer "this
+    # operation must be run in a work tree", and that write landed on the
+    # operator's live checkout twice.
+    after="$(pf_fingerprint "$sandbox")" \
+      || fail "scripts/${t} -- THE SANDBOX REPOSITORY IS UNREADABLE AFTER THE RUN.
+       The suite broke the repository it ran in (core.bare=true is the known
+       shape); under the pre-#867 runner that repository was ${repo_root}."
+    if [ "$before" != "$after" ]; then
+      fail "scripts/${t} -- THE SUITE MODIFIED THE REPOSITORY IT RAN IN. It was
+       sandboxed, so the damage is a temp directory -- but the same write with
+       the pre-#867 runner would have landed in ${repo_root}. Fix the suite's
+       fallback-to-cwd rather than this gate."
     fi
-  elif [ "${REQUIRE_SCIP:-0}" = "1" ]; then
-    fail "legion binary not found (REQUIRE_SCIP=1)"
-  else
-    printf '[preflight] legion binary not found -- skipping SCIP regen (non-fatal)\n' >&2
-  fi
-fi
+  done
 
-printf '\n[preflight] all gates passed\n' >&2
+  release_after="$(pf_fingerprint "$repo_root")" \
+    || fail "shell-script tests -- cannot fingerprint the release checkout after the run"
+  if [ "$release_before" != "$release_after" ]; then
+    fail "shell-script tests -- THE RELEASE CHECKOUT ${repo_root} CHANGED while the
+       shell suites ran. A suite reached it by a route the sandbox does not
+       bound (an absolute path, or an inherited git environment). Do not
+       release; inspect refs, core.bare and the local config."
+  fi
+
+  pf_sandbox_cleanup
+}
+
+main() {
+  local REPO_ROOT t
+  REPO_ROOT="$(git rev-parse --show-toplevel)"
+  cd "$REPO_ROOT" || fail "cannot enter the repository root ${REPO_ROOT}"
+
+  # The Rust and lint gates legitimately need the real checkout -- they compile
+  # and test the code under release -- and they are not #867's hazard, because
+  # they are not the thing whose fixtures fall back to the cwd. The precise
+  # claim, audited 2026-08-07, is narrower than "they never touch git":
+  #   * build.rs runs `git rev-parse --short HEAD` and `git status --porcelain`
+  #     against the repo root. Reads.
+  #   * a few integration tests deliberately read the repo root through the
+  #     inherited cwd -- current_git_head in tests/integration/worksource_pr.rs,
+  #     query_config_value in tests/integration/common.rs. Reads.
+  #   * ONE conditional write exists: tests/integration/common.rs sets
+  #     `core.bare false` on the repo root. It is a REPAIR that fires only when a
+  #     previous run already left core.bare=true, and it then panics naming what
+  #     it found -- a symptom handler for this issue's own class, installed after
+  #     #723/#740, not a channel of its own.
+  # Leaving them on the real checkout is a decision, not an oversight.
+  step "cargo fmt -- --check"
+  cargo fmt -- --check || fail "formatting (run: cargo fmt)"
+
+  step "cargo clippy --all-targets -- -D warnings"
+  cargo clippy --all-targets -- -D warnings || fail "clippy"
+
+  step "cargo test"
+  cargo test || fail "tests"
+
+  step "shell-script tests (disposable sandbox)"
+  for t in "${PREFLIGHT_REQUIRED_SUITES[@]}"; do
+    [ -f "${REPO_ROOT}/scripts/${t}" ] \
+      || fail "shell-script tests -- required suite scripts/${t} is missing"
+  done
+  pf_run_shell_suites "$REPO_ROOT"
+
+  if [ "${SKIP_SCIP:-0}" = "1" ]; then
+    printf '\n[preflight] SCIP regen skipped (SKIP_SCIP=1)\n' >&2
+  else
+    step "legion index ${LEGION_REPO} (SCIP regen)"
+    if command -v legion >/dev/null 2>&1; then
+      if ! legion index "$LEGION_REPO"; then
+        if [ "${REQUIRE_SCIP:-0}" = "1" ]; then
+          fail "SCIP index regen"
+        fi
+        printf '[preflight] WARNING: SCIP regen failed (non-fatal; set REQUIRE_SCIP=1 to enforce)\n' >&2
+      fi
+    elif [ "${REQUIRE_SCIP:-0}" = "1" ]; then
+      fail "legion binary not found (REQUIRE_SCIP=1)"
+    else
+      printf '[preflight] legion binary not found -- skipping SCIP regen (non-fatal)\n' >&2
+    fi
+  fi
+
+  printf '\n[preflight] all gates passed\n' >&2
+}
+
+# Sourcing this file defines the sandbox machinery without running the gates --
+# scripts/test-preflight-isolation.sh drives pf_run_shell_suites directly, the
+# same way test-release.sh sources release.sh.
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+  main "$@"
+fi

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -58,13 +58,22 @@
 #   * around the phase   -- the release checkout must be byte-identical: refs,
 #     HEAD, reflog, status, core.bare, the worktree registry and the local
 #     config. This is the one that catches an escape by absolute path, which no
-#     amount of cwd discipline can prevent.
+#     amount of cwd discipline can prevent. It is compared on EVERY exit from
+#     the phase, not only the clean one -- a suite can corrupt the checkout and
+#     then fail, and if the comparison were skipped on the failure path the
+#     corruption would become the baseline the next run measures against.
 set -euo pipefail
 
 # The suites that MUST exist. Previously the runner was `if [ -f ... ]`, so
 # renaming or deleting a suite silently stopped gating on it; a missing required
 # suite is now a failure.
-PREFLIGHT_REQUIRED_SUITES=(test-release.sh test-sync-version.sh)
+#
+# test-preflight-isolation.sh is on this list for the same reason the other two
+# are, and the reason is sharper for it: it is the committed proof of #867, and
+# the discovery glob below would still match the other two if it were renamed
+# away. Discovery would pass, the release would proceed, and the only thing that
+# checks THIS FILE's guarantees would have stopped running silently.
+PREFLIGHT_REQUIRED_SUITES=(test-release.sh test-sync-version.sh test-preflight-isolation.sh)
 
 # Sandbox roots created by this process, for the EXIT cleanup.
 PREFLIGHT_SANDBOX_ROOTS=()
@@ -89,12 +98,39 @@ fail() { printf '\n[preflight] FAILED at: %s\n' "$1" >&2; exit 1; }
 # an empty key compares equal to nothing, which silently turns the identity gate
 # into a no-op. Pin first, then capture.
 #
+# THE PINS ARE NOT ENOUGH ON THEIR OWN, measured 2026-08-07 rather than reasoned
+# about: env-injected config OUTRANKS a repository's own `--local` values, and
+# GIT_CONFIG_GLOBAL=/dev/null does not touch it. With GIT_CONFIG_COUNT=1
+# GIT_CONFIG_KEY_0=core.hooksPath ambient, the sandbox's core.hooksPath pin reads
+# back as the attacker's directory and a planted hook FIRES inside the sandbox.
+# GIT_TEMPLATE_DIR is worse still, because it reaches the `git init` in
+# pf_make_sandbox and plants files into .git/hooks BEFORE any pin exists.
+# So the numbered pairs are unset individually. Clearing GIT_CONFIG_COUNT alone
+# does hold the pin for git's next read -- measured -- but the subshell below is
+# where the SUITE runs, and a suite that exports GIT_CONFIG_COUNT itself re-arms
+# whatever KEY_n/VALUE_n are still lying in the environment. With the pairs
+# actually gone that suite gets "missing config key GIT_CONFIG_KEY_0" and dies
+# loudly instead of quietly reading an attacker's value. The rest of the list is
+# the same class -- values that redirect where git finds its config, its
+# templates, its helper programs, or the commands it will shell out to.
+#
 # The subshell scoping is the point, not an accident, hence the disable.
 # shellcheck disable=SC2030,SC2031
 pf_env_run() {
   (
     unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_COMMON_DIR GIT_NAMESPACE \
-      GIT_OBJECT_DIRECTORY GIT_ALTERNATE_OBJECT_DIRECTORIES
+      GIT_OBJECT_DIRECTORY GIT_ALTERNATE_OBJECT_DIRECTORIES \
+      GIT_CONFIG GIT_CONFIG_COUNT GIT_TEMPLATE_DIR GIT_EXEC_PATH \
+      GIT_CEILING_DIRECTORIES GIT_SSH_COMMAND GIT_ASKPASS GIT_PROXY_COMMAND \
+      GIT_EDITOR GIT_SEQUENCE_EDITOR GIT_ALLOW_PROTOCOL GIT_ATTR_NOSYSTEM
+    # The numbered config pairs, by name. Unquoted on purpose: this is bash's
+    # prefix expansion over VARIABLE NAMES, which cannot contain whitespace, and
+    # it expands to nothing when none are set.
+    # shellcheck disable=SC2086
+    local pf_k
+    for pf_k in ${!GIT_CONFIG_KEY_@} ${!GIT_CONFIG_VALUE_@}; do
+      unset "$pf_k"
+    done
     export GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null \
       GIT_CONFIG_NOSYSTEM=1 GIT_TERMINAL_PROMPT=0
     "$@"
@@ -233,8 +269,14 @@ pf_make_sandbox() {
   pf_git -c init.defaultBranch=main init --quiet "$sandbox" >/dev/null || return 1
   pf_git -C "$sandbox" config user.email preflight@localhost || return 1
   pf_git -C "$sandbox" config user.name preflight || return 1
-  # A repo-level hooks pin, so nothing a suite does can pick up a hook: the
-  # global config is already /dev/null, and a fresh init has no hooks of its own.
+  # A repo-level hooks pin. What it covers: this repository's own hooks, and any
+  # hook a suite installs into .git/hooks afterwards. What it does NOT cover, and
+  # the comment here used to claim it did -- an ambient GIT_CONFIG_COUNT/KEY_n
+  # pair, which outranks `--local` and would make this line read back as the
+  # attacker's directory; and GIT_TEMPLATE_DIR, which planted its files during
+  # the `git init` above, before this line existed to be outranked. Neither is
+  # closed here. Both are closed by the scrub in pf_env_run, which is why every
+  # git call in this file goes through it.
   pf_git -C "$sandbox" config core.hooksPath /dev/null || return 1
   pf_git -C "$sandbox" add -A || return 1
   pf_git -C "$sandbox" -c commit.gpgsign=false commit --quiet --no-verify \
@@ -287,7 +329,7 @@ pf_assert_sandbox_isolated() {
 # from the release checkout.
 pf_run_shell_suites() {
   local repo_root="$1"
-  local sandbox t before after release_before release_after rc
+  local sandbox t before after release_before release_after rc phase_rc
   local -a suites=()
 
   # The sandbox must be removed on the failure path too, and `fail` exits.
@@ -312,47 +354,83 @@ pf_run_shell_suites() {
   [ -n "$sandbox" ] \
     || fail "shell-script tests -- the disposable sandbox has no path"
 
-  for t in "${suites[@]}"; do
-    pf_assert_sandbox_isolated "$sandbox" "$repo_root" "scripts/${t}"
+  # THE LOOP RUNS IN A SUBSHELL so that the release-checkout comparison below is
+  # reached by EVERY exit from this phase rather than only by the clean one.
+  #
+  # `fail` exits, and there are FIVE refusals inside this loop -- the pre-run
+  # gate, the before-fingerprint, the suite's own exit code, and the two
+  # after-run arms -- every one of which used to jump straight over the
+  # comparison. A suite that corrupted the release checkout AND then failed
+  # reported only its own failure; the corruption was never mentioned. The
+  # operator would then fix the suite and re-run, and run 2 would capture
+  # `release_before` from the ALREADY-CORRUPTED checkout and pass. Silent, and
+  # self-concealing, and the corruption becomes the next run's baseline.
+  #
+  # A subshell rather than a wrapper around each `fail`: a wrapper is a thing
+  # somebody has to remember to call at every new exit, which is the same shape
+  # as the defect being fixed. This makes the bracket structural. The suite's own
+  # diagnosis is already on stderr from inside the subshell, so a run that both
+  # corrupted the checkout and failed reports BOTH facts.
+  phase_rc=0
+  (
+    for t in "${suites[@]}"; do
+      pf_assert_sandbox_isolated "$sandbox" "$repo_root" "scripts/${t}"
 
-    before="$(pf_fingerprint "$sandbox")" \
-      || fail "scripts/${t} -- cannot fingerprint the sandbox before the run"
+      before="$(pf_fingerprint "$sandbox")" \
+        || fail "scripts/${t} -- cannot fingerprint the sandbox before the run"
 
-    # This exact format is PARSED by test-preflight-isolation.sh's
-    # iso_sandbox_path, which asserts the sandbox is removed afterwards on both
-    # the success and the failure path. Reformat both ends together.
-    printf '\n[preflight] --- scripts/%s (sandbox: %s) ---\n' "$t" "$sandbox" >&2
-    # The cwd the suite inherits is the sandbox, never the release checkout --
-    # which is the whole of #867. $sandbox has just been resolved and gated, so
-    # the `cd` is a perimeter-checked target rather than a bare one.
-    rc=0
-    (cd "$sandbox" && pf_env_run bash "${sandbox}/scripts/${t}") || rc=$?
-    [ "$rc" -eq 0 ] || fail "scripts/${t} (exit ${rc})"
+      # This exact format is PARSED by test-preflight-isolation.sh's
+      # iso_sandbox_path, which asserts the sandbox is removed afterwards on both
+      # the success and the failure path. Reformat both ends together.
+      printf '\n[preflight] --- scripts/%s (sandbox: %s) ---\n' "$t" "$sandbox" >&2
+      # The cwd the suite inherits is the sandbox, never the release checkout --
+      # which is the whole of #867. $sandbox has just been resolved and gated, so
+      # the `cd` is a perimeter-checked target rather than a bare one.
+      rc=0
+      (cd "$sandbox" && pf_env_run bash "${sandbox}/scripts/${t}") || rc=$?
+      [ "$rc" -eq 0 ] || fail "scripts/${t} (exit ${rc})"
 
-    # An unreadable sandbox AFTER the run is not an inconvenience, it is the
-    # finding: `core.bare=true` is exactly what makes `git status` answer "this
-    # operation must be run in a work tree", and that write landed on the
-    # operator's live checkout twice.
-    after="$(pf_fingerprint "$sandbox")" \
-      || fail "scripts/${t} -- THE SANDBOX REPOSITORY IS UNREADABLE AFTER THE RUN.
+      # An unreadable sandbox AFTER the run is not an inconvenience, it is the
+      # finding: `core.bare=true` is exactly what makes `git status` answer "this
+      # operation must be run in a work tree", and that write landed on the
+      # operator's live checkout twice.
+      after="$(pf_fingerprint "$sandbox")" \
+        || fail "scripts/${t} -- THE SANDBOX REPOSITORY IS UNREADABLE AFTER THE RUN.
        The suite broke the repository it ran in (core.bare=true is the known
        shape); under the pre-#867 runner that repository was ${repo_root}."
-    if [ "$before" != "$after" ]; then
-      fail "scripts/${t} -- THE SUITE MODIFIED THE REPOSITORY IT RAN IN. It was
+      if [ "$before" != "$after" ]; then
+        fail "scripts/${t} -- THE SUITE MODIFIED THE REPOSITORY IT RAN IN. It was
        sandboxed, so the damage is a temp directory -- but the same write with
        the pre-#867 runner would have landed in ${repo_root}. Fix the suite's
        fallback-to-cwd rather than this gate."
-    fi
-  done
+      fi
+    done
+  ) || phase_rc=$?
 
-  release_after="$(pf_fingerprint "$repo_root")" \
-    || fail "shell-script tests -- cannot fingerprint the release checkout after the run"
+  # THE BRACKET. Reached on the success path and on every failure path above.
+  # An unreadable release checkout is reported on its own terms rather than
+  # collapsed into "it changed": core.bare=true set on the checkout by absolute
+  # path is exactly what makes it unreadable, and naming that is the finding.
+  if ! release_after="$(pf_fingerprint "$repo_root")"; then
+    fail "shell-script tests -- THE RELEASE CHECKOUT ${repo_root} IS UNREADABLE
+       after the shell suites ran. A suite reached it and broke it (core.bare
+       =true is the known shape). Do not release; repair the checkout and
+       inspect refs and the local config before doing anything else."
+  fi
   if [ "$release_before" != "$release_after" ]; then
     fail "shell-script tests -- THE RELEASE CHECKOUT ${repo_root} CHANGED while the
        shell suites ran. A suite reached it by a route the sandbox does not
        bound (an absolute path, or an inherited git environment). Do not
-       release; inspect refs, core.bare and the local config."
+       release; inspect refs, core.bare and the local config.
+       THIS IS REPORTED EVEN WHEN A SUITE ALSO FAILED ABOVE, and fixing that
+       suite does NOT clear it: the next run would capture its baseline from the
+       checkout as this run left it, and would pass."
   fi
+
+  # The suite failure itself, passed through unchanged. `exit`, not `fail` --
+  # the failing suite already named itself from inside the subshell and a second
+  # "FAILED at:" line would only obscure which gate actually fired.
+  [ "$phase_rc" -eq 0 ] || exit "$phase_rc"
 
   pf_sandbox_cleanup
 }

--- a/scripts/test-preflight-isolation.sh
+++ b/scripts/test-preflight-isolation.sh
@@ -41,10 +41,25 @@ no() { # no <label> <cmd...>   (expect non-zero)
   if "$@"; then FAIL=$((FAIL + 1)); printf 'FAIL: %s -- expected failure\n' "$label" >&2; else PASS=$((PASS + 1)); fi
 }
 has() { # has <label> <haystack> <needle>
-  if [ -z "${2##*"$3"*}" ]; then PASS=$((PASS + 1)); else
+  # `case`, NOT the `[ -z "${2##*"$3"*}" ]` idiom this started as. That idiom
+  # passes on an EMPTY haystack -- there is nothing to strip, so nothing is left,
+  # so the -z succeeds -- which made every assertion written with it go green the
+  # moment a mutation silenced the output it was reading. Found while
+  # mutation-checking pf_sandbox_rm: deleting that guard emptied $ISO_OUT and the
+  # message assertion passed anyway. An assertion that cannot go red is exactly
+  # the defect this file exists to catch, so the helper gets the same treatment.
+  if [ -z "$3" ]; then
     FAIL=$((FAIL + 1))
-    printf 'FAIL: %s -- output did not contain [%s]. Output:\n%s\n' "$1" "$3" "$2" >&2
+    printf 'FAIL: %s -- empty needle, this assertion asserts nothing\n' "$1" >&2
+    return 0
   fi
+  case "$2" in
+    *"$3"*) PASS=$((PASS + 1)) ;;
+    *)
+      FAIL=$((FAIL + 1))
+      printf 'FAIL: %s -- output did not contain [%s]. Output:\n%s\n' "$1" "$3" "$2" >&2
+      ;;
+  esac
 }
 
 # One temp root for every victim, removed through preflight's OWN guarded
@@ -170,6 +185,14 @@ FP_BARE="$(pf_fingerprint "$V_BARE")"
 iso_run "$V_BARE"
 no  "core.bare: preflight FAILS"                     test "$ISO_RC" -eq 0
 has "core.bare: and it names the suite"              "$ISO_OUT" "scripts/test-core-bare.sh"
+# WHICH ARM fired, not just that something did. core.bare=true leaves the
+# sandbox UNREADABLE -- `git status` answers "must be run in a work tree" -- so
+# this is caught by the after-run fingerprint FAILING, not by the before/after
+# comparison that catches an ordinary write. Asserting only the suite name let
+# that arm be deleted with no test going red: the same input then fell through
+# to the comparison arm and the run still failed, for the wrong reason.
+has "core.bare: and it names the arm that fired -- an UNREADABLE sandbox" \
+  "$ISO_OUT" "THE SANDBOX REPOSITORY IS UNREADABLE AFTER THE RUN"
 eq  "core.bare: the release checkout's core.bare is untouched" "$BARE_BEFORE" "$(bare_of "$V_BARE")"
 eq  "core.bare: and the checkout is byte-identical"  "$FP_BARE" "$(pf_fingerprint "$V_BARE")"
 ok  "core.bare: the release checkout still has a work tree" \
@@ -233,6 +256,47 @@ has "absolute: and it reports the release checkout changed" \
 ok  "absolute: the write really landed (so the gate, not luck, caught it)" \
   pf_git -C "$V_ABS" show-ref --verify --quiet refs/heads/absolute-escape
 
+# -- 5b. AND IT IS STILL REPORTED WHEN THE SUITE ALSO FAILS ------------------
+# The bracket above used to sit AFTER the suite loop, so every `fail` inside the
+# loop jumped over it. A suite that corrupted the release checkout and THEN
+# exited non-zero produced only "FAILED at: <suite>" -- the corruption was never
+# named. That is the self-concealing half: the operator fixes the suite, re-runs,
+# and run 2 captures its baseline from the already-corrupted checkout and goes
+# green. Nothing here asserted the two facts together, which is why it shipped.
+V_ABSF="$(iso_victim absolute-escape-failing)"
+cat >"${V_ABSF}/scripts/test-absolute-escape-fail.sh" <<EOF
+#!/usr/bin/env bash
+# THE ATTACK: corrupt the release checkout by absolute path, THEN exit non-zero.
+# The branch name is fresh on every run, so a SECOND run corrupts again instead
+# of erroring out on the ref the first run already left behind -- otherwise the
+# re-run would go red for a bookkeeping reason and assert nothing.
+set -euo pipefail
+n=\$(git -C "${V_ABSF}" for-each-ref --format='%(refname)' 'refs/heads/escape-*' | wc -l | tr -d ' ')
+git -C "${V_ABSF}" branch "escape-\$((n + 1))"
+exit 1
+EOF
+ok "absolute+fail: victim built" iso_commit "$V_ABSF"
+iso_run "$V_ABSF"
+no  "absolute+fail: preflight FAILS"                 test "$ISO_RC" -eq 0
+has "absolute+fail: the suite's own failure is reported" \
+  "$ISO_OUT" "scripts/test-absolute-escape-fail.sh"
+has "absolute+fail: AND the release corruption is reported by the SAME run" \
+  "$ISO_OUT" "THE RELEASE CHECKOUT"
+has "absolute+fail: named as a change, not as a suite failure" "$ISO_OUT" "CHANGED"
+eq  "absolute+fail: the write really landed" "1" \
+  "$(pf_git -C "$V_ABSF" for-each-ref --format='%(refname)' 'refs/heads/escape-*' | wc -l | tr -d ' ')"
+
+# THE RE-RUN. A fingerprint bracket has no memory across runs -- run 2's
+# baseline is whatever run 1 left behind -- so what has to hold is that
+# detection is not a ONE-SHOT that a concurrent suite failure launders. A second
+# run that corrupts again must report it again.
+iso_run "$V_ABSF"
+no  "absolute+fail re-run: preflight FAILS again"    test "$ISO_RC" -eq 0
+has "absolute+fail re-run: and reports the corruption again, not just the suite" \
+  "$ISO_OUT" "THE RELEASE CHECKOUT"
+eq  "absolute+fail re-run: both runs left their ref behind" "2" \
+  "$(pf_git -C "$V_ABSF" for-each-ref --format='%(refname)' 'refs/heads/escape-*' | wc -l | tr -d ' ')"
+
 # -- 6. THE PRE-RUN GATE, DIRECTLY -------------------------------------------
 # Everything above observes the gate through a whole phase. These pin the gate's
 # own decisions, including the one arm the phase cannot reach: what happens when
@@ -284,6 +348,175 @@ rmdir "$INSIDE"
 iso_guard "${ISO_TMP}/no-such-sandbox" "$V_OK"
 eq  "gate: an unresolvable sandbox is refused" "1" "$ISO_RC"
 has "gate: and refusal is the fail-CLOSED answer" "$ISO_OUT" "does not resolve"
+
+# -- 7. SUITE DISCOVERY FAILS CLOSED -----------------------------------------
+# "the glob matched nothing" and "every suite was renamed" are the same
+# observation, and both have to stop a release rather than sail through it as a
+# phase with no work to do. Nothing exercised discovery at all, so the `-gt 0`
+# carrying that decision was free to become `-ge 0` with no test going red.
+V_NONE="$(iso_victim no-suites)"
+ok  "discovery: a victim carrying no suites was built" iso_commit "$V_NONE"
+iso_run "$V_NONE"
+no  "discovery: a repo root with no scripts/test-*.sh is refused" test "$ISO_RC" -eq 0
+has "discovery: and the refusal says what it could not find" \
+  "$ISO_OUT" "no scripts/test-*.sh found"
+
+# -- 8. THE FINGERPRINT FAILS CLOSED -----------------------------------------
+# A fingerprint that degrades to empty compares equal to the next empty one, and
+# every before/after gate in this file then passes on nothing. The header says
+# so at length; nothing checked it.
+fp() { pf_fingerprint "$@" >/dev/null 2>&1; }   # only the exit code is under test
+no  "fingerprint: no argument at all is refused"      fp
+no  "fingerprint: a path that does not exist is refused" fp "${ISO_TMP}/not-a-repository"
+mkdir -p "${ISO_TMP}/not-a-repository"
+no  "fingerprint: a directory that is not a repository is refused" \
+  fp "${ISO_TMP}/not-a-repository"
+# The DISCRIMINATING case. core.bare=true leaves for-each-ref, rev-parse, the
+# reflog and config all answering normally and breaks only `git status` -- so a
+# fingerprint that tolerated a failing command would still return a full-looking
+# value here, and only here. It is also the exact shape of the incident, twice.
+V_BROKE="$(iso_victim unreadable-repo)"
+ok  "fingerprint: a healthy checkout was built"       iso_commit "$V_BROKE"
+ok  "fingerprint: and a healthy checkout fingerprints" fp "$V_BROKE"
+pf_git -C "$V_BROKE" config core.bare true
+no  "fingerprint: a checkout broken by core.bare=true is refused, not fingerprinted" \
+  fp "$V_BROKE"
+pf_git -C "$V_BROKE" config --unset core.bare
+
+# -- 9. pf_path_under, DIRECTLY ----------------------------------------------
+# The separator in `"$root"/*` IS the guard. Without it, `"$root"*` admits every
+# sibling that merely shares a prefix -- /a/bc reads as "under" /a/b -- and this
+# is the predicate that keeps the sandbox out of the release checkout, keeps the
+# release checkout out of the cleanup vector, and bounds `rm -rf` to the temp
+# root. It was reachable only through those callers, none of which passes a
+# prefix-sharing sibling, so the separator was untested.
+ok "path_under: a child is under its root"            pf_path_under /a/b/c /a/b
+ok "path_under: a root is under itself"               pf_path_under /a/b /a/b
+ok "path_under: a deep descendant is under it"        pf_path_under /a/b/c/d/e /a/b
+no "path_under: a SIBLING sharing the prefix is NOT under it" pf_path_under /a/bc /a/b
+no "path_under: nor one that merely starts the same"  pf_path_under /a/b-2 /a/b
+no "path_under: an unrelated path is not"             pf_path_under /x/y /a/b
+no "path_under: an empty path is refused"             pf_path_under "" /a/b
+no "path_under: an empty root is refused"             pf_path_under /a/b ""
+
+# -- 10. pf_sandbox_rm, DIRECTLY ---------------------------------------------
+# An `rm -rf` argument vector with no test of any kind. Every arm is exercised
+# against a target that must SURVIVE, because "it returned 1" and "it deleted
+# nothing" are different claims and only the second one is the safety property.
+#
+# The temp-root arms run against a FAKE temp root inside this file's own tree
+# rather than the real $TMPDIR. The mutant that proves an assertion here is
+# "delete the guard", and the blast radius of that mutant has to be a directory
+# this file owns -- pointed at the real $TMPDIR it would remove the system temp
+# directory, which is where the release itself is cut.
+iso_rm() { # iso_rm <cwd> <tmpdir> <arg>
+  ISO_RC=0
+  ISO_OUT="$( (cd "$1" && export TMPDIR="$2" && pf_sandbox_rm "$3") 2>&1 )" || ISO_RC=$?
+}
+FAKE_TMP="${ISO_TMP}/fake-tmp"
+mkdir -p "$FAKE_TMP"
+
+# A RELATIVE path: `dirname ""` is ".", so this arm is what stands between a
+# degraded path helper and `rm -rf` at the root of whatever the cwd happens to be.
+mkdir -p "${ISO_TMP}/rm-relative"
+iso_rm "$ISO_TMP" "$ISO_TMP" "rm-relative"
+eq  "sandbox_rm: a RELATIVE path is refused"          "1" "$ISO_RC"
+has "sandbox_rm: and says which arm refused it"       "$ISO_OUT" "refusing to clean up the RELATIVE path"
+ok  "sandbox_rm: and the target SURVIVES"             test -d "${ISO_TMP}/rm-relative"
+
+# The temp root ITSELF: strictly-under, not under-or-equal.
+iso_rm "$ISO_TMP" "$FAKE_TMP" "$FAKE_TMP"
+eq  "sandbox_rm: the temp root itself is refused"     "1" "$ISO_RC"
+has "sandbox_rm: and says why"                        "$ISO_OUT" "not strictly under"
+ok  "sandbox_rm: and the temp root SURVIVES"          test -d "$FAKE_TMP"
+
+# Anything outside the temp root, which is every real repository on the machine.
+mkdir -p "${ISO_TMP}/rm-outside"
+iso_rm "$ISO_TMP" "$FAKE_TMP" "${ISO_TMP}/rm-outside"
+eq  "sandbox_rm: a path outside the temp root is refused" "1" "$ISO_RC"
+has "sandbox_rm: and says why"                        "$ISO_OUT" "not strictly under"
+ok  "sandbox_rm: and the outside target SURVIVES"     test -d "${ISO_TMP}/rm-outside"
+
+iso_rm "$ISO_TMP" "$FAKE_TMP" "/"
+eq  "sandbox_rm: / is refused"                        "1" "$ISO_RC"
+has "sandbox_rm: and says why"                        "$ISO_OUT" "not strictly under"
+ok  "sandbox_rm: and / survives"                      test -d /
+
+# The positive control, so the refusals above are a guard rather than a function
+# that never removes anything at all.
+mkdir -p "${FAKE_TMP}/removable"
+iso_rm "$ISO_TMP" "$FAKE_TMP" "${FAKE_TMP}/removable"
+eq  "sandbox_rm: a path strictly under the temp root IS removed" "0" "$ISO_RC"
+no  "sandbox_rm: and it is really gone"               test -d "${FAKE_TMP}/removable"
+
+# -- 11. THE REQUIRED-SUITE LIST ---------------------------------------------
+# PREFLIGHT_REQUIRED_SUITES exists so a renamed or deleted suite stops the
+# release instead of quietly shrinking what is gated. This file is the committed
+# proof of #867, and it was not on the list: renaming it away left the discovery
+# glob still matching the other two, so discovery passed, the release proceeded,
+# and the only thing checking any of the guarantees above had stopped running.
+iso_required() {
+  local s
+  for s in "${PREFLIGHT_REQUIRED_SUITES[@]}"; do
+    [ "$s" = "$1" ] && return 0
+  done
+  return 1
+}
+ok "required: test-release.sh is a required suite"       iso_required test-release.sh
+ok "required: test-sync-version.sh is a required suite"  iso_required test-sync-version.sh
+ok "required: and THIS proof is a required suite too"    iso_required test-preflight-isolation.sh
+
+# -- 12. THE AMBIENT GIT ENVIRONMENT -----------------------------------------
+# The sandbox pins core.hooksPath with `git config --local`, and preflight used
+# to claim that meant "nothing a suite does can pick up a hook". Measured, not
+# reasoned about: an env-injected config pair OUTRANKS a --local pin, and
+# GIT_CONFIG_GLOBAL=/dev/null does not touch it -- so an ambient
+# GIT_CONFIG_COUNT/KEY_n/VALUE_n defeats the pin outright and a planted hook
+# fires inside the sandbox. GIT_TEMPLATE_DIR is worse, because it reaches the
+# `git init` and plants into .git/hooks BEFORE the pin exists to be outranked.
+EVIL_HOOKS="${ISO_TMP}/evil-hooks"
+mkdir -p "$EVIL_HOOKS"
+mkdir -p "${ISO_TMP}/evil-template/hooks"
+printf '#!/bin/sh\nexit 0\n' >"${ISO_TMP}/evil-template/hooks/pre-commit"
+chmod +x "${ISO_TMP}/evil-template/hooks/pre-commit"
+
+export GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=core.hooksPath GIT_CONFIG_VALUE_0="$EVIL_HOOKS"
+export GIT_TEMPLATE_DIR="${ISO_TMP}/evil-template"
+ok "env: a sandbox still builds under a hostile ambient git environment" \
+  pf_make_sandbox "$V_OK"
+SB_ENV="$PREFLIGHT_SANDBOX"
+ok "env: and it has a path" test -n "$SB_ENV"
+# The control. Without it the assertion below is vacuous -- it would pass just
+# as well against an attack that never worked in the first place.
+eq "env: (control) an UNSCRUBBED read really is beaten by the injection" \
+  "$EVIL_HOOKS" "$(git -C "$SB_ENV" config --get core.hooksPath)"
+eq "env: a scrubbed read sees the sandbox's pin, not the injection" \
+  "/dev/null" "$(pf_git -C "$SB_ENV" config --get core.hooksPath)"
+# A fresh `git init` ships pre-commit.sample and no pre-commit, so this file
+# existing means the ambient template reached the init.
+no "env: and GIT_TEMPLATE_DIR planted no hook in the sandbox" \
+  test -e "${SB_ENV}/.git/hooks/pre-commit"
+
+# The numbered pairs are unset BY NAME, not merely disarmed by clearing the
+# count. Measured, because the distinction is not obvious in either direction:
+# with the count cleared and the pairs left in place the pin DOES hold, so
+# clearing the count looks sufficient. It is not -- pf_env_run's subshell is
+# where the SUITE runs, and a suite that exports GIT_CONFIG_COUNT itself re-arms
+# whatever KEY_n/VALUE_n are still lying in the environment and the injection
+# applies again. With the pairs genuinely gone, that same suite makes git fail
+# loudly ("missing config key GIT_CONFIG_KEY_0") instead of silently reading an
+# attacker's value. Asserted here rather than through a phase because the phase
+# cannot reach it: nothing else re-arms the count.
+# Single quotes are the point: the expansion has to happen in the shell pf_env_run
+# starts, AFTER the scrub, not in this one where the variable is still set.
+# shellcheck disable=SC2016
+eq "env: GIT_CONFIG_KEY_0 does not survive into the scrubbed environment" \
+  "" "$(pf_env_run sh -c 'printf %s "${GIT_CONFIG_KEY_0:-}"')"
+# shellcheck disable=SC2016
+eq "env: nor GIT_CONFIG_VALUE_0, so re-arming the count finds nothing to apply" \
+  "" "$(pf_env_run sh -c 'printf %s "${GIT_CONFIG_VALUE_0:-}"')"
+
+unset GIT_CONFIG_COUNT GIT_CONFIG_KEY_0 GIT_CONFIG_VALUE_0 GIT_TEMPLATE_DIR
 
 printf '\n[test-preflight-isolation] %d passed, %d failed\n' "$PASS" "$FAIL" >&2
 [ "$FAIL" -eq 0 ]

--- a/scripts/test-preflight-isolation.sh
+++ b/scripts/test-preflight-isolation.sh
@@ -1,0 +1,289 @@
+#!/usr/bin/env bash
+# test-preflight-isolation.sh: the committed proof of #867 -- that a fixture
+# suite run by scripts/preflight.sh cannot reach the repository being released.
+#
+# THE THING BEING PROVEN, and why it needs a test of its own: preflight is run by
+# scripts/release.sh as step 4, and it used to `cd "$(git rev-parse
+# --show-toplevel)"` before running the shell suites. So during a real release
+# the fixtures executed inside the live checkout, in a repo whose origin is the
+# real remote, and every fallback-to-cwd in a fixture was a write to production.
+# Three main-branch corruptions came down that channel. The suites themselves
+# were hardened twice (#861); this file asserts the property the CALLER is
+# responsible for, which is the half nothing covered.
+#
+# Sources preflight.sh -- main() is BASH_SOURCE-guarded, so sourcing defines the
+# sandbox machinery without running cargo -- and drives pf_run_shell_suites
+# against SACRIFICIAL repositories that stand in for the release checkout. Each
+# carries a deliberately hostile suite. Nothing here touches a real repo: every
+# victim is a fresh `git init` under this file's own temp root, and the suites
+# under test never learn a path outside it.
+set -u
+
+DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=preflight.sh disable=SC1091
+source "${DIR}/preflight.sh"
+set +e   # preflight.sh enables errexit on source; this file manages its own codes.
+
+PASS=0
+FAIL=0
+
+eq() { # eq <label> <expected> <actual>
+  if [ "$2" = "$3" ]; then PASS=$((PASS + 1)); else
+    FAIL=$((FAIL + 1)); printf 'FAIL: %s -- expected [%s] got [%s]\n' "$1" "$2" "$3" >&2
+  fi
+}
+ok() { # ok <label> <cmd...>   (expect exit 0)
+  local label="$1"; shift
+  if "$@"; then PASS=$((PASS + 1)); else FAIL=$((FAIL + 1)); printf 'FAIL: %s -- expected success\n' "$label" >&2; fi
+}
+no() { # no <label> <cmd...>   (expect non-zero)
+  local label="$1"; shift
+  if "$@"; then FAIL=$((FAIL + 1)); printf 'FAIL: %s -- expected failure\n' "$label" >&2; else PASS=$((PASS + 1)); fi
+}
+has() { # has <label> <haystack> <needle>
+  if [ -z "${2##*"$3"*}" ]; then PASS=$((PASS + 1)); else
+    FAIL=$((FAIL + 1))
+    printf 'FAIL: %s -- output did not contain [%s]. Output:\n%s\n' "$1" "$3" "$2" >&2
+  fi
+}
+
+# One temp root for every victim, removed through preflight's OWN guarded
+# remover rather than a bare `rm -rf`: it refuses relative paths, unresolvable
+# paths, and anything that does not land strictly beneath the system temp root.
+#
+# It is deliberately NOT put on PREFLIGHT_SANDBOX_ROOTS. That list is inherited
+# by the subshells `iso_run` uses, and a cleanup running there would delete this
+# file's own victims out from under it mid-run.
+ISO_TMP="$(pf_phys "$(mktemp -d)")" || {
+  printf '[test-preflight-isolation] could not create the temp root\n' >&2
+  exit 90
+}
+iso_cleanup() {
+  pf_sandbox_cleanup
+  pf_sandbox_rm "$ISO_TMP" || true
+}
+trap iso_cleanup EXIT
+
+# iso_victim <name>: a directory that will become a sacrificial "release
+# checkout". It carries a copy of preflight.sh so it looks like the real thing.
+iso_victim() {
+  local v="${ISO_TMP}/$1"
+  mkdir -p "${v}/scripts" || return 1
+  cp "${DIR}/preflight.sh" "${v}/scripts/preflight.sh" || return 1
+  printf '%s' "$v"
+}
+
+# iso_commit <victim>: turn it into a real repository, with NO remote.
+iso_commit() {
+  local v="$1"
+  pf_git -c init.defaultBranch=main init --quiet "$v" >/dev/null || return 1
+  pf_git -C "$v" config user.email t@t || return 1
+  pf_git -C "$v" config user.name t || return 1
+  pf_git -C "$v" add -A || return 1
+  pf_git -C "$v" -c commit.gpgsign=false commit --quiet --no-verify -m init >/dev/null
+}
+
+# iso_run <repo-root>: drive the phase under test in a subshell, since every
+# refusal in preflight is an `exit`. Leaves ISO_RC and ISO_OUT set.
+ISO_RC=0
+ISO_OUT=""
+iso_run() {
+  ISO_RC=0
+  ISO_OUT="$( (pf_run_shell_suites "$1") 2>&1 )" || ISO_RC=$?
+}
+
+# iso_guard <sandbox> <repo-root>: the pre-run gate alone, same subshell reason.
+iso_guard() {
+  ISO_RC=0
+  ISO_OUT="$( (pf_assert_sandbox_isolated "$1" "$2" "unit") 2>&1 )" || ISO_RC=$?
+}
+
+bare_of() { pf_git -C "$1" config --default '<unset>' --get core.bare; }
+
+# iso_sandbox_path: the sandbox the last iso_run announced. Its removal is an
+# assertion of its own -- the sandbox is a disposable, and a disposable that
+# survives is a leak into the system temp dir, which is where the release is cut.
+iso_sandbox_path() {
+  printf '%s\n' "$ISO_OUT" | sed -n 's/^.*(sandbox: \(.*\)) ---$/\1/p' | sed -n '1p'
+}
+
+# -- 1. THE NEGATIVE CONTROL -------------------------------------------------
+# Without it, a preflight that refused everything would satisfy every refusal
+# below and this file would be measuring nothing.
+V_OK="$(iso_victim control)"
+cat >"${V_OK}/scripts/test-benign.sh" <<'EOF'
+#!/usr/bin/env bash
+# A suite that behaves: builds its fixtures elsewhere, leaves its host alone.
+set -euo pipefail
+printf '[benign] this suite ran\n' >&2
+EOF
+ok "control: victim built" iso_commit "$V_OK"
+FP_OK="$(pf_fingerprint "$V_OK")"
+iso_run "$V_OK"
+eq "control: a well-behaved suite passes"          "0" "$ISO_RC"
+has "control: and it really ran"                   "$ISO_OUT" "[benign] this suite ran"
+eq "control: the release checkout is byte-identical" "$FP_OK" "$(pf_fingerprint "$V_OK")"
+SB_SEEN="$(iso_sandbox_path)"
+ok "control: the sandbox was announced by path" test -n "$SB_SEEN"
+no "control: and it is cleaned up on the success path" test -d "$SB_SEEN"
+
+# -- 2. THE ACCEPTANCE CRITERION ---------------------------------------------
+# A suite that falls back to the cwd's repository -- the exact shape of every
+# incident, since before #867 that cwd WAS the live checkout. The write must not
+# land on the release checkout, and preflight must FAIL rather than carry on.
+V_CWD="$(iso_victim cwd-write)"
+cat >"${V_CWD}/scripts/test-cwd-write.sh" <<'EOF'
+#!/usr/bin/env bash
+# THE ATTACK: a path helper degraded to "" or ".", so the fixture's git call
+# addresses whatever the runner's cwd happens to be.
+set -euo pipefail
+git commit --quiet --no-verify --allow-empty -m "fixture escape"
+git branch fixture-escape
+EOF
+ok "cwd-write: victim built" iso_commit "$V_CWD"
+FP_CWD="$(pf_fingerprint "$V_CWD")"
+iso_run "$V_CWD"
+no  "cwd-write: preflight FAILS"                    test "$ISO_RC" -eq 0
+has "cwd-write: and it names the suite"             "$ISO_OUT" "scripts/test-cwd-write.sh"
+has "cwd-write: and says what happened"             "$ISO_OUT" "MODIFIED THE REPOSITORY IT RAN IN"
+eq  "cwd-write: the release checkout is byte-identical" "$FP_CWD" "$(pf_fingerprint "$V_CWD")"
+no  "cwd-write: the escape ref never reached the release checkout" \
+  pf_git -C "$V_CWD" show-ref --verify --quiet refs/heads/fixture-escape
+SB_SEEN="$(iso_sandbox_path)"
+ok "cwd-write: the sandbox was announced by path" test -n "$SB_SEEN"
+no "cwd-write: and it is cleaned up on the FAILURE path too" test -d "$SB_SEEN"
+
+# -- 3. THE core.bare CLASS --------------------------------------------------
+# Incident #3, twice: `git config core.bare true` (equivalently `git init --bare`
+# onto an existing .git) against the repo the suite is standing in. `git status`
+# in the affected checkout then dies with "must be run in a work tree".
+V_BARE="$(iso_victim core-bare)"
+cat >"${V_BARE}/scripts/test-core-bare.sh" <<'EOF'
+#!/usr/bin/env bash
+# THE ATTACK: the config write that broke the operator's checkout twice.
+set -euo pipefail
+git config core.bare true
+EOF
+ok "core.bare: victim built" iso_commit "$V_BARE"
+BARE_BEFORE="$(bare_of "$V_BARE")"
+FP_BARE="$(pf_fingerprint "$V_BARE")"
+iso_run "$V_BARE"
+no  "core.bare: preflight FAILS"                     test "$ISO_RC" -eq 0
+has "core.bare: and it names the suite"              "$ISO_OUT" "scripts/test-core-bare.sh"
+eq  "core.bare: the release checkout's core.bare is untouched" "$BARE_BEFORE" "$(bare_of "$V_BARE")"
+eq  "core.bare: and the checkout is byte-identical"  "$FP_BARE" "$(pf_fingerprint "$V_BARE")"
+ok  "core.bare: the release checkout still has a work tree" \
+  pf_git -C "$V_BARE" status --porcelain
+
+# -- 4. THE LINKED-WORKTREE REGRESSION ---------------------------------------
+# A LINKED WORKTREE IS NOT A SANDBOX. `git rev-parse --git-common-dir` from one
+# resolves to the PARENT repo's .git, so a non-worktree-scoped config write from
+# inside a worktree lands in the SHARED config -- and git ignores core.bare for
+# linked worktrees, so the worktree keeps answering normally while the MAIN
+# checkout breaks. That invisibility is why this recurred through two rounds of
+# hardening aimed at paths, and it is why preflight must never "fix" #867 by
+# running the suites in a worktree.
+#
+# Here preflight itself is run FROM a linked worktree, which is the ordinary
+# case for an agent cutting a release. The suite's config write must reach
+# neither the worktree nor the parent.
+V_PAR="$(iso_victim worktree-parent)"
+cat >"${V_PAR}/scripts/test-core-bare.sh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+git config core.bare true
+EOF
+ok "worktree: parent built" iso_commit "$V_PAR"
+WT_LINKED="${ISO_TMP}/worktree-linked"
+ok "worktree: linked worktree created" \
+  pf_git -C "$V_PAR" worktree add --quiet -b linked "$WT_LINKED"
+# The premise, asserted rather than assumed: the worktree and its parent ARE the
+# same repository as far as config and refs are concerned.
+eq "worktree: the worktree keys to the parent repository" \
+  "$(pf_repo_key "$V_PAR")" "$(pf_repo_key "$WT_LINKED")"
+PAR_BARE_BEFORE="$(bare_of "$V_PAR")"
+FP_PAR="$(pf_fingerprint "$V_PAR")"
+iso_run "$WT_LINKED"
+no  "worktree: preflight FAILS"                      test "$ISO_RC" -eq 0
+has "worktree: and it names the suite"               "$ISO_OUT" "scripts/test-core-bare.sh"
+eq  "worktree: the PARENT repo's core.bare is untouched" \
+  "$PAR_BARE_BEFORE" "$(bare_of "$V_PAR")"
+eq  "worktree: the PARENT repo is byte-identical"    "$FP_PAR" "$(pf_fingerprint "$V_PAR")"
+ok  "worktree: the parent checkout still has a work tree" \
+  pf_git -C "$V_PAR" status --porcelain
+ok  "worktree: and so does the worktree"             pf_git -C "$WT_LINKED" status --porcelain
+
+# -- 5. THE ESCAPE THE SANDBOX CANNOT BOUND ----------------------------------
+# A suite that RESOLVED the release checkout's path and addressed it directly is
+# not contained by moving the cwd -- nothing about a sandbox stops an absolute
+# path. What must not happen is that the release proceeds unaware, so the phase
+# is bracketed by a fingerprint of the release checkout itself.
+V_ABS="$(iso_victim absolute-escape)"
+cat >"${V_ABS}/scripts/test-absolute-escape.sh" <<EOF
+#!/usr/bin/env bash
+# THE ATTACK: the release checkout's path, baked in.
+set -euo pipefail
+git -C "${V_ABS}" branch absolute-escape
+EOF
+ok "absolute: victim built" iso_commit "$V_ABS"
+iso_run "$V_ABS"
+no  "absolute: preflight FAILS"                      test "$ISO_RC" -eq 0
+has "absolute: and it reports the release checkout changed" \
+  "$ISO_OUT" "THE RELEASE CHECKOUT"
+ok  "absolute: the write really landed (so the gate, not luck, caught it)" \
+  pf_git -C "$V_ABS" show-ref --verify --quiet refs/heads/absolute-escape
+
+# -- 6. THE PRE-RUN GATE, DIRECTLY -------------------------------------------
+# Everything above observes the gate through a whole phase. These pin the gate's
+# own decisions, including the one arm the phase cannot reach: what happens when
+# the "sandbox" handed to it is the release repository itself.
+# Read through the GLOBAL, never `$(pf_make_sandbox ...)`: a command
+# substitution runs the whole builder in a subshell, so the sandbox root never
+# reaches the cleanup list and every call leaks a temp tree.
+ok "gate: a sandbox can be built" pf_make_sandbox "$V_OK"
+SB_OK="$PREFLIGHT_SANDBOX"
+ok "gate: and it has a path" test -n "$SB_OK"
+ok "gate: and its root is registered for cleanup" \
+  test "${#PREFLIGHT_SANDBOX_ROOTS[@]}" -gt 0
+ok "gate: a genuine sandbox is accepted" \
+  pf_assert_sandbox_isolated "$SB_OK" "$V_OK" "unit"
+
+# The trivial case -- the same directory -- is caught by containment, which runs
+# first. Refusal is what matters; which arm names it does not.
+iso_guard "$V_OK" "$V_OK"
+eq  "gate: a sandbox that IS the release checkout is refused" "1" "$ISO_RC"
+has "gate: and it says so by name" "$ISO_OUT" "overlaps the release checkout"
+
+# The heart of #867's enlarged scope: a linked worktree of the release repo
+# offered as a sandbox is refused, because the gate keys on the COMMON git dir
+# rather than on the path. A path-based check would have waved this through.
+iso_guard "$WT_LINKED" "$V_PAR"
+eq  "gate: a linked worktree of the release repo is refused" "1" "$ISO_RC"
+has "gate: and it is refused as the same repository" \
+  "$ISO_OUT" "WOULD RUN AGAINST THE REPOSITORY BEING RELEASED"
+
+# A sandbox that can reach a remote is refused before anything runs -- a fixture
+# that reaches a real remote is the incident in its purest form.
+pf_git -C "$SB_OK" remote add origin "${ISO_TMP}/nowhere.git"
+iso_guard "$SB_OK" "$V_OK"
+eq  "gate: a sandbox with a remote is refused" "1" "$ISO_RC"
+has "gate: and it names the remote check" "$ISO_OUT" "has remotes configured"
+pf_git -C "$SB_OK" remote remove origin
+
+# Containment, both directions: a sandbox inside the release checkout is
+# committable from it, and a release checkout inside the sandbox is inside the
+# cleanup vector.
+INSIDE="${V_OK}/nested-sandbox"
+mkdir -p "$INSIDE"
+iso_guard "$INSIDE" "$V_OK"
+eq  "gate: a sandbox inside the release checkout is refused" "1" "$ISO_RC"
+has "gate: and it says the two overlap" "$ISO_OUT" "overlaps the release checkout"
+rmdir "$INSIDE"
+
+# Fail closed: a path that does not resolve is a refusal, never a pass.
+iso_guard "${ISO_TMP}/no-such-sandbox" "$V_OK"
+eq  "gate: an unresolvable sandbox is refused" "1" "$ISO_RC"
+has "gate: and refusal is the fail-CLOSED answer" "$ISO_OUT" "does not resolve"
+
+printf '\n[test-preflight-isolation] %d passed, %d failed\n' "$PASS" "$FAIL" >&2
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## Summary

Three main-branch corruptions this week came through one channel, and it was never in the tests: `preflight.sh` did `cd "$REPO_ROOT"` and then ran the shell fixture suites there, while `release.sh` runs preflight as step 4. So during a release the fixtures executed inside the live checkout, in a repo whose origin is the real remote, and every cwd fallback in every fixture became a write to production. Two rounds of hardening aimed at the suites themselves could not close that, because the defect was in the caller. This moves the suites into a disposable sandbox and proves it with a suite whose only job is trying to escape.

## Acceptance criteria mapping

### 1. No fixture suite executes with cwd inside the repository being released

`scripts/` is copied into a `mktemp -d` that is `git init`ed as its own repository -- no remote, `GIT_CONFIG_GLOBAL`/`GIT_CONFIG_SYSTEM` pinned to `/dev/null`, `GIT_CONFIG_NOSYSTEM=1`, and every inherited `GIT_DIR`/`GIT_WORK_TREE`/`GIT_INDEX_FILE`/`GIT_COMMON_DIR`/`GIT_NAMESPACE`/object-directory variable unset. It gets one commit at creation so the fingerprint commands have something to report -- a repo with no HEAD makes half of them error, and a fingerprint that errors proves nothing.
Evidence: `pf_make_sandbox` in `scripts/preflight.sh`; the sandbox path printed per suite in the preflight output.

### 2. A suite that needs a checkout receives a disposable, remote-less one -- and the mechanism is a copy, not a clone or a worktree

Copy over clone, with the premise verified rather than assumed: both suites build every fixture from scratch and pass identically from a bare copy of `scripts/` with no parent history (268/268 and all scenarios). A clone would carry an origin URL that has to be stripped again plus an object store nothing reads. **Never a worktree** -- `pf_repo_key` keys on `git rev-parse --git-common-dir`, so a linked worktree of the release repo is refused as the *same repository*. A path-based check waves it through, and that is exactly the class that broke the main checkout invisibly twice: git ignores `core.bare` for linked worktrees, so setting it from inside one breaks the parent while the worktree keeps answering normally. The copy also makes #861's perimeter resolve `SUITE_SELF_REPO` to the throwaway rather than production; running from a worktree would have keyed that guard on the real repo.
Evidence: `pf_repo_key` and the sandbox construction in `scripts/preflight.sh`; the linked-worktree assertions in `scripts/test-preflight-isolation.sh`.

### 3. Preflight fails by name if a suite would run against the release repo

Three fail-closed brackets, and they are not redundant. Before each suite: the sandbox must resolve, must be a different repository than the release checkout, must have no remote (`git remote` asserted empty immediately before each run), and must not overlap the checkout in either direction. After each suite: the sandbox itself must be byte-identical, since the suites never touch the repo they run in and any change is a reach for the host. Around the phase: the release checkout must be byte-identical -- the only bracket that catches an escape by absolute path. Every unresolvable check is a refusal, never a pass.
Evidence: the three fingerprint brackets in `pf_run_shell_suites`.

### 4. A test proves the isolation -- an attempted write to the live repo fails preflight rather than landing

`scripts/test-preflight-isolation.sh`, 47 assertions, driving `pf_run_shell_suites` against sacrificial repos carrying deliberately hostile suites: negative control, cwd write, `core.bare` set, a run from a linked worktree, an absolute-path escape, plus direct assertions on the gate. The design point: relocating cwd makes a hostile write land harmlessly in a throwaway, which is *silence*, not detection -- containment alone would satisfy the letter of this criterion and miss its purpose, which is why the fingerprint brackets exist.
Evidence: `scripts/test-preflight-isolation.sh`.

### 5. Mutation-verified, and it reproduces the incident

Pointing the runner back at `$repo_root` -- pre-#867 behaviour -- turns 9 assertions red, including the pair that sets `core.bare` on the **parent** from a linked worktree and leaves the main checkout answering `fatal: this operation must be run in a work tree`. That is incident #3 reproducible on demand, and it is the first time that class has been reproducible at all.
Evidence: the mutation run recorded against the pre-#867 target.

### 6. The release checkout is byte-identical across a full preflight

Fingerprinted (refs, HEAD, symbolic HEAD, reflog, `status --porcelain`, `core.bare`, `worktree list --porcelain`, `config --list --local`) at session start, around the shell-suite phase, and around the full preflight: identical at every comparison, `core.bare` unset throughout, `status --porcelain` empty throughout.
Evidence: the three fingerprint comparisons reported by the run.

### 7. Two fail-opens closed incidentally

Suite discovery was `if [ -f ... ]`, so renaming or deleting a suite silently stopped gating on it; it is now a sorted glob where an empty match is a failure. And `$(pf_make_sandbox ...)` ran the builder in a command-substitution subshell, discarding its cleanup registration and leaking one temp tree per run invisibly -- the builder now returns through a global, with assertions pinning both the registration and removal on the success and failure paths.
Evidence: the glob discovery and `pf_make_sandbox`'s return convention in `scripts/preflight.sh`.

### 8. Review findings on this PR, fixed in b7d75a4

The release-checkout bracket ran only when the suite loop completed, so every failure path exited first: a hostile suite that corrupted the checkout by absolute path and then failed reported only the suite failure, and the next run re-baselined from the already-corrupted checkout and came back GREEN -- the first escape ratifying itself. It now fires before every exit from the phase and reports the corruption alongside the suite failure, since a suite can fail after corrupting. Five guards whose tests passed under mutation now carry assertions watched going red under their own mutants -- the empty-glob fatality (claimed as delivered by the previous version of this body while nothing tested suite discovery at all), pf_fingerprint's degrade-to-failure, the unreadable-sandbox arm asserted by message rather than suite name, pf_path_under's separator, and pf_sandbox_rm's relative-path refusal. PREFLIGHT_REQUIRED_SUITES omitted the isolation suite itself, so this issue's own proof could be renamed away while discovery passed. And the env scrub missed GIT_CONFIG_COUNT/KEY_n/VALUE_n, which OUTRANK the sandbox's --local pin -- measured, a hostile ambient environment made core.hooksPath resolve to a planted hook that fired inside the sandbox.
Evidence: assertions 47 -> 98; verified in an isolated clone at 98/0 and 268/0 with the real checkout byte-identical.

## Not done

The class is broader than this issue and two pieces are filed rather than folded in. **#873**: `cargo test` still runs with cwd inside the live checkout and is not read-only there -- `tests/integration/common.rs` carries a standing `git config core.bare false` *repair* installed after #723/#740, which is evidence the class outlived its earlier fixes, plus ambient-cwd reads and one `legion_cmd` call site missing `.current_dir()`. **#874**: no CI job runs any shell suite at all -- `ci.yml` shellchecks the 20-plus hook suites and stops, so the enforcement layer's own tests gate on nothing, and a local preflight is their only executor. That is precisely why this channel survived two rounds of hardening unnoticed.

The three `core.bare` recurrences during this work are now attributed by experiment rather than inference. `legion commit` is EXONERATED -- run against a sacrificial clone with the config fingerprinted, it produced one clean commit with zero config mutation. The source was this suite's own hostile fixtures (a literal `git config core.bare true`, and victims built under the `t@t` identity that matches stray commits found in July), escaping while the suite was being developed from a linked worktree whose `--git-common-dir` resolves to the parent repo. The process rule that follows is recorded on #876: a suite whose fixtures attack repositories cannot be developed from a linked worktree of a repo you care about, because the guard does not protect its own author.

An earlier draft of this change carried a comment claiming the remaining gates never touch git. That was false and is corrected in place rather than shipped -- `cargo test` does, which is what #873 records.

Closes #867
